### PR TITLE
Fix SCCM Run Matching 500 on imported JSON exports (#129)

### DIFF
--- a/app/api/sccm/import/route.ts
+++ b/app/api/sccm/import/route.ts
@@ -18,6 +18,42 @@ import type {
 import type { Json } from '@/types/database';
 
 /**
+ * PowerShell's ConvertTo-Json serializes a single-element array as a bare
+ * object and an empty array as null. SCCM JSON exports therefore arrive with
+ * fields like deploymentTypes or detectionClauses that may be an object or null
+ * instead of an array. Downstream matching iterates these with the spread and
+ * for...of operators, which throw on a non-iterable and surface as an HTTP 500
+ * on Run Matching. Coerce every such field back to an array at import time so
+ * the stored sccm_app_data is always well-shaped, including for exports that
+ * were generated before the export script was fixed.
+ */
+function toArray<T>(value: unknown): T[] {
+  if (Array.isArray(value)) return value as T[];
+  if (value === null || value === undefined) return [];
+  return [value as T];
+}
+
+function normalizeSccmApplication(app: SccmApplication): SccmApplication {
+  const deploymentTypes = toArray<SccmApplication['deploymentTypes'][number]>(
+    app.deploymentTypes
+  ).map(dt => ({
+    ...dt,
+    detectionClauses: toArray<SccmApplication['deploymentTypes'][number]['detectionClauses'][number]>(
+      dt?.detectionClauses
+    ),
+    requirementsRules: toArray<NonNullable<SccmApplication['deploymentTypes'][number]['requirementsRules']>[number]>(
+      dt?.requirementsRules
+    ),
+  }));
+
+  return {
+    ...app,
+    deploymentTypes,
+    adminCategories: toArray<string>(app.adminCategories),
+  };
+}
+
+/**
  * Parse CSV content to array of rows
  */
 function parseCsv(content: string): SccmCsvRow[] {
@@ -172,9 +208,14 @@ function parseJsonImport(content: string): SccmImportFormat | null {
   try {
     const parsed = JSON.parse(content);
 
-    // Check if it's our expected format
-    if (parsed.version && parsed.applications && Array.isArray(parsed.applications)) {
-      return parsed as SccmImportFormat;
+    // Check if it's our expected format. applications may be a single object
+    // (not an array) when the export contained exactly one app, due to the
+    // ConvertTo-Json single-element quirk, so coerce it.
+    if (parsed.version && parsed.applications) {
+      return {
+        ...parsed,
+        applications: toArray<SccmApplication>(parsed.applications),
+      } as SccmImportFormat;
     }
 
     // Check if it's a raw array of applications
@@ -277,7 +318,7 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
-      applications = parsed.applications;
+      applications = parsed.applications.map(normalizeSccmApplication);
 
       // Validate required fields
       applications = applications.filter((app, i) => {

--- a/lib/matching/sccm-matcher.ts
+++ b/lib/matching/sccm-matcher.ts
@@ -80,8 +80,10 @@ export function normalizeSccmAppName(name: string): string {
  * Extract MSI product code from SCCM detection clauses
  */
 export function extractProductCode(app: SccmApplication): string | null {
-  for (const dt of app.deploymentTypes) {
-    for (const clause of dt.detectionClauses) {
+  // deploymentTypes / detectionClauses can arrive as a non-array from quirky
+  // JSON exports; guard so matching never throws on a bad shape.
+  for (const dt of Array.isArray(app.deploymentTypes) ? app.deploymentTypes : []) {
+    for (const clause of Array.isArray(dt?.detectionClauses) ? dt.detectionClauses : []) {
       if (clause.type === 'MSI') {
         const msiClause = clause as SccmMsiDetectionClause;
         if (msiClause.productCode) {
@@ -104,8 +106,11 @@ export function isSupportedTechnology(technology: SccmDeploymentTechnology): boo
  * Get the primary deployment type for an SCCM app
  */
 export function getPrimaryDeploymentType(app: SccmApplication) {
+  // deploymentTypes can arrive as a non-array (single object) or null from
+  // quirky JSON exports; guard against a non-iterable before spreading.
+  const deploymentTypes = Array.isArray(app.deploymentTypes) ? app.deploymentTypes : [];
   // Sort by priority (lower is better) and return first
-  const sorted = [...app.deploymentTypes].sort((a, b) =>
+  const sorted = [...deploymentTypes].sort((a, b) =>
     (a.priority ?? 999) - (b.priority ?? 999)
   );
   return sorted[0] || null;

--- a/public/scripts/Export-SCCMApps.ps1
+++ b/public/scripts/Export-SCCMApps.ps1
@@ -378,9 +378,11 @@ foreach ($app in $apps) {
             $categories = @($fullApp.LocalizedCategoryInstanceNames)
         }
 
-        # Get deployment types
+        # Get deployment types.
+        # Get-CMDeploymentType has no -ApplicationId parameter; pass the
+        # application object via -InputObject (alias Application) instead.
         $deploymentTypes = @()
-        $dtList = Get-CMDeploymentType -ApplicationId $app.CI_ID
+        $dtList = Get-CMDeploymentType -InputObject $fullApp
 
         foreach ($dt in $dtList) {
             $dtDetails = Get-DeploymentTypeDetails -DeploymentType $dt
@@ -390,7 +392,9 @@ foreach ($app in $apps) {
         # Get deployment count
         $deploymentCount = 0
         try {
-            $deployments = Get-CMApplicationDeployment -ApplicationId $app.CI_ID -ErrorAction SilentlyContinue
+            # Get-CMApplicationDeployment has no -ApplicationId parameter; pass
+            # the application object via -InputObject (alias Application).
+            $deployments = Get-CMApplicationDeployment -InputObject $fullApp -ErrorAction SilentlyContinue
             if ($deployments) {
                 $deploymentCount = @($deployments).Count
             }


### PR DESCRIPTION
## Summary
Run Matching returned HTTP 500 (`Failed to match SCCM applications`) for any imported SCCM JSON export, even a single app.

Root cause is two well-known PowerShell `ConvertTo-Json` quirks in the export output:
- a single-element array serializes as a bare object (so `deploymentTypes` for an app with one deployment type is an object, not an array)
- an empty array serializes as `null` (so `detectionClauses` is `null`)

The matcher spreads and `for...of`-iterates those fields, which throws `TypeError: ... is not iterable` and surfaces as the generic 500. This is why it failed consistently, including for a single Google Chrome app, and why swapping `detectionClauses: null` for `[]` did not help (the real thrower was `deploymentTypes`).

## Changes
- **Import normalization** (`app/api/sccm/import/route.ts`): coerce `deploymentTypes`, `detectionClauses`, `requirementsRules`, `adminCategories`, and a single-object `applications` payload to arrays before storing `sccm_app_data`. This repairs already-exported files without re-running the script.
- **Matcher hardening** (`lib/matching/sccm-matcher.ts`): guard `getPrimaryDeploymentType` and `extractProductCode` against non-array shapes as a backstop.
- **Export script** (`public/scripts/Export-SCCMApps.ps1`): `Get-CMDeploymentType` and `Get-CMApplicationDeployment` have no `-ApplicationId` parameter (confirmed against the ConfigurationManager module docs); pass the application object via `-InputObject` instead. This was the separate export failure the reporter hit first.

## Testing
- `next lint`: clean
- `tsc --noEmit`: no new errors in changed files
- Reproduced the original `TypeError: app.deploymentTypes is not iterable` against the quirky shape and confirmed the guards + normalizer resolve it (object -> 1-element array, null clauses -> [])

Fixes #129