### PR TITLE
Fix Discovered Apps throttling on large tenants (#125) + clarify Azure env naming (#124)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,15 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 #      - User.Read
 # 5. Create a client secret (for service principal auth in GitHub Actions)
 
+# NAMING: the self-hosted WEB APP reads these two variables:
+#   NEXT_PUBLIC_AZURE_AD_CLIENT_ID  (client / application id)
+#   AZURE_AD_CLIENT_SECRET          (client secret, for consent verification)
+# The AZURE_CLIENT_ID / AZURE_CLIENT_SECRET names are the GitHub Secrets used by
+# the packaging workflow; the app also accepts them as fallbacks, but in
+# .env.local you only need the two AZURE_AD_* names above. A missing or expired
+# AZURE_AD_CLIENT_SECRET is the usual cause of "Request failed" on the consent
+# screen even for Global Admins.
+
 # Client ID (Application ID) - Required for MSAL
 # In Docker deployments, NEXT_PUBLIC_* vars are inlined as empty at build time.
 # docker-compose.yml automatically derives AZURE_CLIENT_ID from this value,

--- a/app/api/intune/unmanaged-apps/route.ts
+++ b/app/api/intune/unmanaged-apps/route.ts
@@ -248,8 +248,14 @@ export async function GET(request: NextRequest) {
     // Note: no $orderby — server-side sorting of the full detectedApps collection
     // is expensive and a frequent throttling (429) trigger. We re-sort by device
     // count in code after consolidation instead.
+    // $top=1000: detectedApps honors page sizes well above the old default of 100
+    // (verified against Graph). A larger page size means far fewer sequential
+    // requests on large tenants, which both reduces 429 throttling and avoids the
+    // 300s function timeout that otherwise surfaces as a generic fetch failure.
+    // Graph caps the page size server-side if needed and returns @odata.nextLink,
+    // which the loop below already follows.
     const graphApps: GraphUnmanagedApp[] = [];
-    let nextUrl: string | null = `${GRAPH_API_BASE}/deviceManagement/detectedApps?$top=100`;
+    let nextUrl: string | null = `${GRAPH_API_BASE}/deviceManagement/detectedApps?$top=1000`;
 
     while (nextUrl) {
       const graphResponse: Response = await fetchWithRetry(nextUrl, {


### PR DESCRIPTION
## Summary
- Raise `detectedApps` page size from `$top=100` to `$top=1000` in the Discovered Apps route, cutting Graph request count ~10x on large tenants. Fewer sequential calls means fewer 429s and avoids the 300s function timeout that was surfacing as a generic "Failed to fetch unmanaged apps". Verified against a live tenant that `detectedApps` honors page sizes above 100; Graph still caps server-side and returns `@odata.nextLink`, which the existing pagination loop follows.
- Clarify in `.env.example` that the self-hosted web app reads `NEXT_PUBLIC_AZURE_AD_CLIENT_ID` + `AZURE_AD_CLIENT_SECRET`, while `AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` are the GitHub Secrets names used by the packaging workflow (accepted as fallbacks). Addresses the naming confusion in #124.

## Testing
- `next lint`: clean
- `tsc --noEmit`: no new errors in the changed route
- Graph behavior confirmed end-to-end against a live tenant

Refs #125, #124