### PR TITLE
Add discovered-apps device drill-down and fix cart count

### DIFF
--- a/app/api/intune/detected-app-devices/route.ts
+++ b/app/api/intune/detected-app-devices/route.ts
@@ -1,0 +1,222 @@
+/**
+ * Detected App Devices API Route
+ *
+ * Drill-down for the discovered/unmanaged apps device count: lists the devices
+ * a detected app is installed on. The displayed device count is summed across
+ * all detected versions of an app, but the consolidated app only keeps the
+ * newest version's id. So we read every merged version id from the cache and
+ * fan out `detectedApps/{id}/managedDevices`, deduplicating by device id, to
+ * return the complete distinct-device list.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
+import { parseAccessToken } from '@/lib/auth-utils';
+import {
+  GRAPH_API_BASE,
+  fetchWithRetry,
+  getServicePrincipalToken,
+  invalidateServicePrincipalToken,
+} from '@/lib/intune/graph-client';
+import type { DeviceListItem, DetectedAppDevicesResponse } from '@/types/unmanaged';
+
+export const maxDuration = 60;
+
+// Cap the per-version fan-out for pathological churn (e.g. browsers with dozens
+// of detected versions). Realistically never hit; guards latency/throttling.
+const MAX_VERSIONS = 25;
+// Concurrent managedDevices fetches across version ids (avoids tripping 429).
+const CONCURRENCY = 4;
+
+interface GraphManagedDevice {
+  id: string;
+  deviceName?: string | null;
+  operatingSystem?: string | null;
+}
+
+interface GraphFetchError extends Error {
+  status: number;
+  bodyText: string;
+}
+
+/**
+ * Fetch all managed devices for a single detected-app id, following pagination.
+ * A 404 (stale/removed version id) yields an empty list rather than failing the
+ * whole request. Other non-OK responses throw a GraphFetchError.
+ */
+async function fetchDevicesForDetectedApp(
+  detectedAppId: string,
+  token: string,
+  tenantId: string
+): Promise<GraphManagedDevice[]> {
+  const devices: GraphManagedDevice[] = [];
+  let nextUrl: string | null =
+    `${GRAPH_API_BASE}/deviceManagement/detectedApps/${encodeURIComponent(detectedAppId)}/managedDevices` +
+    `?$select=id,deviceName,operatingSystem`;
+
+  while (nextUrl) {
+    const response: Response = await fetchWithRetry(nextUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        invalidateServicePrincipalToken(tenantId);
+      }
+      // Stale version id no longer present — treat as no devices.
+      if (response.status === 404) {
+        await response.text().catch(() => {});
+        return devices;
+      }
+      const bodyText = await response.text().catch(() => '');
+      const error = new Error(
+        `Graph managedDevices ${response.status} for detectedApp ${detectedAppId}`
+      ) as GraphFetchError;
+      error.status = response.status;
+      error.bodyText = bodyText;
+      throw error;
+    }
+
+    const data: { value?: GraphManagedDevice[]; '@odata.nextLink'?: string } =
+      await response.json();
+    if (Array.isArray(data.value)) {
+      devices.push(...data.value);
+    }
+    nextUrl = data['@odata.nextLink'] || null;
+  }
+
+  return devices;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await parseAccessToken(request.headers.get('Authorization'));
+    if (!user) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const appId = searchParams.get('appId');
+    if (!appId) {
+      return NextResponse.json({ error: 'Missing appId parameter' }, { status: 400 });
+    }
+
+    const supabase = createServerClient();
+    const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+
+    const tenantResolution = await resolveTargetTenantId({
+      supabase,
+      userId: user.userId,
+      tokenTenantId: user.tenantId,
+      requestedTenantId: mspTenantId,
+    });
+
+    if (tenantResolution.errorResponse) {
+      return tenantResolution.errorResponse;
+    }
+
+    const tenantId = tenantResolution.tenantId;
+
+    // Verify admin consent (mirrors the unmanaged-apps route)
+    const { data: consentData, error: consentError } = await supabase
+      .from('tenant_consent')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('is_active', true)
+      .single();
+
+    if (consentError || !consentData) {
+      return NextResponse.json(
+        { error: 'Admin consent not found. Please complete the admin consent flow.' },
+        { status: 403 }
+      );
+    }
+
+    // Resolve the full set of detected-app (version) ids for this app from the
+    // sync cache; fall back to the single id for rows written before this field
+    // existed or evicted rows.
+    const { data: cacheRow } = await supabase
+      .from('discovered_apps_cache')
+      .select('app_data, device_count')
+      .eq('tenant_id', tenantId)
+      .eq('discovered_app_id', appId)
+      .maybeSingle();
+
+    const appData = (cacheRow?.app_data ?? null) as unknown as { mergedAppIds?: string[] } | null;
+    const allVersionIds =
+      appData?.mergedAppIds && appData.mergedAppIds.length > 0
+        ? appData.mergedAppIds
+        : [appId];
+    const truncated = allVersionIds.length > MAX_VERSIONS;
+    const versionIds = truncated ? allVersionIds.slice(0, MAX_VERSIONS) : allVersionIds;
+    const summedDeviceCount = cacheRow?.device_count ?? undefined;
+
+    const token = await getServicePrincipalToken(tenantId);
+    if (!token) {
+      return NextResponse.json({ error: 'Failed to get Graph API token' }, { status: 500 });
+    }
+
+    // Fan out across version ids with a small concurrency cap, deduplicating
+    // devices by id (a device may run more than one version of the app).
+    const deviceMap = new Map<string, DeviceListItem>();
+    try {
+      for (let i = 0; i < versionIds.length; i += CONCURRENCY) {
+        const chunk = versionIds.slice(i, i + CONCURRENCY);
+        const chunkResults = await Promise.all(
+          chunk.map((id) => fetchDevicesForDetectedApp(id, token, tenantId))
+        );
+        for (const deviceList of chunkResults) {
+          for (const device of deviceList) {
+            if (!device.id || deviceMap.has(device.id)) continue;
+            deviceMap.set(device.id, {
+              id: device.id,
+              deviceName: device.deviceName || 'Unknown device',
+              operatingSystem: device.operatingSystem ?? null,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      const graphError = err as GraphFetchError;
+      if (
+        graphError.status === 403 &&
+        graphError.bodyText?.includes('DeviceManagementManagedDevices')
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              'Missing required permission: DeviceManagementManagedDevices.Read.All. Please add this permission to your Azure AD app registration and grant admin consent.',
+            permissionRequired: 'DeviceManagementManagedDevices.Read.All',
+          },
+          { status: 403 }
+        );
+      }
+      console.error('Error fetching detected app devices:', err);
+      return NextResponse.json(
+        { error: 'Failed to fetch devices from Intune' },
+        { status: graphError.status && graphError.status >= 400 ? graphError.status : 502 }
+      );
+    }
+
+    const devices = [...deviceMap.values()].sort((a, b) =>
+      a.deviceName.localeCompare(b.deviceName)
+    );
+
+    return NextResponse.json({
+      devices,
+      total: devices.length,
+      summedDeviceCount,
+      truncated,
+    } as DetectedAppDevicesResponse);
+  } catch (error) {
+    console.error('Error in detected-app-devices route:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to fetch devices' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/intune/unmanaged-apps/route.ts
+++ b/app/api/intune/unmanaged-apps/route.ts
@@ -319,13 +319,19 @@ export async function GET(request: NextRequest) {
 
     // Consolidate apps: group by normalized name+publisher, keep newest version, sum device counts
     const appGroups = new Map<string, GraphUnmanagedApp>();
+    // Track every detected-app id merged into each group, keyed by group key.
+    // The consolidated app only keeps the newest version's id, but the device
+    // drill-down must fan out across all versions to list every device.
+    const groupMemberIds = new Map<string, string[]>();
     for (const app of graphApps) {
       const key = `${normalizeAppName(app.displayName)}::${(app.publisher || '').toLowerCase().trim()}`;
       const existing = appGroups.get(key);
       if (!existing) {
         appGroups.set(key, { ...app });
+        groupMemberIds.set(key, [app.id]);
       } else {
         existing.deviceCount += app.deviceCount;
+        groupMemberIds.get(key)!.push(app.id);
         if (app.version && (!existing.version || compareVersions(app.version, existing.version) > 0)) {
           existing.id = app.id;
           existing.displayName = app.displayName;
@@ -334,6 +340,17 @@ export async function GET(request: NextRequest) {
       }
     }
     const consolidatedApps = [...appGroups.values()];
+
+    // Re-key the merged ids by the consolidated winner's id so the cache write
+    // can attach the full version list to each app (fallback handled on read).
+    // Winner ids are unique across groups (each detected-app id belongs to one
+    // group), but merge defensively so a collision could never drop a version.
+    const mergedIdsByWinnerId = new Map<string, string[]>();
+    for (const [key, group] of appGroups) {
+      const ids = groupMemberIds.get(key) ?? [group.id];
+      const existing = mergedIdsByWinnerId.get(group.id);
+      mergedIdsByWinnerId.set(group.id, existing ? [...new Set([...existing, ...ids])] : ids);
+    }
 
     // Filter to Windows apps only
     const windowsApps = consolidatedApps.filter(app => app.platform === 'windows');
@@ -417,7 +434,12 @@ export async function GET(request: NextRequest) {
       matched_package_id: app.matchedPackageId,
       match_confidence: app.matchConfidence,
       match_status: app.matchStatus,
-      app_data: filteredApps.find(a => a.id === app.discoveredAppId) as unknown as Json,
+      // Store the winner GraphUnmanagedApp plus every detected-app id merged
+      // into this group, so the device drill-down can fan out across versions.
+      app_data: {
+        ...(filteredApps.find(a => a.id === app.discoveredAppId) as unknown as Record<string, unknown>),
+        mergedAppIds: mergedIdsByWinnerId.get(app.discoveredAppId) ?? [app.discoveredAppId],
+      } as unknown as Json,
       last_synced: now,
     }));
 

--- a/app/dashboard/unmanaged/page.tsx
+++ b/app/dashboard/unmanaged/page.tsx
@@ -31,6 +31,7 @@ import { UnmanagedListRow } from '@/components/unmanaged/UnmanagedListRow';
 import { UnmanagedEmptyState } from '@/components/unmanaged/UnmanagedEmptyState';
 import { UnmanagedPageSkeleton } from '@/components/unmanaged/UnmanagedLoadingSkeleton';
 import { useUnmanagedApps } from '@/hooks/use-unmanaged-apps';
+import { useCartStore } from '@/stores/cart-store';
 import { staggerContainerFast, fadeUp } from '@/lib/animations/variants';
 import { cn } from '@/lib/utils';
 
@@ -69,6 +70,12 @@ export default function UnmanagedAppsPage() {
     retryFailedClaims,
     clearFilters,
   } = useUnmanagedApps();
+
+  // Actual number of apps in the cart. The banner says "in your cart", so it
+  // must reflect the real cart size — not computedStats.claimed, which counts
+  // discovered apps and over-counts when several discovered entries (e.g. two
+  // installed versions) map to the same winget package already in the cart.
+  const cartItemCount = useCartStore((state) => state.items.length);
 
   const prefersReducedMotion = useReducedMotion();
 
@@ -348,7 +355,7 @@ export default function UnmanagedAppsPage() {
           <div className="flex items-center gap-3">
             <ShoppingCart className="w-5 h-5 text-accent-violet" />
             <p className="text-sm text-text-secondary">
-              <T><span className="font-medium text-text-primary"><Var>{computedStats.claimed}</Var> {computedStats.claimed === 1 ? 'app' : 'apps'}</span> in your cart ready for deployment</T>
+              <T><span className="font-medium text-text-primary"><Var>{cartItemCount}</Var> {cartItemCount === 1 ? 'app' : 'apps'}</span> in your cart ready for deployment</T>
             </p>
           </div>
           <Button asChild size="sm" className="bg-gradient-to-r from-accent-violet to-accent-violet-bright hover:opacity-90 text-white border-0 flex-shrink-0">

--- a/app/dashboard/unmanaged/page.tsx
+++ b/app/dashboard/unmanaged/page.tsx
@@ -25,6 +25,7 @@ import {
   ClaimAppModal,
   LinkPackageModal,
   ClaimAllModal,
+  DeviceListModal,
 } from '@/components/unmanaged';
 import { UnmanagedToolbar } from '@/components/unmanaged/UnmanagedToolbar';
 import { UnmanagedListRow } from '@/components/unmanaged/UnmanagedListRow';
@@ -55,11 +56,14 @@ export default function UnmanagedAppsPage() {
     claimModalApp,
     linkModalApp,
     claimAllModal,
+    deviceListApp,
     setFilters,
     setViewMode,
     setClaimModalApp,
     setLinkModalApp,
     setClaimAllModal,
+    setDeviceListApp,
+    fetchAppDevices,
     setPermissionError,
     handleRefresh,
     handleClaimApp,
@@ -404,6 +408,7 @@ export default function UnmanagedAppsPage() {
                 app={app}
                 onClaim={() => setClaimModalApp(app)}
                 onLink={() => setLinkModalApp(app)}
+                onDeviceCountClick={() => setDeviceListApp(app)}
                 isClaimLoading={claimingAppId === app.discoveredAppId}
               />
             </motion.div>
@@ -422,6 +427,7 @@ export default function UnmanagedAppsPage() {
                 app={app}
                 onClaim={() => setClaimModalApp(app)}
                 onLink={() => setLinkModalApp(app)}
+                onDeviceCountClick={() => setDeviceListApp(app)}
                 isClaimLoading={claimingAppId === app.discoveredAppId}
               />
             </motion.div>
@@ -456,6 +462,15 @@ export default function UnmanagedAppsPage() {
           onConfirm={processClaimAll}
           onCancel={cancelClaimAll}
           onRetryFailed={retryFailedClaims}
+        />
+      )}
+
+      {deviceListApp && (
+        <DeviceListModal
+          app={deviceListApp}
+          isOpen={!!deviceListApp}
+          onClose={() => setDeviceListApp(null)}
+          fetchDevices={fetchAppDevices}
         />
       )}
     </div>

--- a/components/unmanaged/DeviceListModal.tsx
+++ b/components/unmanaged/DeviceListModal.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Monitor, Loader2, AlertTriangle, RefreshCw, Search, Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import type { UnmanagedApp, DetectedAppDevicesResponse } from '@/types/unmanaged';
+
+interface DeviceListModalProps {
+  app: UnmanagedApp;
+  isOpen: boolean;
+  onClose: () => void;
+  fetchDevices: (app: UnmanagedApp) => Promise<DetectedAppDevicesResponse>;
+}
+
+export function DeviceListModal({ app, isOpen, onClose, fetchDevices }: DeviceListModalProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<DetectedAppDevicesResponse | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // Fetch device list whenever the modal opens (or a retry is requested). The
+  // `active` flag prevents stale state updates if the user closes/switches apps
+  // before the request resolves.
+  useEffect(() => {
+    if (!isOpen) return;
+    let active = true;
+
+    setIsLoading(true);
+    setError(null);
+    setData(null);
+    setSearchQuery('');
+
+    fetchDevices(app)
+      .then((result) => {
+        if (active) setData(result);
+      })
+      .catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : 'Failed to load devices');
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [isOpen, app, fetchDevices, reloadKey]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) onClose();
+  };
+
+  const devices = data?.devices ?? [];
+  const filteredDevices = searchQuery
+    ? devices.filter((d) => d.deviceName.toLowerCase().includes(searchQuery.toLowerCase()))
+    : devices;
+  const showSearch = devices.length > 10;
+  const showMismatch =
+    data?.summedDeviceCount != null && data.summedDeviceCount !== data.total;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg mx-4">
+        <DialogHeader>
+          <DialogTitle>
+            {data ? `${data.total} ${data.total === 1 ? 'device' : 'devices'}` : 'Devices'}
+          </DialogTitle>
+          <DialogDescription>
+            Devices with &ldquo;{app.displayName}&rdquo; installed
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-6 py-4">
+          {/* Loading */}
+          {isLoading && (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Loader2 className="w-8 h-8 text-accent-cyan animate-spin mb-3" />
+              <p className="text-sm text-text-muted">Loading devices...</p>
+            </div>
+          )}
+
+          {/* Error */}
+          {!isLoading && error && (
+            <div className="flex flex-col items-center py-10 text-center">
+              <AlertTriangle className="w-10 h-10 text-amber-400 mb-3" />
+              <p className="text-text-secondary text-sm mb-3">{error}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setReloadKey((k) => k + 1)}
+                className="border-overlay/10"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {/* Empty */}
+          {!isLoading && !error && data && devices.length === 0 && (
+            <div className="text-center py-10 text-text-muted">
+              <Monitor className="w-12 h-12 mx-auto mb-3 opacity-50" />
+              <p className="text-sm">No devices found for this app</p>
+            </div>
+          )}
+
+          {/* Device list */}
+          {!isLoading && !error && devices.length > 0 && (
+            <div className="space-y-3">
+              {/* Multi-version mismatch hint */}
+              {showMismatch && (
+                <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-bg-elevated/60 border border-overlay/5">
+                  <Info className="w-4 h-4 text-accent-cyan flex-shrink-0 mt-0.5" />
+                  <p className="text-xs text-text-muted">
+                    {data!.summedDeviceCount!.toLocaleString()} total installs across{' '}
+                    {data!.total.toLocaleString()} distinct devices (some devices run more than one
+                    version).
+                  </p>
+                </div>
+              )}
+
+              {/* Truncation note */}
+              {data?.truncated && (
+                <p className="text-xs text-text-muted">
+                  Showing devices from the first {25} detected versions.
+                </p>
+              )}
+
+              {/* Search */}
+              {showSearch && (
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Filter devices..."
+                    className="pl-9 bg-bg-elevated border-overlay/10 focus:border-accent-cyan/50"
+                  />
+                </div>
+              )}
+
+              <div className="space-y-1.5 max-h-80 overflow-y-auto">
+                {filteredDevices.length === 0 ? (
+                  <p className="text-center py-6 text-sm text-text-muted">
+                    No devices match &ldquo;{searchQuery}&rdquo;
+                  </p>
+                ) : (
+                  filteredDevices.map((device) => (
+                    <div
+                      key={device.id}
+                      className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-bg-elevated border border-overlay/5"
+                    >
+                      <Monitor className="w-4 h-4 text-accent-cyan flex-shrink-0" />
+                      <p className="text-sm text-text-primary truncate flex-1 min-w-0">
+                        {device.deviceName}
+                      </p>
+                      {device.operatingSystem && (
+                        <span className="text-xs text-text-muted flex-shrink-0">
+                          {device.operatingSystem}
+                        </span>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/unmanaged/UnmanagedAppCard.tsx
+++ b/components/unmanaged/UnmanagedAppCard.tsx
@@ -12,6 +12,7 @@ interface UnmanagedAppCardProps {
   app: UnmanagedApp;
   onClaim?: (app: UnmanagedApp) => void;
   onLink?: (app: UnmanagedApp) => void;
+  onDeviceCountClick?: () => void;
   isClaimLoading?: boolean;
 }
 
@@ -26,6 +27,7 @@ function UnmanagedAppCardComponent({
   app,
   onClaim,
   onLink,
+  onDeviceCountClick,
   isClaimLoading = false,
 }: UnmanagedAppCardProps) {
   const canClaim = app.matchStatus === 'matched' && !app.isClaimed;
@@ -76,15 +78,32 @@ function UnmanagedAppCardComponent({
 
           {/* Device count + status */}
           <div className="flex items-center gap-4 mt-3">
-            <div className="flex items-center gap-1.5 bg-bg-elevated/80 px-2.5 py-1 rounded-lg border border-overlay/5">
-              <Monitor className="w-4 h-4 text-accent-cyan" />
-              <span className="text-sm font-semibold text-text-primary tabular-nums">
-                {app.deviceCount.toLocaleString()}
-              </span>
-              <span className="text-xs text-text-muted">
-                {app.deviceCount === 1 ? 'device' : 'devices'}
-              </span>
-            </div>
+            {onDeviceCountClick ? (
+              <button
+                type="button"
+                onClick={onDeviceCountClick}
+                aria-label={`View ${app.deviceCount.toLocaleString()} ${app.deviceCount === 1 ? 'device' : 'devices'} for ${app.displayName}`}
+                className="flex items-center gap-1.5 bg-bg-elevated/80 px-2.5 py-1 rounded-lg border border-overlay/5 transition-colors hover:border-accent-cyan/40 hover:bg-bg-elevated focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface"
+              >
+                <Monitor className="w-4 h-4 text-accent-cyan" />
+                <span className="text-sm font-semibold text-text-primary tabular-nums">
+                  {app.deviceCount.toLocaleString()}
+                </span>
+                <span className="text-xs text-text-muted">
+                  {app.deviceCount === 1 ? 'device' : 'devices'}
+                </span>
+              </button>
+            ) : (
+              <div className="flex items-center gap-1.5 bg-bg-elevated/80 px-2.5 py-1 rounded-lg border border-overlay/5">
+                <Monitor className="w-4 h-4 text-accent-cyan" />
+                <span className="text-sm font-semibold text-text-primary tabular-nums">
+                  {app.deviceCount.toLocaleString()}
+                </span>
+                <span className="text-xs text-text-muted">
+                  {app.deviceCount === 1 ? 'device' : 'devices'}
+                </span>
+              </div>
+            )}
             <MatchStatusBadge status={app.matchStatus} confidence={app.matchConfidence} />
           </div>
 
@@ -189,6 +208,7 @@ export const UnmanagedAppCard = memo(UnmanagedAppCardComponent, (prev, next) => 
     prev.app.partialMatches === next.app.partialMatches &&
     prev.isClaimLoading === next.isClaimLoading &&
     prev.onClaim === next.onClaim &&
-    prev.onLink === next.onLink
+    prev.onLink === next.onLink &&
+    prev.onDeviceCountClick === next.onDeviceCountClick
   );
 });

--- a/components/unmanaged/UnmanagedListRow.tsx
+++ b/components/unmanaged/UnmanagedListRow.tsx
@@ -20,6 +20,7 @@ interface UnmanagedListRowProps {
   app: UnmanagedApp;
   onClaim: () => void;
   onLink: () => void;
+  onDeviceCountClick?: () => void;
   isClaimLoading: boolean;
 }
 
@@ -34,6 +35,7 @@ export const UnmanagedListRow = memo(function UnmanagedListRow({
   app,
   onClaim,
   onLink,
+  onDeviceCountClick,
   isClaimLoading,
 }: UnmanagedListRowProps) {
   const prefersReducedMotion = useReducedMotion();
@@ -93,10 +95,22 @@ export const UnmanagedListRow = memo(function UnmanagedListRow({
           </div>
 
           {/* Device count */}
-          <div className="flex items-center gap-2 text-text-secondary">
-            <Monitor className="w-4 h-4" />
-            <span className="text-sm font-semibold tabular-nums">{app.deviceCount.toLocaleString()}</span>
-          </div>
+          {onDeviceCountClick ? (
+            <button
+              type="button"
+              onClick={onDeviceCountClick}
+              aria-label={`View ${app.deviceCount.toLocaleString()} ${app.deviceCount === 1 ? 'device' : 'devices'} for ${app.displayName}`}
+              className="flex items-center gap-2 text-text-secondary justify-self-start rounded-lg px-2 py-1 -mx-2 transition-colors hover:text-accent-cyan hover:bg-overlay/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+            >
+              <Monitor className="w-4 h-4" />
+              <span className="text-sm font-semibold tabular-nums">{app.deviceCount.toLocaleString()}</span>
+            </button>
+          ) : (
+            <div className="flex items-center gap-2 text-text-secondary">
+              <Monitor className="w-4 h-4" />
+              <span className="text-sm font-semibold tabular-nums">{app.deviceCount.toLocaleString()}</span>
+            </div>
+          )}
 
           {/* Status badge */}
           <MatchStatusBadge status={app.matchStatus} confidence={app.matchConfidence} />

--- a/components/unmanaged/index.ts
+++ b/components/unmanaged/index.ts
@@ -7,6 +7,7 @@ export { MatchStatusBadge } from './MatchStatusBadge';
 export { ClaimAppModal } from './ClaimAppModal';
 export { LinkPackageModal } from './LinkPackageModal';
 export { ClaimAllModal } from './ClaimAllModal';
+export { DeviceListModal } from './DeviceListModal';
 export type { ClaimAllModalState, ClaimAllItemStatus } from './ClaimAllModal';
 export { FilterChip } from './FilterChip';
 export { UnmanagedToolbar } from './UnmanagedToolbar';

--- a/hooks/use-unmanaged-apps.ts
+++ b/hooks/use-unmanaged-apps.ts
@@ -14,6 +14,7 @@ import type {
   UnmanagedAppsStats,
   UnmanagedAppsFilters,
   MatchStatus,
+  DetectedAppDevicesResponse,
 } from '@/types/unmanaged';
 import type { ClaimAllModalState, ClaimAllItemStatus } from '@/components/unmanaged';
 
@@ -52,6 +53,7 @@ export interface UseUnmanagedAppsReturn {
   claimModalApp: UnmanagedApp | null;
   linkModalApp: UnmanagedApp | null;
   claimAllModal: ClaimAllModalState | null;
+  deviceListApp: UnmanagedApp | null;
 
   // Actions
   setFilters: (filters: UnmanagedAppsFilters) => void;
@@ -59,6 +61,8 @@ export interface UseUnmanagedAppsReturn {
   setClaimModalApp: (app: UnmanagedApp | null) => void;
   setLinkModalApp: (app: UnmanagedApp | null) => void;
   setClaimAllModal: (state: ClaimAllModalState | null) => void;
+  setDeviceListApp: (app: UnmanagedApp | null) => void;
+  fetchAppDevices: (app: UnmanagedApp) => Promise<DetectedAppDevicesResponse>;
   setPermissionError: (error: string | null) => void;
   handleRefresh: () => Promise<void>;
   handleClaimApp: (app: UnmanagedApp) => Promise<void>;
@@ -124,6 +128,7 @@ export function useUnmanagedApps(): UseUnmanagedAppsReturn {
   const [linkModalApp, setLinkModalApp] = useState<UnmanagedApp | null>(null);
   const [claimingAppId, setClaimingAppId] = useState<string | null>(null);
   const [claimAllModal, setClaimAllModal] = useState<ClaimAllModalState | null>(null);
+  const [deviceListApp, setDeviceListApp] = useState<UnmanagedApp | null>(null);
 
   // Get current access token
   const getToken = useCallback(async (): Promise<string | null> => {
@@ -209,6 +214,32 @@ export function useUnmanagedApps(): UseUnmanagedAppsReturn {
       });
     }
   }, [fetchApps]);
+
+  // Fetch the devices a discovered app is installed on (device count drill-down).
+  // Resolves the complete deduplicated device list across all detected versions.
+  const fetchAppDevices = useCallback(
+    async (app: UnmanagedApp): Promise<DetectedAppDevicesResponse> => {
+      const accessToken = await getToken();
+      if (!accessToken) {
+        throw new Error('Authentication failed. Please sign in again.');
+      }
+      const response = await fetch(
+        `/api/intune/detected-app-devices?appId=${encodeURIComponent(app.discoveredAppId)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            ...mspHeaders,
+          },
+        }
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to load devices');
+      }
+      return response.json();
+    },
+    [getToken, mspHeaders]
+  );
 
   // Cart winget IDs for quick lookup
   const cartWingetIds = useMemo(() => {
@@ -726,11 +757,14 @@ export function useUnmanagedApps(): UseUnmanagedAppsReturn {
     claimModalApp,
     linkModalApp,
     claimAllModal,
+    deviceListApp,
     setFilters,
     setViewMode,
     setClaimModalApp,
     setLinkModalApp,
     setClaimAllModal,
+    setDeviceListApp,
+    fetchAppDevices,
     setPermissionError,
     handleRefresh,
     handleClaimApp,

--- a/lib/intune/graph-client.ts
+++ b/lib/intune/graph-client.ts
@@ -1,0 +1,137 @@
+/**
+ * Microsoft Graph client helpers (service-principal / app-only)
+ *
+ * Shared Graph plumbing for Intune API routes that authenticate with the
+ * service principal (client-credentials flow) rather than a delegated user
+ * token: a retrying fetch and a per-tenant token cache.
+ *
+ * NOTE: this is currently consumed only by the detected-app-devices route.
+ * Several other routes still define their own copies of this logic; converging
+ * them onto this module is a deliberate follow-up, not a drive-by change.
+ */
+
+export const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
+
+// Module-scoped token cache keyed by tenantId
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+const tokenInflight = new Map<string, Promise<string | null>>();
+
+/**
+ * Fetch with retry logic for Graph API rate limiting (429) and transient errors (5xx).
+ * Respects Retry-After header; falls back to exponential backoff capped at 30s.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  maxRetries = 3
+): Promise<Response> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+    const status = response.status;
+
+    const isRetryable = status === 429 || status >= 500;
+    if (!isRetryable || attempt === maxRetries) {
+      return response;
+    }
+
+    // Consume body to prevent memory leaks in serverless
+    await response.text().catch(() => {});
+
+    const retryAfter = response.headers.get('Retry-After');
+    let delayMs: number;
+    if (retryAfter) {
+      const parsed = Number(retryAfter);
+      delayMs = Number.isNaN(parsed) ? Math.pow(2, attempt) * 1000 : parsed * 1000;
+    } else {
+      delayMs = Math.pow(2, attempt) * 1000;
+    }
+    delayMs = Math.min(delayMs, 30000);
+
+    console.warn(
+      `Graph API ${status} on attempt ${attempt + 1}/${maxRetries + 1}, retrying in ${delayMs}ms`
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  // Unreachable: loop always returns on attempt === maxRetries
+  throw new Error('Failed to fetch data from Intune');
+}
+
+/**
+ * Get an access token for the service principal using the client-credentials
+ * flow. Tokens are cached per tenant (with a 10-minute pre-expiry buffer) and
+ * concurrent fetches for the same tenant are deduplicated.
+ */
+export async function getServicePrincipalToken(tenantId: string): Promise<string | null> {
+  // Return cached token if still valid (with 10-min buffer)
+  const cached = tokenCache.get(tenantId);
+  if (cached && cached.expiresAt > Date.now() + 10 * 60 * 1000) {
+    return cached.token;
+  }
+
+  // Deduplicate concurrent token fetches for the same tenant
+  const inflight = tokenInflight.get(tenantId);
+  if (inflight) return inflight;
+
+  const promise = fetchServicePrincipalToken(tenantId).finally(() => {
+    tokenInflight.delete(tenantId);
+  });
+  tokenInflight.set(tenantId, promise);
+  return promise;
+}
+
+/**
+ * Invalidate the cached service-principal token for a tenant. Call this when
+ * Graph returns 401 (token revoked/expired) so the next request re-acquires.
+ */
+export function invalidateServicePrincipalToken(tenantId: string): void {
+  tokenCache.delete(tenantId);
+}
+
+async function fetchServicePrincipalToken(tenantId: string): Promise<string | null> {
+  const clientId = process.env.AZURE_CLIENT_ID || process.env.NEXT_PUBLIC_AZURE_AD_CLIENT_ID;
+  const clientSecret = process.env.AZURE_CLIENT_SECRET || process.env.AZURE_AD_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    console.error('Service principal token failure: missing AZURE_CLIENT_ID or AZURE_CLIENT_SECRET');
+    return null;
+  }
+
+  try {
+    const tokenResponse = await fetch(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          scope: 'https://graph.microsoft.com/.default',
+          grant_type: 'client_credentials',
+        }),
+      }
+    );
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text().catch(() => 'unknown error');
+      console.error(`Service principal token failure for tenant ${tenantId}: ${tokenResponse.status} - ${errorText}`);
+      tokenCache.delete(tenantId);
+      return null;
+    }
+
+    const tokenData = await tokenResponse.json();
+    const token = tokenData.access_token;
+    const expiresIn = tokenData.expires_in || 3600;
+    tokenCache.set(tenantId, {
+      token,
+      expiresAt: Date.now() + expiresIn * 1000,
+    });
+    return token;
+  } catch (error) {
+    console.error('Service principal token error:', error);
+    tokenCache.delete(tenantId);
+    return null;
+  }
+}

--- a/types/unmanaged.ts
+++ b/types/unmanaged.ts
@@ -138,6 +138,33 @@ export interface UnmanagedAppsResponse {
 }
 
 /**
+ * A single device an app is installed on (drill-down from the device count)
+ */
+export interface DeviceListItem {
+  id: string;
+  deviceName: string;
+  operatingSystem?: string | null;
+}
+
+/**
+ * Response from the detected-app-devices API (device drill-down)
+ */
+export interface DetectedAppDevicesResponse {
+  /** Distinct devices the app is installed on, deduplicated across versions */
+  devices: DeviceListItem[];
+  /** Number of distinct devices (devices.length) */
+  total: number;
+  /**
+   * The app's displayed device count (summed across versions). Present so the
+   * modal can explain a discrepancy when a device has multiple versions
+   * installed and is therefore counted once here but twice in the sum.
+   */
+  summedDeviceCount?: number;
+  /** True when the per-version fan-out was capped (very high version churn) */
+  truncated?: boolean;
+}
+
+/**
  * Request body for claiming an app
  */
 export interface ClaimAppRequest {


### PR DESCRIPTION
## Summary

Two changes to the Discovered Apps (unmanaged apps) page:

1. **Fix cart count in the deployment banner.** The "X apps in your cart ready for deployment" banner read `computedStats.claimed`, which counts discovered apps whose package is in the cart. When several discovered entries (different installed versions, or 32/64-bit) map to the same package, that over-counted vs. the actual cart. The banner now reads the real cart size (`items.length`), matching the Selected Apps modal.

2. **Add a device drill-down.** Clicking the device count on a discovered app opens a modal listing the devices it is installed on, fetched live from Intune. The count is summed across all detected versions of an app, but only the newest version's detected-app id was kept, so a naive lookup would under-count. Each version's id is now persisted at sync time and the new route fans out `detectedApps/{id}/managedDevices` across all of them, deduplicating by device, so the list matches the count.

### New
- `lib/intune/graph-client.ts` — shared service-principal Graph helpers (token cache + retry).
- `app/api/intune/detected-app-devices/route.ts` — `GET ?appId=`; auth + MSP tenant + consent, cross-version fan-out, pagination, dedupe.
- `components/unmanaged/DeviceListModal.tsx` — fetch-on-open modal (loading / error / empty / list, search filter, multi-version hint).

## Validation
- Typecheck and lint clean (remaining `tsc` errors are pre-existing test-file noise).
- Graph call verified end-to-end against a live Intune tenant: endpoint + `$select`, `deviceCount` equals device-list length, `@odata.nextLink` pagination (absolute URL, preserves `$select`), and cross-version fan-out (e.g. a 3-version app resolves to all 4 distinct devices vs. 1 without the fan-out). Dedup-by-device-id confirmed against a device appearing under multiple apps. Unknown/stale ids return an empty 200 and are handled gracefully.
