### PR TITLE
Fix SCCM Run Matching 500: snake_case mapping columns (#129)

### DIFF
--- a/lib/matching/sccm-matcher.ts
+++ b/lib/matching/sccm-matcher.ts
@@ -13,7 +13,6 @@ import {
 import { APP_MAPPINGS, getWingetIdFromName, searchCuratedApps } from '@/lib/app-mappings';
 import type {
   SccmApplication,
-  SccmWingetMapping,
   SccmMsiDetectionClause,
   SccmDeploymentTechnology,
 } from '@/types/sccm';
@@ -127,13 +126,40 @@ export async function checkSccmMapping(
   const normalizedName = app.localizedDisplayName.toLowerCase().trim();
   const productCode = extractProductCode(app);
 
+  // sccm_winget_mappings columns are snake_case. Read the row with the actual
+  // column names: reading camelCase here returned undefined and threw on
+  // wingetPackageId.split(...), which surfaced as a 500 on Run Matching for any
+  // app that hit a seeded mapping (e.g. "google chrome").
+  type SccmWingetMappingRow = {
+    id: string;
+    winget_package_id: string | null;
+    winget_package_name: string | null;
+    confidence: number | null;
+    is_verified: boolean | null;
+    tenant_id: string | null;
+    sccm_product_code: string | null;
+  };
+
+  // Build the OR conditions defensively: quote values so names containing
+  // spaces or parentheses (e.g. "Zoom Workplace (64-bit)") don't break the
+  // PostgREST or() parser, and only filter on product code when one exists
+  // (eq.null would not match NULL rows anyway).
+  const quote = (v: string) => `"${v.replace(/"/g, '')}"`;
+  const orConditions = [
+    `sccm_display_name_normalized.eq.${quote(normalizedName)}`,
+    `sccm_ci_id.eq.${quote(String(app.ci_id ?? ''))}`,
+  ];
+  if (productCode) {
+    orConditions.push(`sccm_product_code.eq.${quote(productCode)}`);
+  }
+
   // Query custom SCCM mappings
   const { data, error } = await (supabaseClient.from('sccm_winget_mappings') as {
     select: (columns: string) => {
       or: (filter: string) => {
         order: (column: string, options: { ascending: boolean }) => {
           limit: (count: number) => Promise<{
-            data: SccmWingetMapping[] | null;
+            data: SccmWingetMappingRow[] | null;
             error: { message: string } | null;
           }>;
         };
@@ -141,7 +167,7 @@ export async function checkSccmMapping(
     };
   })
     .select('*')
-    .or(`sccm_display_name_normalized.eq.${normalizedName},sccm_product_code.eq.${productCode || 'null'},sccm_ci_id.eq.${app.ci_id}`)
+    .or(orConditions.join(','))
     .order('is_verified', { ascending: false })
     .limit(1);
 
@@ -152,17 +178,23 @@ export async function checkSccmMapping(
   const mapping = data[0];
 
   // Check tenant scope
-  if (mapping.tenantId && mapping.tenantId !== tenantId) {
+  if (mapping.tenant_id && mapping.tenant_id !== tenantId) {
+    return null;
+  }
+
+  // Guard against a mapping row without a winget package id.
+  const wingetId = mapping.winget_package_id;
+  if (!wingetId) {
     return null;
   }
 
   return {
     status: 'matched',
-    wingetId: mapping.wingetPackageId,
-    wingetName: mapping.wingetPackageName || mapping.wingetPackageId.split('.').pop() || mapping.wingetPackageId,
-    confidence: mapping.confidence,
+    wingetId,
+    wingetName: mapping.winget_package_name || wingetId.split('.').pop() || wingetId,
+    confidence: mapping.confidence ?? 1.0,
     partialMatches: [],
-    matchedBy: mapping.sccmProductCode && productCode ? 'product_code' : 'mapping',
+    matchedBy: mapping.sccm_product_code && productCode ? 'product_code' : 'mapping',
     mappingId: mapping.id,
   };
 }

--- a/public/scripts/Export-SCCMApps.ps1
+++ b/public/scripts/Export-SCCMApps.ps1
@@ -220,15 +220,19 @@ function Get-DeploymentTypeDetails {
                     $details.uninstallCommand = $uninstallAction.'#text'
                 }
 
-                # Execution context
-                $executionContext = $installer.InstallAction.Args.Arg |
+                # Execution context. Do not name this $executionContext: that
+                # collides with PowerShell's read-only automatic $ExecutionContext
+                # variable and throws "Cannot overwrite variable ExecutionContext
+                # because it is read-only or constant", which aborts deployment
+                # type parsing and leaves installBehavior and friends null.
+                $execContextArg = $installer.InstallAction.Args.Arg |
                     Where-Object { $_.Name -eq "ExecutionContext" }
-                if ($executionContext) {
-                    $details.installBehavior = switch ($executionContext.'#text') {
+                if ($execContextArg) {
+                    $details.installBehavior = switch ($execContextArg.'#text') {
                         "System" { "InstallForSystem" }
                         "User" { "InstallForUser" }
                         "Any" { "InstallForSystemIfResourceIsDeviceOtherwiseInstallForUser" }
-                        default { $executionContext.'#text' }
+                        default { $execContextArg.'#text' }
                     }
                 }
 


### PR DESCRIPTION
## Summary
Follow-up to #130. The SCCM Run Matching 500 persisted after that PR because the real cause was elsewhere. Production logs showed:

```
Match POST error: TypeError: Cannot read properties of undefined (reading 'split')
```

`checkSccmMapping` read the `sccm_winget_mappings` row with camelCase keys (`wingetPackageId`, `wingetPackageName`, `tenantId`, `sccmProductCode`), but the columns are snake_case. When an app matched a seeded mapping (there is a `google chrome` -> `Google.Chrome` row), `mapping.wingetPackageId` was `undefined` and `.split('.')` threw. That is why it reproduced even for a single Google Chrome app, and why a local run with no matching rows did not.

## Changes
- `lib/matching/sccm-matcher.ts`: read `winget_package_id` / `winget_package_name` / `tenant_id` / `sccm_product_code` with their real column names; guard a row with no winget id. Build the OR filter defensively (quote values so names with spaces/parentheses like `Zoom Workplace (64-bit)` don't break PostgREST; only filter on product code when present). Also fixes a latent cross-tenant scope check that never ran because `tenantId` was always undefined.
- `public/scripts/Export-SCCMApps.ps1`: rename `$executionContext` to `$execContextArg`; it collided with PowerShell's read-only automatic `$ExecutionContext` and aborted deployment-type parsing (the reporter's "Cannot overwrite variable ExecutionContext" warning, which left installBehavior null).

## Testing
- `next lint` clean, `tsc` no new errors in changed file
- Verified against production runtime logs (Vercel) that the 500 was the `.split` TypeError
- Confirmed the `google chrome` seeded row exists in `sccm_winget_mappings` (Supabase), and that the fixed `checkSccmMapping` returns matched -> Google.Chrome on that exact snake_case row instead of throwing

Fixes #129