### PR TITLE
Move update count badge from Inventory to App Updates menu item

### DIFF
--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -56,8 +56,8 @@ const coreNav: NavItem[] = [
 
 const managementNav: NavItem[] = [
   { name: 'SCCM Migration', href: '/dashboard/sccm', icon: FolderSync },
-  { name: 'Inventory', href: '/dashboard/inventory', icon: Server, badge: <UpdateBadge /> },
-  { name: 'App Updates', href: '/dashboard/updates', icon: ArrowUpCircle },
+  { name: 'Inventory', href: '/dashboard/inventory', icon: Server },
+  { name: 'App Updates', href: '/dashboard/updates', icon: ArrowUpCircle, badge: <UpdateBadge /> },
 ];
 
 const analyticsNav: NavItem[] = [


### PR DESCRIPTION
The badge showing available update count belongs on the dedicated "App Updates" nav item, not "Inventory".

https://claude.ai/code/session_01F9VHY3eTWHP7cQdvy9cRLQ

## Description

<!-- What does this PR do? Why is it needed? -->

## Changes

<!-- Bullet-point summary of what changed -->

-

## Testing

<!-- How did you verify this works? -->

-

---

> **Note:** First-time contributors will be asked to sign the [Contributor License Agreement](https://github.com/ugurkocde/IntuneGet/blob/main/CLA.md) via a PR comment. It's a one-time, 5-second step.
