### PR TITLE
fix: route Freeplane installer downloads to GitHub Releases

### DIFF
--- a/lib/__tests__/installer-url-overrides.test.ts
+++ b/lib/__tests__/installer-url-overrides.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  INSTALLER_URL_OVERRIDES,
+  applyInstallerUrlOverride,
+} from '../installer-url-overrides';
+
+describe('applyInstallerUrlOverride', () => {
+  it('returns the original URL when the winget ID has no override', () => {
+    const url = applyInstallerUrlOverride(
+      'Google.Chrome',
+      '124.0.6367.91',
+      'x64',
+      'https://dl.google.com/chrome/installer.exe',
+    );
+
+    expect(url).toBe('https://dl.google.com/chrome/installer.exe');
+  });
+
+  it('routes Freeplane to GitHub Releases instead of SourceForge', () => {
+    const url = applyInstallerUrlOverride(
+      'Freeplane.Freeplane',
+      '1.12.8',
+      'x64',
+      'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/Freeplane-Setup-1.12.8.exe/download',
+    );
+
+    expect(url).toBe(
+      'https://github.com/freeplane/freeplane/releases/download/release-1.12.8/Freeplane-Setup-1.12.8.exe',
+    );
+  });
+
+  it('interpolates the version into the Freeplane GitHub Releases URL', () => {
+    const url = applyInstallerUrlOverride(
+      'Freeplane.Freeplane',
+      '1.13.3-pre05',
+      'x64',
+      'https://sourceforge.net/projects/freeplane/files/whatever',
+    );
+
+    expect(url).toBe(
+      'https://github.com/freeplane/freeplane/releases/download/release-1.13.3-pre05/Freeplane-Setup-1.13.3-pre05.exe',
+    );
+  });
+
+  it('ignores architecture for Freeplane (single installer)', () => {
+    const x64 = applyInstallerUrlOverride(
+      'Freeplane.Freeplane',
+      '1.12.8',
+      'x64',
+      'https://sourceforge.net/...',
+    );
+    const arm64 = applyInstallerUrlOverride(
+      'Freeplane.Freeplane',
+      '1.12.8',
+      'arm64',
+      'https://sourceforge.net/...',
+    );
+
+    expect(x64).toBe(arm64);
+  });
+});
+
+describe('INSTALLER_URL_OVERRIDES', () => {
+  it('contains the Freeplane entry', () => {
+    expect(INSTALLER_URL_OVERRIDES['Freeplane.Freeplane']).toBeDefined();
+  });
+});

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -4,6 +4,8 @@
  * Uses repository_dispatch to a private workflows repository
  */
 
+import { applyInstallerUrlOverride } from './installer-url-overrides';
+
 export interface WorkflowInputs {
   jobId: string;
   tenantId: string;
@@ -96,6 +98,13 @@ export async function triggerPackagingWorkflow(
 ): Promise<TriggerResult> {
   const cfg = config || getGitHubActionsConfig();
 
+  const finalInstallerUrl = applyInstallerUrlOverride(
+    inputs.wingetId,
+    inputs.version,
+    inputs.architecture ?? '',
+    inputs.installerUrl,
+  );
+
   // Record time before triggering to help find the run
   const triggerTime = new Date();
 
@@ -129,7 +138,7 @@ export async function triggerPackagingWorkflow(
           architecture: inputs.architecture,
         },
         installer: {
-          url: inputs.installerUrl,
+          url: finalInstallerUrl,
           sha256: inputs.installerSha256,
           type: inputs.installerType,
           silentSwitches: inputs.silentSwitches,

--- a/lib/installer-url-overrides.ts
+++ b/lib/installer-url-overrides.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-app overrides for winget manifests that point at unreliable hosts.
+ *
+ * SourceForge mirrors fail frequently (Cloudflare challenges, dead mirrors,
+ * rate limits). Some projects publish the same binary to a more reliable host
+ * (e.g. GitHub Releases). The winget manifest's pinned SHA256 still applies,
+ * so a wrong override URL fails fast with HASH_MISMATCH at the workflow.
+ */
+
+/**
+ * Builds an override URL for the given winget id. Return `null` to fall
+ * through to the manifest's original URL. Implementations that ignore the
+ * `architecture` parameter are only safe when the app ships a single
+ * universal installer.
+ */
+type OverrideFn = (version: string, architecture: string) => string | null;
+
+export const INSTALLER_URL_OVERRIDES: Record<string, OverrideFn> = {
+  'Freeplane.Freeplane': (version) =>
+    `https://github.com/freeplane/freeplane/releases/download/release-${version}/Freeplane-Setup-${version}.exe`,
+};
+
+export function applyInstallerUrlOverride(
+  wingetId: string,
+  version: string,
+  architecture: string,
+  originalUrl: string,
+): string {
+  const fn = INSTALLER_URL_OVERRIDES[wingetId];
+  if (!fn) return originalUrl;
+  return fn(version, architecture) ?? originalUrl;
+}


### PR DESCRIPTION
## Summary
- Adds a per-app installer-URL override applied at the single dispatch bottleneck in `triggerPackagingWorkflow()`. Today it carries one entry: `Freeplane.Freeplane` is routed to its GitHub Releases asset instead of SourceForge.
- The winget manifest's pinned `InstallerSha256` is still validated by the workflow, so a wrong override URL fails fast with `HASH_MISMATCH` — the override is self-validating.
- 5 new vitest cases cover passthrough, version interpolation (including pre-release versions like `1.13.3-pre05`), and the architecture-ignored contract for single-installer apps.

## Why only Freeplane today
Verified live before writing the PR:
- **Freeplane** publishes the same installer to GitHub Releases (`release-{version}` tag, `Freeplane-Setup-{version}.exe` asset). Confirmed against `release-1.13.3-pre05`.
- **WinSCP** and **WinSCP.RC**: `winscp.net/download/...` 302-redirects to the same SourceForge mirror network (`altushost-bul.dl.sourceforge.net`, `sf-eu-introserv-1.dl.sourceforge.net`). FossHub's listing is stale at 6.1.2 vs current 6.5.6 and uses time-signed URLs that can't be templated. No clean alternative exists.
- **TigerVNC**: zero release assets across `v1.12.0` through `v1.16.2` on GitHub. Project release notes literally point to SourceForge. SF-only by design.

So WinSCP and TigerVNC stay on SF. The companion PR in `IntuneGet-Workflows` reframes the failure message as transient so the user can retry instead of seeing a terminal error.

## Coverage
Of the 39 `DOWNLOAD_SOURCEFORGE_FAILED` events recorded in the last 90 days, this PR addresses 6 (Freeplane). The remaining 33 (WinSCP 27, WinSCP.RC 3, TigerVNC 3) gain a friendlier error message via the workflow PR.

## Test plan
- [ ] `npx vitest run lib/__tests__/installer-url-overrides.test.ts` passes (5/5)
- [ ] Trigger a packaging job for `Freeplane.Freeplane` from the UI and confirm the dispatch payload's `installer.url` is `https://github.com/freeplane/freeplane/releases/download/release-{version}/Freeplane-Setup-{version}.exe`
- [ ] Trigger a packaging job for any non-overridden app (e.g. `Google.Chrome`) and confirm `installer.url` is unchanged
- [ ] Verify the Freeplane workflow run completes without `DOWNLOAD_SOURCEFORGE_FAILED`

## Follow-ups
- Submit upstream PR to `microsoft/winget-pkgs` updating the Freeplane manifest's `InstallerUrl`. Once merged, this override entry can be deleted.
- Watch user-driven retry behavior for WinSCP/TigerVNC over ~30 days; if the friendlier message + ~35% mirror success rate isn't enough, revisit (e.g. self-hosted mirror).