### PR TITLE
feat: add ESP profile support for app deployments

### DIFF
--- a/app/api/intune/esp-profiles/add-app/route.ts
+++ b/app/api/intune/esp-profiles/add-app/route.ts
@@ -1,0 +1,127 @@
+/**
+ * ESP Profile Add App API Route
+ * Adds an Intune app to one or more ESP profiles
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
+import { parseAccessToken } from '@/lib/auth-utils';
+import { acquireGraphToken } from '@/lib/graph-token';
+import { addAppToEspProfile } from '@/lib/esp-api';
+import type { AddToEspResult } from '@/types/esp';
+
+interface AddAppRequestBody {
+  intuneAppId: string;
+  espProfileIds: string[];
+  espProfileNames?: Record<string, string>;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await parseAccessToken(request.headers.get('Authorization'));
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const body: AddAppRequestBody = await request.json();
+
+    if (!body.intuneAppId || typeof body.intuneAppId !== 'string') {
+      return NextResponse.json(
+        { error: 'intuneAppId is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!Array.isArray(body.espProfileIds) || body.espProfileIds.length === 0) {
+      return NextResponse.json(
+        { error: 'espProfileIds must be a non-empty array' },
+        { status: 400 }
+      );
+    }
+
+    if (!body.espProfileIds.every((id) => typeof id === 'string' && id.trim().length > 0)) {
+      return NextResponse.json(
+        { error: 'espProfileIds must contain non-empty strings' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createServerClient();
+    const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+
+    const tenantResolution = await resolveTargetTenantId({
+      supabase,
+      userId: user.userId,
+      tokenTenantId: user.tenantId,
+      requestedTenantId: mspTenantId,
+    });
+
+    if (tenantResolution.errorResponse) {
+      return tenantResolution.errorResponse;
+    }
+
+    const tenantId = tenantResolution.tenantId;
+
+    const { data: consentData, error: consentError } = await supabase
+      .from('tenant_consent')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('is_active', true)
+      .single();
+
+    if (consentError || !consentData) {
+      return NextResponse.json(
+        { error: 'Admin consent not found. Please complete the admin consent flow.' },
+        { status: 403 }
+      );
+    }
+
+    let graphToken: string;
+    try {
+      const tokenResult = await acquireGraphToken(tenantId);
+      graphToken = tokenResult.accessToken;
+    } catch {
+      return NextResponse.json(
+        { error: 'Failed to get Graph API token' },
+        { status: 500 }
+      );
+    }
+
+    const profileNames = body.espProfileNames || {};
+    const results: AddToEspResult[] = [];
+
+    for (const profileId of body.espProfileIds) {
+      try {
+        const { alreadyAdded } = await addAppToEspProfile(
+          graphToken,
+          profileId,
+          body.intuneAppId
+        );
+        results.push({
+          profileId,
+          profileName: profileNames[profileId] || profileId,
+          success: true,
+          alreadyAdded,
+        });
+      } catch (err) {
+        results.push({
+          profileId,
+          profileName: profileNames[profileId] || profileId,
+          success: false,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        });
+      }
+    }
+
+    return NextResponse.json({ results });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to add app to ESP profiles' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/intune/esp-profiles/route.ts
+++ b/app/api/intune/esp-profiles/route.ts
@@ -1,0 +1,76 @@
+/**
+ * ESP Profiles API Route
+ * Fetches available Enrollment Status Page profiles from the tenant
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
+import { parseAccessToken } from '@/lib/auth-utils';
+import { acquireGraphToken } from '@/lib/graph-token';
+import { listEspProfiles } from '@/lib/esp-api';
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await parseAccessToken(request.headers.get('Authorization'));
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createServerClient();
+    const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+
+    const tenantResolution = await resolveTargetTenantId({
+      supabase,
+      userId: user.userId,
+      tokenTenantId: user.tenantId,
+      requestedTenantId: mspTenantId,
+    });
+
+    if (tenantResolution.errorResponse) {
+      return tenantResolution.errorResponse;
+    }
+
+    const tenantId = tenantResolution.tenantId;
+
+    const { data: consentData, error: consentError } = await supabase
+      .from('tenant_consent')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('is_active', true)
+      .single();
+
+    if (consentError || !consentData) {
+      return NextResponse.json(
+        { error: 'Admin consent not found. Please complete the admin consent flow.' },
+        { status: 403 }
+      );
+    }
+
+    let graphToken: string;
+    try {
+      const tokenResult = await acquireGraphToken(tenantId);
+      graphToken = tokenResult.accessToken;
+    } catch {
+      return NextResponse.json(
+        { error: 'Failed to get Graph API token' },
+        { status: 500 }
+      );
+    }
+
+    const profiles = await listEspProfiles(graphToken);
+
+    return NextResponse.json({
+      profiles,
+      count: profiles.length,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to fetch ESP profiles' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -391,6 +391,7 @@ export async function POST(request: NextRequest) {
               requirementRules: item.requirementRules ? JSON.stringify(item.requirementRules) : undefined,
               assignments: item.assignments ? JSON.stringify(item.assignments) : undefined,
               categories: item.categories ? JSON.stringify(item.categories) : undefined,
+              espProfiles: item.espProfiles ? JSON.stringify(item.espProfiles) : undefined,
               installScope: item.installScope,
               forceCreate: item.forceCreate || forceCreate,
             };

--- a/app/dashboard/uploads/page.tsx
+++ b/app/dashboard/uploads/page.tsx
@@ -38,6 +38,7 @@ import { cn } from '@/lib/utils';
 import { useMicrosoftAuth } from '@/hooks/useMicrosoftAuth';
 import { ProgressStepper } from '@/components/ProgressStepper';
 import { ErrorDisplay } from '@/components/ErrorDisplay';
+import { EspProfileSelector } from '@/components/EspProfileSelector';
 import { PageHeader, AnimatedStatCard, StatCardGrid, AnimatedEmptyState, SkeletonGrid } from '@/components/dashboard';
 import type { PackageAssignment } from '@/types/upload';
 
@@ -919,6 +920,9 @@ function UploadJobCard({
                 View in Intune Portal
                 <ChevronRight className="w-4 h-4" />
               </a>
+              {job.intune_app_id && job.status === 'deployed' && (
+                <EspProfileSelector mode="post-deploy" intuneAppId={job.intune_app_id} />
+              )}
             </div>
           )}
 

--- a/components/CartItemConfig.tsx
+++ b/components/CartItemConfig.tsx
@@ -18,12 +18,15 @@ import {
   Clock,
   FolderTree,
   Palette,
+  Shield,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { AssignmentConfig } from '@/components/AssignmentConfig';
 import { CategoryConfig } from '@/components/CategoryConfig';
+import { EspProfileSelector } from '@/components/EspProfileSelector';
 import type { CartItem, StoreCartItem, IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
+import type { EspProfileSelection } from '@/types/esp';
 import { isStoreCartItem, isWin32CartItem } from '@/types/upload';
 import type { RequirementRule } from '@/types/intune';
 import type {
@@ -54,6 +57,7 @@ type ConfigSection =
   | 'diskspace'
   | 'assignment'
   | 'category'
+  | 'esp'
   | 'branding'
   | 'advanced';
 
@@ -79,6 +83,9 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   );
   const [categories, setCategories] = useState<IntuneAppCategorySelection[]>(
     item.categories || []
+  );
+  const [espProfiles, setEspProfiles] = useState<EspProfileSelection[]>(
+    item.espProfiles || []
   );
   const [installCommand, setInstallCommand] = useState(isWin32 ? item.installCommand : '');
   const [uninstallCommand, setUninstallCommand] = useState(isWin32 ? item.uninstallCommand : '');
@@ -125,11 +132,12 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
     setIsSaving(true);
     try {
       if (isStore) {
-        // Store apps: only update install experience, assignments, categories
+        // Store apps: only update install experience, assignments, categories, ESP
         updateItem(item.id, {
           installExperience: storeInstallExperience,
           assignments: assignments.length > 0 ? assignments : undefined,
           categories: categories.length > 0 ? categories : undefined,
+          espProfiles: espProfiles.length > 0 ? espProfiles : undefined,
         } as Partial<StoreCartItem>);
       } else {
         // Win32 apps: full config update
@@ -147,6 +155,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
           psadtConfig: config,
           assignments: assignments.length > 0 ? assignments : undefined,
           categories: categories.length > 0 ? categories : undefined,
+          espProfiles: espProfiles.length > 0 ? espProfiles : undefined,
           requirementRules,
           installCommand,
           uninstallCommand,
@@ -1002,6 +1011,21 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
                 <CategoryConfig
                   categories={categories}
                   onChange={setCategories}
+                />
+              </ConfigSection>
+
+              {/* ESP Configuration */}
+              <ConfigSection
+                title="Enrollment Status Page"
+                icon={<Shield className="w-4 h-4" />}
+                expanded={expandedSection === 'esp'}
+                onToggle={() => toggleSection('esp')}
+              >
+                <EspProfileSelector
+                  espProfiles={espProfiles}
+                  onChange={setEspProfiles}
+                  mode="pre-deploy"
+                  hasRequiredAssignment={assignments.some((a) => a.intent === 'required')}
                 />
               </ConfigSection>
 

--- a/components/EspProfileSelector.tsx
+++ b/components/EspProfileSelector.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Loader2,
+  RefreshCw,
+  Search,
+  Shield,
+  ToggleLeft,
+  ToggleRight,
+  Check,
+  AlertTriangle,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useEspProfiles, useAddToEsp } from '@/hooks/use-esp-profiles';
+import type { EspProfileSelection, EspProfileSummary, AddToEspResult } from '@/types/esp';
+
+interface EspProfileSelectorProps {
+  espProfiles?: EspProfileSelection[];
+  onChange?: (profiles: EspProfileSelection[]) => void;
+  intuneAppId?: string;
+  mode: 'pre-deploy' | 'post-deploy';
+  hasRequiredAssignment?: boolean;
+}
+
+export function EspProfileSelector({
+  espProfiles = [],
+  onChange,
+  intuneAppId,
+  mode,
+  hasRequiredAssignment = true,
+}: EspProfileSelectorProps) {
+  const [enabled, setEnabled] = useState(() => espProfiles.length > 0);
+  const [query, setQuery] = useState('');
+  const [addResults, setAddResults] = useState<AddToEspResult[] | null>(null);
+
+  // Sync enabled state when parent resets espProfiles externally
+  useEffect(() => {
+    if (espProfiles.length === 0 && enabled) {
+      setEnabled(false);
+    } else if (espProfiles.length > 0 && !enabled) {
+      setEnabled(true);
+    }
+    // Only react to espProfiles changes, not enabled
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [espProfiles.length]);
+
+  const {
+    data: profilesData,
+    isLoading,
+    error: queryError,
+    refetch,
+  } = useEspProfiles();
+
+  const addToEspMutation = useAddToEsp();
+
+  const availableProfiles = useMemo(() => {
+    return (profilesData?.profiles || [])
+      .filter((p) => p?.id && p?.displayName)
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }, [profilesData]);
+
+  const error = queryError?.message || null;
+
+  const selectedIds = useMemo(
+    () => new Set(espProfiles.map((p) => p.id)),
+    [espProfiles]
+  );
+
+  const filteredProfiles = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return availableProfiles;
+    return availableProfiles.filter((p) =>
+      p.displayName.toLowerCase().includes(normalizedQuery)
+    );
+  }, [availableProfiles, query]);
+
+  const handleToggleEnabled = () => {
+    const next = !enabled;
+    setEnabled(next);
+    if (!next) {
+      onChange?.([]);
+    }
+  };
+
+  const toggleProfile = (profile: EspProfileSummary) => {
+    if (selectedIds.has(profile.id)) {
+      onChange?.(espProfiles.filter((p) => p.id !== profile.id));
+    } else {
+      onChange?.([...espProfiles, { id: profile.id, displayName: profile.displayName }]);
+    }
+  };
+
+  // Post-deploy mode: selected profiles managed locally
+  const [postDeploySelections, setPostDeploySelections] = useState<Set<string>>(new Set());
+
+  const togglePostDeployProfile = (profile: EspProfileSummary) => {
+    setPostDeploySelections((prev) => {
+      const next = new Set(prev);
+      if (next.has(profile.id)) {
+        next.delete(profile.id);
+      } else {
+        next.add(profile.id);
+      }
+      return next;
+    });
+  };
+
+  const handleAddToEsp = async () => {
+    if (!intuneAppId || postDeploySelections.size === 0) return;
+    setAddResults(null);
+
+    try {
+      const profileIds = Array.from(postDeploySelections);
+      const profileNames: Record<string, string> = {};
+      for (const id of profileIds) {
+        const profile = availableProfiles.find((p) => p.id === id);
+        if (profile) profileNames[id] = profile.displayName;
+      }
+
+      const result = await addToEspMutation.mutateAsync({
+        intuneAppId,
+        espProfileIds: profileIds,
+        espProfileNames: profileNames,
+      });
+      setAddResults(result.results);
+    } catch {
+      // Error handled by mutation state
+    }
+  };
+
+  const showValidationWarning = mode === 'pre-deploy' && enabled && espProfiles.length > 0 && !hasRequiredAssignment;
+
+  // Post-deploy mode: compact self-contained component
+  if (mode === 'post-deploy') {
+    return (
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setEnabled(!enabled)}
+          className="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        >
+          <Shield className="w-4 h-4" />
+          Add to ESP Profile
+        </button>
+
+        {enabled && (
+          <div className="mt-2 p-3 rounded-lg border border-overlay/15 bg-bg-elevated/50 space-y-3">
+            {isLoading && availableProfiles.length === 0 ? (
+              <div className="flex items-center gap-2 text-text-muted text-sm">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Loading ESP profiles...
+              </div>
+            ) : error ? (
+              <div className="text-sm text-red-300">{error}</div>
+            ) : (
+              <>
+                <div className="max-h-40 overflow-y-auto space-y-1">
+                  {availableProfiles.length === 0 ? (
+                    <p className="text-text-muted text-sm">No ESP profiles found</p>
+                  ) : (
+                    availableProfiles.map((profile) => {
+                      const selected = postDeploySelections.has(profile.id);
+                      return (
+                        <button
+                          key={profile.id}
+                          type="button"
+                          onClick={() => togglePostDeployProfile(profile)}
+                          className={cn(
+                            'w-full text-left px-3 py-2 rounded-lg border transition-colors flex items-center gap-2',
+                            selected
+                              ? 'bg-blue-600/20 border-blue-500/40 text-blue-200'
+                              : 'bg-bg-elevated/60 border-overlay/15 text-text-secondary hover:border-overlay/20 hover:bg-overlay/10'
+                          )}
+                        >
+                          <Shield className="w-4 h-4 flex-shrink-0" />
+                          <span className="text-sm truncate flex-1">{profile.displayName}</span>
+                          <span className="text-xs text-text-muted">{profile.selectedAppCount} apps</span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+
+                {postDeploySelections.size > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleAddToEsp}
+                    disabled={addToEspMutation.isPending}
+                    className="w-full py-2 px-3 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+                  >
+                    {addToEspMutation.isPending ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Shield className="w-4 h-4" />
+                    )}
+                    Add to {postDeploySelections.size} ESP Profile{postDeploySelections.size > 1 ? 's' : ''}
+                  </button>
+                )}
+
+                {addResults && (
+                  <div className="space-y-1">
+                    {addResults.map((result) => (
+                      <div
+                        key={result.profileId}
+                        className={cn(
+                          'flex items-center gap-2 text-xs px-2 py-1.5 rounded',
+                          result.success
+                            ? result.alreadyAdded
+                              ? 'text-yellow-300 bg-yellow-500/10'
+                              : 'text-green-300 bg-green-500/10'
+                            : 'text-red-300 bg-red-500/10'
+                        )}
+                      >
+                        {result.success ? (
+                          result.alreadyAdded ? (
+                            <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+                          ) : (
+                            <Check className="w-3.5 h-3.5 flex-shrink-0" />
+                          )
+                        ) : (
+                          <X className="w-3.5 h-3.5 flex-shrink-0" />
+                        )}
+                        <span className="truncate">
+                          {result.success
+                            ? result.alreadyAdded
+                              ? 'Already in profile'
+                              : 'Added successfully'
+                            : result.error || 'Failed'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Pre-deploy mode: toggle + multi-select (matches CategoryConfig pattern)
+  return (
+    <div className="space-y-4">
+      <button
+        type="button"
+        onClick={handleToggleEnabled}
+        className="flex items-center gap-3 w-full p-3 rounded-lg border border-overlay/15 bg-bg-elevated/50 hover:bg-overlay/10 transition-colors"
+      >
+        {enabled ? (
+          <ToggleRight className="w-6 h-6 text-blue-400 flex-shrink-0" />
+        ) : (
+          <ToggleLeft className="w-6 h-6 text-text-muted flex-shrink-0" />
+        )}
+        <div className="flex-1 text-left">
+          <p className={cn('text-sm font-medium', enabled ? 'text-text-primary' : 'text-text-muted')}>
+            Add to ESP Profile
+          </p>
+          <p className="text-xs text-text-muted">
+            {enabled
+              ? 'This app will be required to install before users can access their device during Autopilot enrollment. This modifies a shared tenant-wide profile.'
+              : 'Deploy without adding to Enrollment Status Page'}
+          </p>
+        </div>
+      </button>
+
+      {showValidationWarning && (
+        <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2">
+          <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5" />
+          <p className="text-xs text-yellow-300">
+            ESP profiles only track required app installations. Consider adding a &quot;required&quot; assignment.
+          </p>
+        </div>
+      )}
+
+      {enabled && (
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search ESP profiles..."
+                className="w-full pl-10 pr-3 py-2.5 bg-bg-elevated border border-overlay/15 rounded-lg text-text-primary text-sm placeholder-text-muted focus:border-overlay/20 focus:outline-none"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              disabled={isLoading}
+              className="px-3 py-2.5 rounded-lg border border-overlay/15 bg-bg-elevated text-text-secondary hover:bg-overlay/10 transition-colors disabled:opacity-50"
+              title="Refresh ESP profiles"
+            >
+              {isLoading ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <RefreshCw className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          {isLoading && availableProfiles.length === 0 ? (
+            <div className="flex items-center gap-2 text-text-muted text-sm py-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading ESP profiles...
+            </div>
+          ) : (
+            <div className="max-h-56 overflow-y-auto space-y-1 pr-1">
+              {filteredProfiles.length === 0 ? (
+                <p className="text-text-muted text-sm py-2">
+                  {availableProfiles.length === 0
+                    ? 'No ESP profiles found in tenant'
+                    : 'No profiles match your search'}
+                </p>
+              ) : (
+                filteredProfiles.map((profile) => {
+                  const selected = selectedIds.has(profile.id);
+                  return (
+                    <button
+                      key={profile.id}
+                      type="button"
+                      onClick={() => toggleProfile(profile)}
+                      className={cn(
+                        'w-full text-left px-3 py-2.5 rounded-lg border transition-colors flex items-center gap-2',
+                        selected
+                          ? 'bg-blue-600/20 border-blue-500/40 text-blue-200'
+                          : 'bg-bg-elevated/60 border-overlay/15 text-text-secondary hover:border-overlay/20 hover:bg-overlay/10'
+                      )}
+                    >
+                      <Shield className="w-4 h-4 flex-shrink-0" />
+                      <span className="text-sm truncate flex-1">{profile.displayName}</span>
+                      <span className="text-xs text-text-muted">{profile.selectedAppCount} apps</span>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          )}
+
+          <p className="text-xs text-text-muted">
+            Selected: {espProfiles.length}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/use-esp-profiles.ts
+++ b/hooks/use-esp-profiles.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMicrosoftAuth } from './useMicrosoftAuth';
+import { useMspOptional } from './useMspOptional';
+import type { EspProfileSummary, AddToEspResult } from '@/types/esp';
+
+interface EspProfilesResponse {
+  profiles: EspProfileSummary[];
+  count: number;
+}
+
+interface AddToEspResponse {
+  results: AddToEspResult[];
+}
+
+interface AddToEspRequest {
+  intuneAppId: string;
+  espProfileIds: string[];
+  espProfileNames?: Record<string, string>;
+}
+
+export function useEspProfiles() {
+  const { getAccessToken, isAuthenticated } = useMicrosoftAuth();
+  const { isMspUser, selectedTenantId } = useMspOptional();
+  const tenantKey = isMspUser ? selectedTenantId || 'primary' : 'self';
+
+  return useQuery<EspProfilesResponse>({
+    queryKey: ['intune', 'esp-profiles', tenantKey],
+    queryFn: async () => {
+      const token = await getAccessToken();
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch('/api/intune/esp-profiles', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(isMspUser && selectedTenantId
+            ? { 'X-MSP-Tenant-Id': selectedTenantId }
+            : {}),
+        },
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to fetch ESP profiles');
+      }
+
+      return response.json();
+    },
+    enabled: isAuthenticated,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
+export function useAddToEsp() {
+  const { getAccessToken } = useMicrosoftAuth();
+  const { isMspUser, selectedTenantId } = useMspOptional();
+
+  return useMutation<AddToEspResponse, Error, AddToEspRequest>({
+    mutationFn: async (request: AddToEspRequest) => {
+      const token = await getAccessToken();
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch('/api/intune/esp-profiles/add-app', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          ...(isMspUser && selectedTenantId
+            ? { 'X-MSP-Tenant-Id': selectedTenantId }
+            : {}),
+        },
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to add app to ESP profiles');
+      }
+
+      return response.json();
+    },
+  });
+}

--- a/lib/esp-api.ts
+++ b/lib/esp-api.ts
@@ -1,0 +1,141 @@
+/**
+ * Enrollment Status Page (ESP) Profile API
+ * Manages ESP profiles via Microsoft Graph API (beta)
+ */
+
+import type { EspProfileSummary } from '@/types/esp';
+
+const GRAPH_API_BASE = 'https://graph.microsoft.com/beta';
+
+interface DeviceEnrollmentConfiguration {
+  id: string;
+  displayName: string;
+  description?: string;
+  '@odata.type': string;
+  selectedMobileAppIds?: string[];
+}
+
+interface GraphApiListResponse<T> {
+  value: T[];
+}
+
+/**
+ * List all ESP profiles (windows10EnrollmentCompletionPageConfiguration) in the tenant.
+ * Note: selectedMobileAppIds is not requested in the list call because the Graph beta
+ * API does not reliably return it via $select on the collection endpoint. The count
+ * shown in the UI is an approximation; the individual GET (used at PATCH time) is
+ * the authoritative source.
+ */
+export async function listEspProfiles(
+  accessToken: string
+): Promise<EspProfileSummary[]> {
+  const url = new URL(
+    `${GRAPH_API_BASE}/deviceManagement/deviceEnrollmentConfigurations`
+  );
+  url.searchParams.set('$select', 'id,displayName,description');
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to list device enrollment configurations');
+  }
+
+  const data: GraphApiListResponse<DeviceEnrollmentConfiguration> =
+    await response.json();
+
+  return (data.value || [])
+    .filter(
+      (config) =>
+        config['@odata.type'] ===
+        '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration'
+    )
+    .map((config) => ({
+      id: config.id,
+      displayName: config.displayName,
+      description: config.description,
+      selectedAppCount: config.selectedMobileAppIds?.length || 0,
+    }))
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+/**
+ * Get a single ESP profile with its selectedMobileAppIds.
+ */
+export async function getEspProfile(
+  accessToken: string,
+  profileId: string
+): Promise<{ id: string; selectedMobileAppIds: string[] }> {
+  const response = await fetch(
+    `${GRAPH_API_BASE}/deviceManagement/deviceEnrollmentConfigurations/${profileId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to get ESP profile ${profileId}`);
+  }
+
+  const data: DeviceEnrollmentConfiguration = await response.json();
+  return {
+    id: data.id,
+    selectedMobileAppIds: data.selectedMobileAppIds || [],
+  };
+}
+
+/**
+ * Add an app to an ESP profile's selectedMobileAppIds.
+ * Reads current IDs first to avoid overwriting, then PATCHes the appended list.
+ * Returns { alreadyAdded: true } if the app was already present.
+ *
+ * Known limitation: The Graph API has no atomic append for selectedMobileAppIds.
+ * Concurrent calls targeting the same profile can race (read-modify-write).
+ * Callers that deploy multiple apps to the same ESP profile should serialize
+ * their calls to this function per profile ID.
+ */
+export async function addAppToEspProfile(
+  accessToken: string,
+  profileId: string,
+  appId: string
+): Promise<{ alreadyAdded: boolean }> {
+  // Get current selected apps
+  const profile = await getEspProfile(accessToken, profileId);
+
+  if (profile.selectedMobileAppIds.includes(appId)) {
+    return { alreadyAdded: true };
+  }
+
+  // Append the new app ID
+  const updatedIds = [...profile.selectedMobileAppIds, appId];
+
+  const patchResponse = await fetch(
+    `${GRAPH_API_BASE}/deviceManagement/deviceEnrollmentConfigurations/${profileId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        '@odata.type':
+          '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration',
+        selectedMobileAppIds: updatedIds,
+      }),
+    }
+  );
+
+  if (!patchResponse.ok) {
+    const errorBody = await patchResponse.text().catch(() => '');
+    throw new Error(
+      `Failed to update ESP profile ${profileId} (${patchResponse.status}): ${errorBody}`
+    );
+  }
+
+  return { alreadyAdded: false };
+}

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -24,6 +24,7 @@ export interface WorkflowInputs {
   requirementRules?: string; // JSON-serialized RequirementRule[]
   assignments?: string; // JSON-serialized PackageAssignment[]
   categories?: string; // JSON-serialized IntuneAppCategorySelection[]
+  espProfiles?: string; // JSON-serialized EspProfileSelection[]
   installScope?: 'machine' | 'user'; // Install scope for per-user vs per-machine
   forceCreate?: boolean; // Skip duplicate check and force create new app
 }
@@ -137,6 +138,7 @@ export async function triggerPackagingWorkflow(
           requirementRules: inputs.requirementRules || '[]',
           assignments: inputs.assignments || '[]',
           categories: inputs.categories || '[]',
+          espProfiles: inputs.espProfiles || '[]',
           installScope: inputs.installScope || 'machine',
           forceCreate: inputs.forceCreate ? 'true' : 'false',
         },

--- a/types/esp.ts
+++ b/types/esp.ts
@@ -1,0 +1,24 @@
+/**
+ * Enrollment Status Page (ESP) Profile Types
+ * For managing ESP profiles during app deployment
+ */
+
+export interface EspProfileSummary {
+  id: string;
+  displayName: string;
+  description?: string;
+  selectedAppCount: number;
+}
+
+export interface EspProfileSelection {
+  id: string;
+  displayName: string;
+}
+
+export interface AddToEspResult {
+  profileId: string;
+  profileName: string;
+  success: boolean;
+  error?: string;
+  alreadyAdded?: boolean;
+}

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -6,6 +6,7 @@
 import type { DetectionRule, RequirementRule } from './intune';
 import type { WingetArchitecture, WingetScope, WingetInstallerType } from './winget';
 import type { PSADTConfig } from './psadt';
+import type { EspProfileSelection } from './esp';
 
 // Staged package awaiting upload to Intune
 export interface StagedPackage {
@@ -140,6 +141,9 @@ interface CartItemBase {
 
   // Intune category configuration
   categories?: IntuneAppCategorySelection[];
+
+  // ESP profile configuration
+  espProfiles?: EspProfileSelection[];
 
   // Redeploy flag - skip duplicate detection during deployment
   forceCreate?: boolean;


### PR DESCRIPTION
## Summary

- Adds ability to add deployed apps to Enrollment Status Page (ESP) profiles, both during deployment (pre-deploy) and after deployment (post-deploy)
- New Graph API integration for `windows10EnrollmentCompletionPageConfiguration` (beta)
- ESP section in PackageConfig and CartItemConfig with validation warning when no "required" assignment is set
- Post-deploy ESP selector on uploads page for already-deployed jobs

## Changes

### New files (6)
| File | Purpose |
|------|---------|
| `types/esp.ts` | ESP type definitions |
| `lib/esp-api.ts` | Graph API: list, get, add-app-to ESP profiles |
| `app/api/intune/esp-profiles/route.ts` | GET endpoint for listing ESP profiles |
| `app/api/intune/esp-profiles/add-app/route.ts` | POST endpoint for adding app to profiles |
| `hooks/use-esp-profiles.ts` | React Query hooks (useEspProfiles, useAddToEsp) |
| `components/EspProfileSelector.tsx` | Dual-mode selector (pre-deploy / post-deploy) |

### Modified files (8)
| File | Change |
|------|--------|
| `types/upload.ts` | Added `espProfiles` to `CartItemBase` |
| `components/PackageConfig.tsx` | ESP section + state wiring |
| `components/CartItemConfig.tsx` | ESP section + save handler |
| `lib/store-app-deploy.ts` | Non-fatal ESP application after store deploy |
| `lib/github-actions.ts` | `espProfiles` in WorkflowInputs + client_payload |
| `app/api/package/route.ts` | Pass espProfiles in workflow dispatch |
| `app/api/package/callback/route.ts` | Apply ESP after Win32 deploy + duplicate_skipped |
| `app/dashboard/uploads/page.tsx` | Post-deploy ESP selector |

## Prerequisites

`DeviceManagementServiceConfig.ReadWrite.All` must be added to the Azure App Registration and admin consent re-granted.

## Test plan

- [ ] Pre-deploy: add app to cart with ESP profile selected, deploy, verify app appears in ESP profile in Intune Portal
- [ ] Post-deploy: deploy app without ESP, then use uploads page to add to ESP profile
- [ ] Validation: select ESP but set all assignments to "available" -- warning appears
- [ ] Idempotency: add same app to same ESP profile twice -- shows "already added"
- [ ] Store + Win32: both app types support ESP through their respective deploy paths

Closes #47