### PR TITLE
CatalogSource abstraction over app-catalog reads (Phase 1 of self-host catalog)

### DIFF
--- a/app/api/apps/[id]/rate/route.ts
+++ b/app/api/apps/[id]/rate/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
   ratingSchema,
@@ -162,11 +163,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const supabase = createServerClient();
 
     // Verify the app exists
-    const { data: existingApp } = await supabase
-      .from('curated_apps')
-      .select('id, winget_id')
-      .eq('winget_id', decodedAppId)
-      .single();
+    const existingApp = await getCatalogSource().appExists(decodedAppId);
 
     if (!existingApp) {
       return NextResponse.json(

--- a/app/api/community/detection-feedback/route.ts
+++ b/app/api/community/detection-feedback/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
   feedbackSchema,
@@ -58,11 +59,7 @@ export async function POST(request: NextRequest) {
     const supabase = createServerClient();
 
     // Verify the app exists in curated_apps
-    const { data: existingApp } = await supabase
-      .from('curated_apps')
-      .select('id, winget_id, name')
-      .eq('winget_id', app_id)
-      .single();
+    const existingApp = await getCatalogSource().appExists(app_id);
 
     if (!existingApp) {
       return NextResponse.json(

--- a/app/api/community/suggestions/route.ts
+++ b/app/api/community/suggestions/route.ts
@@ -22,6 +22,7 @@ import {
 } from '@/lib/rate-limit';
 import { createAppSuggestionIssue } from '@/lib/github-issues';
 import { checkWingetPackageExists } from '@/lib/winget-existence';
+import { getCatalogSource } from '@/lib/catalog';
 
 /**
  * GET /api/community/suggestions
@@ -182,12 +183,7 @@ export async function POST(request: NextRequest) {
 
     // Check if app already exists in curated_apps (case-insensitive: users
     // often type a differently-cased but otherwise correct id)
-    const { data: existingApp } = await supabase
-      .from('curated_apps')
-      .select('id, winget_id')
-      .ilike('winget_id', winget_id)
-      .limit(1)
-      .maybeSingle();
+    const existingApp = await getCatalogSource().appExistsCaseInsensitive(winget_id);
 
     if (existingApp) {
       return NextResponse.json(
@@ -206,14 +202,9 @@ export async function POST(request: NextRequest) {
     if (existence === 'not-found') {
       // Offer close matches from the catalog to help correct the id
       const lastSegment = winget_id.split('.').pop() || winget_id;
-      const { data: similar } = await supabase
-        .from('curated_apps')
-        .select('winget_id, name')
-        .or(`winget_id.ilike.%${lastSegment}%,name.ilike.%${lastSegment}%`)
-        .eq('is_verified', true)
-        .limit(3);
+      const similar = await getCatalogSource().findSimilarVerifiedApps(lastSegment, 3);
 
-      const matches = (similar || []).map((s) => s.winget_id);
+      const matches = similar.map((s) => s.winget_id);
       const hint =
         matches.length > 0
           ? ` Did you mean: ${matches.join(', ')}?`

--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -13,6 +13,7 @@ import {
   getLatestInstallerInfo,
 } from '@/lib/auto-update/trigger';
 import { AppUpdatePolicy, shouldSkipUpdate } from '@/types/update-policies';
+import { getCatalogSource } from '@/lib/catalog';
 
 const BATCH_SIZE = 50;
 
@@ -24,11 +25,6 @@ interface UploadHistoryRecord {
   display_name: string;
   intune_app_id: string;
   intune_tenant_id: string | null;
-}
-
-interface CuratedApp {
-  winget_id: string;
-  latest_version: string;
 }
 
 interface UpdateCheckInsert {
@@ -264,18 +260,11 @@ export async function GET(request: Request) {
     }
 
     // Get all curated apps with their latest versions
-    const { data: curatedApps, error: curatedError } = await supabase
-      .from('curated_apps')
-      .select('winget_id, latest_version')
-      .not('latest_version', 'is', null);
-
-    if (curatedError) {
-      throw curatedError;
-    }
+    const curatedApps = await getCatalogSource().getAllLatestVersions();
 
     // Create a map for quick lookup
     const latestVersions = new Map<string, string>();
-    curatedApps?.forEach((app: CuratedApp) => {
+    curatedApps?.forEach((app) => {
       if (app.latest_version) {
         latestVersions.set(app.winget_id, app.latest_version);
       }

--- a/app/api/intune/apps/updates/route.ts
+++ b/app/api/intune/apps/updates/route.ts
@@ -16,6 +16,7 @@ import {
 import { compareVersions, hasUpdate, normalizeVersion } from '@/lib/version-compare';
 import { isSelfUpdatingApp } from '@/lib/self-updating-apps';
 import { parseAccessToken } from '@/lib/auth-utils';
+import { getCatalogSource } from '@/lib/catalog';
 import type { IntuneWin32App, AppUpdateInfo } from '@/types/inventory';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/beta';
@@ -301,16 +302,11 @@ export async function GET(request: NextRequest) {
     const wingetIdsToLookup = Array.from(new Set(matchedApps.map((m) => m.wingetId)));
 
     if (wingetIdsToLookup.length > 0) {
-      const { data: cachedPackages, error: cacheError } = await supabase
-        .from('curated_apps')
-        .select('winget_id, latest_version')
-        .in('winget_id', wingetIdsToLookup);
+      const cachedPackages = await getCatalogSource().getAppsByWingetIds(wingetIdsToLookup);
 
-      if (!cacheError && cachedPackages) {
-        for (const pkg of cachedPackages as CuratedPackageRow[]) {
-          if (pkg.latest_version) {
-            versionMap.set(pkg.winget_id, pkg.latest_version);
-          }
+      for (const pkg of cachedPackages as CuratedPackageRow[]) {
+        if (pkg.latest_version) {
+          versionMap.set(pkg.winget_id, pkg.latest_version);
         }
       }
     }

--- a/app/api/sccm/migrate/route.ts
+++ b/app/api/sccm/migrate/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { getAuthFromRequest } from '@/lib/auth/parse-token';
 import { logMigrationHistoryAsync, createSuccessEntry } from '@/lib/sccm/history-logger';
 import {
@@ -105,15 +106,14 @@ function rowToAppRecord(row: SccmAppRow): SccmAppRecord {
  */
 async function fetchWingetPackage(
   wingetId: string,
-  supabase: ReturnType<typeof createServerClient>
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabase: ReturnType<typeof createServerClient>
 ): Promise<NormalizedPackage | null> {
-  const { data, error } = (await supabase
-    .from('curated_apps')
-    .select('winget_id, name, publisher, latest_version, description, homepage, license, tags, category, icon_path')
-    .eq('winget_id', wingetId)
-    .single()) as { data: CuratedAppRow | null; error: Error | null };
+  const data = (await getCatalogSource().getSccmCuratedApp(
+    wingetId
+  )) as CuratedAppRow | null;
 
-  if (error || !data) {
+  if (!data) {
     return null;
   }
 
@@ -136,16 +136,15 @@ async function fetchWingetPackage(
  */
 async function fetchBestInstaller(
   pkg: NormalizedPackage,
-  supabase: ReturnType<typeof createServerClient>
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabase: ReturnType<typeof createServerClient>
 ): Promise<NormalizedInstaller | null> {
-  const { data, error } = (await supabase
-    .from('version_history')
-    .select('installers, installer_url, installer_sha256, installer_type, installer_scope')
-    .eq('winget_id', pkg.id)
-    .eq('version', pkg.version)
-    .single()) as { data: VersionHistoryRow | null; error: Error | null };
+  const data = (await getCatalogSource().getVersionInstallerInfo(
+    pkg.id,
+    pkg.version
+  )) as VersionHistoryRow | null;
 
-  if (error || !data) {
+  if (!data) {
     return null;
   }
 

--- a/app/api/stats/public/route.ts
+++ b/app/api/stats/public/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { getCatalogSource } from '@/lib/catalog';
 
 const NO_STORE_HEADERS = {
   'Cache-Control': 'no-store, max-age=0, must-revalidate',
@@ -22,14 +23,12 @@ export async function GET() {
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Fetch site counters and curated apps count in parallel
-    const [countersResult, curatedAppsResult] = await Promise.all([
+    const [countersResult, catalogStats] = await Promise.all([
       supabase
         .from('site_counters')
         .select('*')
         .in('id', ['signin_clicks', 'apps_deployed']),
-      supabase
-        .from('curated_apps')
-        .select('*', { count: 'exact', head: true }),
+      getCatalogSource().getCatalogStats(),
     ]);
 
     if (countersResult.error) {
@@ -39,7 +38,7 @@ export async function GET() {
     const stats = {
       signinClicks: countersResult.data?.find((row) => row.id === 'signin_clicks')?.value ?? 0,
       appsDeployed: countersResult.data?.find((row) => row.id === 'apps_deployed')?.value ?? 0,
-      appsSupported: curatedAppsResult.count ?? 0,
+      appsSupported: catalogStats.totalApps,
     };
 
     return NextResponse.json(stats, {

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
   AutoUpdateTrigger,
@@ -484,11 +485,7 @@ export async function POST(request: NextRequest) {
               // Distinguish missing installer data from a missing catalog
               // entry so the user knows whether waiting for the catalog
               // sync can help
-              const { data: catalogRow } = await supabase
-                .from('curated_apps')
-                .select('winget_id')
-                .eq('winget_id', req.winget_id)
-                .maybeSingle();
+              const catalogRow = await getCatalogSource().appExists(req.winget_id);
               response.failed++;
               response.results.push({
                 winget_id: req.winget_id,
@@ -729,28 +726,23 @@ export async function POST(request: NextRequest) {
  * that were never deployed through IntuneGet.
  */
 async function buildDefaultDeploymentConfig(
-  supabase: ReturnType<typeof createServerClient>,
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabase: ReturnType<typeof createServerClient>,
   wingetId: string,
   latestVersion: string
 ): Promise<DeploymentConfig | null> {
   // Get curated app info
-  const { data: curatedApp } = await supabase
-    .from('curated_apps')
-    .select('name, publisher')
-    .eq('winget_id', wingetId)
-    .single();
+  const curatedApp = await getCatalogSource().getAppNamePublisher(wingetId);
 
   if (!curatedApp) {
     return null;
   }
 
   // Get version history for installer metadata
-  const { data: versionInfo } = await supabase
-    .from('version_history')
-    .select('installer_url, installer_sha256, installer_type, installers')
-    .eq('winget_id', wingetId)
-    .eq('version', latestVersion)
-    .single();
+  const versionInfo = await getCatalogSource().getVersionInstallerInfo(
+    wingetId,
+    latestVersion
+  );
 
   if (!versionInfo?.installer_url) {
     return null;

--- a/app/api/winget/categories/route.ts
+++ b/app/api/winget/categories/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { getCategories } from '@/lib/winget-api';
+import { getCatalogSource } from '@/lib/catalog';
 
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
@@ -26,11 +26,7 @@ export async function GET() {
     // Get actual total count of verified apps (not just sum of categories)
     let totalApps = categories.reduce((sum, cat) => sum + cat.count, 0);
 
-    const supabase = createClient(supabaseUrl, supabaseKey);
-    const { count } = await supabase
-      .from('curated_apps')
-      .select('*', { count: 'exact', head: true })
-      .eq('is_verified', true);
+    const count = await getCatalogSource().getCategoryCount({ verifiedOnly: true });
 
     if (count !== null) {
       totalApps = count;

--- a/app/api/winget/popular/route.ts
+++ b/app/api/winget/popular/route.ts
@@ -1,99 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { getCatalogSource } from '@/lib/catalog';
 
 export const runtime = 'edge';
 export const fetchCache = 'force-no-store';
 
-interface CuratedAppResult {
-  id: number;
-  winget_id: string;
-  name: string;
-  publisher: string;
-  latest_version: string;
-  description: string | null;
-  homepage: string | null;
-  category: string | null;
-  tags: string[] | null;
-  icon_path: string | null;
-  popularity_rank: number | null;
-  app_source: string | null;
-  store_package_id: string | null;
-}
-
 type SortBy = 'popular' | 'name' | 'newest';
-
-interface PopularPackagesResult {
-  data: CuratedAppResult[];
-  total: number;
-}
-
-async function getCuratedPackages(
-  limit: number,
-  offset: number,
-  category: string | null,
-  sort: SortBy
-): Promise<PopularPackagesResult | null> {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseKey) {
-    return null;
-  }
-
-  const supabase = createClient(supabaseUrl, supabaseKey);
-
-  const baseQuery = supabase
-    .from('curated_apps')
-    .select('*', { count: 'exact', head: true })
-    .eq('is_verified', true)
-    .eq('is_locale_variant', false);
-
-  const countQuery = category ? baseQuery.eq('category', category) : baseQuery;
-  const { count: totalCount, error: countError } = await countQuery;
-
-  if (countError) {
-    console.error('Failed to count curated packages', { error: countError, category });
-    return null;
-  }
-
-  let dataQuery = supabase
-    .from('curated_apps')
-    .select('id, winget_id, name, publisher, latest_version, description, homepage, category, tags, icon_path, popularity_rank, app_source, store_package_id')
-    .eq('is_verified', true)
-    .eq('is_locale_variant', false);
-
-  if (category) {
-    dataQuery = dataQuery.eq('category', category);
-  }
-
-  switch (sort) {
-    case 'name':
-      dataQuery = dataQuery.order('name', { ascending: true });
-      break;
-    case 'newest':
-      dataQuery = dataQuery.order('created_at', { ascending: false });
-      break;
-    case 'popular':
-    default:
-      dataQuery = dataQuery
-        .order('popularity_rank', { ascending: true, nullsFirst: false })
-        .order('name', { ascending: true });
-      break;
-  }
-
-  const { data, error } = await dataQuery.range(offset, offset + limit - 1);
-
-  if (error) {
-    console.error('Failed to query curated packages', { error, category, sort, limit, offset });
-    return null;
-  }
-
-  return {
-    data: (data || []) as CuratedAppResult[],
-    total: totalCount || 0,
-  };
-}
 
 export async function GET(request: NextRequest) {
   try {
@@ -126,12 +37,12 @@ export async function GET(request: NextRequest) {
       ? Math.max(requestedOffset, 0)
       : 0;
 
-    const result = await getCuratedPackages(
-      sanitizedLimit,
-      sanitizedOffset,
+    const result = await getCatalogSource().getPopularApps({
+      limit: sanitizedLimit,
+      offset: sanitizedOffset,
       category,
-      sort
-    );
+      sort,
+    });
 
     if (!result) {
       return NextResponse.json(

--- a/app/api/winget/search/route.ts
+++ b/app/api/winget/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { getCatalogSource } from '@/lib/catalog';
 
 export const runtime = 'edge';
 export const fetchCache = 'force-no-store';
@@ -36,15 +36,9 @@ async function searchCachedPackages(
     return null;
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-  const { data: curatedData, error: curatedError } = await supabase.rpc(
-    'search_curated_apps',
-    {
-      search_query: query,
-      category_filter: category || null,
-      result_limit: limit,
-    }
+  const { data: curatedData, error: curatedError } = await getCatalogSource().searchApps(
+    query,
+    { limit, category: category || null }
   );
 
   if (curatedError) {

--- a/lib/app-mappings.ts
+++ b/lib/app-mappings.ts
@@ -3,6 +3,8 @@
  * Pre-defined mappings between common app names and their Winget IDs
  */
 
+import { getCatalogSource } from '@/lib/catalog';
+
 export interface AppMapping {
   wingetId: string;
   aliases: string[];
@@ -590,57 +592,10 @@ export interface CuratedAppMatch {
  */
 export async function searchCuratedApps(
   searchTerm: string,
-  supabaseClient: { from: (table: string) => unknown }
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabaseClient?: { from: (table: string) => unknown }
 ): Promise<CuratedAppMatch[]> {
-  if (!searchTerm || searchTerm.length < 2) {
-    return [];
-  }
-
-  const normalizedSearch = searchTerm.toLowerCase().trim();
-
-  try {
-    // Query curated_apps table for verified apps with latest_version
-    const { data, error } = await (supabaseClient.from('curated_apps') as {
-      select: (columns: string) => {
-        not: (column: string, operator: string, value: null) => {
-          or: (filter: string) => {
-            order: (column: string, options: { ascending: boolean; nullsFirst: boolean }) => {
-              limit: (count: number) => Promise<{ data: Array<{
-                winget_id: string;
-                name: string;
-                publisher: string;
-                latest_version: string | null;
-              }> | null; error: { message: string } | null }>;
-            };
-          };
-        };
-      };
-    })
-      .select('winget_id, name, publisher, latest_version')
-      .not('latest_version', 'is', null)
-      .or(`name.ilike.%${normalizedSearch}%,publisher.ilike.%${normalizedSearch}%,winget_id.ilike.%${normalizedSearch}%`)
-      .order('popularity_rank', { ascending: true, nullsFirst: false })
-      .limit(10);
-
-    if (error) {
-      console.error('Error searching curated apps:', error.message);
-      return [];
-    }
-
-    if (!data || data.length === 0) {
-      return [];
-    }
-
-    return data.map(app => ({
-      wingetId: app.winget_id,
-      name: app.name,
-      publisher: app.publisher,
-      latestVersion: app.latest_version,
-    }));
-  } catch (e) {
-    console.error('Failed to search curated apps:', e);
-    return [];
-  }
+  return getCatalogSource().searchCuratedAppsForMatching(searchTerm);
 }
 
 /**

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -14,6 +14,7 @@ import {
   canAutoUpdate,
 } from '@/types/update-policies';
 import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
+import { getCatalogSource } from '@/lib/catalog';
 
 interface TriggerResult {
   success: boolean;
@@ -676,29 +677,26 @@ export function createAutoUpdateTrigger(): AutoUpdateTrigger | null {
  * Get installer info from curated_apps and version_history
  */
 export async function getLatestInstallerInfo(
-  supabase: SupabaseClient,
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabase: SupabaseClient,
   wingetId: string
 ): Promise<UpdateInfo | null> {
-  // Get the curated app info
-  const { data: curatedApp, error: appError } = await supabase
-    .from('curated_apps')
-    .select('winget_id, name, latest_version')
-    .eq('winget_id', wingetId)
-    .single();
+  const catalog = getCatalogSource();
 
-  if (appError || !curatedApp?.latest_version) {
+  // Get the curated app info
+  const curatedApp = await catalog.getAppForInstaller(wingetId);
+
+  if (!curatedApp?.latest_version) {
     return null;
   }
 
   // Get the version history for the latest version
-  const { data: versionInfo, error: versionError } = await supabase
-    .from('version_history')
-    .select('installer_url, installer_sha256, installer_type, installers')
-    .eq('winget_id', wingetId)
-    .eq('version', curatedApp.latest_version)
-    .single();
+  const versionInfo = await catalog.getVersionInstallerInfo(
+    wingetId,
+    curatedApp.latest_version
+  );
 
-  if (versionError || !versionInfo) {
+  if (!versionInfo) {
     return null;
   }
 

--- a/lib/catalog/index.ts
+++ b/lib/catalog/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Catalog source selector.
+ *
+ * Returns the active CatalogSource implementation. In Phase 1 this is always
+ * the Supabase-backed source (singleton).
+ *
+ * TODO(Phase 3): branch on isSupabaseConfigured() and return a
+ * SnapshotCatalogSource (better-sqlite3 over a downloaded catalog snapshot)
+ * for self-hosted sqlite mode when Supabase is not configured.
+ */
+
+import type { CatalogSource } from './types';
+import { SupabaseCatalogSource } from './supabase-source';
+
+let _source: CatalogSource | null = null;
+
+export function getCatalogSource(): CatalogSource {
+  if (!_source) {
+    _source = new SupabaseCatalogSource();
+  }
+  return _source;
+}
+
+export type { CatalogSource } from './types';

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -1,0 +1,677 @@
+/**
+ * Supabase-backed CatalogSource.
+ *
+ * Each method contains the catalog query moved verbatim from its original
+ * call site. The two client constructions used by the original code are
+ * preserved exactly:
+ *  - `serviceOrAnonClient()` -> createClient(url, SERVICE_ROLE_KEY || ANON_KEY)
+ *    (used by winget-api.ts, manifest-api.ts and the winget/* routes)
+ *  - `createServerClient()` -> service-role-only typed client
+ *    (used by community/sccm/stats/auto-update call sites)
+ *
+ * Where it does not change which key is used, the original helper is reused.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createServerClient } from '@/lib/supabase';
+import { getLocaleDisplay } from '@/lib/locale-utils';
+import type { LocaleVariant } from '@/types/winget';
+import type { CuratedAppMatch } from '@/lib/app-mappings';
+import type { InstallationSnapshot } from '@/lib/winget-api';
+import type {
+  CatalogSource,
+  CategoryCount,
+  CuratedAppRpcRow,
+  CuratedAppWithDetails,
+  PopularPackagesResult,
+  SccmCuratedAppRow,
+  SccmMappingQuery,
+  SccmMappingResult,
+  SearchSort,
+  VersionInstallerInfo,
+  WingetIdLatestVersion,
+} from './types';
+
+/**
+ * Raw Supabase client using the service-or-anon key, matching the
+ * getSupabaseClient() helpers previously inlined in winget-api.ts and
+ * manifest-api.ts. Returns null when unconfigured (manifest-api semantics);
+ * throwing variants handle the missing-config case at the call site.
+ */
+function serviceOrAnonClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    return null;
+  }
+
+  return createClient(url, key);
+}
+
+export class SupabaseCatalogSource implements CatalogSource {
+  // ---------------------------------------------------------------------------
+  // search / discovery
+  // ---------------------------------------------------------------------------
+
+  async searchApps(
+    query: string,
+    opts: { limit: number; category?: string | null; sort?: SearchSort }
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return { data: null, error: { message: 'Supabase configuration missing' } };
+    }
+
+    const { data: curatedData, error: curatedError } = await supabase.rpc(
+      'search_curated_apps',
+      {
+        search_query: query,
+        category_filter: opts.category || null,
+        result_limit: opts.limit,
+      }
+    );
+
+    return {
+      data: (curatedData || null) as CuratedAppRpcRow[] | null,
+      error: curatedError,
+    };
+  }
+
+  async getPopularApps(opts: {
+    limit: number;
+    offset: number;
+    category?: string | null;
+    sort: SearchSort;
+  }): Promise<PopularPackagesResult | null> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseKey =
+      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseKey) {
+      return null;
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { limit, offset, category, sort } = opts;
+
+    const baseQuery = supabase
+      .from('curated_apps')
+      .select('*', { count: 'exact', head: true })
+      .eq('is_verified', true)
+      .eq('is_locale_variant', false);
+
+    const countQuery = category ? baseQuery.eq('category', category) : baseQuery;
+    const { count: totalCount, error: countError } = await countQuery;
+
+    if (countError) {
+      console.error('Failed to count curated packages', { error: countError, category });
+      return null;
+    }
+
+    let dataQuery = supabase
+      .from('curated_apps')
+      .select(
+        'id, winget_id, name, publisher, latest_version, description, homepage, category, tags, icon_path, popularity_rank, app_source, store_package_id'
+      )
+      .eq('is_verified', true)
+      .eq('is_locale_variant', false);
+
+    if (category) {
+      dataQuery = dataQuery.eq('category', category);
+    }
+
+    switch (sort) {
+      case 'name':
+        dataQuery = dataQuery.order('name', { ascending: true });
+        break;
+      case 'newest':
+        dataQuery = dataQuery.order('created_at', { ascending: false });
+        break;
+      case 'popular':
+      default:
+        dataQuery = dataQuery
+          .order('popularity_rank', { ascending: true, nullsFirst: false })
+          .order('name', { ascending: true });
+        break;
+    }
+
+    const { data, error } = await dataQuery.range(offset, offset + limit - 1);
+
+    if (error) {
+      console.error('Failed to query curated packages', { error, category, sort, limit, offset });
+      return null;
+    }
+
+    return {
+      data: (data || []) as PopularPackagesResult['data'],
+      total: totalCount || 0,
+    };
+  }
+
+  async getPopularPackages(
+    limit: number,
+    category?: string | null
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return { data: null, error: { message: 'Supabase configuration missing' } };
+    }
+
+    const { data: curatedData, error: curatedError } = await supabase.rpc(
+      'get_popular_curated_apps',
+      {
+        result_limit: limit,
+        category_filter: category || null,
+      }
+    );
+
+    return {
+      data: (curatedData || null) as CuratedAppRpcRow[] | null,
+      error: curatedError,
+    };
+  }
+
+  async getCategories(): Promise<CategoryCount[]> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return [];
+    }
+
+    const { data, error } = await supabase.rpc('get_curated_categories');
+
+    if (error) {
+      console.error('Error getting categories:', error);
+      return [];
+    }
+
+    return ((data || []) as { category: string; app_count: number }[]).map((c) => ({
+      category: c.category,
+      count: c.app_count,
+    }));
+  }
+
+  async getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseKey =
+      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseKey) {
+      return null;
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    let query = supabase
+      .from('curated_apps')
+      .select('*', { count: 'exact', head: true });
+
+    if (opts.verifiedOnly) {
+      query = query.eq('is_verified', true);
+    }
+
+    const { count } = await query;
+    return count ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // app detail
+  // ---------------------------------------------------------------------------
+
+  async getAppByWingetId(wingetId: string): Promise<CuratedAppWithDetails | null> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return null;
+    }
+
+    const { data: curatedData } = await supabase
+      .from('curated_apps')
+      .select('*')
+      .eq('winget_id', wingetId)
+      .single();
+
+    if (!curatedData) {
+      return null;
+    }
+
+    // Get versions from version_history
+    const { data: versionData } = await supabase
+      .from('version_history')
+      .select('version')
+      .eq('winget_id', wingetId)
+      .order('created_at', { ascending: false });
+
+    const versions = versionData?.map((v) => v.version) || [];
+
+    // Fetch locale variants if this is a parent app (not a variant itself)
+    let localeVariants: LocaleVariant[] | undefined;
+    if (!curatedData.is_locale_variant) {
+      const { data: variantData } = await supabase.rpc('get_locale_variants', {
+        parent_id: wingetId,
+      });
+      if (variantData && variantData.length > 0) {
+        localeVariants = variantData.map(
+          (v: { winget_id: string; locale_code: string; latest_version: string | null }) => {
+            const display = getLocaleDisplay(v.locale_code);
+            return {
+              wingetId: v.winget_id,
+              localeCode: v.locale_code,
+              localeName: display.name,
+              countryFlag: display.flag,
+              version: v.latest_version || undefined,
+            };
+          }
+        );
+      }
+    }
+
+    return {
+      app: curatedData as CuratedAppWithDetails['app'],
+      versions,
+      localeVariants,
+    };
+  }
+
+  async getVersions(wingetId: string): Promise<string[]> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return [];
+    }
+
+    const { data } = await supabase
+      .from('version_history')
+      .select('version')
+      .eq('winget_id', wingetId)
+      .order('created_at', { ascending: false });
+
+    if (data && data.length > 0) {
+      return data.map((v) => v.version);
+    }
+
+    return [];
+  }
+
+  async getVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('version_history')
+      .select('installer_url, installer_sha256, installer_type, installer_scope, installers')
+      .eq('winget_id', wingetId)
+      .eq('version', version)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data as unknown as VersionInstallerInfo;
+  }
+
+  async getLatestVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('version_history')
+      .select('installer_url, installer_sha256, installer_type, installer_scope, installers')
+      .eq('winget_id', wingetId)
+      .eq('version', version)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data as unknown as VersionInstallerInfo;
+  }
+
+  async getInstallationChangelog(
+    wingetId: string,
+    version?: string
+  ): Promise<InstallationSnapshot | null> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) {
+      return null;
+    }
+
+    const { data, error } = await supabase.rpc('get_installation_changelog', {
+      app_winget_id: wingetId,
+      app_version: version || null,
+    });
+
+    if (error || !data || data.length === 0) {
+      return null;
+    }
+
+    return data[0] as InstallationSnapshot;
+  }
+
+  // ---------------------------------------------------------------------------
+  // update detection
+  // ---------------------------------------------------------------------------
+
+  async getAppsByWingetIds(ids: string[]): Promise<WingetIdLatestVersion[]> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('curated_apps')
+      .select('winget_id, latest_version')
+      .in('winget_id', ids);
+
+    if (error || !data) {
+      return [];
+    }
+
+    return data as WingetIdLatestVersion[];
+  }
+
+  async getAllLatestVersions(): Promise<WingetIdLatestVersion[]> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('curated_apps')
+      .select('winget_id, latest_version')
+      .not('latest_version', 'is', null);
+
+    // Preserve the original cron behavior: propagate the error so the route's
+    // outer try/catch returns a 500 (it did `throw curatedError`).
+    if (error) {
+      throw error;
+    }
+
+    return (data || []) as WingetIdLatestVersion[];
+  }
+
+  // ---------------------------------------------------------------------------
+  // small metadata lookups
+  // ---------------------------------------------------------------------------
+
+  async getAppNamePublisher(
+    wingetId: string
+  ): Promise<{ name: string; publisher: string | null } | null> {
+    const supabase = createServerClient();
+
+    const { data } = await supabase
+      .from('curated_apps')
+      .select('name, publisher')
+      .eq('winget_id', wingetId)
+      .single();
+
+    if (!data) {
+      return null;
+    }
+
+    return data as { name: string; publisher: string | null };
+  }
+
+  async getAppForInstaller(wingetId: string): Promise<{
+    winget_id: string;
+    name: string;
+    latest_version: string | null;
+  } | null> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('curated_apps')
+      .select('winget_id, name, latest_version')
+      .eq('winget_id', wingetId)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data as { winget_id: string; name: string; latest_version: string | null };
+  }
+
+  async getSccmCuratedApp(wingetId: string): Promise<SccmCuratedAppRow | null> {
+    const supabase = createServerClient();
+
+    const { data, error } = (await supabase
+      .from('curated_apps')
+      .select(
+        'winget_id, name, publisher, latest_version, description, homepage, license, tags, category, icon_path'
+      )
+      .eq('winget_id', wingetId)
+      .single()) as { data: SccmCuratedAppRow | null; error: Error | null };
+
+    if (error || !data) {
+      return null;
+    }
+
+    return data;
+  }
+
+  async getAppDescription(wingetId: string): Promise<string | undefined> {
+    const supabase = createServerClient();
+
+    const { data, error } = await supabase
+      .from('curated_apps')
+      .select('description')
+      .eq('winget_id', wingetId)
+      .limit(1)
+      .maybeSingle();
+
+    if (error || !data?.description || typeof data.description !== 'string') {
+      return undefined;
+    }
+
+    return data.description;
+  }
+
+  // ---------------------------------------------------------------------------
+  // matching
+  // ---------------------------------------------------------------------------
+
+  async searchCuratedAppsForMatching(term: string): Promise<CuratedAppMatch[]> {
+    if (!term || term.length < 2) {
+      return [];
+    }
+
+    const normalizedSearch = term.toLowerCase().trim();
+    const supabase = createServerClient();
+
+    try {
+      const { data, error } = await supabase
+        .from('curated_apps')
+        .select('winget_id, name, publisher, latest_version')
+        .not('latest_version', 'is', null)
+        .or(
+          `name.ilike.%${normalizedSearch}%,publisher.ilike.%${normalizedSearch}%,winget_id.ilike.%${normalizedSearch}%`
+        )
+        .order('popularity_rank', { ascending: true, nullsFirst: false })
+        .limit(10);
+
+      if (error) {
+        console.error('Error searching curated apps:', error.message);
+        return [];
+      }
+
+      if (!data || data.length === 0) {
+        return [];
+      }
+
+      return (
+        data as Array<{
+          winget_id: string;
+          name: string;
+          publisher: string;
+          latest_version: string | null;
+        }>
+      ).map((app) => ({
+        wingetId: app.winget_id,
+        name: app.name,
+        publisher: app.publisher,
+        latestVersion: app.latest_version,
+      }));
+    } catch (e) {
+      console.error('Failed to search curated apps:', e);
+      return [];
+    }
+  }
+
+  async getSccmMapping(
+    query: SccmMappingQuery,
+    tenantId: string
+  ): Promise<SccmMappingResult | null> {
+    const supabase = createServerClient();
+
+    const { displayNameNormalized, ciId, productCode } = query;
+
+    // sccm_winget_mappings columns are snake_case. Read the row with the actual
+    // column names: reading camelCase here returned undefined and threw on
+    // wingetPackageId.split(...), which surfaced as a 500 on Run Matching for any
+    // app that hit a seeded mapping (e.g. "google chrome").
+    type SccmWingetMappingRow = {
+      id: string;
+      winget_package_id: string | null;
+      winget_package_name: string | null;
+      confidence: number | null;
+      is_verified: boolean | null;
+      tenant_id: string | null;
+      sccm_product_code: string | null;
+    };
+
+    // Build the OR conditions defensively: quote values so names containing
+    // spaces or parentheses (e.g. "Zoom Workplace (64-bit)") don't break the
+    // PostgREST or() parser, and only filter on product code when one exists
+    // (eq.null would not match NULL rows anyway).
+    const quote = (v: string) => `"${v.replace(/"/g, '')}"`;
+    const orConditions = [
+      `sccm_display_name_normalized.eq.${quote(displayNameNormalized)}`,
+      `sccm_ci_id.eq.${quote(ciId)}`,
+    ];
+    if (productCode) {
+      orConditions.push(`sccm_product_code.eq.${quote(productCode)}`);
+    }
+
+    // sccm_winget_mappings is not in the generated Database types; use the
+    // same loosely-typed access shape the original checkSccmMapping used.
+    const looseClient = supabase as unknown as {
+      from: (table: string) => {
+        select: (columns: string) => {
+          or: (filter: string) => {
+            order: (column: string, options: { ascending: boolean }) => {
+              limit: (count: number) => Promise<{
+                data: SccmWingetMappingRow[] | null;
+                error: { message: string } | null;
+              }>;
+            };
+          };
+        };
+      };
+    };
+
+    const { data, error } = await looseClient
+      .from('sccm_winget_mappings')
+      .select('*')
+      .or(orConditions.join(','))
+      .order('is_verified', { ascending: false })
+      .limit(1);
+
+    if (error || !data || data.length === 0) {
+      return null;
+    }
+
+    const mapping = data[0];
+
+    // Check tenant scope
+    if (mapping.tenant_id && mapping.tenant_id !== tenantId) {
+      return null;
+    }
+
+    // Guard against a mapping row without a winget package id.
+    const wingetId = mapping.winget_package_id;
+    if (!wingetId) {
+      return null;
+    }
+
+    return {
+      status: 'matched',
+      wingetId,
+      wingetName: mapping.winget_package_name || wingetId.split('.').pop() || wingetId,
+      confidence: mapping.confidence ?? 1.0,
+      partialMatches: [],
+      matchedBy: mapping.sccm_product_code && productCode ? 'product_code' : 'mapping',
+      mappingId: mapping.id,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // existence checks
+  // ---------------------------------------------------------------------------
+
+  async appExists(wingetId: string): Promise<boolean> {
+    const supabase = createServerClient();
+
+    const { data } = await supabase
+      .from('curated_apps')
+      .select('id, winget_id')
+      .eq('winget_id', wingetId)
+      .single();
+
+    return Boolean(data);
+  }
+
+  async appExistsCaseInsensitive(
+    wingetId: string
+  ): Promise<{ winget_id: string } | null> {
+    const supabase = createServerClient();
+
+    const { data } = await supabase
+      .from('curated_apps')
+      .select('id, winget_id')
+      .ilike('winget_id', wingetId)
+      .limit(1)
+      .maybeSingle();
+
+    return (data as { winget_id: string } | null) || null;
+  }
+
+  async findSimilarVerifiedApps(
+    term: string,
+    limit: number
+  ): Promise<{ winget_id: string; name: string }[]> {
+    const supabase = createServerClient();
+
+    const { data } = await supabase
+      .from('curated_apps')
+      .select('winget_id, name')
+      .or(`winget_id.ilike.%${term}%,name.ilike.%${term}%`)
+      .eq('is_verified', true)
+      .limit(limit);
+
+    return (data as { winget_id: string; name: string }[] | null) || [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // stats
+  // ---------------------------------------------------------------------------
+
+  async getCatalogStats(): Promise<{ totalApps: number }> {
+    // The stats route builds its own client (service-role-only) and runs this
+    // count alongside a site_counters query; here we only own the catalog count.
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return { totalApps: 0 };
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const { count } = await supabase
+      .from('curated_apps')
+      .select('*', { count: 'exact', head: true });
+
+    return { totalApps: count ?? 0 };
+  }
+}

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -1,0 +1,264 @@
+/**
+ * Catalog Source abstraction
+ *
+ * Defines the read surface over the app catalog (curated_apps,
+ * version_history, sccm_winget_mappings, and the catalog RPCs). Every
+ * catalog read in the app goes through a CatalogSource implementation so the
+ * backing store (Supabase today, a downloaded SQLite snapshot later) can be
+ * swapped without touching call sites.
+ *
+ * Phase 1: the only implementation is SupabaseCatalogSource, which contains
+ * the queries moved verbatim from their original call sites. No behavior
+ * change.
+ */
+
+import type { LocaleVariant } from '@/types/winget';
+import type { SccmMatchResult } from '@/lib/matching/sccm-matcher';
+import type { CuratedAppMatch } from '@/lib/app-mappings';
+import type { InstallationSnapshot } from '@/lib/winget-api';
+
+/**
+ * Raw row returned by the search_curated_apps / get_popular_curated_apps RPCs.
+ */
+export interface CuratedAppRpcRow {
+  id: number;
+  winget_id: string;
+  name: string;
+  publisher: string;
+  latest_version: string;
+  description: string | null;
+  homepage: string | null;
+  category: string | null;
+  tags: string[] | null;
+  icon_path: string | null;
+  popularity_rank: number | null;
+  installer_type?: string | null;
+  rank?: number;
+  app_source: string | null;
+  store_package_id: string | null;
+}
+
+/**
+ * Row shape returned by the curated_apps data query in /api/winget/popular.
+ */
+export interface PopularCuratedAppRow {
+  id: number;
+  winget_id: string;
+  name: string;
+  publisher: string;
+  latest_version: string;
+  description: string | null;
+  homepage: string | null;
+  category: string | null;
+  tags: string[] | null;
+  icon_path: string | null;
+  popularity_rank: number | null;
+  app_source: string | null;
+  store_package_id: string | null;
+}
+
+export interface PopularPackagesResult {
+  data: PopularCuratedAppRow[];
+  total: number;
+}
+
+export type SearchSort = 'popular' | 'name' | 'newest';
+
+/**
+ * Full curated_apps row (select('*')) used by getPackage.
+ */
+export interface CuratedAppFullRow {
+  winget_id: string;
+  name: string;
+  publisher: string;
+  latest_version: string | null;
+  description?: string;
+  homepage?: string;
+  license?: string;
+  tags?: string[] | null;
+  icon_path?: string;
+  category?: string;
+  popularity_rank?: number;
+  is_locale_variant?: boolean;
+  parent_winget_id?: string | null;
+  locale_code?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Combined curated app + versions + locale variants returned by
+ * getAppByWingetId (the curated portion of getPackage).
+ */
+export interface CuratedAppWithDetails {
+  app: CuratedAppFullRow;
+  versions: string[];
+  localeVariants?: LocaleVariant[];
+}
+
+export interface CategoryCount {
+  category: string;
+  count: number;
+}
+
+/**
+ * Installer metadata from version_history. Different callers select different
+ * column subsets; this is the union so a single method can serve each caller.
+ * Callers ignore the fields they did not originally request.
+ */
+export interface VersionInstallerInfo {
+  installer_url: string | null;
+  installer_sha256: string | null;
+  installer_type: string | null;
+  installer_scope?: string | null;
+  installers: unknown;
+}
+
+export interface WingetIdLatestVersion {
+  winget_id: string;
+  latest_version: string | null;
+}
+
+/**
+ * Curated app metadata used by the SCCM migrate route (fetchWingetPackage).
+ */
+export interface SccmCuratedAppRow {
+  winget_id: string;
+  name: string;
+  publisher: string;
+  latest_version: string | null;
+  description: string | null;
+  homepage: string | null;
+  license: string | null;
+  tags: string[] | null;
+  category: string | null;
+  icon_path: string | null;
+}
+
+export interface SccmMappingQuery {
+  displayNameNormalized: string;
+  ciId: string;
+  productCode: string | null;
+}
+
+/**
+ * Subset of SccmMatchResult fields the catalog source can derive from a
+ * mapping row. The matcher adds matchedBy/confidence semantics; the source
+ * returns the raw resolution.
+ */
+export type SccmMappingResult = SccmMatchResult;
+
+/**
+ * The catalog read surface. Every method maps 1:1 to a former direct query.
+ */
+export interface CatalogSource {
+  // --- search / discovery ---
+
+  /** RPC search_curated_apps. Returns the raw rows + error so each caller keeps
+   *  its own error-handling (winget-api logs+throws; the route returns null). */
+  searchApps(
+    query: string,
+    opts: { limit: number; category?: string | null; sort?: SearchSort }
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }>;
+
+  /** curated_apps count + data query from /api/winget/popular getCuratedPackages. */
+  getPopularApps(opts: {
+    limit: number;
+    offset: number;
+    category?: string | null;
+    sort: SearchSort;
+  }): Promise<PopularPackagesResult | null>;
+
+  /** RPC get_popular_curated_apps (normalized in winget-api). */
+  getPopularPackages(
+    limit: number,
+    category?: string | null
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }>;
+
+  /** RPC get_curated_categories. */
+  getCategories(): Promise<CategoryCount[]>;
+
+  /** curated_apps count(head) with optional is_verified filter. */
+  getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null>;
+
+  // --- app detail ---
+
+  /** curated_apps select('*') + version_history versions + get_locale_variants. */
+  getAppByWingetId(wingetId: string): Promise<CuratedAppWithDetails | null>;
+
+  /** version_history select('version') ordered by created_at desc. */
+  getVersions(wingetId: string): Promise<string[]>;
+
+  /** version_history installer info for a specific version. */
+  getVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null>;
+
+  /** version_history installer info for a version, taking the most recently
+   *  created row (order created_at desc, limit 1) — batch-orchestrator variant. */
+  getLatestVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null>;
+
+  /** RPC get_installation_changelog. */
+  getInstallationChangelog(
+    wingetId: string,
+    version?: string
+  ): Promise<InstallationSnapshot | null>;
+
+  // --- update detection ---
+
+  /** curated_apps latest versions for a set of winget ids (.in). */
+  getAppsByWingetIds(ids: string[]): Promise<WingetIdLatestVersion[]>;
+
+  /** curated_apps all rows with non-null latest_version. */
+  getAllLatestVersions(): Promise<WingetIdLatestVersion[]>;
+
+  // --- small metadata lookups ---
+
+  /** curated_apps name+publisher (.single) for buildDefaultDeploymentConfig. */
+  getAppNamePublisher(
+    wingetId: string
+  ): Promise<{ name: string; publisher: string | null } | null>;
+
+  /** curated_apps winget_id+name+latest_version (.single) for getLatestInstallerInfo. */
+  getAppForInstaller(wingetId: string): Promise<{
+    winget_id: string;
+    name: string;
+    latest_version: string | null;
+  } | null>;
+
+  /** curated_apps metadata column set for the SCCM migrate route. */
+  getSccmCuratedApp(wingetId: string): Promise<SccmCuratedAppRow | null>;
+
+  /** curated_apps description (.maybeSingle) for batch-orchestrator. */
+  getAppDescription(wingetId: string): Promise<string | undefined>;
+
+  // --- matching ---
+
+  /** searchCuratedApps body from lib/app-mappings (ILIKE on name/publisher/id). */
+  searchCuratedAppsForMatching(term: string): Promise<CuratedAppMatch[]>;
+
+  /** sccm_winget_mappings resolution from lib/matching/sccm-matcher checkSccmMapping. */
+  getSccmMapping(query: SccmMappingQuery, tenantId: string): Promise<SccmMappingResult | null>;
+
+  // --- existence checks ---
+
+  /** curated_apps id+winget_id (.single) exact-match existence. */
+  appExists(wingetId: string): Promise<boolean>;
+
+  /** curated_apps id+winget_id (.ilike .maybeSingle) case-insensitive existence. */
+  appExistsCaseInsensitive(wingetId: string): Promise<{ winget_id: string } | null>;
+
+  /** curated_apps similar verified apps for the suggestions hint (.or ILIKE). */
+  findSimilarVerifiedApps(
+    term: string,
+    limit: number
+  ): Promise<{ winget_id: string; name: string }[]>;
+
+  // --- stats ---
+
+  /** curated_apps count(head) for /api/stats/public. */
+  getCatalogStats(): Promise<{ totalApps: number }>;
+}

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -12,6 +12,7 @@ import type {
   NormalizedInstaller,
   WingetInstallerType,
 } from '@/types/winget';
+import { getCatalogSource } from '@/lib/catalog';
 
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests';
 const GITHUB_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests';
@@ -61,22 +62,14 @@ function getManifestPaths(wingetId: string) {
  * Priority: Supabase version_history -> GitHub API
  */
 export async function fetchAvailableVersions(wingetId: string): Promise<string[]> {
-  // Try Supabase first
-  const supabase = getSupabaseClient();
-  if (supabase) {
-    try {
-      const { data: versions } = await supabase
-        .from('version_history')
-        .select('version')
-        .eq('winget_id', wingetId)
-        .order('created_at', { ascending: false });
-
-      if (versions && versions.length > 0) {
-        return versions.map(v => v.version);
-      }
-    } catch (error) {
-      console.warn(`Supabase version lookup failed for ${wingetId}:`, error);
+  // Try the catalog first
+  try {
+    const versions = await getCatalogSource().getVersions(wingetId);
+    if (versions.length > 0) {
+      return versions;
     }
+  } catch (error) {
+    console.warn(`Supabase version lookup failed for ${wingetId}:`, error);
   }
 
   // Fallback to GitHub API

--- a/lib/matching/sccm-matcher.ts
+++ b/lib/matching/sccm-matcher.ts
@@ -11,6 +11,7 @@ import {
   type MatchResult,
 } from './app-matcher';
 import { APP_MAPPINGS, getWingetIdFromName, searchCuratedApps } from '@/lib/app-mappings';
+import { getCatalogSource } from '@/lib/catalog';
 import type {
   SccmApplication,
   SccmMsiDetectionClause,
@@ -121,82 +122,20 @@ export function getPrimaryDeploymentType(app: SccmApplication) {
 export async function checkSccmMapping(
   app: SccmApplication,
   tenantId: string,
-  supabaseClient: { from: (table: string) => unknown }
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabaseClient?: { from: (table: string) => unknown }
 ): Promise<SccmMatchResult | null> {
   const normalizedName = app.localizedDisplayName.toLowerCase().trim();
   const productCode = extractProductCode(app);
 
-  // sccm_winget_mappings columns are snake_case. Read the row with the actual
-  // column names: reading camelCase here returned undefined and threw on
-  // wingetPackageId.split(...), which surfaced as a 500 on Run Matching for any
-  // app that hit a seeded mapping (e.g. "google chrome").
-  type SccmWingetMappingRow = {
-    id: string;
-    winget_package_id: string | null;
-    winget_package_name: string | null;
-    confidence: number | null;
-    is_verified: boolean | null;
-    tenant_id: string | null;
-    sccm_product_code: string | null;
-  };
-
-  // Build the OR conditions defensively: quote values so names containing
-  // spaces or parentheses (e.g. "Zoom Workplace (64-bit)") don't break the
-  // PostgREST or() parser, and only filter on product code when one exists
-  // (eq.null would not match NULL rows anyway).
-  const quote = (v: string) => `"${v.replace(/"/g, '')}"`;
-  const orConditions = [
-    `sccm_display_name_normalized.eq.${quote(normalizedName)}`,
-    `sccm_ci_id.eq.${quote(String(app.ci_id ?? ''))}`,
-  ];
-  if (productCode) {
-    orConditions.push(`sccm_product_code.eq.${quote(productCode)}`);
-  }
-
-  // Query custom SCCM mappings
-  const { data, error } = await (supabaseClient.from('sccm_winget_mappings') as {
-    select: (columns: string) => {
-      or: (filter: string) => {
-        order: (column: string, options: { ascending: boolean }) => {
-          limit: (count: number) => Promise<{
-            data: SccmWingetMappingRow[] | null;
-            error: { message: string } | null;
-          }>;
-        };
-      };
-    };
-  })
-    .select('*')
-    .or(orConditions.join(','))
-    .order('is_verified', { ascending: false })
-    .limit(1);
-
-  if (error || !data || data.length === 0) {
-    return null;
-  }
-
-  const mapping = data[0];
-
-  // Check tenant scope
-  if (mapping.tenant_id && mapping.tenant_id !== tenantId) {
-    return null;
-  }
-
-  // Guard against a mapping row without a winget package id.
-  const wingetId = mapping.winget_package_id;
-  if (!wingetId) {
-    return null;
-  }
-
-  return {
-    status: 'matched',
-    wingetId,
-    wingetName: mapping.winget_package_name || wingetId.split('.').pop() || wingetId,
-    confidence: mapping.confidence ?? 1.0,
-    partialMatches: [],
-    matchedBy: mapping.sccm_product_code && productCode ? 'product_code' : 'mapping',
-    mappingId: mapping.id,
-  };
+  return getCatalogSource().getSccmMapping(
+    {
+      displayNameNormalized: normalizedName,
+      ciId: String(app.ci_id ?? ''),
+      productCode,
+    },
+    tenantId
+  );
 }
 
 /**

--- a/lib/msp/batch-orchestrator.ts
+++ b/lib/msp/batch-orchestrator.ts
@@ -5,6 +5,7 @@
  */
 
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { getDatabase } from '@/lib/db';
 import {
   isGitHubActionsConfigured,
@@ -542,20 +543,7 @@ async function advanceBatch(batchId: string): Promise<boolean> {
  * Returns undefined when the app is not in the catalog or has no description.
  */
 async function lookupAppDescription(wingetId: string): Promise<string | undefined> {
-  const supabase = createServerClient();
-
-  const { data, error } = await supabase
-    .from('curated_apps')
-    .select('description')
-    .eq('winget_id', wingetId)
-    .limit(1)
-    .maybeSingle();
-
-  if (error || !data?.description || typeof data.description !== 'string') {
-    return undefined;
-  }
-
-  return data.description;
+  return getCatalogSource().getAppDescription(wingetId);
 }
 
 /**
@@ -566,18 +554,9 @@ async function lookupInstallerDetails(
   wingetId: string,
   version: string
 ): Promise<InstallerDetails | null> {
-  const supabase = createServerClient();
+  const data = await getCatalogSource().getLatestVersionInstallerInfo(wingetId, version);
 
-  const { data, error } = await supabase
-    .from('version_history')
-    .select('installer_url, installer_sha256, installer_type, installer_scope, installers')
-    .eq('winget_id', wingetId)
-    .eq('version', version)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .single();
-
-  if (error || !data) {
+  if (!data) {
     return null;
   }
 

--- a/lib/winget-api.ts
+++ b/lib/winget-api.ts
@@ -4,7 +4,6 @@
  * Uses GitHub raw manifests for installer data via manifest-api.ts
  */
 
-import { createClient } from '@supabase/supabase-js';
 import type {
   WingetManifest,
   WingetInstaller,
@@ -18,20 +17,8 @@ import {
   getBestInstaller as getManifestBestInstaller,
   fetchAvailableVersions,
 } from './manifest-api';
-import { getLocaleDisplay } from './locale-utils';
-import type { LocaleVariant } from '@/types/winget';
-
-// Supabase client for server-side operations
-function getSupabaseClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !key) {
-    throw new Error('Supabase configuration missing');
-  }
-
-  return createClient(url, key);
-}
+import { getCatalogSource } from './catalog';
+import type { CuratedAppRpcRow } from './catalog/types';
 
 /**
  * Extended package type with curated app fields
@@ -55,15 +42,11 @@ export async function searchPackages(
   }
 
   try {
-    const supabase = getSupabaseClient();
-
     // Search curated apps
-    const { data: curatedData, error: curatedError } = await supabase
-      .rpc('search_curated_apps', {
-        search_query: query,
-        category_filter: category || null,
-        result_limit: limit,
-      });
+    const { data: curatedData, error: curatedError } = await getCatalogSource().searchApps(
+      query,
+      { limit, category: category || null }
+    );
 
     if (!curatedError && curatedData && curatedData.length > 0) {
       return curatedData.map(normalizeCuratedApp);
@@ -91,44 +74,13 @@ export async function getPackage(packageId: string): Promise<CuratedPackage | nu
   }
 
   try {
-    const supabase = getSupabaseClient();
-
     // Try curated_apps first
-    const { data: curatedData } = await supabase
-      .from('curated_apps')
-      .select('*')
-      .eq('winget_id', packageId)
-      .single();
+    const curated = await getCatalogSource().getAppByWingetId(packageId);
 
-    if (curatedData) {
-      // Get versions from version_history
-      const { data: versionData } = await supabase
-        .from('version_history')
-        .select('version')
-        .eq('winget_id', packageId)
-        .order('created_at', { ascending: false });
-
-      const versions = versionData?.map(v => v.version) || [];
-
-      // Fetch locale variants if this is a parent app (not a variant itself)
-      let localeVariants: LocaleVariant[] | undefined;
-      if (!curatedData.is_locale_variant) {
-        const { data: variantData } = await supabase.rpc('get_locale_variants', {
-          parent_id: packageId,
-        });
-        if (variantData && variantData.length > 0) {
-          localeVariants = variantData.map((v: { winget_id: string; locale_code: string; latest_version: string | null }) => {
-            const display = getLocaleDisplay(v.locale_code);
-            return {
-              wingetId: v.winget_id,
-              localeCode: v.locale_code,
-              localeName: display.name,
-              countryFlag: display.flag,
-              version: v.latest_version || undefined,
-            };
-          });
-        }
-      }
+    if (curated) {
+      const curatedData = curated.app;
+      const versions = curated.versions;
+      const localeVariants = curated.localeVariants;
 
       return {
         id: curatedData.winget_id,
@@ -179,17 +131,11 @@ export async function getPackage(packageId: string): Promise<CuratedPackage | nu
  */
 export async function getPackageVersions(packageId: string): Promise<string[]> {
   try {
-    const supabase = getSupabaseClient();
-
     // Try version_history table first
-    const { data } = await supabase
-      .from('version_history')
-      .select('version')
-      .eq('winget_id', packageId)
-      .order('created_at', { ascending: false });
+    const versions = await getCatalogSource().getVersions(packageId);
 
-    if (data && data.length > 0) {
-      return data.map(v => v.version);
+    if (versions.length > 0) {
+      return versions;
     }
 
     // Fallback to manifest API
@@ -241,13 +187,10 @@ export async function getPopularPackages(
   category?: string
 ): Promise<CuratedPackage[]> {
   try {
-    const supabase = getSupabaseClient();
-
-    const { data: curatedData, error: curatedError } = await supabase
-      .rpc('get_popular_curated_apps', {
-        result_limit: limit,
-        category_filter: category || null,
-      });
+    const { data: curatedData, error: curatedError } = await getCatalogSource().getPopularPackages(
+      limit,
+      category || null
+    );
 
     if (curatedError) {
       console.error('Error getting popular packages:', curatedError);
@@ -270,19 +213,7 @@ export async function getPopularPackages(
  */
 export async function getCategories(): Promise<{ category: string; count: number }[]> {
   try {
-    const supabase = getSupabaseClient();
-
-    const { data, error } = await supabase.rpc('get_curated_categories');
-
-    if (error) {
-      console.error('Error getting categories:', error);
-      return [];
-    }
-
-    return (data || []).map((c: { category: string; app_count: number }) => ({
-      category: c.category,
-      count: c.app_count,
-    }));
+    return await getCatalogSource().getCategories();
   } catch (error) {
     console.error('Error getting categories:', error);
     return [];
@@ -297,19 +228,7 @@ export async function getInstallationChangelog(
   version?: string
 ): Promise<InstallationSnapshot | null> {
   try {
-    const supabase = getSupabaseClient();
-
-    const { data, error } = await supabase
-      .rpc('get_installation_changelog', {
-        app_winget_id: wingetId,
-        app_version: version || null,
-      });
-
-    if (error || !data || data.length === 0) {
-      return null;
-    }
-
-    return data[0] as InstallationSnapshot;
+    return await getCatalogSource().getInstallationChangelog(wingetId, version);
   } catch (error) {
     console.error('Error getting installation changelog:', error);
     return null;
@@ -386,22 +305,22 @@ export interface InstallationSnapshot {
 
 // Helper functions
 
-function normalizeCuratedApp(app: Record<string, unknown>): CuratedPackage {
+function normalizeCuratedApp(app: CuratedAppRpcRow): CuratedPackage {
   return {
-    id: app.winget_id as string,
-    name: app.name as string,
-    publisher: app.publisher as string,
-    version: app.latest_version as string || '',
-    description: app.description as string | undefined,
-    homepage: app.homepage as string | undefined,
+    id: app.winget_id,
+    name: app.name,
+    publisher: app.publisher,
+    version: app.latest_version || '',
+    description: app.description ?? undefined,
+    homepage: app.homepage ?? undefined,
     license: undefined,
-    tags: app.tags as string[] || [],
+    tags: app.tags || [],
     versions: undefined,
-    iconPath: app.icon_path as string | undefined,
-    category: app.category as string | undefined,
-    popularityRank: app.popularity_rank as number | undefined,
+    iconPath: app.icon_path ?? undefined,
+    category: app.category ?? undefined,
+    popularityRank: app.popularity_rank ?? undefined,
     appSource: app.app_source === 'store' ? 'store' : 'win32',
-    packageIdentifier: app.store_package_id as string | undefined,
+    packageIdentifier: app.store_package_id ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
Phase 1 of letting self-hosters use the app catalog without their own Supabase (background: the catalog is global public winget data, but today ~17 code paths read it directly from Supabase, so SQLite-mode self-hosters get 503s).

This PR is a **pure refactor with no behavior change**: every catalog read now goes through a `CatalogSource` interface (`lib/catalog/`) backed by a single `SupabaseCatalogSource`. `getCatalogSource()` always returns the Supabase backend for now; a later phase adds a local **SQLite snapshot** backend (downloaded from a GitHub Release) selected when Supabase is absent.

## What changed
- New: `lib/catalog/{types,supabase-source,index}.ts`.
- 17 read sites rerouted: winget `search`/`popular`/`categories`, `winget-api`/`manifest-api`, update detection (`check-updates`, `intune/apps/updates`, `updates/trigger`, `auto-update/trigger`), SCCM `migrate` + matcher, community endpoints, `stats/public`, `apps/[id]/rate`, `msp/batch-orchestrator`, `app-mappings`.
- Unchanged on purpose: 503 guards + messages, `runtime='edge'`/`fetchCache`/`maxDuration`, JSON response shapes, manifest/GitHub fallbacks, and the #133 SCCM mapping fix (preserved inside `getSccmMapping`). The `sync-packages` cron (writes the catalog) stays on Supabase.

## Verification
- `tsc --noEmit`: clean (no new errors)
- `next lint`: clean
- `vitest`: 408/408 pass
- grep: no catalog table/RPC accessed outside `lib/catalog/` and `sync-packages`
- Independent behavior-preservation code review: 0 regressions found (same tables/columns/filters/ordering/keys; no `single`/`maybeSingle` swaps)

## Next
- Phase 2: snapshot build script + CI + GitHub Release publishing.
- Phase 3: `SnapshotCatalogSource` + download/refresh; wire selector for sqlite mode (catalog routes move off `edge` runtime since better-sqlite3 is native).