### PR TITLE
feat: add cookie consent, test sub-stepper UI, and packaging improvements

### DIFF
--- a/.github/workflows-reference/package-intunewin.yml
+++ b/.github/workflows-reference/package-intunewin.yml
@@ -272,11 +272,87 @@ jobs:
             }
           }
 
+      - name: Test package installation
+        env:
+          CALLBACK_SECRET: ${{ secrets.CALLBACK_SECRET }}
+        run: |
+          . "$env:GITHUB_WORKSPACE\Send-Callback.ps1"
+
+          try {
+            $env:INPUT_PACKAGE_DIR = ".\package"
+            $env:INPUT_DETECTION_RULES = $env:DETECTION_RULES
+            $env:INPUT_WINGET_ID = $env:WINGET_ID
+            $env:INPUT_VERSION = $env:VERSION
+            $env:INPUT_INSTALL_SCOPE = $env:INSTALL_SCOPE
+            $env:INPUT_INSTALLER_TYPE = $env:INSTALLER_TYPE
+            $env:INPUT_TIMEOUT_SECONDS = "300"
+
+            & "$env:GITHUB_WORKSPACE\.github\scripts\Test-PSADTPackage.ps1"
+
+            $results = Get-Content ".\test-results.json" | ConvertFrom-Json
+            if (-not $results.passed) {
+              $failMsg = "Package test failed: $($results.failureReason)"
+              Send-Callback -Body @{
+                jobId = $env:JOB_ID
+                status = "failed"
+                message = $failMsg
+                progress = 0
+                errorStage = "test"
+                errorCategory = "validation"
+                errorCode = $results.failureReason
+                errorDetails = @{
+                  testResults = $results
+                  displayName = $env:DISPLAY_NAME
+                  version = $env:VERSION
+                }
+              } -CallbackUrl $env:CALLBACK_URL -CallbackSecret $env:CALLBACK_SECRET | Out-Null
+              $env:ERROR_SENT = "true"
+              throw $failMsg
+            }
+
+            Send-Callback -Body @{
+              jobId    = $env:JOB_ID
+              status   = "testing"
+              message  = "Package test passed"
+              progress = 62
+            } -CallbackUrl $env:CALLBACK_URL -CallbackSecret $env:CALLBACK_SECRET | Out-Null
+
+            Write-Host "Package test passed in $($results.totalDuration_ms)ms"
+
+          } catch {
+            if ($env:ERROR_SENT -ne "true") {
+              Send-Callback -Body @{
+                jobId = $env:JOB_ID
+                status = "failed"
+                message = "Package test error: $($_.Exception.Message)"
+                progress = 0
+                errorStage = "test"
+                errorCategory = "validation"
+                errorCode = "PACKAGE_TEST_ERROR"
+                errorDetails = @{ error = $_.Exception.Message }
+              } -CallbackUrl $env:CALLBACK_URL -CallbackSecret $env:CALLBACK_SECRET | Out-Null
+            }
+            throw
+          }
+
+      - name: Upload test debug logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-debug-logs
+          path: |
+            test-debug.log
+            test-results.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Clean up temp files
         run: |
           Remove-Item -Path ".\installer" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path ".\psadt" -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item -Path ".\package" -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path ".\test-results.json" -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path ".\test-debug.log" -Force -ErrorAction SilentlyContinue
 
       - name: Authenticate to Microsoft Graph
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ docker-compose.override.yml
 # OS files
 Thumbs.db
 
+# Playwright MCP logs
+.playwright-mcp/
+
 # Packager
 packager/node_modules/
 packager/dist/

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -191,7 +191,7 @@ export async function GET(request: NextRequest) {
       completedJobs,
       failedJobs,
       pendingJobs: allJobs.filter((j) =>
-        ['queued', 'packaging', 'uploading'].includes(j.status)
+        ['queued', 'packaging', 'testing', 'uploading'].includes(j.status)
       ).length,
       successRate,
     };

--- a/app/api/analytics/stats/route.ts
+++ b/app/api/analytics/stats/route.ts
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest) {
     let pending = 0;
     let failed = 0;
 
-    const pendingStatuses = ['queued', 'packaging', 'uploading'];
+    const pendingStatuses = ['queued', 'packaging', 'testing', 'uploading'];
 
     for (const job of allJobs) {
       // 'deployed' is the final success status (uploaded to Intune)

--- a/app/api/cron/cleanup-stale-jobs/route.ts
+++ b/app/api/cron/cleanup-stale-jobs/route.ts
@@ -9,7 +9,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
 const STALE_JOB_TIMEOUT_MINUTES = 30;
-const INTERMEDIATE_STATES = ['queued', 'packaging', 'uploading'];
+const INTERMEDIATE_STATES = ['queued', 'packaging', 'testing', 'uploading'];
 
 export async function GET(request: Request) {
   // Verify cron secret

--- a/app/api/msp/reports/analytics/route.ts
+++ b/app/api/msp/reports/analytics/route.ts
@@ -180,7 +180,7 @@ export async function GET(request: NextRequest) {
       completed_deployments: jobsList.filter((j: JobQueryResult) => j.status === 'deployed' || j.status === 'completed').length,
       failed_deployments: jobsList.filter((j: JobQueryResult) => j.status === 'failed').length,
       pending_deployments: jobsList.filter((j: JobQueryResult) =>
-        ['queued', 'packaging', 'uploading'].includes(j.status)
+        ['queued', 'packaging', 'testing', 'uploading'].includes(j.status)
       ).length,
       success_rate: 0,
       total_tenants: tenants.length,

--- a/app/api/package/callback/route.ts
+++ b/app/api/package/callback/route.ts
@@ -11,7 +11,7 @@ import { onJobCompleted } from '@/lib/msp/batch-orchestrator';
 
 interface PackageCallbackBody {
   jobId: string;
-  status: 'packaging' | 'uploading' | 'deployed' | 'failed' | 'duplicate_skipped';
+  status: 'packaging' | 'testing' | 'uploading' | 'deployed' | 'failed' | 'duplicate_skipped';
   message?: string;
   progress?: number;
 
@@ -32,7 +32,7 @@ interface PackageCallbackBody {
   runUrl?: string;
 
   // Enhanced error fields
-  errorStage?: 'download' | 'package' | 'upload' | 'authenticate' | 'finalize' | 'unknown';
+  errorStage?: 'download' | 'package' | 'test' | 'upload' | 'authenticate' | 'finalize' | 'unknown';
   errorCategory?: 'network' | 'validation' | 'permission' | 'installer' | 'intune_api' | 'system';
   errorCode?: string;
   errorDetails?: Record<string, unknown>;

--- a/app/api/package/cancel/route.ts
+++ b/app/api/package/cancel/route.ts
@@ -18,9 +18,9 @@ type PackagingJobRow = Database['public']['Tables']['packaging_jobs']['Row'];
 type PackagingJobUpdate = Database['public']['Tables']['packaging_jobs']['Update'];
 
 // Statuses that can be cancelled (active jobs)
-const CANCELLABLE_STATUSES = ['queued', 'packaging', 'uploading'];
+const CANCELLABLE_STATUSES = ['queued', 'packaging', 'testing', 'uploading'];
 // Statuses that can be force-dismissed by the user
-const DISMISSABLE_STATUSES = ['queued', 'packaging', 'uploading', 'completed', 'failed'];
+const DISMISSABLE_STATUSES = ['queued', 'packaging', 'testing', 'uploading', 'completed', 'failed'];
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/package/cleanup/route.ts
+++ b/app/api/package/cleanup/route.ts
@@ -11,7 +11,7 @@ import { createServerClient } from '@/lib/supabase';
 const STALE_JOB_TIMEOUT_MINUTES = 30;
 
 // Intermediate states that indicate a job might be stuck
-const INTERMEDIATE_STATES = ['queued', 'packaging', 'uploading'];
+const INTERMEDIATE_STATES = ['queued', 'packaging', 'testing', 'uploading'];
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/packager/health/route.ts
+++ b/app/api/packager/health/route.ts
@@ -52,7 +52,7 @@ export async function GET() {
     const stats: PackagerStats = {
       activePackagers: 0, // Will be calculated below
       queuedJobs: jobStats.queued,
-      processingJobs: jobStats.packaging + jobStats.uploading,
+      processingJobs: jobStats.packaging + jobStats.testing + jobStats.uploading,
       recentCompletedJobs: jobStats.deployed,
       recentFailedJobs: jobStats.failed,
     };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
-import Script from "next/script";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { MicrosoftAuthProvider } from "@/components/providers/MicrosoftAuthProvider";
@@ -8,10 +7,11 @@ import { QueryProvider } from "@/components/providers/QueryProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { UserSettingsProvider } from "@/components/providers/UserSettingsProvider";
 import { MspProvider } from "@/contexts/MspContext";
+import { CookieConsentBanner } from '@/components/consent/CookieConsentBanner';
+import { PlausibleLoader } from '@/components/analytics/PlausibleLoader';
 
 // Analytics configuration
 const PLAUSIBLE_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
-const ANALYTICS_ENABLED = Boolean(PLAUSIBLE_DOMAIN);
 
 const inter = localFont({
   src: "./fonts/InterVariable.woff2",
@@ -182,15 +182,17 @@ export default function RootLayout({
     <QueryProvider>
       <MicrosoftAuthProvider>
         <UserSettingsProvider>
-          <ThemeProvider>
-            <MspProvider>
-              {children}
-              <Toaster />
-            </MspProvider>
-          </ThemeProvider>
-        </UserSettingsProvider>
-      </MicrosoftAuthProvider>
-    </QueryProvider>
+              <ThemeProvider>
+                <MspProvider>
+                  {children}
+                  <PlausibleLoader domain={PLAUSIBLE_DOMAIN} />
+                  <CookieConsentBanner plausibleDomain={PLAUSIBLE_DOMAIN} />
+                  <Toaster />
+                </MspProvider>
+              </ThemeProvider>
+            </UserSettingsProvider>
+          </MicrosoftAuthProvider>
+        </QueryProvider>
   );
 
   return (
@@ -244,14 +246,6 @@ export default function RootLayout({
             __html: JSON.stringify(websiteJsonLd),
           }}
         />
-        {ANALYTICS_ENABLED && PLAUSIBLE_DOMAIN && (
-          <Script
-            defer
-            data-domain={PLAUSIBLE_DOMAIN}
-            src="https://plausible.io/js/script.js"
-            strategy="afterInteractive"
-          />
-        )}
       </head>
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -123,8 +123,12 @@ export default function PrivacyPage() {
                 views, referrers, and device types.
               </li>
               <li>
-                Your consent preference for analytics is stored in localStorage
-                (not a cookie) and remains on your device only.
+                Your consent choice is managed by the cookie banner and stored in
+                localStorage (not a cookie) and remains on your device only.
+              </li>
+              <li>
+                You can revisit this page anytime to review what enabling or
+                disabling analytics changes.
               </li>
             </ul>
           </section>

--- a/components/ProgressStepper.tsx
+++ b/components/ProgressStepper.tsx
@@ -126,8 +126,8 @@ export function ProgressStepper({
           isJobFailed ? 'text-status-error' : 'text-text-secondary'
         )}>
           {isJobFailed
-            ? statusMessage || 'Failed'
-            : statusMessage || currentStage?.description || 'Processing...'}
+            ? (statusMessage?.replace(/^\[test:\d+\/\d+\]\s*/, '') || 'Failed')
+            : (statusMessage?.replace(/^\[test:\d+\/\d+\]\s*/, '') || currentStage?.description || 'Processing...')}
         </span>
         <div className="flex items-center gap-2 text-text-muted">
           <Clock className="w-3.5 h-3.5" />

--- a/components/TestSubStepper.tsx
+++ b/components/TestSubStepper.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { Check, Loader2, XCircle, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  TEST_SUBSTEPS,
+  parseTestStep,
+  getSubStepStatuses,
+  type SubStepStatus,
+} from '@/lib/test-substeps';
+
+interface TestSubStepperProps {
+  statusMessage: string | null | undefined;
+  isJobFailed: boolean;
+}
+
+export function TestSubStepper({ statusMessage, isJobFailed }: TestSubStepperProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const activeStep = parseTestStep(statusMessage);
+  // Test is complete when we have a message, no [test:N/5] prefix, and the job hasn't failed
+  const isTestComplete = !!statusMessage && activeStep === null && !isJobFailed;
+  const statuses = getSubStepStatuses(activeStep, isJobFailed, isTestComplete);
+
+  return (
+    <motion.div
+      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+      transition={{ duration: prefersReducedMotion ? 0.1 : 0.25 }}
+      className="mt-3 ml-1 pl-3 border-l-2 border-overlay/10"
+    >
+      <div className="space-y-1.5 py-1">
+        {TEST_SUBSTEPS.map((step, i) => (
+          <SubStepRow
+            key={step.id}
+            label={step.label}
+            description={step.description}
+            status={statuses[i]}
+            prefersReducedMotion={!!prefersReducedMotion}
+          />
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+
+function SubStepRow({
+  label,
+  description,
+  status,
+  prefersReducedMotion,
+}: {
+  label: string;
+  description: string;
+  status: SubStepStatus;
+  prefersReducedMotion: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2.5">
+      {/* Icon circle */}
+      <div
+        className={cn(
+          'w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 transition-colors duration-200',
+          status === 'completed' && 'bg-status-success/20',
+          status === 'active' && 'bg-accent-cyan/20',
+          status === 'failed' && 'bg-status-error/20',
+          status === 'pending' && 'bg-overlay/5'
+        )}
+      >
+        {status === 'completed' && (
+          <Check className="w-3 h-3 text-status-success" />
+        )}
+        {status === 'active' && (
+          <Loader2
+            className={cn(
+              'w-3 h-3 text-accent-cyan',
+              !prefersReducedMotion && 'animate-spin'
+            )}
+          />
+        )}
+        {status === 'failed' && (
+          <XCircle className="w-3 h-3 text-status-error" />
+        )}
+        {status === 'pending' && (
+          <Minus className="w-3 h-3 text-text-muted/50" />
+        )}
+      </div>
+
+      {/* Label */}
+      <span
+        className={cn(
+          'text-xs font-medium transition-colors',
+          status === 'completed' && 'text-status-success',
+          status === 'active' && 'text-accent-cyan',
+          status === 'failed' && 'text-status-error',
+          status === 'pending' && 'text-text-muted'
+        )}
+      >
+        {label}
+      </span>
+
+      {/* Description (only for active or failed step) */}
+      <AnimatePresence>
+        {(status === 'active' || status === 'failed') && (
+          <motion.span
+            initial={prefersReducedMotion ? {} : { opacity: 0, x: -4 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={prefersReducedMotion ? {} : { opacity: 0, x: -4 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.15 }}
+            className={cn(
+              'text-xs',
+              status === 'active' && 'text-text-secondary',
+              status === 'failed' && 'text-status-error/70'
+            )}
+          >
+            {description}
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/analytics/PlausibleLoader.tsx
+++ b/components/analytics/PlausibleLoader.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Script from 'next/script';
+import { type AnalyticsConsent, getAnalyticsConsent, onConsentChange } from '@/lib/consent/cookie-consent';
+
+interface PlausibleLoaderProps {
+  domain?: string;
+}
+
+export function PlausibleLoader({ domain }: PlausibleLoaderProps) {
+  const [consent, setConsent] = useState<AnalyticsConsent>('unset');
+
+  useEffect(() => {
+    if (!domain) {
+      setConsent('unset');
+      return;
+    }
+
+    const current = getAnalyticsConsent();
+    setConsent(current);
+
+    const unsubscribe = onConsentChange((nextConsent) => {
+      setConsent(nextConsent);
+    });
+
+    return unsubscribe;
+  }, [domain]);
+
+  if (!domain || consent !== 'granted') {
+    return null;
+  }
+
+  return (
+    <Script
+      key={`plausible-${domain}`}
+      defer
+      data-domain={domain}
+      src="https://plausible.io/js/script.js"
+      strategy="afterInteractive"
+    />
+  );
+}
+

--- a/components/consent/CookieConsentBanner.tsx
+++ b/components/consent/CookieConsentBanner.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Link from 'next/link';
+import * as React from 'react';
+import { Cookie, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  getAnalyticsConsent,
+  onConsentChange,
+  setAnalyticsConsent,
+} from '@/lib/consent/cookie-consent';
+
+interface CookieConsentBannerProps {
+  plausibleDomain?: string;
+}
+
+export function CookieConsentBanner({
+  plausibleDomain,
+}: CookieConsentBannerProps) {
+  const [isVisible, setIsVisible] = React.useState(false);
+  const [isReady, setIsReady] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!plausibleDomain) {
+      return;
+    }
+
+    const current = getAnalyticsConsent();
+    setIsVisible(current === 'unset');
+    setIsReady(true);
+
+    const unsubscribe = onConsentChange((status) => {
+      setIsVisible(status === 'unset');
+    });
+
+    return unsubscribe;
+  }, [plausibleDomain]);
+
+  const handleAccept = () => {
+    setAnalyticsConsent('granted');
+    setIsVisible(false);
+  };
+
+  const handleDecline = () => {
+    setAnalyticsConsent('denied');
+    setIsVisible(false);
+  };
+
+  if (!plausibleDomain) return null;
+  if (!isReady || !isVisible) return null;
+
+  return (
+    <div className="fixed inset-x-4 bottom-4 z-50 sm:right-4 sm:left-auto sm:w-[420px] lg:w-[480px]">
+      <div className="glass-light rounded-xl border border-overlay/10 bg-bg-elevated p-4 shadow-soft-md animate-fade-up">
+        <div className="space-y-3">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 rounded-lg bg-accent-cyan/10 p-2 text-accent-cyan">
+              <Cookie className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-text-primary">
+                Help us improve the app with anonymous usage analytics
+              </p>
+              <p className="mt-1 text-xs text-text-muted">
+                We use Plausible for privacy-friendly aggregate insights. No
+                personal data, cookies, or fingerprinting.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-1 flex-col gap-2 sm:flex-row">
+              <Button
+                onClick={handleAccept}
+                size="sm"
+                className="w-full sm:w-auto bg-accent-cyan text-black font-medium hover:bg-accent-cyan-bright"
+              >
+                <ShieldCheck className="w-4 h-4 mr-2" />
+                Accept analytics
+              </Button>
+              <Button
+                onClick={handleDecline}
+                size="sm"
+                variant="outline"
+                className="w-full sm:w-auto border-overlay/20"
+              >
+                Decline
+              </Button>
+            </div>
+
+            <Button asChild variant="ghost" size="sm" className="w-full sm:w-auto">
+              <Link href="/privacy">Learn more</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/msp/CrossTenantJobsTable.tsx
+++ b/components/msp/CrossTenantJobsTable.tsx
@@ -10,6 +10,7 @@ import {
   XCircle,
   Loader2,
   ExternalLink,
+  FlaskConical,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useMicrosoftAuth } from '@/hooks/useMicrosoftAuth';
@@ -78,6 +79,8 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
       case 'packaging':
       case 'uploading':
         return <Loader2 className="w-4 h-4 text-accent-cyan animate-spin" />;
+      case 'testing':
+        return <FlaskConical className="w-4 h-4 text-amber-500" />;
       default:
         return <Clock className="w-4 h-4 text-text-muted" />;
     }
@@ -93,6 +96,8 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
         return 'Packaging';
       case 'uploading':
         return 'Uploading';
+      case 'testing':
+        return 'Testing';
       case 'queued':
         return 'Queued';
       default:
@@ -236,6 +241,7 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
                         job.status === 'completed' && 'text-green-500',
                         job.status === 'failed' && 'text-red-500',
                         (job.status === 'packaging' || job.status === 'uploading') && 'text-accent-cyan',
+                        job.status === 'testing' && 'text-amber-500',
                         job.status === 'queued' && 'text-text-muted'
                       )}>
                         {getStatusText(job.status)}

--- a/lib/consent/cookie-consent.ts
+++ b/lib/consent/cookie-consent.ts
@@ -1,0 +1,89 @@
+const COOKIE_CONSENT_EVENT = 'intuneget:cookie-consent-changed';
+export const COOKIE_CONSENT_KEY = 'intuneget_cookie_consent';
+export const COOKIE_CONSENT_UPDATED_AT_KEY = 'intuneget_cookie_consent_updated_at';
+
+export type AnalyticsConsent = 'granted' | 'denied' | 'unset';
+
+export function getAnalyticsConsent(): AnalyticsConsent {
+  if (typeof window === 'undefined') return 'unset';
+
+  try {
+    const storedConsent = window.localStorage.getItem(COOKIE_CONSENT_KEY);
+
+    if (storedConsent === 'granted' || storedConsent === 'denied') {
+      return storedConsent;
+    }
+  } catch (error) {
+    console.warn('Failed to read cookie consent state:', error);
+  }
+
+  return 'unset';
+}
+
+export function setAnalyticsConsent(
+  consent: Exclude<AnalyticsConsent, 'unset'>,
+): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(COOKIE_CONSENT_KEY, consent);
+    window.localStorage.setItem(
+      COOKIE_CONSENT_UPDATED_AT_KEY,
+      Date.now().toString(),
+    );
+  } catch (error) {
+    console.error('Failed to persist cookie consent:', error);
+    return;
+  }
+
+  dispatchConsentChanged(consent);
+}
+
+export function clearAnalyticsConsent(): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.removeItem(COOKIE_CONSENT_KEY);
+    window.localStorage.removeItem(COOKIE_CONSENT_UPDATED_AT_KEY);
+  } catch (error) {
+    console.error('Failed to clear cookie consent:', error);
+  }
+
+  dispatchConsentChanged('unset');
+}
+
+type ConsentChangeListener = (consent: AnalyticsConsent) => void;
+
+export function onConsentChange(
+  listener: ConsentChangeListener,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const handler = (event: Event) => {
+    const customEvent = event as CustomEvent<{ consent: AnalyticsConsent }>;
+    const consent = customEvent?.detail?.consent;
+
+    if (consent === 'granted' || consent === 'denied' || consent === 'unset') {
+      listener(consent);
+      return;
+    }
+
+    listener(getAnalyticsConsent());
+  };
+
+  window.addEventListener(COOKIE_CONSENT_EVENT, handler);
+  return () => window.removeEventListener(COOKIE_CONSENT_EVENT, handler);
+}
+
+function dispatchConsentChanged(consent: AnalyticsConsent): void {
+  if (typeof window === 'undefined') return;
+
+  window.dispatchEvent(
+    new CustomEvent(COOKIE_CONSENT_EVENT, {
+      detail: {
+        consent,
+      },
+    }),
+  );
+}
+

--- a/lib/db/__tests__/sqlite.test.ts
+++ b/lib/db/__tests__/sqlite.test.ts
@@ -278,6 +278,7 @@ function createTestAdapter(): DatabaseAdapter & { close: () => void } {
       async getStats(): Promise<{
         queued: number;
         packaging: number;
+        testing: number;
         uploading: number;
         deployed: number;
         failed: number;
@@ -293,6 +294,7 @@ function createTestAdapter(): DatabaseAdapter & { close: () => void } {
         const stats = {
           queued: 0,
           packaging: 0,
+          testing: 0,
           uploading: 0,
           deployed: 0,
           failed: 0,

--- a/lib/db/sqlite.ts
+++ b/lib/db/sqlite.ts
@@ -175,7 +175,7 @@ export const sqliteDb: DatabaseAdapter = {
         SELECT * FROM packaging_jobs
         WHERE user_id = ?
         AND (
-          status IN ('queued', 'packaging', 'uploading')
+          status IN ('queued', 'packaging', 'testing', 'uploading')
           OR created_at >= ?
         )
         ORDER BY created_at DESC
@@ -364,6 +364,7 @@ export const sqliteDb: DatabaseAdapter = {
     async getStats(): Promise<{
       queued: number;
       packaging: number;
+      testing: number;
       uploading: number;
       deployed: number;
       failed: number;
@@ -380,6 +381,7 @@ export const sqliteDb: DatabaseAdapter = {
       const stats = {
         queued: 0,
         packaging: 0,
+        testing: 0,
         uploading: 0,
         deployed: 0,
         failed: 0,

--- a/lib/db/supabase-adapter.ts
+++ b/lib/db/supabase-adapter.ts
@@ -156,7 +156,7 @@ export const supabaseDb: DatabaseAdapter = {
       const supabase = createServerClient();
       const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
       const terminalStatuses = ['completed', 'deployed', 'failed', 'cancelled', 'duplicate_skipped'];
-      const activeStatuses = ['queued', 'packaging', 'uploading'];
+      const activeStatuses = ['queued', 'packaging', 'testing', 'uploading'];
 
       // Fetch jobs: either active (any age) or terminal within last 7 days
       const { data, error } = await supabase
@@ -354,6 +354,7 @@ export const supabaseDb: DatabaseAdapter = {
       const stats: JobStats = {
         queued: 0,
         packaging: 0,
+        testing: 0,
         uploading: 0,
         deployed: 0,
         failed: 0,

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -80,6 +80,7 @@ export interface UploadHistoryRecord {
 export interface JobStats {
   queued: number;
   packaging: number;
+  testing: number;
   uploading: number;
   deployed: number;
   failed: number;

--- a/lib/progress-stages.ts
+++ b/lib/progress-stages.ts
@@ -34,17 +34,24 @@ export const PROGRESS_STAGES: ProgressStage[] = [
     maxProgress: 50,
   },
   {
+    id: 'test',
+    label: 'Test',
+    description: 'Testing install/uninstall cycle',
+    minProgress: 50,
+    maxProgress: 62,
+  },
+  {
     id: 'authenticate',
     label: 'Auth',
     description: 'Authenticating with Intune',
-    minProgress: 50,
-    maxProgress: 60,
+    minProgress: 62,
+    maxProgress: 70,
   },
   {
     id: 'upload',
     label: 'Upload',
     description: 'Uploading to Intune',
-    minProgress: 60,
+    minProgress: 70,
     maxProgress: 90,
   },
   {
@@ -56,7 +63,7 @@ export const PROGRESS_STAGES: ProgressStage[] = [
   },
 ];
 
-export type StageId = 'queued' | 'download' | 'package' | 'authenticate' | 'upload' | 'finalize';
+export type StageId = 'queued' | 'download' | 'package' | 'test' | 'authenticate' | 'upload' | 'finalize';
 
 /**
  * Get the current active stage based on progress percentage.

--- a/lib/test-substeps.ts
+++ b/lib/test-substeps.ts
@@ -1,0 +1,62 @@
+/**
+ * Test Sub-Steps Configuration
+ * Defines the 5 sub-steps of the package test phase and provides
+ * parsing utilities for the [test:N/5] convention in status_message.
+ */
+
+export interface TestSubStep {
+  id: string;
+  index: number;
+  label: string;
+  description: string;
+}
+
+export type SubStepStatus = 'completed' | 'active' | 'pending' | 'failed';
+
+export const TEST_SUBSTEPS: TestSubStep[] = [
+  { id: 'structure', index: 1, label: 'Structure', description: 'Validating package structure' },
+  { id: 'install', index: 2, label: 'Install', description: 'Running silent install' },
+  { id: 'detect', index: 3, label: 'Detect', description: 'Verifying detection rules' },
+  { id: 'uninstall', index: 4, label: 'Uninstall', description: 'Running silent uninstall' },
+  { id: 'verify', index: 5, label: 'Verify', description: 'Verifying clean removal' },
+];
+
+/**
+ * Parse the active test step number from a status message.
+ * Expects format: "[test:N/5] ..." where N is 1-5.
+ * Returns the step number or null if not found.
+ */
+export function parseTestStep(statusMessage: string | null | undefined): number | null {
+  if (!statusMessage) return null;
+  const match = statusMessage.match(/^\[test:(\d+)\/5\]/);
+  if (!match) return null;
+  const step = parseInt(match[1], 10);
+  if (step < 1 || step > 5) return null;
+  return step;
+}
+
+/**
+ * Compute the status of each sub-step based on the active step,
+ * whether the job has failed, and whether testing is complete.
+ */
+export function getSubStepStatuses(
+  activeStep: number | null,
+  isJobFailed: boolean,
+  isTestComplete: boolean
+): SubStepStatus[] {
+  // All completed (test passed, no prefix in message)
+  if (isTestComplete) {
+    return TEST_SUBSTEPS.map(() => 'completed');
+  }
+
+  // No step parsed yet -- all pending
+  if (activeStep === null) {
+    return TEST_SUBSTEPS.map(() => 'pending');
+  }
+
+  return TEST_SUBSTEPS.map((step) => {
+    if (step.index < activeStep) return 'completed';
+    if (step.index === activeStep) return isJobFailed ? 'failed' : 'active';
+    return 'pending';
+  });
+}


### PR DESCRIPTION
## Summary

- Add GDPR-compliant cookie consent banner with Plausible analytics integration
- Add real-time test sub-stepper showing 5 test phases (structure, install, detect, uninstall, verify) during package testing
- Add test step with debug logging and artifact upload to reference workflow
- Add error_stage field to job types for granular failure tracking
- Update progress stages to include testing phase

## Test plan

- [ ] Verify cookie consent banner appears on first visit and respects user choice
- [ ] Verify test sub-stepper renders correctly during testing status with `[test:N/5]` prefix messages
- [ ] Verify failed and completed test states display correctly in sub-stepper
- [ ] Verify Plausible analytics only loads after consent is granted
- [ ] Run `npx tsc --noEmit` and `npx eslint` with no new errors