### PR TITLE
fix: Entra authority should match public client config

### DIFF
--- a/lib/msal-config.ts
+++ b/lib/msal-config.ts
@@ -8,7 +8,7 @@ import { getPublicClientId } from "@/lib/runtime-config";
 export const msalConfig: Configuration = {
   auth: {
     clientId: getPublicClientId(),
-    authority: "https://login.microsoftonline.com/common",
+    authority: "https://login.microsoftonline.com/organizations",
     redirectUri:
       typeof window !== "undefined" ? window.location.origin : "",
   },


### PR DESCRIPTION
This looks really cool! Just a small bug fix. Avoids https://login.microsoftonline.com/error?code=AADSTS500202 for B2B guests using consumer accounts, like me. Tested with https://www.intuneget.com/ using https://developer.chrome.com/docs/devtools/overrides