### PR TITLE
Fix version selector and sign-in hang; restrict updates to managed apps

### DIFF
--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -40,6 +40,7 @@ interface UpdateCheckInsert {
   current_version: string;
   latest_version: string;
   is_critical: boolean;
+  is_managed: boolean;
   detected_at: string;
   updated_at: string;
 }
@@ -384,6 +385,9 @@ export async function GET(request: Request) {
               current_version: app.version,
               latest_version: latestVersion,
               is_critical: isCritical,
+              // The cron only ever scans apps from upload_history, so every
+              // detected update here is for an IntuneGet-managed app.
+              is_managed: true,
               detected_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
             };

--- a/app/api/intune/apps/updates/route.test.ts
+++ b/app/api/intune/apps/updates/route.test.ts
@@ -45,6 +45,11 @@ function createSupabaseMock(
       discovered_app_name: string;
       winget_package_id: string;
     }>;
+    uploadHistoryRows?: Array<{
+      intune_app_id: string;
+      winget_id: string;
+      version: string | null;
+    }>;
   } = {}
 ) {
   return {
@@ -62,7 +67,7 @@ function createSupabaseMock(
         chain.select = vi.fn(() => chain);
         chain.eq = vi.fn(() => chain);
         chain.then = (resolve: (value: { data: unknown; error: unknown }) => unknown) =>
-          Promise.resolve({ data: [], error: null }).then(resolve);
+          Promise.resolve({ data: options.uploadHistoryRows || [], error: null }).then(resolve);
         return chain;
       }
 
@@ -169,6 +174,8 @@ describe('GET /api/intune/apps/updates', () => {
     expect(body.updates[0].intuneApp.id).toBe('app-new');
     expect(body.updates[0].currentVersion).toBe('2.0.0');
     expect(body.updates[0].latestVersion).toBe('2.5.0');
+    // Matched only by the fuzzy matcher -> not IntuneGet-managed
+    expect(body.updates[0].isManaged).toBe(false);
     expect(
       body.checkedApps.some((item: { result: string }) =>
         item.result.includes('Older tenant app object')
@@ -222,6 +229,8 @@ describe('GET /api/intune/apps/updates', () => {
     expect(response.status).toBe(200);
     expect(body.updateCount).toBe(1);
     expect(body.updates[0].wingetId).toBe('VideoLAN.VLC');
+    // Database fuzzy matcher is still a heuristic match -> not managed
+    expect(body.updates[0].isManaged).toBe(false);
     expect(matchAppToWingetWithDatabaseMock).toHaveBeenCalled();
   });
 
@@ -282,6 +291,8 @@ describe('GET /api/intune/apps/updates', () => {
     expect(response.status).toBe(200);
     expect(body.updateCount).toBe(1);
     expect(body.updates[0].wingetId).toBe('Contoso.CustomApp');
+    // Explicit manual mapping -> IntuneGet-managed
+    expect(body.updates[0].isManaged).toBe(true);
     expect(matchAppToWingetMock).not.toHaveBeenCalled();
     expect(matchAppToWingetWithDatabaseMock).not.toHaveBeenCalled();
   });
@@ -339,6 +350,63 @@ describe('GET /api/intune/apps/updates', () => {
     expect(response.status).toBe(200);
     expect(body.updateCount).toBe(1);
     expect(body.updates[0].wingetId).toBe('Fabrikam.Tool');
+    // Explicit claimed-app link -> IntuneGet-managed
+    expect(body.updates[0].isManaged).toBe(true);
+    expect(matchAppToWingetMock).not.toHaveBeenCalled();
+    expect(matchAppToWingetWithDatabaseMock).not.toHaveBeenCalled();
+  });
+
+  it('tags deployment-history matches as managed without fuzzy matching', async () => {
+    createServerClientMock.mockReturnValue(
+      createSupabaseMock(
+        [{ winget_id: 'Git.Git', latest_version: '2.45.0' }],
+        {
+          uploadHistoryRows: [
+            { intune_app_id: 'app-git', winget_id: 'Git.Git', version: '2.40.0' },
+          ],
+        }
+      )
+    );
+
+    matchAppToWingetMock.mockReturnValue(null);
+    matchAppToWingetWithDatabaseMock.mockResolvedValue(null);
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'graph-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [
+            {
+              id: 'app-git',
+              displayName: 'Git',
+              publisher: 'The Git Development Community',
+              displayVersion: '2.40.0',
+              lastModifiedDateTime: '2026-02-02T00:00:00Z',
+            },
+          ],
+        }),
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new NextRequest('http://localhost:3000/api/intune/apps/updates', {
+      headers: {
+        Authorization: 'Bearer mock-token',
+      },
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.updateCount).toBe(1);
+    expect(body.updates[0].wingetId).toBe('Git.Git');
+    // Deployment history is authoritative provenance -> managed, fuzzy skipped
+    expect(body.updates[0].isManaged).toBe(true);
     expect(matchAppToWingetMock).not.toHaveBeenCalled();
     expect(matchAppToWingetWithDatabaseMock).not.toHaveBeenCalled();
   });

--- a/app/api/intune/apps/updates/route.ts
+++ b/app/api/intune/apps/updates/route.ts
@@ -28,6 +28,9 @@ interface CheckedResult {
 interface MatchedApp {
   app: IntuneWin32App;
   wingetId: string;
+  // True for explicit provenance (deployment history, IntuneGet description
+  // marker, or user-claimed/manual mapping); false for fuzzy name matches.
+  isManaged: boolean;
 }
 
 interface CuratedPackageRow {
@@ -230,6 +233,7 @@ export async function GET(request: NextRequest) {
         matchedApps.push({
           app,
           wingetId: historyWingetId,
+          isManaged: true,
         });
         continue;
       }
@@ -239,6 +243,7 @@ export async function GET(request: NextRequest) {
         matchedApps.push({
           app,
           wingetId: descriptionWingetId,
+          isManaged: true,
         });
         continue;
       }
@@ -254,6 +259,7 @@ export async function GET(request: NextRequest) {
         matchedApps.push({
           app,
           wingetId: explicitWingetId,
+          isManaged: true,
         });
         continue;
       }
@@ -285,6 +291,7 @@ export async function GET(request: NextRequest) {
       matchedApps.push({
         app,
         wingetId: match.wingetId,
+        isManaged: false,
       });
     }
 
@@ -379,6 +386,11 @@ export async function GET(request: NextRequest) {
       const normalizedLatest = normalizeVersion(latestVersion);
       const updateAvailable = hasUpdate(currentVersion, normalizedLatest);
 
+      // If IntuneGet has explicit provenance over ANY app object for this
+      // winget ID, treat the whole group as managed -- an unmanaged duplicate
+      // object with a higher version must not mask a package we deployed.
+      const groupIsManaged = candidates.some((candidate) => candidate.isManaged);
+
       if (updateAvailable) {
         updates.push({
           intuneApp: newestCandidate.app,
@@ -386,6 +398,7 @@ export async function GET(request: NextRequest) {
           latestVersion: latestVersion,
           wingetId,
           hasUpdate: true,
+          isManaged: groupIsManaged,
         });
       } else {
         // no-op; tracked in checked entries below

--- a/app/api/updates/available/route.test.ts
+++ b/app/api/updates/available/route.test.ts
@@ -143,4 +143,75 @@ describe('GET /api/updates/available', () => {
       )
     ).toBe(true);
   });
+
+  it('hides unmanaged updates by default and includes them on request', async () => {
+    parseAccessTokenMock.mockResolvedValue({
+      userId: 'user-1',
+      userEmail: 'user@example.com',
+      tenantId: 'home-tenant',
+      userName: 'User',
+    });
+
+    const rows = [
+      {
+        id: 'upd-managed',
+        user_id: 'user-1',
+        tenant_id: 'tenant-a',
+        winget_id: 'Microsoft.Edge',
+        intune_app_id: 'app-1',
+        display_name: 'Edge',
+        current_version: '1.0.0',
+        latest_version: '1.1.0',
+        is_critical: false,
+        is_managed: true,
+        detected_at: '2026-02-01T00:00:00Z',
+        notified_at: null,
+        dismissed_at: null,
+      },
+      {
+        id: 'upd-unmanaged',
+        user_id: 'user-1',
+        tenant_id: 'tenant-a',
+        winget_id: 'VideoLAN.VLC',
+        intune_app_id: 'app-2',
+        display_name: 'VLC',
+        current_version: '2.0.0',
+        latest_version: '2.1.0',
+        is_critical: false,
+        is_managed: false,
+        detected_at: '2026-02-01T00:00:00Z',
+        notified_at: null,
+        dismissed_at: null,
+      },
+    ];
+
+    // Fresh awaitable queries per client call so two GETs don't share state.
+    createServerClientMock.mockImplementation(() => ({
+      from: (table: string) => {
+        if (table === 'update_check_results')
+          return createAwaitableQuery({ data: rows, error: null }, []);
+        if (table === 'app_update_policies')
+          return createAwaitableQuery({ data: [], error: null }, []);
+        if (table === 'upload_history')
+          return createAwaitableQuery({ data: [], error: null }, []);
+        throw new Error(`Unexpected table: ${table}`);
+      },
+    }));
+
+    // Default: unmanaged hidden
+    const defaultReq = new NextRequest('http://localhost:3000/api/updates/available');
+    defaultReq.headers.set('Authorization', 'Bearer test-token');
+    const defaultBody = await (await GET(defaultReq)).json();
+    expect(defaultBody.count).toBe(1);
+    expect(defaultBody.updates[0].winget_id).toBe('Microsoft.Edge');
+    expect(defaultBody.updates[0].is_managed).toBe(true);
+
+    // include_unmanaged=true: both managed and unmanaged shown
+    const allReq = new NextRequest(
+      'http://localhost:3000/api/updates/available?include_unmanaged=true'
+    );
+    allReq.headers.set('Authorization', 'Bearer test-token');
+    const allBody = await (await GET(allReq)).json();
+    expect(allBody.count).toBe(2);
+  });
 });

--- a/app/api/updates/available/route.ts
+++ b/app/api/updates/available/route.ts
@@ -27,6 +27,9 @@ export async function GET(request: NextRequest) {
     const tenantId = searchParams.get('tenant_id')?.trim() || null;
     const includeDismissed = searchParams.get('include_dismissed') === 'true';
     const criticalOnly = searchParams.get('critical_only') === 'true';
+    // By default only surface updates for IntuneGet-managed apps; fuzzy-matched
+    // apps are opt-in to avoid accidentally updating mismatched/customized apps.
+    const includeUnmanaged = searchParams.get('include_unmanaged') === 'true';
 
     const supabase = createServerClient();
 
@@ -126,13 +129,15 @@ export async function GET(request: NextRequest) {
         const policyKey = `${update.winget_id}:${update.tenant_id}`;
         return {
           ...update,
+          is_managed: update.is_managed ?? true,
           has_prior_deployment: deployedSet.has(policyKey),
           policy: policyMap.get(policyKey) || null,
         };
       })
       .filter((u) => u.current_version !== 'Unknown')
       .filter((u) => compareVersions(u.current_version, u.latest_version) < 0)
-      .filter((u) => u.policy?.last_auto_update_version !== u.latest_version);
+      .filter((u) => u.policy?.last_auto_update_version !== u.latest_version)
+      .filter((u) => includeUnmanaged || u.is_managed);
 
     // Count critical updates
     const criticalCount = updatesWithPolicies.filter((u) => u.is_critical).length;

--- a/app/api/updates/refresh/route.ts
+++ b/app/api/updates/refresh/route.ts
@@ -107,6 +107,7 @@ export async function POST(request: NextRequest) {
         current_version: update.currentVersion,
         latest_version: update.latestVersion,
         is_critical: isCriticalUpdate(update.currentVersion, update.latestVersion),
+        is_managed: update.isManaged,
         large_icon_type: update.intuneApp.largeIcon?.type || null,
         large_icon_value: update.intuneApp.largeIcon?.value || null,
         detected_at: now,

--- a/app/api/winget/manifest/route.ts
+++ b/app/api/winget/manifest/route.ts
@@ -60,6 +60,10 @@ export async function GET(request: NextRequest) {
       ? await getBestInstaller(packageId, version || manifest.Version, architecture)
       : installers[0] || null;
 
+    // List of all available versions (Supabase-backed) so the catalog can offer
+    // a version selector. Best-effort: an empty list just hides the selector.
+    const versions = await fetchAvailableVersions(packageId);
+
     return NextResponse.json({
       manifest: {
         id: manifest.Id,
@@ -74,6 +78,7 @@ export async function GET(request: NextRequest) {
       },
       installers,
       recommendedInstaller: bestInstaller,
+      versions,
     });
   } catch (err) {
     return NextResponse.json(

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -42,13 +42,14 @@ function MicrosoftLogo({ className }: { className?: string }) {
 }
 
 function SignInContent() {
-  const { isAuthenticated, signIn, getAccessToken } = useMicrosoftAuth();
+  const { isAuthenticated, signIn, signOut, getAccessToken } = useMicrosoftAuth();
   const { signinClicks, appsSupported } = useLandingStats();
   const router = useRouter();
   const searchParams = useSearchParams();
   const shouldReduceMotion = useReducedMotion();
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [isVerifyingConsent, setIsVerifyingConsent] = useState(false);
+  const [verifyFailed, setVerifyFailed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isConsentSectionOpen, setIsConsentSectionOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -110,13 +111,27 @@ function SignInContent() {
     }
   }, [getAccessToken]);
 
-  // Redirect based on ACTUAL consent status (server-verified, not localStorage)
-  // This ensures users with revoked/incomplete consent are sent to onboarding
-  useEffect(() => {
-    if (isAuthenticated && !isVerifyingConsent) {
-      setIsVerifyingConsent(true);
+  // Run consent verification with a hard timeout so a hung token/popup
+  // acquisition can never leave the user stuck on the loading animation.
+  const runVerification = useCallback(() => {
+    setVerifyFailed(false);
+    setIsVerifyingConsent(true);
 
-      verifyConsentStatus().then((outcome) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      // Verification hung (commonly a blocked or backgrounded sign-in popup).
+      // Surface a retry path instead of spinning forever.
+      setIsVerifyingConsent(false);
+      setVerifyFailed(true);
+    }, 15000);
+
+    verifyConsentStatus()
+      .then((outcome) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
         if (outcome.kind === 'verified') {
           markOnboardingComplete();
           router.push(callbackUrl);
@@ -129,9 +144,23 @@ function SignInContent() {
           // retry banner can re-verify against the live API.
           router.push(callbackUrl);
         }
+      })
+      .catch(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        setIsVerifyingConsent(false);
+        setVerifyFailed(true);
       });
+  }, [verifyConsentStatus, router, callbackUrl]);
+
+  // Redirect based on ACTUAL consent status (server-verified, not localStorage)
+  // This ensures users with revoked/incomplete consent are sent to onboarding
+  useEffect(() => {
+    if (isAuthenticated && !isVerifyingConsent && !verifyFailed) {
+      runVerification();
     }
-  }, [isAuthenticated, router, callbackUrl, verifyConsentStatus, isVerifyingConsent]);
+  }, [isAuthenticated, isVerifyingConsent, verifyFailed, runVerification]);
 
   const handleSignIn = async () => {
     // Track signin click (fire-and-forget)
@@ -151,6 +180,38 @@ function SignInContent() {
       setIsSigningIn(false);
     }
   };
+
+  // Verification hung or failed -- never leave the user on an endless animation.
+  if (verifyFailed) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-bg-deepest px-4">
+        <div className="w-full max-w-md rounded-2xl border border-overlay/[0.08] bg-bg-elevated/95 p-8 text-center shadow-soft-lg">
+          <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-500/10">
+            <AlertTriangle className="h-7 w-7 text-amber-500" />
+          </div>
+          <h2 className="text-xl font-bold text-text-primary">
+            <T>Sign-in is taking longer than expected</T>
+          </h2>
+          <p className="mt-2 text-sm text-text-muted">
+            <T>We couldn&apos;t finish verifying your session. This can happen when a sign-in popup is blocked or closed before it completes.</T>
+          </p>
+          <div className="mt-6 flex flex-col gap-3">
+            <Button onClick={runVerification} size="lg" className="w-full">
+              <T>Try again</T>
+            </Button>
+            <Button
+              onClick={() => { void signOut(); }}
+              variant="outline"
+              size="lg"
+              className="w-full border-overlay/15 text-text-secondary"
+            >
+              <T>Sign out and start over</T>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // Show loading state while checking auth or verifying consent
   if (isAuthenticated || isVerifyingConsent) {

--- a/app/dashboard/apps/page.tsx
+++ b/app/dashboard/apps/page.tsx
@@ -257,6 +257,7 @@ export default function AppCatalogPage() {
     return uniquePackages;
   }, [infiniteData?.pages]);
   const selectedInstallers = manifestData?.installers || [];
+  const selectedVersions = manifestData?.versions || [];
 
   const showSearchResults = hasSearched;
   const showCategoryResults = !hasSearched && selectedCategory !== null;
@@ -920,6 +921,7 @@ export default function AppCatalogPage() {
         <PackageConfig
           package={selectedPackage}
           installers={selectedInstallers}
+          versions={selectedVersions}
           onClose={handleCloseConfig}
           isDeployed={isSelectedDeployed}
           deployedConfig={deployedConfig}

--- a/app/dashboard/updates/page.tsx
+++ b/app/dashboard/updates/page.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   ArrowRight,
   Info,
+  ShieldOff,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -67,6 +68,7 @@ export default function UpdatesPage() {
   const router = useRouter();
   const [search, setSearch] = useState('');
   const [showCriticalOnly, setShowCriticalOnly] = useState(false);
+  const [showUnmanaged, setShowUnmanaged] = useState(false);
   const [updateTypeFilter, setUpdateTypeFilter] = useState<UpdateType | null>(null);
   const [sortBy, setSortBy] = useState<SortOption>('severity');
   const [activeTab, setActiveTab] = useState<'available' | 'history'>('available');
@@ -100,6 +102,7 @@ export default function UpdatesPage() {
   } = useAvailableUpdates({
     tenantId,
     criticalOnly: showCriticalOnly,
+    includeUnmanaged: showUnmanaged,
   });
 
   const {
@@ -179,9 +182,14 @@ export default function UpdatesPage() {
     (h) => h.status === 'failed' && isWithinDays(h.triggered_at, 7)
   ).length;
 
-  // Eligible updates for bulk action (exclude ignore and pinned)
+  // Eligible updates for bulk action (exclude ignore and pinned).
+  // "Update All" never includes unmanaged (fuzzy-matched) apps -- even when the
+  // user has opted to view them -- to avoid mass-updating mismatched/customized apps.
   const eligibleForBulkUpdate = filteredUpdates.filter(
-    (u) => u.policy?.policy_type !== 'ignore' && u.policy?.policy_type !== 'pin_version'
+    (u) =>
+      u.is_managed &&
+      u.policy?.policy_type !== 'ignore' &&
+      u.policy?.policy_type !== 'pin_version'
   );
 
   // Update type counts for filter
@@ -228,7 +236,10 @@ export default function UpdatesPage() {
   }, [triggerUpdate, router]);
 
   const handleTriggerUpdate = useCallback(async (update: AvailableUpdate) => {
-    if (!update.has_prior_deployment) {
+    // Confirm before updating an app that is new to IntuneGet OR not managed by
+    // it (fuzzy-matched) -- the latter may be a mismatched package or carry local
+    // customizations that a standard update could overwrite.
+    if (!update.has_prior_deployment || !update.is_managed) {
       setPendingNewAppUpdate(update);
       setNewAppDialogOpen(true);
       return;
@@ -244,6 +255,10 @@ export default function UpdatesPage() {
       await executeTriggerUpdate(updateToTrigger);
     }
   }, [pendingNewAppUpdate, executeTriggerUpdate]);
+
+  // The confirmation dialog doubles as an "unmanaged app" warning when the
+  // pending update is for an app IntuneGet did not deploy/claim/map.
+  const pendingIsUnmanaged = !!pendingNewAppUpdate && !pendingNewAppUpdate.is_managed;
 
   const handlePolicyChange = useCallback(async (
     update: AvailableUpdate,
@@ -559,11 +574,43 @@ export default function UpdatesPage() {
         <DialogContent className="bg-bg-surface border-overlay/10">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <Info className="w-5 h-5 text-violet-500" />
-              <T>Create new app in Intune</T>
+              {pendingIsUnmanaged ? (
+                <>
+                  <AlertTriangle className="w-5 h-5 text-status-warning" />
+                  <T>Update app not managed by IntuneGet?</T>
+                </>
+              ) : (
+                <>
+                  <Info className="w-5 h-5 text-violet-500" />
+                  <T>Create new app in Intune</T>
+                </>
+              )}
             </DialogTitle>
             <DialogDescription asChild>
               <div className="space-y-3 pt-1">
+                {pendingIsUnmanaged ? (
+                  <>
+                    <p>
+                      <T><Var><span className="font-medium text-text-primary">{pendingNewAppUpdate?.display_name}</span></Var> was matched
+                      to this Winget package automatically and is not managed by IntuneGet.</T>
+                    </p>
+                    <ul className="space-y-1.5 text-sm">
+                      <li className="flex items-start gap-2">
+                        <span className="mt-1 w-1 h-1 rounded-full bg-status-warning flex-shrink-0" />
+                        <T>The match may be incorrect, or the app may use custom installers or steps</T>
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <span className="mt-1 w-1 h-1 rounded-full bg-status-warning flex-shrink-0" />
+                        <T>Updating with the standard package could overwrite those customizations</T>
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <span className="mt-1 w-1 h-1 rounded-full bg-status-warning flex-shrink-0" />
+                        <T>Only continue if you are sure this is the correct package</T>
+                      </li>
+                    </ul>
+                  </>
+                ) : (
+                  <>
                 <p>
                   <T><Var><span className="font-medium text-text-primary">{pendingNewAppUpdate?.display_name}</span></Var> was not
                   originally deployed through IntuneGet.</T>
@@ -598,6 +645,8 @@ export default function UpdatesPage() {
                     </>
                   )}
                 </ul>
+                  </>
+                )}
               </div>
             </DialogDescription>
           </DialogHeader>
@@ -614,9 +663,14 @@ export default function UpdatesPage() {
             </Button>
             <Button
               onClick={() => void handleConfirmNewApp()}
-              className="bg-violet-600 hover:bg-violet-700 text-white font-medium"
+              className={cn(
+                'text-white font-medium',
+                pendingIsUnmanaged
+                  ? 'bg-status-warning hover:bg-status-warning/90'
+                  : 'bg-violet-600 hover:bg-violet-700'
+              )}
             >
-              <T>Create New App</T>
+              {pendingIsUnmanaged ? <T>Update anyway</T> : <T>Create New App</T>}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -758,6 +812,24 @@ export default function UpdatesPage() {
                   {criticalCount > 0 && (
                     <span className="ml-1 tabular-nums">{criticalCount}</span>
                   )}
+                </Button>
+
+                {/* Show unmanaged (fuzzy-matched) apps -- hidden by default and
+                    always excluded from Update All to avoid mismatched updates */}
+                <Button
+                  variant={showUnmanaged ? 'default' : 'ghost'}
+                  size="sm"
+                  onClick={() => setShowUnmanaged(!showUnmanaged)}
+                  title="Show updates for apps that were matched automatically and are not managed by IntuneGet. Hidden by default and never included in Update All."
+                  className={cn(
+                    'h-8 text-xs',
+                    showUnmanaged
+                      ? 'bg-accent-violet/20 text-accent-violet hover:bg-accent-violet/30 border border-accent-violet/20'
+                      : 'text-text-secondary hover:text-text-primary'
+                  )}
+                >
+                  <ShieldOff className="w-3.5 h-3.5 mr-1.5" />
+                  <T>Unmanaged</T>
                 </Button>
 
                 {/* Update type filter */}

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -54,13 +54,14 @@ import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt'
 import { useCartStore, createStoreCartItem } from '@/stores/cart-store';
 import { useUpdateAppSettings } from '@/hooks/use-update-app-settings';
 import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
-import { useLocaleVariants } from '@/hooks/use-packages';
+import { useLocaleVariants, usePackageManifest } from '@/hooks/use-packages';
 import { countryCodeToFlag, cleanPackageName } from '@/lib/locale-utils';
 import { Store } from 'lucide-react';
 
 interface PackageConfigProps {
   package: NormalizedPackage;
   installers: NormalizedInstaller[];
+  versions?: string[];
   onClose: () => void;
   isDeployed?: boolean;
   deployedConfig?: CartItem | null;
@@ -83,7 +84,7 @@ type ConfigSection =
   | 'branding'
   | 'advanced';
 
-export function PackageConfig({ package: pkg, installers, onClose, isDeployed = false, deployedConfig, intuneAppId, storeManifest }: PackageConfigProps) {
+export function PackageConfig({ package: pkg, installers, versions = [], onClose, isDeployed = false, deployedConfig, intuneAppId, storeManifest }: PackageConfigProps) {
   const isStoreApp = pkg.appSource === 'store';
 
   // Store app install experience state
@@ -227,9 +228,27 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
   }, [isDeployed, deployedConfig, assignments, categories, espProfiles,
       selectedVersion, selectedArch, selectedScope, selectedLocale, config]);
 
+  // Installers always arrive for the package's default (latest) version. When the
+  // user selects a different version we must re-fetch so the installer URL/SHA
+  // (which flow straight into the cart item) match the chosen version rather than
+  // silently deploying the latest binary under an older version label.
+  const isNonDefaultVersion = !isStoreApp && !!selectedVersion && selectedVersion !== pkg.version;
+  const { data: versionManifest, isFetching: isFetchingVersionInstallers } = usePackageManifest(
+    pkg.id,
+    selectedVersion,
+    undefined,
+    !isNonDefaultVersion
+  );
+  const effectiveInstallers =
+    isNonDefaultVersion && versionManifest?.installers?.length
+      ? versionManifest.installers
+      : installers;
+
   // Get selected installer (not relevant for store apps)
-  const selectedInstaller = installers.find((i) => i.architecture === selectedArch) || installers[0];
-  const availableArchitectures = [...new Set(installers.map((i) => i.architecture))];
+  const selectedInstaller = effectiveInstallers.find((i) => i.architecture === selectedArch) || effectiveInstallers[0];
+  const availableArchitectures = [...new Set(effectiveInstallers.map((i) => i.architecture))];
+  const availableVersions = versions.length > 0 ? versions : (pkg.versions ?? []);
+  const hasMultipleVersions = availableVersions.length > 1;
   const inCart = isStoreApp
     ? isInCart(pkg.packageIdentifier || pkg.id, selectedVersion, undefined, storeInstallExperience)
     : selectedInstaller
@@ -258,6 +277,18 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
     }
   }, [selectedInstaller]);
 
+  // When the installer set changes (e.g. after switching to a different version),
+  // ensure the selected architecture still exists; otherwise fall back to the
+  // first available one so the selection and the deployed installer stay in sync.
+  useEffect(() => {
+    if (
+      effectiveInstallers.length > 0 &&
+      !effectiveInstallers.some((i) => i.architecture === selectedArch)
+    ) {
+      setSelectedArch(effectiveInstallers[0].architecture as WingetArchitecture);
+    }
+  }, [effectiveInstallers, selectedArch]);
+
   // Generate detection rules when installer, version, locale, or marker path changes
   // Pass effectiveWingetId so locale variant packages get correct detection markers
   useEffect(() => {
@@ -282,6 +313,9 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
 
     // Store apps don't need an installer
     if (!isStoreApp && !selectedInstaller) return;
+    // Don't add while installers for a newly-selected version are still loading,
+    // otherwise the cart could capture the previous version's installer.
+    if (!isStoreApp && isFetchingVersionInstallers) return;
     if (!isStoreApp && inCart) return;
 
     setIsAddingToCart(true);
@@ -541,16 +575,26 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
                 <label className="block text-sm font-medium text-text-muted mb-2">Version</label>
                 <div className="relative">
                   <button
-                    onClick={() => setShowVersions(!showVersions)}
-                    className="w-full flex items-center justify-between px-4 py-2.5 bg-bg-elevated border border-overlay/15 rounded-lg text-text-primary hover:border-overlay/20 transition-colors text-sm"
+                    type="button"
+                    onClick={() => hasMultipleVersions && setShowVersions(!showVersions)}
+                    disabled={!hasMultipleVersions}
+                    className={cn(
+                      'w-full flex items-center justify-between px-4 py-2.5 bg-bg-elevated border border-overlay/15 rounded-lg text-text-primary transition-colors text-sm',
+                      hasMultipleVersions ? 'hover:border-overlay/20 cursor-pointer' : 'cursor-default'
+                    )}
                   >
                     <span>v{selectedVersion}</span>
-                    <ChevronDown className={cn('w-4 h-4 transition-transform', showVersions && 'rotate-180')} />
+                    {isFetchingVersionInstallers ? (
+                      <Loader2 className="w-4 h-4 animate-spin text-text-muted" />
+                    ) : hasMultipleVersions ? (
+                      <ChevronDown className={cn('w-4 h-4 transition-transform', showVersions && 'rotate-180')} />
+                    ) : null}
                   </button>
-                  {showVersions && pkg.versions && (
+                  {showVersions && hasMultipleVersions && (
                     <div className="absolute z-10 w-full mt-1 bg-bg-elevated border border-overlay/15 rounded-lg shadow-xl max-h-48 overflow-y-auto">
-                      {pkg.versions.slice(0, 10).map((version) => (
+                      {availableVersions.slice(0, 50).map((version) => (
                         <button
+                          type="button"
                           key={version}
                           onClick={() => {
                             setSelectedVersion(version);
@@ -1825,7 +1869,7 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
                 </Button>
                 <Button
                   onClick={handleAddToCart}
-                  disabled={(!isStoreApp && !selectedInstaller) || inCart || isAddingToCart || addedToCartSuccess}
+                  disabled={(!isStoreApp && (!selectedInstaller || isFetchingVersionInstallers)) || inCart || isAddingToCart || addedToCartSuccess}
                   variant="outline"
                   className={cn(
                     'py-5 text-base font-medium',
@@ -1850,7 +1894,7 @@ export function PackageConfig({ package: pkg, installers, onClose, isDeployed = 
           ) : (
             <Button
               onClick={handleAddToCart}
-              disabled={(!isStoreApp && !selectedInstaller) || inCart || isAddingToCart || addedToCartSuccess}
+              disabled={(!isStoreApp && (!selectedInstaller || isFetchingVersionInstallers)) || inCart || isAddingToCart || addedToCartSuccess}
               className={cn(
                 'w-full py-5 text-base font-medium',
                 inCart || addedToCartSuccess

--- a/components/providers/MicrosoftAuthProvider.tsx
+++ b/components/providers/MicrosoftAuthProvider.tsx
@@ -35,6 +35,11 @@ export function MicrosoftAuthProvider({
         // Sync auth hint cookie for server-side middleware protection
         const accounts = instance.getAllAccounts();
         if (accounts.length > 0) {
+          // Ensure an active account is set for returning sessions so silent
+          // token acquisition has a deterministic target across tabs/reloads.
+          if (!instance.getActiveAccount()) {
+            instance.setActiveAccount(accounts[0]);
+          }
           document.cookie = "msal-auth-hint=1; path=/; SameSite=Lax; max-age=86400";
         } else {
           document.cookie = "msal-auth-hint=; path=/; SameSite=Lax; max-age=0";

--- a/components/updates/UpdateCard.tsx
+++ b/components/updates/UpdateCard.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   Zap,
   Plus,
+  ShieldOff,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { AppIcon } from '@/components/AppIcon';
@@ -159,6 +160,15 @@ export function UpdateCard({
                   <T>Critical</T>
                 </span>
               )}
+              {!update.is_managed && (
+                <span
+                  className="flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-semibold text-accent-violet bg-accent-violet/10 border border-accent-violet/20 rounded-md flex-shrink-0 uppercase tracking-wide"
+                  title="Matched automatically; not managed by IntuneGet. Update with care -- excluded from Update All."
+                >
+                  <ShieldOff className="w-2.5 h-2.5" />
+                  <T>Unmanaged</T>
+                </span>
+              )}
             </div>
             <span className="text-xs font-mono text-text-muted leading-none">{update.winget_id}</span>
           </div>
@@ -210,7 +220,7 @@ export function UpdateCard({
 
         {/* Status metadata line */}
         <div className="flex items-center gap-2.5 mb-3.5 flex-wrap">
-          {!update.has_prior_deployment && (
+          {!update.has_prior_deployment && update.is_managed && (
             <span className="flex items-center gap-1 text-[11px] font-medium text-violet-500">
               <Plus className="w-3 h-3" />
               <T>New to IntuneGet</T>

--- a/hooks/use-packages.ts
+++ b/hooks/use-packages.ts
@@ -21,6 +21,7 @@ interface SearchPackagesResponse {
 interface ManifestResponse {
   installers: NormalizedInstaller[];
   recommendedInstaller?: NormalizedInstaller;
+  versions?: string[];
 }
 
 interface Category {

--- a/hooks/use-updates.ts
+++ b/hooks/use-updates.ts
@@ -33,6 +33,7 @@ export interface UseAvailableUpdatesOptions {
   tenantId?: string;
   criticalOnly?: boolean;
   includeDismissed?: boolean;
+  includeUnmanaged?: boolean;
 }
 
 export function buildAvailableUpdatesQueryParams(options: UseAvailableUpdatesOptions = {}): URLSearchParams {
@@ -41,6 +42,7 @@ export function buildAvailableUpdatesQueryParams(options: UseAvailableUpdatesOpt
   if (options.tenantId) queryParams.set('tenant_id', options.tenantId);
   if (options.criticalOnly) queryParams.set('critical_only', 'true');
   if (options.includeDismissed) queryParams.set('include_dismissed', 'true');
+  if (options.includeUnmanaged) queryParams.set('include_unmanaged', 'true');
 
   return queryParams;
 }
@@ -59,6 +61,7 @@ export function useAvailableUpdates(options: UseAvailableUpdatesOptions = {}) {
       options.tenantId || null,
       options.criticalOnly === true,
       options.includeDismissed === true,
+      options.includeUnmanaged === true,
     ],
     queryFn: async () => {
       const token = await getAccessToken();

--- a/hooks/useMicrosoftAuth.ts
+++ b/hooks/useMicrosoftAuth.ts
@@ -53,11 +53,12 @@ export function useMicrosoftAuth() {
     if (accounts.length === 0) {
       return null;
     }
+    const account = instance.getActiveAccount() ?? accounts[0];
 
     try {
       const tokenResponse = await instance.acquireTokenSilent({
         scopes: graphScopes,
-        account: accounts[0],
+        account,
         forceRefresh: true,
       });
 
@@ -70,7 +71,7 @@ export function useMicrosoftAuth() {
         try {
           const tokenResponse = await instance.acquireTokenPopup({
             scopes: graphScopes,
-            account: accounts[0],
+            account,
           });
 
           cachedTokenRef.current = tokenResponse.accessToken;
@@ -92,6 +93,7 @@ export function useMicrosoftAuth() {
     if (accounts.length === 0) {
       return null;
     }
+    const account = instance.getActiveAccount() ?? accounts[0];
 
     // Check if we have a cached token that's expiring soon (< 5 minutes)
     if (
@@ -105,7 +107,7 @@ export function useMicrosoftAuth() {
     try {
       const tokenResponse = await instance.acquireTokenSilent({
         scopes: graphScopes,
-        account: accounts[0],
+        account,
       });
 
       cachedTokenRef.current = tokenResponse.accessToken;
@@ -117,7 +119,7 @@ export function useMicrosoftAuth() {
         try {
           const tokenResponse = await instance.acquireTokenPopup({
             scopes: graphScopes,
-            account: accounts[0],
+            account,
           });
 
           cachedTokenRef.current = tokenResponse.accessToken;
@@ -169,6 +171,10 @@ export function useMicrosoftAuth() {
     try {
       const result = await instance.loginPopup({ scopes: graphScopes });
       if (result?.account) {
+        // Pin the account we just signed in with so subsequent silent token
+        // calls target it instead of blindly using accounts[0], which breaks
+        // when multiple Microsoft accounts are signed in.
+        instance.setActiveAccount(result.account);
         document.cookie = 'msal-auth-hint=1; path=/; SameSite=Lax; max-age=86400';
         hasTrackedSignInRef.current = result.account.localAccountId;
         await trackSignInToServer(result.account, 'popup');

--- a/lib/msal-config.ts
+++ b/lib/msal-config.ts
@@ -13,7 +13,11 @@ export const msalConfig: Configuration = {
       typeof window !== "undefined" ? `${window.location.origin}/redirect` : "",
   },
   cache: {
-    cacheLocation: "sessionStorage",
+    // localStorage so the session is shared across tabs and survives reloads,
+    // preventing the "signed out when switching tabs" loop. The browser-held
+    // token is low-privilege (User.Read/openid/profile); all privileged Graph
+    // operations run server-side via the service principal.
+    cacheLocation: "localStorage",
   },
   system: {
     loggerOptions: {

--- a/supabase/migrations/031_add_is_managed_to_update_check_results.sql
+++ b/supabase/migrations/031_add_is_managed_to_update_check_results.sql
@@ -1,0 +1,13 @@
+-- Track whether a detected update belongs to an IntuneGet-managed app
+-- (deployed, claimed, or explicitly mapped through IntuneGet) versus an app
+-- that was only matched to a winget package by fuzzy name heuristics.
+--
+-- Default is true because:
+--   * the daily cron only scans upload_history (always managed), and
+--   * existing rows predate this column and should remain visible until the
+--     next refresh re-tags them.
+-- The manual refresh path (live Intune scan) is the only writer that records
+-- false, and it fully replaces a tenant's rows on each run, so any stale
+-- defaults self-heal on the first refresh after deploy.
+ALTER TABLE update_check_results
+  ADD COLUMN IF NOT EXISTS is_managed BOOLEAN NOT NULL DEFAULT true;

--- a/types/database.ts
+++ b/types/database.ts
@@ -709,6 +709,7 @@ export interface Database {
           current_version: string;
           latest_version: string;
           is_critical: boolean;
+          is_managed: boolean;
           large_icon_type: string | null;
           large_icon_value: string | null;
           notified_at: string | null;
@@ -726,6 +727,7 @@ export interface Database {
           current_version: string;
           latest_version: string;
           is_critical?: boolean;
+          is_managed?: boolean;
           large_icon_type?: string | null;
           large_icon_value?: string | null;
           notified_at?: string | null;
@@ -743,6 +745,7 @@ export interface Database {
           current_version?: string;
           latest_version?: string;
           is_critical?: boolean;
+          is_managed?: boolean;
           large_icon_type?: string | null;
           large_icon_value?: string | null;
           notified_at?: string | null;

--- a/types/inventory.ts
+++ b/types/inventory.ts
@@ -117,4 +117,7 @@ export interface AppUpdateInfo {
   latestVersion: string;
   wingetId: string | null;
   hasUpdate: boolean;
+  // True when the app was deployed/claimed/mapped through IntuneGet (explicit
+  // provenance); false when matched only by fuzzy name/heuristics.
+  isManaged: boolean;
 }

--- a/types/update-policies.ts
+++ b/types/update-policies.ts
@@ -171,6 +171,9 @@ export interface AvailableUpdate {
   dismissed_at: string | null;
   // Whether this app was previously deployed through IntuneGet
   has_prior_deployment: boolean;
+  // Whether this update was matched to an IntuneGet-managed app (deployed,
+  // claimed, or explicitly mapped) vs. a fuzzy/heuristic name match.
+  is_managed: boolean;
   // Policy data (if exists)
   policy?: {
     id: string;


### PR DESCRIPTION
Addresses three open issues.

## #112 — Version dropdown appeared broken
The catalog version control was inert: the dropdown list was gated on a `versions` field the catalog/manifest APIs never returned, and changing the version did not refetch installers (so an older version could deploy with the latest installer URL/SHA256).

- `/api/winget/manifest` now returns the available versions list
- The dropdown renders from the live list with a single-version guard and a loading state
- Selecting a version refetches its installers and keeps the cart item's version, installer URL and SHA256 in sync; add-to-cart is blocked while those load

Verified end-to-end: `?version=0.98.0` returns the v0.98.0 installer + SHA256 vs latest 0.100.0; packages with 0/1 versions render a static field.

## #113 — Stuck in cube animation / session appears to expire on tab switch
The consent check set a one-way verifying flag with no timeout or error path, so a hung token/popup acquisition left the loader spinning forever; multiple accounts made it worse because token calls always used `accounts[0]`.

- Consent verification is now timeout-bounded and falls back to a retry / sign-out card — the loader can no longer be terminal
- Active account is set on sign-in and on init, and used for token acquisition
- MSAL cache moved to `localStorage` so the session is shared across tabs (the browser token is only User.Read/openid/profile; privileged Graph work uses the server-side service principal)

## #111 — Restrict updates to IntuneGet-managed apps
Fuzzy-matched apps could be swept up by Update All, risking accidental updates to mismatched or customized apps.

- Provenance (managed vs fuzzy) is tagged in the live Intune scan and persisted on `update_check_results` via a new `is_managed` column; a winget id is managed if any of its app objects are managed
- Unmanaged updates are hidden by default behind an opt-in toggle, badged, and excluded from Update All unconditionally; updating one individually requires explicit confirmation
- Cron-detected updates (from `upload_history`) are always managed

The `is_managed` column migration has already been applied to the project database.

## Verification
- `tsc --noEmit` clean (source); `eslint` clean; `vitest run` 397 passing (added provenance tests for the live and stored update routes)

Closes #112
Closes #113
Closes #111