### PR TITLE
chore: release 0.6.6

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -27,6 +27,17 @@ interface Release {
 
 const releases: Release[] = [
   {
+    version: "0.6.6",
+    date: "2026-04-28",
+    title: "SourceForge Reliability Improvements",
+    type: "patch",
+    highlights: [
+      "Freeplane installer downloads now go through GitHub Releases instead of SourceForge, eliminating frequent SourceForge mirror failures for this app",
+      "SourceForge download failures now surface as a transient error with a clear retry hint, since SourceForge mirror availability fluctuates and a quick retry usually succeeds",
+      "Added a per-app installer URL override mechanism so future SourceForge-hosted apps with cleaner download sources can be redirected without workflow changes",
+    ],
+  },
+  {
     version: "0.6.5",
     date: "2026-03-30",
     title: "App Dependencies & Supersedence, Changelog, and Bug Fixes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intuneget",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "intuneget",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@azure/msal-browser": "^5.6.2",
         "@azure/msal-node": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuneget",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bumps `package.json` and `package-lock.json` to `0.6.6`.
- Adds the 0.6.6 entry to the public changelog page covering the SourceForge reliability work.

## Merge order
This PR should be merged **after** [#92](https://github.com/ugurkocde/IntuneGet/pull/92) and the companion [IntuneGet-Workflows#1](https://github.com/ugurkocde/IntuneGet-Workflows/pull/1), so the changelog reflects shipped behavior.

## Test plan
- [ ] `npm run build` succeeds locally (translations regenerate via `gt translate`).
- [ ] Visit `/changelog` after deploy and confirm 0.6.6 is the top entry with the three highlights, dated 2026-04-28.
- [ ] Confirm the version shown anywhere the app surfaces it (footer, about, etc.) reads 0.6.6.