### PR TITLE
Fix update notifications: re-notify on new version + near-immediate send (#132)

### DIFF
--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -41,6 +41,7 @@ interface UpdateCheckInsert {
   latest_version: string;
   is_critical: boolean;
   is_managed: boolean;
+  notified_at: string | null;
   detected_at: string;
   updated_at: string;
 }
@@ -325,6 +326,23 @@ export async function GET(request: Request) {
         continue;
       }
 
+      // Load prior update rows for this batch so the upsert can preserve
+      // notified_at for unchanged updates but reset it to null when
+      // latest_version changed. Without the reset, an app that was already
+      // notified for an older version never notifies again on the next bump.
+      const { data: priorRows } = await supabase
+        .from('update_check_results')
+        .select('user_id, tenant_id, winget_id, intune_app_id, latest_version, notified_at')
+        .in('user_id', batch);
+      const priorMap = new Map<string, { latest_version: string; notified_at: string | null }>();
+      (priorRows as Array<{ user_id: string; tenant_id: string; winget_id: string; intune_app_id: string; latest_version: string; notified_at: string | null }> | null)?.forEach(
+        (r) =>
+          priorMap.set(`${r.user_id}:${r.tenant_id}:${r.winget_id}:${r.intune_app_id}`, {
+            latest_version: r.latest_version,
+            notified_at: r.notified_at,
+          })
+      );
+
       // Group by user and tenant
       const userTenantApps = new Map<string, UploadHistoryRecord[]>();
       deployedApps.forEach((app: UploadHistoryRecord) => {
@@ -376,6 +394,14 @@ export async function GET(request: Request) {
             // Check if it's a critical update (major version change)
             const isCritical = latestParsed.major > currentParsed.major;
 
+            // Preserve notified_at only when the same version is still pending;
+            // a changed latest_version resets it so the new version notifies.
+            const prior = priorMap.get(
+              `${userId}:${tenantId}:${app.winget_id}:${app.intune_app_id}`
+            );
+            const notifiedAt =
+              prior && prior.latest_version === latestVersion ? prior.notified_at : null;
+
             const updateRecord = {
               user_id: userId,
               tenant_id: tenantId,
@@ -388,6 +414,7 @@ export async function GET(request: Request) {
               // The cron only ever scans apps from upload_history, so every
               // detected update here is for an IntuneGet-managed app.
               is_managed: true,
+              notified_at: notifiedAt,
               detected_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
             };

--- a/app/api/cron/send-notifications/route.ts
+++ b/app/api/cron/send-notifications/route.ts
@@ -5,24 +5,10 @@
 
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { sendUpdateNotificationEmail, isEmailConfigured } from '@/lib/email/service';
-import { deliverWebhook } from '@/lib/webhooks/service';
-import type {
-  NotificationPreferences,
-  WebhookConfiguration,
-  UpdateCheckResult,
-  NotificationPayload,
-  AppUpdate,
-} from '@/types/notifications';
+import { notifyUserOfPendingUpdates } from '@/lib/notifications/notify-user';
+import type { UpdateCheckResult } from '@/types/notifications';
 
 const BATCH_SIZE = 20;
-
-interface UserProfile {
-  id: string;
-  email: string | null;
-  name: string | null;
-  tenant_name: string | null;
-}
 
 export async function GET(request: Request) {
   // Verify cron secret
@@ -67,7 +53,7 @@ export async function GET(request: Request) {
 
     // Group updates by user
     const userUpdates = new Map<string, UpdateCheckResult[]>();
-    pendingUpdates.forEach((update: UpdateCheckResult) => {
+    (pendingUpdates as UpdateCheckResult[]).forEach((update) => {
       if (!userUpdates.has(update.user_id)) {
         userUpdates.set(update.user_id, []);
       }
@@ -76,212 +62,27 @@ export async function GET(request: Request) {
 
     let emailsSent = 0;
     let webhooksSent = 0;
+    let updatesProcessed = 0;
     const errors: string[] = [];
-    const notifiedUpdateIds: string[] = [];
 
-    // Process users in batches
+    // Process users in batches, delegating per-user delivery to the shared
+    // helper that the on-demand refresh path also uses.
     const userIds = Array.from(userUpdates.keys());
 
     for (let i = 0; i < userIds.length; i += BATCH_SIZE) {
       const batchUserIds = userIds.slice(i, i + BATCH_SIZE);
 
-      // Get notification preferences for these users
-      const { data: preferences, error: prefsError } = await supabase
-        .from('notification_preferences')
-        .select('*')
-        .in('user_id', batchUserIds);
-
-      if (prefsError) {
-        errors.push(`Error fetching preferences: ${prefsError.message}`);
-        continue;
-      }
-
-      // Get webhooks for these users
-      const { data: webhooks, error: webhooksError } = await supabase
-        .from('webhook_configurations')
-        .select('*')
-        .in('user_id', batchUserIds)
-        .eq('is_enabled', true);
-
-      if (webhooksError) {
-        errors.push(`Error fetching webhooks: ${webhooksError.message}`);
-        continue;
-      }
-
-      // Get user profiles for email and name
-      const { data: profiles, error: profilesError } = await supabase
-        .from('user_profiles')
-        .select('id, email, name, tenant_name')
-        .in('id', batchUserIds);
-
-      if (profilesError) {
-        errors.push(`Error fetching profiles: ${profilesError.message}`);
-      }
-
-      const profileMap = new Map<string, UserProfile>();
-      profiles?.forEach((p: UserProfile) => profileMap.set(p.id, p));
-
-      const prefsMap = new Map<string, NotificationPreferences>();
-      preferences?.forEach((p: NotificationPreferences) =>
-        prefsMap.set(p.user_id, p)
+      await Promise.all(
+        batchUserIds.map(async (userId) => {
+          const res = await notifyUserOfPendingUpdates(supabase, userId, {
+            pendingUpdates: userUpdates.get(userId)!,
+          });
+          emailsSent += res.emailsSent;
+          webhooksSent += res.webhooksSent;
+          updatesProcessed += res.notifiedUpdateIds.length;
+          errors.push(...res.errors);
+        })
       );
-
-      const webhookMap = new Map<string, WebhookConfiguration[]>();
-      webhooks?.forEach((w: WebhookConfiguration) => {
-        if (!webhookMap.has(w.user_id)) {
-          webhookMap.set(w.user_id, []);
-        }
-        webhookMap.get(w.user_id)!.push(w);
-      });
-
-      // Process each user
-      for (const userId of batchUserIds) {
-        const updates = userUpdates.get(userId)!;
-        const prefs = prefsMap.get(userId);
-        const userWebhooks = webhookMap.get(userId) || [];
-        const profile = profileMap.get(userId);
-
-        // Filter updates based on preferences
-        let filteredUpdates = updates;
-        if (prefs?.notify_critical_only) {
-          filteredUpdates = updates.filter((u) => u.is_critical);
-        }
-
-        if (filteredUpdates.length === 0) {
-          // Mark all as notified even if filtered out
-          notifiedUpdateIds.push(...updates.map((u) => u.id));
-          continue;
-        }
-
-        // Group by tenant for payload
-        const tenantUpdates = new Map<string, UpdateCheckResult[]>();
-        filteredUpdates.forEach((u) => {
-          if (!tenantUpdates.has(u.tenant_id)) {
-            tenantUpdates.set(u.tenant_id, []);
-          }
-          tenantUpdates.get(u.tenant_id)!.push(u);
-        });
-
-        // Send notifications for each tenant
-        for (const [tenantId, tenantUpdateList] of tenantUpdates) {
-          const appUpdates: AppUpdate[] = tenantUpdateList.map((u) => ({
-            app_name: u.display_name,
-            winget_id: u.winget_id,
-            intune_app_id: u.intune_app_id,
-            current_version: u.current_version,
-            latest_version: u.latest_version,
-            is_critical: u.is_critical,
-          }));
-
-          const criticalCount = appUpdates.filter((u) => u.is_critical).length;
-
-          const payload: NotificationPayload = {
-            event: 'app_updates_available',
-            timestamp: new Date().toISOString(),
-            tenant_id: tenantId,
-            tenant_name: profile?.tenant_name || undefined,
-            updates: appUpdates,
-            summary: {
-              total: appUpdates.length,
-              critical: criticalCount,
-            },
-          };
-
-          let delivered = false;
-
-          // Send email if enabled and configured
-          if (prefs?.email_enabled && isEmailConfigured()) {
-            // Check frequency
-            const shouldSendEmail = shouldSendBasedOnFrequency(
-              prefs.email_frequency
-            );
-
-            if (shouldSendEmail) {
-              const emailAddress = prefs.email_address || profile?.email;
-              if (emailAddress) {
-                const result = await sendUpdateNotificationEmail(
-                  emailAddress,
-                  payload,
-                  profile?.name || undefined
-                );
-
-                // Record notification history
-                await supabase.from('notification_history').insert({
-                  user_id: userId,
-                  channel: 'email',
-                  payload,
-                  status: result.success ? 'sent' : 'failed',
-                  error_message: result.error || null,
-                  apps_notified: appUpdates.length,
-                  sent_at: result.success ? new Date().toISOString() : null,
-                });
-
-                if (result.success) {
-                  delivered = true;
-                  emailsSent++;
-                } else {
-                  errors.push(
-                    `Email to ${emailAddress} failed: ${result.error}`
-                  );
-                }
-              } else {
-                errors.push(
-                  `No email address available for user ${userId} (email_enabled is true but no address found)`
-                );
-              }
-            }
-          }
-
-          // Send webhooks
-          for (const webhook of userWebhooks) {
-            const result = await deliverWebhook(webhook, payload);
-
-            // Update webhook status
-            const statusUpdate: Record<string, unknown> = {
-              updated_at: new Date().toISOString(),
-            };
-
-            if (result.success) {
-              statusUpdate.last_success_at = new Date().toISOString();
-              statusUpdate.failure_count = 0;
-            } else {
-              statusUpdate.last_failure_at = new Date().toISOString();
-              statusUpdate.failure_count = (webhook.failure_count || 0) + 1;
-            }
-
-            await supabase
-              .from('webhook_configurations')
-              .update(statusUpdate)
-              .eq('id', webhook.id);
-
-            // Record notification history
-            await supabase.from('notification_history').insert({
-              user_id: userId,
-              channel: 'webhook',
-              webhook_id: webhook.id,
-              payload,
-              status: result.success ? 'sent' : 'failed',
-              error_message: result.error || null,
-              apps_notified: appUpdates.length,
-              sent_at: result.success ? new Date().toISOString() : null,
-            });
-
-            if (result.success) {
-              delivered = true;
-              webhooksSent++;
-            } else {
-              errors.push(`Webhook ${webhook.name} failed: ${result.error}`);
-            }
-          }
-
-          // Only mark updates as notified when at least one channel delivered.
-          // Undelivered updates will be retried on the next cron run until the
-          // user configures a valid email address or webhook.
-          if (delivered) {
-            notifiedUpdateIds.push(...tenantUpdateList.map((u) => u.id));
-          }
-        }
-      }
 
       // Rate limiting between batches
       if (i + BATCH_SIZE < userIds.length) {
@@ -289,52 +90,17 @@ export async function GET(request: Request) {
       }
     }
 
-    // Update notified_at for all processed updates
-    if (notifiedUpdateIds.length > 0) {
-      // Process in chunks to avoid query size limits
-      const chunkSize = 100;
-      for (let i = 0; i < notifiedUpdateIds.length; i += chunkSize) {
-        const chunk = notifiedUpdateIds.slice(i, i + chunkSize);
-        await supabase
-          .from('update_check_results')
-          .update({ notified_at: new Date().toISOString() })
-          .in('id', chunk);
-      }
-    }
-
     return NextResponse.json({
       success: errors.length === 0,
       emailsSent,
       webhooksSent,
-      updatesProcessed: notifiedUpdateIds.length,
+      updatesProcessed,
       errors: errors.length > 0 ? errors : undefined,
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
-}
-
-/**
- * Determine if notification should be sent based on frequency
- * For daily: always send (cron runs daily)
- * For weekly: only send on Sundays
- * For immediate: should be handled separately (not by cron)
- */
-function shouldSendBasedOnFrequency(frequency: string): boolean {
-  if (frequency === 'immediate') {
-    // Immediate notifications should be sent when updates are detected
-    // For daily cron, we treat immediate as "send now"
-    return true;
-  }
-
-  if (frequency === 'weekly') {
-    // Only send on Sundays
-    return new Date().getDay() === 0;
-  }
-
-  // Daily - always send
-  return true;
 }
 
 // Allow up to 5 minutes for the job to complete

--- a/app/api/updates/refresh/route.ts
+++ b/app/api/updates/refresh/route.ts
@@ -9,6 +9,7 @@ import { createServerClient } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { GET as getLiveIntuneUpdates } from '@/app/api/intune/apps/updates/route';
+import { notifyUserOfPendingUpdates } from '@/lib/notifications/notify-user';
 import type { AppUpdateInfo } from '@/types/inventory';
 
 interface RefreshRequestBody {
@@ -95,24 +96,45 @@ export async function POST(request: NextRequest) {
 
     const liveData = (await liveResponse.json()) as LiveUpdatesResponse;
     const now = new Date().toISOString();
+
+    // Load the prior rows so the upsert can preserve notified_at for unchanged
+    // updates but reset it to null when latest_version changed. Without the
+    // reset, a row that was already notified for an older version keeps its
+    // notified_at and the next version bump is never notified.
+    const { data: priorRows } = await supabase
+      .from('update_check_results')
+      .select('winget_id, intune_app_id, latest_version, notified_at')
+      .eq('user_id', user.userId)
+      .eq('tenant_id', tenantId);
+    const priorMap = new Map<string, { latest_version: string; notified_at: string | null }>();
+    (priorRows as Array<{ winget_id: string; intune_app_id: string; latest_version: string; notified_at: string | null }> | null)?.forEach(
+      (r) => priorMap.set(`${r.winget_id}:${r.intune_app_id}`, { latest_version: r.latest_version, notified_at: r.notified_at })
+    );
+
     const rows = liveData.updates
       .filter((update) => Boolean(update.wingetId))
       .filter((update) => update.currentVersion !== 'Unknown')
-      .map((update) => ({
-        user_id: user.userId,
-        tenant_id: tenantId,
-        winget_id: update.wingetId as string,
-        intune_app_id: update.intuneApp.id,
-        display_name: update.intuneApp.displayName,
-        current_version: update.currentVersion,
-        latest_version: update.latestVersion,
-        is_critical: isCriticalUpdate(update.currentVersion, update.latestVersion),
-        is_managed: update.isManaged,
-        large_icon_type: update.intuneApp.largeIcon?.type || null,
-        large_icon_value: update.intuneApp.largeIcon?.value || null,
-        detected_at: now,
-        updated_at: now,
-      }));
+      .map((update) => {
+        const prior = priorMap.get(`${update.wingetId as string}:${update.intuneApp.id}`);
+        const notifiedAt =
+          prior && prior.latest_version === update.latestVersion ? prior.notified_at : null;
+        return {
+          user_id: user.userId,
+          tenant_id: tenantId,
+          winget_id: update.wingetId as string,
+          intune_app_id: update.intuneApp.id,
+          display_name: update.intuneApp.displayName,
+          current_version: update.currentVersion,
+          latest_version: update.latestVersion,
+          is_critical: isCriticalUpdate(update.currentVersion, update.latestVersion),
+          is_managed: update.isManaged,
+          large_icon_type: update.intuneApp.largeIcon?.type || null,
+          large_icon_value: update.intuneApp.largeIcon?.value || null,
+          notified_at: notifiedAt,
+          detected_at: now,
+          updated_at: now,
+        };
+      });
 
     if (rows.length > 0) {
       const { error: upsertError } = await supabase
@@ -162,10 +184,32 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Near-immediate notifications: if this refresh surfaced any new or changed
+    // update (notified_at reset to null above), deliver to the user's channels
+    // now instead of waiting for the daily cron. Force-send regardless of the
+    // user's email frequency, since they just ran an on-demand check. Failures
+    // here must not fail the refresh; the daily cron remains the backstop.
+    const hasPendingNotifications = rows.some((row) => row.notified_at === null);
+    let notified: { emailsSent: number; webhooksSent: number } | undefined;
+    if (hasPendingNotifications) {
+      try {
+        const res = await notifyUserOfPendingUpdates(supabase, user.userId, {
+          respectFrequency: false,
+        });
+        notified = { emailsSent: res.emailsSent, webhooksSent: res.webhooksSent };
+      } catch (notifyError) {
+        console.error(
+          'On-demand update notification failed:',
+          notifyError instanceof Error ? notifyError.message : notifyError
+        );
+      }
+    }
+
     return NextResponse.json({
       success: true,
       refreshedCount: rows.length,
       removedCount: staleIds.length,
+      ...(notified ? { notified } : {}),
       updateCount: liveData.updateCount,
       matchingSummary: {
         totalChecked: liveData.checkedApps?.length || 0,

--- a/lib/notifications/notify-user.test.ts
+++ b/lib/notifications/notify-user.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { sendEmailMock, isEmailConfiguredMock, deliverWebhookMock } = vi.hoisted(() => ({
+  sendEmailMock: vi.fn(),
+  isEmailConfiguredMock: vi.fn(),
+  deliverWebhookMock: vi.fn(),
+}));
+
+vi.mock('@/lib/email/service', () => ({
+  sendUpdateNotificationEmail: sendEmailMock,
+  isEmailConfigured: isEmailConfiguredMock,
+}));
+vi.mock('@/lib/webhooks/service', () => ({
+  deliverWebhook: deliverWebhookMock,
+}));
+
+import { notifyUserOfPendingUpdates } from '@/lib/notifications/notify-user';
+
+// Minimal chainable Supabase stub. Per-table results; webhook_configurations is
+// awaited as a thenable list, prefs/profile via maybeSingle.
+function makeSupabase(tables: Record<string, unknown>, calls: { markNotified: string[][]; histInserts: string[] }) {
+  function builder(table: string) {
+    const b: any = {
+      select: () => b,
+      eq: () => b,
+      is: () => b,
+      order: () => b,
+      maybeSingle: () => Promise.resolve({ data: tables[table] ?? null, error: null }),
+      insert: (row: any) => { if (table === 'notification_history') calls.histInserts.push(row.status); return Promise.resolve({ data: null, error: null }); },
+      update: () => ({
+        eq: () => Promise.resolve({ data: null, error: null }),
+        in: (_c: string, ids: string[]) => { if (table === 'update_check_results') calls.markNotified.push(ids); return Promise.resolve({ data: null, error: null }); },
+      }),
+      then: (res: any) => res({ data: tables[table] ?? [], error: null }),
+    };
+    return b;
+  }
+  return { from: (t: string) => builder(t) } as any;
+}
+
+describe('notifyUserOfPendingUpdates', () => {
+  beforeEach(() => {
+    sendEmailMock.mockReset();
+    isEmailConfiguredMock.mockReset();
+    deliverWebhookMock.mockReset();
+  });
+
+  it('sends email + webhook and marks the update notified', async () => {
+    isEmailConfiguredMock.mockReturnValue(true);
+    sendEmailMock.mockResolvedValue({ success: true });
+    deliverWebhookMock.mockResolvedValue({ success: true });
+
+    const calls = { markNotified: [] as string[][], histInserts: [] as string[] };
+    const supabase = makeSupabase({
+      notification_preferences: { user_id: 'u1', email_enabled: true, email_frequency: 'daily', notify_critical_only: false, email_address: 'u1@test.com' },
+      webhook_configurations: [{ id: 'w1', user_id: 'u1', name: 'WH', is_enabled: true, failure_count: 0 }],
+      user_profiles: { id: 'u1', email: 'u1@test.com', name: 'User One', tenant_name: 'Tenant' },
+    }, calls);
+
+    const pending = [{ id: 'upd1', user_id: 'u1', tenant_id: 't1', winget_id: 'Google.Chrome', intune_app_id: 'a1', display_name: 'Chrome', current_version: '1.0', latest_version: '2.0', is_critical: false }] as any;
+
+    const res = await notifyUserOfPendingUpdates(supabase, 'u1', { pendingUpdates: pending });
+
+    expect(res.emailsSent).toBe(1);
+    expect(res.webhooksSent).toBe(1);
+    expect(res.notifiedUpdateIds).toEqual(['upd1']);
+    expect(calls.markNotified.flat()).toContain('upd1');
+    expect(calls.histInserts).toEqual(['sent', 'sent']);
+  });
+
+  it('does NOT mark notified when all channels fail (retried next run)', async () => {
+    isEmailConfiguredMock.mockReturnValue(true);
+    sendEmailMock.mockResolvedValue({ success: false, error: 'smtp down' });
+    deliverWebhookMock.mockResolvedValue({ success: false, error: 'HTTP 403' });
+
+    const calls = { markNotified: [] as string[][], histInserts: [] as string[] };
+    const supabase = makeSupabase({
+      notification_preferences: { user_id: 'u1', email_enabled: true, email_frequency: 'daily', notify_critical_only: false, email_address: 'u1@test.com' },
+      webhook_configurations: [{ id: 'w1', user_id: 'u1', name: 'WH', is_enabled: true, failure_count: 0 }],
+      user_profiles: { id: 'u1', email: 'u1@test.com', name: 'User One', tenant_name: 'Tenant' },
+    }, calls);
+
+    const pending = [{ id: 'upd1', user_id: 'u1', tenant_id: 't1', winget_id: 'Google.Chrome', intune_app_id: 'a1', display_name: 'Chrome', current_version: '1.0', latest_version: '2.0', is_critical: false }] as any;
+
+    const res = await notifyUserOfPendingUpdates(supabase, 'u1', { pendingUpdates: pending });
+
+    expect(res.notifiedUpdateIds).toEqual([]);
+    expect(calls.markNotified.flat()).not.toContain('upd1');
+  });
+});

--- a/lib/notifications/notify-user.ts
+++ b/lib/notifications/notify-user.ts
@@ -1,0 +1,248 @@
+/**
+ * Per-user update notification dispatch.
+ *
+ * Shared by the daily send-notifications cron and the on-demand
+ * /api/updates/refresh route so update notifications go out the same way
+ * whether they are batched nightly or triggered right after a user-facing
+ * refresh detects a new update. Keeping this in one place avoids the two
+ * paths drifting apart.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sendUpdateNotificationEmail, isEmailConfigured } from '@/lib/email/service';
+import { deliverWebhook } from '@/lib/webhooks/service';
+import type {
+  NotificationPreferences,
+  WebhookConfiguration,
+  UpdateCheckResult,
+  NotificationPayload,
+  AppUpdate,
+} from '@/types/notifications';
+
+interface UserProfile {
+  id: string;
+  email: string | null;
+  name: string | null;
+  tenant_name: string | null;
+}
+
+export interface NotifyUserResult {
+  emailsSent: number;
+  webhooksSent: number;
+  notifiedUpdateIds: string[];
+  errors: string[];
+}
+
+/**
+ * Determine if an email notification should be sent based on frequency.
+ * daily/immediate: always send (the cron runs daily; immediate means "now").
+ * weekly: only on Sundays.
+ */
+export function shouldSendBasedOnFrequency(frequency: string): boolean {
+  if (frequency === 'weekly') {
+    return new Date().getDay() === 0;
+  }
+  // daily and immediate both send on this run
+  return true;
+}
+
+/**
+ * Send email + webhook notifications for a single user's pending updates and
+ * mark the delivered ones notified.
+ *
+ * @param pendingUpdates Optional preloaded pending rows for the user. When
+ *   omitted, the function loads update_check_results rows with notified_at and
+ *   dismissed_at null itself. Pass `respectFrequency: false` to force-send
+ *   regardless of the user's email frequency (used by on-demand refresh, where
+ *   the user just asked for a check).
+ */
+export async function notifyUserOfPendingUpdates(
+  supabase: SupabaseClient,
+  userId: string,
+  options: {
+    pendingUpdates?: UpdateCheckResult[];
+    respectFrequency?: boolean;
+  } = {}
+): Promise<NotifyUserResult> {
+  const respectFrequency = options.respectFrequency ?? true;
+
+  const result: NotifyUserResult = {
+    emailsSent: 0,
+    webhooksSent: 0,
+    notifiedUpdateIds: [],
+    errors: [],
+  };
+
+  // Load pending updates for the user if not supplied
+  let updates = options.pendingUpdates;
+  if (!updates) {
+    const { data, error } = await supabase
+      .from('update_check_results')
+      .select('*')
+      .eq('user_id', userId)
+      .is('notified_at', null)
+      .is('dismissed_at', null)
+      .order('detected_at', { ascending: false });
+    if (error) {
+      result.errors.push(`Error fetching pending updates: ${error.message}`);
+      return result;
+    }
+    updates = (data as UpdateCheckResult[]) || [];
+  }
+
+  if (updates.length === 0) {
+    return result;
+  }
+
+  const [{ data: prefsRow }, { data: webhookRows }, { data: profileRow }] =
+    await Promise.all([
+      supabase.from('notification_preferences').select('*').eq('user_id', userId).maybeSingle(),
+      supabase.from('webhook_configurations').select('*').eq('user_id', userId).eq('is_enabled', true),
+      supabase.from('user_profiles').select('id, email, name, tenant_name').eq('id', userId).maybeSingle(),
+    ]);
+
+  const prefs = (prefsRow as NotificationPreferences | null) || undefined;
+  const userWebhooks = (webhookRows as WebhookConfiguration[] | null) || [];
+  const profile = (profileRow as UserProfile | null) || undefined;
+
+  // Filter updates based on preferences
+  let filteredUpdates = updates;
+  if (prefs?.notify_critical_only) {
+    filteredUpdates = updates.filter((u) => u.is_critical);
+  }
+
+  if (filteredUpdates.length === 0) {
+    // Nothing matches the user's filter; mark all as notified so they are not
+    // reconsidered every run.
+    result.notifiedUpdateIds.push(...updates.map((u) => u.id));
+    await markNotified(supabase, result.notifiedUpdateIds);
+    return result;
+  }
+
+  // Group by tenant for payload
+  const tenantUpdates = new Map<string, UpdateCheckResult[]>();
+  filteredUpdates.forEach((u) => {
+    if (!tenantUpdates.has(u.tenant_id)) {
+      tenantUpdates.set(u.tenant_id, []);
+    }
+    tenantUpdates.get(u.tenant_id)!.push(u);
+  });
+
+  for (const [tenantId, tenantUpdateList] of tenantUpdates) {
+    const appUpdates: AppUpdate[] = tenantUpdateList.map((u) => ({
+      app_name: u.display_name,
+      winget_id: u.winget_id,
+      intune_app_id: u.intune_app_id,
+      current_version: u.current_version,
+      latest_version: u.latest_version,
+      is_critical: u.is_critical,
+    }));
+
+    const criticalCount = appUpdates.filter((u) => u.is_critical).length;
+
+    const payload: NotificationPayload = {
+      event: 'app_updates_available',
+      timestamp: new Date().toISOString(),
+      tenant_id: tenantId,
+      tenant_name: profile?.tenant_name || undefined,
+      updates: appUpdates,
+      summary: { total: appUpdates.length, critical: criticalCount },
+    };
+
+    let delivered = false;
+
+    // Send email if enabled and configured
+    if (prefs?.email_enabled && isEmailConfigured()) {
+      const shouldSendEmail = !respectFrequency || shouldSendBasedOnFrequency(prefs.email_frequency);
+      if (shouldSendEmail) {
+        const emailAddress = prefs.email_address || profile?.email;
+        if (emailAddress) {
+          const emailResult = await sendUpdateNotificationEmail(
+            emailAddress,
+            payload,
+            profile?.name || undefined
+          );
+
+          await supabase.from('notification_history').insert({
+            user_id: userId,
+            channel: 'email',
+            payload,
+            status: emailResult.success ? 'sent' : 'failed',
+            error_message: emailResult.error || null,
+            apps_notified: appUpdates.length,
+            sent_at: emailResult.success ? new Date().toISOString() : null,
+          });
+
+          if (emailResult.success) {
+            delivered = true;
+            result.emailsSent++;
+          } else {
+            result.errors.push(`Email to ${emailAddress} failed: ${emailResult.error}`);
+          }
+        } else {
+          result.errors.push(
+            `No email address available for user ${userId} (email_enabled is true but no address found)`
+          );
+        }
+      }
+    }
+
+    // Send webhooks
+    for (const webhook of userWebhooks) {
+      const webhookResult = await deliverWebhook(webhook, payload);
+
+      const statusUpdate: Record<string, unknown> = {
+        updated_at: new Date().toISOString(),
+      };
+      if (webhookResult.success) {
+        statusUpdate.last_success_at = new Date().toISOString();
+        statusUpdate.failure_count = 0;
+      } else {
+        statusUpdate.last_failure_at = new Date().toISOString();
+        statusUpdate.failure_count = (webhook.failure_count || 0) + 1;
+      }
+
+      await supabase.from('webhook_configurations').update(statusUpdate).eq('id', webhook.id);
+
+      await supabase.from('notification_history').insert({
+        user_id: userId,
+        channel: 'webhook',
+        webhook_id: webhook.id,
+        payload,
+        status: webhookResult.success ? 'sent' : 'failed',
+        error_message: webhookResult.error || null,
+        apps_notified: appUpdates.length,
+        sent_at: webhookResult.success ? new Date().toISOString() : null,
+      });
+
+      if (webhookResult.success) {
+        delivered = true;
+        result.webhooksSent++;
+      } else {
+        result.errors.push(`Webhook ${webhook.name} failed: ${webhookResult.error}`);
+      }
+    }
+
+    // Only mark updates notified when at least one channel delivered, so
+    // undelivered updates are retried on the next run until a valid channel
+    // exists.
+    if (delivered) {
+      result.notifiedUpdateIds.push(...tenantUpdateList.map((u) => u.id));
+    }
+  }
+
+  await markNotified(supabase, result.notifiedUpdateIds);
+  return result;
+}
+
+async function markNotified(supabase: SupabaseClient, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const chunkSize = 100;
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize);
+    await supabase
+      .from('update_check_results')
+      .update({ notified_at: new Date().toISOString() })
+      .in('id', chunk);
+  }
+}


### PR DESCRIPTION
## Summary
Reporter set up email + webhook notifications, the test notification worked, but a detected app update produced no notification.

Two root causes:

1. **No repeat notifications.** `update_check_results` was upserted (by both the `check-updates` cron and the on-demand `/api/updates/refresh`) without `notified_at` in the payload. On a conflict for an app that was already notified, the old `notified_at` was preserved, so when `latest_version` later changed, `send-notifications` (which filters `notified_at IS NULL`) skipped it. Net effect: a user was notified once per app and never again for subsequent versions. Confirmed against production data (234 already-notified rows, each now silent on its next bump).

2. **Daily-only delivery.** Notifications only went out via the 04:00 UTC cron, so an update shown on the App Updates page had no notification until the next day.

## Changes
- Both upsert sites now reset `notified_at` to null when `latest_version` changed, and preserve it for an unchanged pending update (so the same update is not re-sent every run).
- `/api/updates/refresh` delivers to the user's channels immediately when it detects a new or changed update (force-send regardless of email frequency, since the user requested an on-demand check). Failures don't fail the refresh; the daily cron stays the backstop.
- Per-user delivery extracted into `lib/notifications/notify-user.ts`, shared by the cron and the refresh route so they can't drift (the same duplication that bit #129).
- Unit tests for delivery+marking and the all-channels-failed retry case.

## Testing
- `next lint` clean, `tsc` 0 errors
- `vitest` updates + notifications suites pass (8 tests)
- Diagnosed against production: Vercel logs (send-notifications runs 200) and Supabase (notification_history shows emails sending; webhook "failures" are destination-side: HTTP 403 and a disabled Power Automate flow, not an IntuneGet bug)

Fixes #132