### PR TITLE
Serve catalog from SQLite snapshot in self-hosted mode (Phase 3)

### DIFF
--- a/app/api/intune/apps/updates/route.test.ts
+++ b/app/api/intune/apps/updates/route.test.ts
@@ -21,6 +21,9 @@ vi.mock('@/lib/auth-utils', () => ({
 
 vi.mock('@/lib/supabase', () => ({
   createServerClient: createServerClientMock,
+  // getCatalogSource() now branches on isSupabaseConfigured(); the route
+  // imports it transitively, so the mock must provide it (Supabase mode).
+  isSupabaseConfigured: () => true,
 }));
 
 vi.mock('@/lib/msp/tenant-resolution', () => ({

--- a/app/api/winget/categories/route.ts
+++ b/app/api/winget/categories/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 import { getCategories } from '@/lib/winget-api';
 import { getCatalogSource } from '@/lib/catalog';
 
-export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
 

--- a/app/api/winget/changelog/route.ts
+++ b/app/api/winget/changelog/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getInstallationChangelog } from '@/lib/winget-api';
 
-export const runtime = 'edge';
-
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/app/api/winget/manifest/route.ts
+++ b/app/api/winget/manifest/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getManifest, getInstallers, getBestInstaller, getPackage } from '@/lib/winget-api';
 import { fetchSimilarPackages, fetchAvailableVersions } from '@/lib/manifest-api';
 
-export const runtime = 'edge';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/winget/package/route.ts
+++ b/app/api/winget/package/route.ts
@@ -2,8 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPackage, getPackageVersions, getInstallers } from '@/lib/winget-api';
 import { fetchSimilarPackages } from '@/lib/manifest-api';
 
-export const runtime = 'edge';
-
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/app/api/winget/popular/route.ts
+++ b/app/api/winget/popular/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCatalogSource } from '@/lib/catalog';
 
-export const runtime = 'edge';
 export const fetchCache = 'force-no-store';
 
 type SortBy = 'popular' | 'name' | 'newest';

--- a/app/api/winget/search/route.ts
+++ b/app/api/winget/search/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCatalogSource } from '@/lib/catalog';
 
-export const runtime = 'edge';
 export const fetchCache = 'force-no-store';
 
 interface CuratedAppResult {

--- a/app/api/winget/variants/route.ts
+++ b/app/api/winget/variants/route.ts
@@ -2,8 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getLocaleDisplay, countryCodeToFlag } from '@/lib/locale-utils';
 
-export const runtime = 'edge';
-
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/lib/catalog/index.ts
+++ b/lib/catalog/index.ts
@@ -1,22 +1,51 @@
 /**
  * Catalog source selector.
  *
- * Returns the active CatalogSource implementation. In Phase 1 this is always
- * the Supabase-backed source (singleton).
+ * Returns the active CatalogSource implementation as a process singleton. The
+ * backing store is decided once, on first access, from isSupabaseConfigured():
+ *  - configured   -> SupabaseCatalogSource
+ *  - not configured (self-hosted sqlite mode) -> SnapshotCatalogSource over a
+ *    downloaded/verified catalog snapshot.
  *
- * TODO(Phase 3): branch on isSupabaseConfigured() and return a
- * SnapshotCatalogSource (better-sqlite3 over a downloaded catalog snapshot)
- * for self-hosted sqlite mode when Supabase is not configured.
+ * snapshot-source.ts transitively pulls node:fs and better-sqlite3, so it must
+ * never be statically imported here or it would land in the Supabase-mode/edge
+ * bundles. Instead it is lazy-loaded via a Proxy that dynamic-imports the
+ * module on the first method call.
  */
 
 import type { CatalogSource } from './types';
 import { SupabaseCatalogSource } from './supabase-source';
+import { isSupabaseConfigured } from '@/lib/supabase';
 
 let _source: CatalogSource | null = null;
 
+/**
+ * Returns a CatalogSource whose methods dynamic-import SnapshotCatalogSource on
+ * first call, so the native snapshot module is only pulled in for self-hosted
+ * sqlite mode (never into Supabase-mode/edge bundles).
+ */
+function lazySnapshotSource(): CatalogSource {
+  let p: Promise<CatalogSource> | null = null;
+  const load = () =>
+    (p ??= import('./snapshot-source').then((m) => new m.SnapshotCatalogSource()));
+  return new Proxy(
+    {},
+    {
+      get:
+        (_t, prop) =>
+        (...args: unknown[]) =>
+          load().then((s) =>
+            (s as unknown as Record<string, (...a: unknown[]) => unknown>)[prop as string](
+              ...args
+            )
+          ),
+    }
+  ) as CatalogSource;
+}
+
 export function getCatalogSource(): CatalogSource {
   if (!_source) {
-    _source = new SupabaseCatalogSource();
+    _source = isSupabaseConfigured() ? new SupabaseCatalogSource() : lazySnapshotSource();
   }
   return _source;
 }

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -1,0 +1,263 @@
+/**
+ * SnapshotCatalogSource tests.
+ *
+ * Builds a real catalog snapshot file from mock rows using buildSqlite (the
+ * same builder the production snapshot pipeline uses), points
+ * CATALOG_SNAPSHOT_FILE at it, and asserts the source's behavior matches the
+ * SupabaseCatalogSource semantics it replaces.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildSqlite } from '../../scripts/build-catalog-snapshot.mjs';
+import { SnapshotCatalogSource } from './snapshot-source';
+import { _resetSnapshotStoreForTest } from './snapshot-store';
+
+let tmpDir: string;
+let dbPath: string;
+
+const curatedApps = [
+  {
+    id: 1,
+    winget_id: 'Google.Chrome',
+    name: 'Google Chrome',
+    publisher: 'Google LLC',
+    latest_version: '120.0',
+    description: 'Fast web browser',
+    homepage: 'https://google.com',
+    tags: ['browser', 'web'],
+    category: 'Browsers',
+    is_verified: true,
+    is_locale_variant: false,
+    popularity_rank: 1,
+    app_source: 'winget',
+    has_icon: true,
+  },
+  {
+    id: 2,
+    winget_id: 'Mozilla.Firefox',
+    name: 'Mozilla Firefox',
+    publisher: 'Mozilla',
+    latest_version: '121.0',
+    description: 'Open source browser',
+    tags: ['browser'],
+    category: 'Browsers',
+    is_verified: true,
+    is_locale_variant: false,
+    popularity_rank: 2,
+  },
+  {
+    id: 3,
+    winget_id: 'Zoom.Zoom',
+    name: 'Zoom Workplace',
+    publisher: 'Zoom',
+    latest_version: '6.0',
+    tags: null,
+    category: 'Communication',
+    is_verified: true,
+    is_locale_variant: false,
+    popularity_rank: 5,
+  },
+  {
+    id: 4,
+    winget_id: 'Google.Chrome.de',
+    name: 'Google Chrome (German)',
+    publisher: 'Google LLC',
+    latest_version: '120.0',
+    category: 'Browsers',
+    is_verified: true,
+    is_locale_variant: true,
+    parent_winget_id: 'Google.Chrome',
+    locale_code: 'de',
+    popularity_rank: 10,
+  },
+];
+
+const versionHistory = [
+  {
+    winget_id: 'Google.Chrome',
+    version: '120.0',
+    installer_url: 'https://x/chrome.msi',
+    installer_sha256: 'abc',
+    installer_type: 'msi',
+    installer_scope: 'machine',
+    installers: [{ Architecture: 'x64', InstallerUrl: 'https://x/chrome.msi' }],
+    created_at: '2026-01-02T00:00:00Z',
+  },
+  {
+    winget_id: 'Google.Chrome',
+    version: '119.0',
+    installer_url: 'https://x/chrome119.msi',
+    installer_sha256: 'def',
+    installer_type: 'msi',
+    installers: [{ Architecture: 'x64', InstallerUrl: 'https://x/chrome119.msi' }],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const sccmMappings = [
+  {
+    id: 'm1',
+    sccm_display_name_normalized: 'google chrome',
+    sccm_ci_id: '123',
+    sccm_product_code: null,
+    winget_package_id: 'Google.Chrome',
+    winget_package_name: 'Google Chrome',
+    confidence: 1,
+    is_verified: true,
+  },
+];
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), 'snapshot-source-test-'));
+  dbPath = path.join(tmpDir, 'catalog.sqlite');
+  buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings });
+  process.env.CATALOG_SNAPSHOT_FILE = dbPath;
+  _resetSnapshotStoreForTest();
+});
+
+afterEach(() => {
+  // keep the same open handle across assertions; nothing to reset per-test
+});
+
+afterAll(() => {
+  _resetSnapshotStoreForTest();
+  delete process.env.CATALOG_SNAPSHOT_FILE;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('SnapshotCatalogSource', () => {
+  const source = new SnapshotCatalogSource();
+
+  it('searchApps("chrome") returns the Chrome row (FTS path)', async () => {
+    const { data, error } = await source.searchApps('chrome', { limit: 10 });
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const ids = (data || []).map((r) => r.winget_id);
+    expect(ids).toContain('Google.Chrome');
+    // locale variant must be excluded
+    expect(ids).not.toContain('Google.Chrome.de');
+    // tags parsed back to an array
+    const chrome = (data || []).find((r) => r.winget_id === 'Google.Chrome');
+    expect(chrome?.tags).toEqual(['browser', 'web']);
+    expect(chrome?.installer_type).toBeNull();
+  });
+
+  it('searchApps falls back to ILIKE for non-FTS-matching publisher terms', async () => {
+    const { data } = await source.searchApps('Mozilla', { limit: 10 });
+    const ids = (data || []).map((r) => r.winget_id);
+    expect(ids).toContain('Mozilla.Firefox');
+  });
+
+  it('getPopularApps orders by popularity and counts verified non-variant apps', async () => {
+    const result = await source.getPopularApps({
+      limit: 10,
+      offset: 0,
+      sort: 'popular',
+    });
+    expect(result).not.toBeNull();
+    expect(result?.data[0].winget_id).toBe('Google.Chrome');
+    // 3 verified non-variant apps (locale variant excluded)
+    expect(result?.total).toBe(3);
+  });
+
+  it('getPopularPackages returns popularity-ordered rows', async () => {
+    const { data, error } = await source.getPopularPackages(10);
+    expect(error).toBeNull();
+    expect((data || [])[0].winget_id).toBe('Google.Chrome');
+  });
+
+  it('getCategories returns per-category counts', async () => {
+    const cats = await source.getCategories();
+    const browsers = cats.find((c) => c.category === 'Browsers');
+    // Google.Chrome, Mozilla.Firefox, Google.Chrome.de are all verified Browsers
+    expect(browsers?.count).toBe(3);
+    const comms = cats.find((c) => c.category === 'Communication');
+    expect(comms?.count).toBe(1);
+  });
+
+  it('getAppByWingetId returns versions (newest first) and locale variants', async () => {
+    const details = await source.getAppByWingetId('Google.Chrome');
+    expect(details).not.toBeNull();
+    expect(details?.app.winget_id).toBe('Google.Chrome');
+    expect(details?.versions).toEqual(['120.0', '119.0']);
+    expect(details?.app.tags).toEqual(['browser', 'web']);
+    expect(details?.localeVariants?.[0].wingetId).toBe('Google.Chrome.de');
+    expect(details?.localeVariants?.[0].localeCode).toBe('de');
+  });
+
+  it('getVersionInstallerInfo parses installers JSON', async () => {
+    const info = await source.getVersionInstallerInfo('Google.Chrome', '120.0');
+    expect(info?.installer_url).toBe('https://x/chrome.msi');
+    expect(Array.isArray(info?.installers)).toBe(true);
+    expect((info?.installers as Array<{ Architecture: string }>)[0].Architecture).toBe('x64');
+  });
+
+  it('getLatestVersionInstallerInfo returns the row for a version', async () => {
+    const info = await source.getLatestVersionInstallerInfo('Google.Chrome', '119.0');
+    expect(info?.installer_url).toBe('https://x/chrome119.msi');
+  });
+
+  it('getInstallationChangelog returns null (not shipped in snapshot)', async () => {
+    expect(await source.getInstallationChangelog('Google.Chrome')).toBeNull();
+  });
+
+  it('getAllLatestVersions returns rows with non-null latest_version', async () => {
+    const all = await source.getAllLatestVersions();
+    const map = new Map(all.map((r) => [r.winget_id, r.latest_version]));
+    expect(map.get('Google.Chrome')).toBe('120.0');
+    expect(map.get('Mozilla.Firefox')).toBe('121.0');
+  });
+
+  it('getAppsByWingetIds returns latest versions for the given ids', async () => {
+    const rows = await source.getAppsByWingetIds(['Google.Chrome', 'Zoom.Zoom']);
+    const map = new Map(rows.map((r) => [r.winget_id, r.latest_version]));
+    expect(map.get('Google.Chrome')).toBe('120.0');
+    expect(map.get('Zoom.Zoom')).toBe('6.0');
+    expect(map.size).toBe(2);
+  });
+
+  it('getSccmMapping("google chrome") resolves to Google.Chrome via mapping', async () => {
+    const result = await source.getSccmMapping(
+      { displayNameNormalized: 'google chrome', ciId: 'unknown', productCode: null },
+      'tenant-xyz'
+    );
+    expect(result?.status).toBe('matched');
+    expect(result?.wingetId).toBe('Google.Chrome');
+    expect(result?.wingetName).toBe('Google Chrome');
+    expect(result?.matchedBy).toBe('mapping');
+    expect(result?.mappingId).toBe('m1');
+  });
+
+  it('searchCuratedAppsForMatching returns CuratedAppMatch shape', async () => {
+    const matches = await source.searchCuratedAppsForMatching('chrome');
+    expect(matches[0]).toMatchObject({
+      wingetId: 'Google.Chrome',
+      name: 'Google Chrome',
+      publisher: 'Google LLC',
+      latestVersion: '120.0',
+    });
+  });
+
+  it('existence checks behave like the Supabase source', async () => {
+    expect(await source.appExists('Google.Chrome')).toBe(true);
+    expect(await source.appExists('Does.NotExist')).toBe(false);
+    expect(await source.appExistsCaseInsensitive('google.chrome')).toEqual({
+      winget_id: 'Google.Chrome',
+    });
+    const similar = await source.findSimilarVerifiedApps('chrome', 5);
+    expect(similar.map((a) => a.winget_id)).toContain('Google.Chrome');
+  });
+
+  it('getCatalogStats counts all curated apps', async () => {
+    const stats = await source.getCatalogStats();
+    expect(stats.totalApps).toBe(4);
+  });
+
+  it('getCategoryCount respects verifiedOnly', async () => {
+    expect(await source.getCategoryCount({ verifiedOnly: true })).toBe(4);
+    expect(await source.getCategoryCount({ verifiedOnly: false })).toBe(4);
+  });
+});

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -1,0 +1,779 @@
+/**
+ * SQLite-snapshot-backed CatalogSource (self-hosted / Supabase-less mode).
+ *
+ * Answers every CatalogSource method by querying the downloaded, verified
+ * catalog snapshot (see snapshot-store.ts) instead of Supabase. Each method
+ * mirrors the return shape and degradation behavior of SupabaseCatalogSource:
+ * when the snapshot is unavailable, methods that return `{ data, error }`
+ * surface the error, and methods that return null/[]/undefined degrade to
+ * their empty value rather than throwing.
+ *
+ * Native dependencies (node:fs, better-sqlite3) are only reachable through
+ * snapshot-store.ts, which is lazy-loaded by the catalog selector so nothing
+ * here is pulled into Supabase-mode or edge bundles.
+ */
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { getSnapshotDb, SnapshotUnavailableError } from './snapshot-store';
+import { getLocaleDisplay } from '@/lib/locale-utils';
+import type { LocaleVariant } from '@/types/winget';
+import type { CuratedAppMatch } from '@/lib/app-mappings';
+import type { InstallationSnapshot } from '@/lib/winget-api';
+import type {
+  CatalogSource,
+  CategoryCount,
+  CuratedAppRpcRow,
+  CuratedAppWithDetails,
+  PopularCuratedAppRow,
+  PopularPackagesResult,
+  SccmCuratedAppRow,
+  SccmMappingQuery,
+  SccmMappingResult,
+  SearchSort,
+  VersionInstallerInfo,
+  WingetIdLatestVersion,
+} from './types';
+
+type DB = BetterSqlite3.Database;
+
+/**
+ * Run a snapshot query, degrading gracefully when the snapshot is unavailable.
+ * `onUnavailable` provides the per-method empty value so each method matches
+ * the corresponding SupabaseCatalogSource degradation semantics.
+ */
+async function withDb<T>(
+  run: (db: DB) => T,
+  onUnavailable: () => T
+): Promise<T> {
+  let db: DB;
+  try {
+    db = await getSnapshotDb();
+  } catch (err) {
+    if (err instanceof SnapshotUnavailableError) {
+      return onUnavailable();
+    }
+    throw err;
+  }
+  return run(db);
+}
+
+/** Columns selected for the RPC-row mapping (curated_apps). */
+interface CuratedAppDbRow {
+  id: number;
+  winget_id: string;
+  name: string;
+  publisher: string;
+  latest_version: string | null;
+  description: string | null;
+  homepage: string | null;
+  category: string | null;
+  tags: string | null;
+  icon_path: string | null;
+  popularity_rank: number | null;
+  app_source: string | null;
+  store_package_id: string | null;
+}
+
+function parseTags(tags: string | null): string[] | null {
+  if (!tags) return null;
+  try {
+    const parsed = JSON.parse(tags);
+    return Array.isArray(parsed) ? (parsed as string[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function toRpcRow(r: CuratedAppDbRow): CuratedAppRpcRow {
+  return {
+    id: r.id,
+    winget_id: r.winget_id,
+    name: r.name,
+    publisher: r.publisher,
+    latest_version: r.latest_version ?? '',
+    description: r.description,
+    homepage: r.homepage,
+    category: r.category,
+    tags: parseTags(r.tags),
+    icon_path: r.icon_path,
+    popularity_rank: r.popularity_rank,
+    // installer_type is not carried in the curated_apps snapshot table.
+    installer_type: null,
+    app_source: r.app_source,
+    store_package_id: r.store_package_id,
+  };
+}
+
+function toPopularRow(r: CuratedAppDbRow): PopularCuratedAppRow {
+  return {
+    id: r.id,
+    winget_id: r.winget_id,
+    name: r.name,
+    publisher: r.publisher,
+    latest_version: r.latest_version ?? '',
+    description: r.description,
+    homepage: r.homepage,
+    category: r.category,
+    tags: parseTags(r.tags),
+    icon_path: r.icon_path,
+    popularity_rank: r.popularity_rank,
+    app_source: r.app_source,
+    store_package_id: r.store_package_id,
+  };
+}
+
+const CURATED_RPC_COLUMNS =
+  'id, winget_id, name, publisher, latest_version, description, homepage, category, tags, icon_path, popularity_rank, app_source, store_package_id';
+
+/**
+ * Build a safe FTS5 MATCH expression from user input. Splits into terms,
+ * strips FTS5 special characters, quotes each term, and joins with spaces
+ * (implicit AND). Returns null when no usable term remains (caller falls back
+ * to ILIKE). Never passes raw user input to MATCH.
+ */
+function buildFtsMatch(query: string): string | null {
+  const terms = query
+    .split(/\s+/)
+    .map((t) => t.replace(/["*^():\-+]/g, '').trim())
+    .filter((t) => t.length > 0);
+  if (terms.length === 0) return null;
+  return terms.map((t) => `"${t}"`).join(' ');
+}
+
+export class SnapshotCatalogSource implements CatalogSource {
+  // ---------------------------------------------------------------------------
+  // search / discovery
+  // ---------------------------------------------------------------------------
+
+  async searchApps(
+    query: string,
+    opts: { limit: number; category?: string | null; sort?: SearchSort }
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }> {
+    return withDb<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }>(
+      (db) => {
+        const category = opts.category || null;
+        const limit = opts.limit;
+        const ftsMatch = buildFtsMatch(query);
+
+        const categoryClause = category ? 'AND ca.category = @category' : '';
+        const params: Record<string, unknown> = {
+          q: query,
+          limit,
+          ...(category ? { category } : {}),
+        };
+
+        let rows: CuratedAppDbRow[] = [];
+
+        if (ftsMatch) {
+          // FTS path: relevance bucket, then bm25, then popularity (nulls last).
+          const ftsSql = `
+            SELECT ${CURATED_RPC_COLUMNS.split(', ').map((c) => `ca.${c}`).join(', ')}
+            FROM curated_fts f
+            JOIN curated_apps ca ON ca.id = f.rowid
+            WHERE curated_fts MATCH @match
+              AND ca.is_verified = 1
+              AND ca.is_locale_variant = 0
+              ${categoryClause}
+            ORDER BY
+              CASE
+                WHEN lower(ca.name) = lower(@q) OR lower(ca.winget_id) = lower(@q) OR ca.winget_id LIKE '%.' || @q THEN 0
+                WHEN lower(ca.name) LIKE lower(@q) || '%' OR ca.winget_id LIKE '%.' || @q || '%' THEN 1
+                ELSE 2
+              END,
+              bm25(curated_fts) ASC,
+              ca.popularity_rank IS NULL,
+              ca.popularity_rank ASC
+            LIMIT @limit
+          `;
+          rows = db
+            .prepare(ftsSql)
+            .all({ ...params, match: ftsMatch }) as CuratedAppDbRow[];
+        }
+
+        // ILIKE fallback when FTS returns nothing (or was skipped).
+        if (rows.length === 0) {
+          const fallbackSql = `
+            SELECT ${CURATED_RPC_COLUMNS}
+            FROM curated_apps ca
+            WHERE ca.is_verified = 1
+              AND ca.is_locale_variant = 0
+              ${categoryClause}
+              AND (
+                ca.name LIKE '%' || @q || '%'
+                OR ca.publisher LIKE '%' || @q || '%'
+                OR ca.winget_id LIKE '%' || @q || '%'
+                OR ca.description LIKE '%' || @q || '%'
+              )
+            ORDER BY
+              CASE
+                WHEN lower(ca.name) = lower(@q) OR lower(ca.winget_id) = lower(@q) OR ca.winget_id LIKE '%.' || @q THEN 1
+                WHEN lower(ca.name) LIKE lower(@q) || '%' THEN 2
+                WHEN ca.winget_id LIKE '%.' || @q || '%' OR ca.name LIKE '%' || @q || '%' THEN 3
+                ELSE 4
+              END,
+              ca.popularity_rank IS NULL,
+              ca.popularity_rank ASC
+            LIMIT @limit
+          `;
+          // The fallback selects ca.* columns without the join alias on FTS;
+          // re-key params so prepared statement names resolve.
+          rows = db.prepare(fallbackSql).all(params) as CuratedAppDbRow[];
+        }
+
+        return { data: rows.map(toRpcRow), error: null };
+      },
+      () => ({ data: null, error: { message: 'Catalog snapshot is not available' } })
+    );
+  }
+
+  async getPopularApps(opts: {
+    limit: number;
+    offset: number;
+    category?: string | null;
+    sort: SearchSort;
+  }): Promise<PopularPackagesResult | null> {
+    return withDb(
+      (db) => {
+        const { limit, offset, category, sort } = opts;
+        const categoryClause = category ? 'AND category = @category' : '';
+        const baseParams: Record<string, unknown> = category ? { category } : {};
+
+        const countRow = db
+          .prepare(
+            `SELECT COUNT(*) AS c FROM curated_apps
+             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}`
+          )
+          .get(baseParams) as { c: number };
+
+        let orderBy: string;
+        switch (sort) {
+          case 'name':
+            orderBy = 'name ASC';
+            break;
+          case 'newest':
+            orderBy = 'created_at DESC';
+            break;
+          case 'popular':
+          default:
+            orderBy = 'popularity_rank IS NULL, popularity_rank ASC, name ASC';
+            break;
+        }
+
+        const rows = db
+          .prepare(
+            `SELECT ${CURATED_RPC_COLUMNS}
+             FROM curated_apps
+             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}
+             ORDER BY ${orderBy}
+             LIMIT @limit OFFSET @offset`
+          )
+          .all({ ...baseParams, limit, offset }) as CuratedAppDbRow[];
+
+        return {
+          data: rows.map(toPopularRow),
+          total: countRow.c || 0,
+        };
+      },
+      () => null
+    );
+  }
+
+  async getPopularPackages(
+    limit: number,
+    category?: string | null
+  ): Promise<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }> {
+    return withDb<{ data: CuratedAppRpcRow[] | null; error: { message: string } | null }>(
+      (db) => {
+        const cat = category || null;
+        const categoryClause = cat ? 'AND category = @category' : '';
+        const params: Record<string, unknown> = cat ? { category: cat, limit } : { limit };
+
+        const rows = db
+          .prepare(
+            `SELECT ${CURATED_RPC_COLUMNS}
+             FROM curated_apps
+             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}
+             ORDER BY popularity_rank IS NULL, popularity_rank ASC, name ASC
+             LIMIT @limit`
+          )
+          .all(params) as CuratedAppDbRow[];
+
+        return { data: rows.map(toRpcRow), error: null };
+      },
+      () => ({ data: null, error: { message: 'Catalog snapshot is not available' } })
+    );
+  }
+
+  async getCategories(): Promise<CategoryCount[]> {
+    return withDb(
+      (db) => {
+        const rows = db
+          .prepare(
+            `SELECT category, COUNT(*) AS count
+             FROM curated_apps
+             WHERE is_verified = 1 AND category IS NOT NULL
+             GROUP BY category`
+          )
+          .all() as { category: string; count: number }[];
+
+        return rows.map((r) => ({ category: r.category, count: r.count }));
+      },
+      () => []
+    );
+  }
+
+  async getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null> {
+    return withDb(
+      (db) => {
+        const where = opts.verifiedOnly ? 'WHERE is_verified = 1' : '';
+        const row = db
+          .prepare(`SELECT COUNT(*) AS c FROM curated_apps ${where}`)
+          .get() as { c: number };
+        return row.c ?? null;
+      },
+      () => null
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // app detail
+  // ---------------------------------------------------------------------------
+
+  async getAppByWingetId(wingetId: string): Promise<CuratedAppWithDetails | null> {
+    return withDb(
+      (db) => {
+        const app = db
+          .prepare(`SELECT * FROM curated_apps WHERE winget_id = ?`)
+          .get(wingetId) as Record<string, unknown> | undefined;
+
+        if (!app) {
+          return null;
+        }
+
+        const versionRows = db
+          .prepare(
+            `SELECT version FROM version_history WHERE winget_id = ? ORDER BY created_at DESC`
+          )
+          .all(wingetId) as { version: string }[];
+        const versions = versionRows.map((v) => v.version);
+
+        // tags are stored as a JSON string; restore the array to match the
+        // Supabase row shape (CuratedAppFullRow.tags is string[] | null).
+        const tags = parseTags((app.tags as string | null) ?? null);
+        const isLocaleVariant = Boolean(app.is_locale_variant);
+
+        let localeVariants: LocaleVariant[] | undefined;
+        if (!isLocaleVariant) {
+          const variantRows = db
+            .prepare(
+              `SELECT winget_id, locale_code, latest_version
+               FROM curated_apps
+               WHERE parent_winget_id = ?`
+            )
+            .all(wingetId) as {
+            winget_id: string;
+            locale_code: string | null;
+            latest_version: string | null;
+          }[];
+
+          if (variantRows.length > 0) {
+            localeVariants = variantRows.map((v) => {
+              const display = getLocaleDisplay(v.locale_code || '');
+              return {
+                wingetId: v.winget_id,
+                localeCode: v.locale_code || '',
+                localeName: display.name,
+                countryFlag: display.flag,
+                version: v.latest_version || undefined,
+              };
+            });
+          }
+        }
+
+        return {
+          app: {
+            ...app,
+            tags,
+            is_locale_variant: isLocaleVariant,
+            has_icon: Boolean(app.has_icon),
+            is_verified: Boolean(app.is_verified),
+          } as unknown as CuratedAppWithDetails['app'],
+          versions,
+          localeVariants,
+        };
+      },
+      () => null
+    );
+  }
+
+  async getVersions(wingetId: string): Promise<string[]> {
+    return withDb(
+      (db) => {
+        const rows = db
+          .prepare(
+            `SELECT version FROM version_history WHERE winget_id = ? ORDER BY created_at DESC`
+          )
+          .all(wingetId) as { version: string }[];
+        return rows.map((v) => v.version);
+      },
+      () => []
+    );
+  }
+
+  async getVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(
+            `SELECT installer_url, installer_sha256, installer_type, installer_scope, installers
+             FROM version_history
+             WHERE winget_id = ? AND version = ?`
+          )
+          .get(wingetId, version) as
+          | {
+              installer_url: string | null;
+              installer_sha256: string | null;
+              installer_type: string | null;
+              installer_scope: string | null;
+              installers: string | null;
+            }
+          | undefined;
+
+        if (!row) return null;
+        return {
+          installer_url: row.installer_url,
+          installer_sha256: row.installer_sha256,
+          installer_type: row.installer_type,
+          installer_scope: row.installer_scope,
+          installers: row.installers ? JSON.parse(row.installers) : null,
+        };
+      },
+      () => null
+    );
+  }
+
+  async getLatestVersionInstallerInfo(
+    wingetId: string,
+    version: string
+  ): Promise<VersionInstallerInfo | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(
+            `SELECT installer_url, installer_sha256, installer_type, installer_scope, installers
+             FROM version_history
+             WHERE winget_id = ? AND version = ?
+             ORDER BY created_at DESC
+             LIMIT 1`
+          )
+          .get(wingetId, version) as
+          | {
+              installer_url: string | null;
+              installer_sha256: string | null;
+              installer_type: string | null;
+              installer_scope: string | null;
+              installers: string | null;
+            }
+          | undefined;
+
+        if (!row) return null;
+        return {
+          installer_url: row.installer_url,
+          installer_sha256: row.installer_sha256,
+          installer_type: row.installer_type,
+          installer_scope: row.installer_scope,
+          installers: row.installers ? JSON.parse(row.installers) : null,
+        };
+      },
+      () => null
+    );
+  }
+
+  async getInstallationChangelog(
+    _wingetId: string,
+    _version?: string
+  ): Promise<InstallationSnapshot | null> {
+    // installation_snapshots is operational data, not catalog data, so it is
+    // not shipped in the snapshot. There is nothing to return in sqlite mode.
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // update detection
+  // ---------------------------------------------------------------------------
+
+  async getAppsByWingetIds(ids: string[]): Promise<WingetIdLatestVersion[]> {
+    return withDb(
+      (db) => {
+        if (ids.length === 0) return [];
+        const placeholders = ids.map(() => '?').join(', ');
+        const rows = db
+          .prepare(
+            `SELECT winget_id, latest_version FROM curated_apps WHERE winget_id IN (${placeholders})`
+          )
+          .all(...ids) as WingetIdLatestVersion[];
+        return rows;
+      },
+      () => []
+    );
+  }
+
+  async getAllLatestVersions(): Promise<WingetIdLatestVersion[]> {
+    return withDb(
+      (db) => {
+        const rows = db
+          .prepare(
+            `SELECT winget_id, latest_version FROM curated_apps WHERE latest_version IS NOT NULL`
+          )
+          .all() as WingetIdLatestVersion[];
+        return rows;
+      },
+      () => []
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // small metadata lookups
+  // ---------------------------------------------------------------------------
+
+  async getAppNamePublisher(
+    wingetId: string
+  ): Promise<{ name: string; publisher: string | null } | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(`SELECT name, publisher FROM curated_apps WHERE winget_id = ?`)
+          .get(wingetId) as { name: string; publisher: string | null } | undefined;
+        return row ?? null;
+      },
+      () => null
+    );
+  }
+
+  async getAppForInstaller(wingetId: string): Promise<{
+    winget_id: string;
+    name: string;
+    latest_version: string | null;
+  } | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(
+            `SELECT winget_id, name, latest_version FROM curated_apps WHERE winget_id = ?`
+          )
+          .get(wingetId) as
+          | { winget_id: string; name: string; latest_version: string | null }
+          | undefined;
+        return row ?? null;
+      },
+      () => null
+    );
+  }
+
+  async getSccmCuratedApp(wingetId: string): Promise<SccmCuratedAppRow | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(
+            `SELECT winget_id, name, publisher, latest_version, description, homepage, license, tags, category, icon_path
+             FROM curated_apps WHERE winget_id = ?`
+          )
+          .get(wingetId) as
+          | (Omit<SccmCuratedAppRow, 'tags'> & { tags: string | null })
+          | undefined;
+
+        if (!row) return null;
+        return { ...row, tags: parseTags(row.tags) };
+      },
+      () => null
+    );
+  }
+
+  async getAppDescription(wingetId: string): Promise<string | undefined> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(`SELECT description FROM curated_apps WHERE winget_id = ? LIMIT 1`)
+          .get(wingetId) as { description: string | null } | undefined;
+        if (!row?.description || typeof row.description !== 'string') {
+          return undefined;
+        }
+        return row.description;
+      },
+      () => undefined
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // matching
+  // ---------------------------------------------------------------------------
+
+  async searchCuratedAppsForMatching(term: string): Promise<CuratedAppMatch[]> {
+    if (!term || term.length < 2) {
+      return [];
+    }
+    const normalizedSearch = term.toLowerCase().trim();
+
+    return withDb(
+      (db) => {
+        const rows = db
+          .prepare(
+            `SELECT winget_id, name, publisher, latest_version
+             FROM curated_apps
+             WHERE latest_version IS NOT NULL
+               AND (
+                 lower(name) LIKE '%' || @term || '%'
+                 OR lower(publisher) LIKE '%' || @term || '%'
+                 OR lower(winget_id) LIKE '%' || @term || '%'
+               )
+             ORDER BY popularity_rank IS NULL, popularity_rank ASC
+             LIMIT 10`
+          )
+          .all({ term: normalizedSearch }) as {
+          winget_id: string;
+          name: string;
+          publisher: string;
+          latest_version: string | null;
+        }[];
+
+        return rows.map((app) => ({
+          wingetId: app.winget_id,
+          name: app.name,
+          publisher: app.publisher,
+          latestVersion: app.latest_version,
+        }));
+      },
+      () => []
+    );
+  }
+
+  async getSccmMapping(
+    query: SccmMappingQuery,
+    _tenantId: string
+  ): Promise<SccmMappingResult | null> {
+    return withDb(
+      (db) => {
+        const { displayNameNormalized, ciId, productCode } = query;
+
+        const conditions = [
+          'sccm_display_name_normalized = @displayNameNormalized',
+          'sccm_ci_id = @ciId',
+        ];
+        const params: Record<string, unknown> = { displayNameNormalized, ciId };
+        if (productCode) {
+          conditions.push('sccm_product_code = @productCode');
+          params.productCode = productCode;
+        }
+
+        const mapping = db
+          .prepare(
+            `SELECT id, winget_package_id, winget_package_name, confidence, is_verified, sccm_product_code
+             FROM sccm_winget_mappings
+             WHERE ${conditions.join(' OR ')}
+             ORDER BY is_verified DESC
+             LIMIT 1`
+          )
+          .get(params) as
+          | {
+              id: string;
+              winget_package_id: string | null;
+              winget_package_name: string | null;
+              confidence: number | null;
+              is_verified: number | null;
+              sccm_product_code: string | null;
+            }
+          | undefined;
+
+        // The snapshot only ships global mappings (no tenant_id column), so
+        // there is no tenant-scope rejection to perform here.
+        if (!mapping) return null;
+
+        const wingetId = mapping.winget_package_id;
+        if (!wingetId) return null;
+
+        return {
+          status: 'matched',
+          wingetId,
+          wingetName: mapping.winget_package_name || wingetId.split('.').pop() || wingetId,
+          confidence: mapping.confidence ?? 1.0,
+          partialMatches: [],
+          matchedBy: mapping.sccm_product_code && productCode ? 'product_code' : 'mapping',
+          mappingId: mapping.id,
+        };
+      },
+      () => null
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // existence checks
+  // ---------------------------------------------------------------------------
+
+  async appExists(wingetId: string): Promise<boolean> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(`SELECT id, winget_id FROM curated_apps WHERE winget_id = ?`)
+          .get(wingetId);
+        return Boolean(row);
+      },
+      () => false
+    );
+  }
+
+  async appExistsCaseInsensitive(
+    wingetId: string
+  ): Promise<{ winget_id: string } | null> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(
+            `SELECT id, winget_id FROM curated_apps WHERE winget_id = ? COLLATE NOCASE LIMIT 1`
+          )
+          .get(wingetId) as { winget_id: string } | undefined;
+        return row ? { winget_id: row.winget_id } : null;
+      },
+      () => null
+    );
+  }
+
+  async findSimilarVerifiedApps(
+    term: string,
+    limit: number
+  ): Promise<{ winget_id: string; name: string }[]> {
+    return withDb(
+      (db) => {
+        const rows = db
+          .prepare(
+            `SELECT winget_id, name
+             FROM curated_apps
+             WHERE is_verified = 1
+               AND (winget_id LIKE '%' || @term || '%' OR name LIKE '%' || @term || '%')
+             LIMIT @limit`
+          )
+          .all({ term, limit }) as { winget_id: string; name: string }[];
+        return rows;
+      },
+      () => []
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // stats
+  // ---------------------------------------------------------------------------
+
+  async getCatalogStats(): Promise<{ totalApps: number }> {
+    return withDb(
+      (db) => {
+        const row = db
+          .prepare(`SELECT COUNT(*) AS c FROM curated_apps`)
+          .get() as { c: number };
+        return { totalApps: row.c ?? 0 };
+      },
+      () => ({ totalApps: 0 })
+    );
+  }
+}

--- a/lib/catalog/snapshot-store.ts
+++ b/lib/catalog/snapshot-store.ts
@@ -1,0 +1,352 @@
+/**
+ * Catalog snapshot store (self-hosted / Supabase-less mode).
+ *
+ * Downloads the published catalog SQLite snapshot from the GitHub `catalog-latest`
+ * release, verifies it, and hands SnapshotCatalogSource a read-only handle.
+ *
+ * Security posture:
+ *  - The download URL must be HTTPS (a non-https override is rejected).
+ *  - The gzip is size-capped while streaming to bound disk use.
+ *  - The gzip's sha256 is verified against the manifest BEFORE it is unpacked
+ *    or opened, so a corrupted/tampered asset is never used.
+ *  - The decompressed DB is validated (opens, expected tables) in a temp file,
+ *    then atomically renamed into place; the live handle is opened read-only
+ *    with query_only enforced.
+ *  - better-sqlite3 (an optionalDependency) is lazy-loaded, so nothing here is
+ *    pulled into Supabase-mode or edge bundles.
+ *
+ * A self-hoster can also point CATALOG_SNAPSHOT_FILE at a local .sqlite they
+ * trust to skip downloading entirely.
+ */
+
+import { createHash } from 'node:crypto';
+import { createGunzip } from 'node:zlib';
+import { createReadStream, createWriteStream, existsSync } from 'node:fs';
+import { mkdir, rename, readFile, writeFile, rm, stat } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { Readable, Transform } from 'node:stream';
+import path from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
+
+export const SNAPSHOT_SCHEMA_VERSION = 1;
+
+const DEFAULT_BASE_URL =
+  'https://github.com/ugurkocde/IntuneGet/releases/download/catalog-latest';
+const MAX_GZ_BYTES = 500 * 1024 * 1024; // hard cap on the downloaded (compressed) asset
+const MAX_DECOMPRESSED_BYTES = 1024 * 1024 * 1024; // hard cap on the unpacked DB (zip-bomb guard)
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000; // re-check the manifest every 6h
+const REQUIRED_TABLES = ['curated_apps', 'curated_fts', 'version_history', 'sccm_winget_mappings'];
+
+type DB = BetterSqlite3.Database;
+
+interface SnapshotManifest {
+  schemaVersion: number;
+  version: string;
+  generatedAt: string;
+  sha256: string;
+  sizeBytes: number;
+  counts?: Record<string, number>;
+}
+
+export class SnapshotUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SnapshotUnavailableError';
+  }
+}
+
+function baseUrl(): string {
+  return (process.env.CATALOG_SNAPSHOT_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+function snapshotDir(): string {
+  if (process.env.CATALOG_SNAPSHOT_DIR) return process.env.CATALOG_SNAPSHOT_DIR;
+  const dbPath = process.env.DATABASE_PATH || './data/intuneget.db';
+  return path.dirname(dbPath);
+}
+
+const dbFilePath = () => path.join(snapshotDir(), 'catalog.sqlite');
+const metaFilePath = () => path.join(snapshotDir(), 'catalog.manifest.json');
+
+// Module-level state (one snapshot per process).
+let _db: DB | null = null;
+let _loadedVersion: string | null = null;
+let _lastCheckedAt = 0;
+let _inflight: Promise<void> | null = null;
+let _DatabaseCtor: typeof BetterSqlite3 | null = null;
+
+async function loadDatabaseCtor(): Promise<typeof BetterSqlite3> {
+  if (_DatabaseCtor) return _DatabaseCtor;
+  try {
+    const mod = await import('better-sqlite3');
+    _DatabaseCtor = (mod.default || mod) as typeof BetterSqlite3;
+    return _DatabaseCtor;
+  } catch {
+    throw new SnapshotUnavailableError(
+      'The better-sqlite3 package is required to read the catalog snapshot in SQLite mode but is not installed.'
+    );
+  }
+}
+
+function openReadOnly(Database: typeof BetterSqlite3, file: string): DB {
+  const db = new Database(file, { readonly: true, fileMustExist: true });
+  db.pragma('query_only = true');
+  return db;
+}
+
+function assertTables(db: DB): void {
+  const names = new Set(
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type IN ('table','view') OR name LIKE 'curated_fts%'")
+      .all()
+      .map((r) => (r as { name: string }).name)
+  );
+  for (const t of REQUIRED_TABLES) {
+    if (!names.has(t)) {
+      throw new SnapshotUnavailableError(`Catalog snapshot is missing the "${t}" table`);
+    }
+  }
+}
+
+async function fetchManifest(): Promise<SnapshotManifest | null> {
+  const url = `${baseUrl()}/manifest.json`;
+  if (!url.startsWith('https://')) {
+    throw new SnapshotUnavailableError('CATALOG_SNAPSHOT_BASE_URL must be an https URL');
+  }
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new SnapshotUnavailableError(`Failed to fetch catalog manifest (HTTP ${res.status})`);
+  }
+  const manifest = (await res.json()) as SnapshotManifest;
+  if (manifest.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+    throw new SnapshotUnavailableError(
+      `Catalog snapshot schemaVersion ${manifest.schemaVersion} is not supported by this build (expected ${SNAPSHOT_SCHEMA_VERSION}). Update the app.`
+    );
+  }
+  if (!manifest.version || !/^[a-f0-9]{64}$/i.test(manifest.sha256 || '')) {
+    throw new SnapshotUnavailableError('Catalog manifest is missing a version or a valid sha256');
+  }
+  return manifest;
+}
+
+async function sha256File(file: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(file), hash);
+  return hash.digest('hex');
+}
+
+/**
+ * A Transform that aborts the pipeline once `maxBytes` have passed through,
+ * without forwarding the over-limit chunk. Used to bound both the compressed
+ * download and the decompressed output before they reach disk.
+ */
+function byteCap(maxBytes: number, message: string): Transform {
+  let total = 0;
+  return new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      total += chunk.length;
+      if (total > maxBytes) {
+        cb(new SnapshotUnavailableError(message));
+      } else {
+        cb(null, chunk);
+      }
+    },
+  });
+}
+
+async function downloadGz(dest: string): Promise<void> {
+  const url = `${baseUrl()}/catalog.sqlite.gz`;
+  if (!url.startsWith('https://')) {
+    throw new SnapshotUnavailableError('CATALOG_SNAPSHOT_BASE_URL must be an https URL');
+  }
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok || !res.body) {
+    throw new SnapshotUnavailableError(`Failed to download catalog snapshot (HTTP ${res.status})`);
+  }
+  const source = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
+  // Cap before the WriteStream, so an over-limit asset never fully lands on disk.
+  await pipeline(
+    source,
+    byteCap(MAX_GZ_BYTES, 'Catalog snapshot exceeds the maximum allowed download size'),
+    createWriteStream(dest)
+  );
+}
+
+async function downloadVerifyAndSwap(manifest: SnapshotManifest): Promise<void> {
+  const Database = await loadDatabaseCtor();
+  const dir = snapshotDir();
+  await mkdir(dir, { recursive: true });
+
+  const gzTmp = path.join(dir, 'catalog.sqlite.gz.download');
+  const dbTmp = path.join(dir, 'catalog.sqlite.tmp');
+
+  try {
+    await downloadGz(gzTmp);
+
+    // Verify integrity BEFORE unpacking or opening.
+    const actualSha = await sha256File(gzTmp);
+    if (actualSha.toLowerCase() !== manifest.sha256.toLowerCase()) {
+      throw new SnapshotUnavailableError('Catalog snapshot sha256 does not match the manifest');
+    }
+
+    await rm(dbTmp, { force: true });
+    // Cap the decompressed output too, so a zip-bomb cannot fill the disk even
+    // if it somehow passed the sha256 check.
+    await pipeline(
+      createReadStream(gzTmp),
+      createGunzip(),
+      byteCap(MAX_DECOMPRESSED_BYTES, 'Decompressed catalog snapshot exceeds the maximum allowed size'),
+      createWriteStream(dbTmp)
+    );
+
+    // Validate the decompressed DB opens and has the expected shape.
+    const test = openReadOnly(Database, dbTmp);
+    try {
+      assertTables(test);
+    } finally {
+      test.close();
+    }
+
+    // Swap in: rename first, open the new handle, then atomically repoint _db at
+    // it and only then close the old handle. This removes any window where _db
+    // is null or where a concurrent reader holds a just-closed handle (queries
+    // are synchronous, so once _db points at newDb no query runs on the old one).
+    await rename(dbTmp, dbFilePath());
+    await writeFile(metaFilePath(), JSON.stringify(manifest));
+    const newDb = openReadOnly(Database, dbFilePath());
+    const oldDb = _db;
+    _db = newDb;
+    _loadedVersion = manifest.version;
+    oldDb?.close();
+  } finally {
+    await rm(gzTmp, { force: true }).catch(() => {});
+    await rm(dbTmp, { force: true }).catch(() => {});
+  }
+}
+
+async function openExistingIfPresent(): Promise<boolean> {
+  const dbFile = dbFilePath();
+  if (!existsSync(dbFile)) return false;
+  const Database = await loadDatabaseCtor();
+  const db = openReadOnly(Database, dbFile);
+  try {
+    assertTables(db);
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+  _db = db;
+  try {
+    const meta = JSON.parse(await readFile(metaFilePath(), 'utf8')) as SnapshotManifest;
+    _loadedVersion = meta.version ?? null;
+  } catch {
+    _loadedVersion = null;
+  }
+  return true;
+}
+
+async function ensureFresh(): Promise<void> {
+  if (_inflight) return _inflight;
+  _inflight = (async () => {
+    try {
+      // Explicit local file wins and skips all networking.
+      const localFile = process.env.CATALOG_SNAPSHOT_FILE;
+      if (localFile) {
+        if (_db) return;
+        const Database = await loadDatabaseCtor();
+        if (!existsSync(localFile)) {
+          throw new SnapshotUnavailableError(`CATALOG_SNAPSHOT_FILE not found: ${localFile}`);
+        }
+        const db = openReadOnly(Database, localFile);
+        assertTables(db);
+        _db = db;
+        _loadedVersion = 'local-file';
+        return;
+      }
+
+      let manifest: SnapshotManifest | null = null;
+      try {
+        manifest = await fetchManifest();
+      } catch (err) {
+        // Network/manifest failure: keep any DB we already have; otherwise try a
+        // previously downloaded file before giving up.
+        if (_db) {
+          console.error('Catalog snapshot manifest check failed; keeping current snapshot:', err);
+          return;
+        }
+        if (await openExistingIfPresent()) {
+          console.error('Catalog snapshot manifest unreachable; using last downloaded snapshot:', err);
+          return;
+        }
+        throw err;
+      }
+
+      if (manifest && manifest.version === _loadedVersion && _db) {
+        return; // already current
+      }
+      if (manifest && !_db && (await tryOpenMatchingLocal(manifest))) {
+        return; // on-disk file already matches the manifest
+      }
+      if (manifest) {
+        await downloadVerifyAndSwap(manifest);
+      }
+    } finally {
+      _lastCheckedAt = Date.now();
+      _inflight = null;
+    }
+  })();
+  return _inflight;
+}
+
+async function tryOpenMatchingLocal(manifest: SnapshotManifest): Promise<boolean> {
+  try {
+    const meta = JSON.parse(await readFile(metaFilePath(), 'utf8')) as SnapshotManifest;
+    if (meta.version === manifest.version && existsSync(dbFilePath())) {
+      return openExistingIfPresent();
+    }
+  } catch {
+    // no usable local metadata
+  }
+  return false;
+}
+
+/**
+ * Return a read-only handle to the catalog snapshot, downloading/refreshing it
+ * as needed. The first call blocks until a verified snapshot is open; later
+ * calls return the cached handle and refresh in the background on an interval.
+ */
+export async function getSnapshotDb(): Promise<DB> {
+  const now = Date.now();
+  if (_db && now - _lastCheckedAt < REFRESH_INTERVAL_MS) {
+    return _db;
+  }
+  if (!_db) {
+    await ensureFresh();
+  } else {
+    _lastCheckedAt = now; // gate background refresh attempts
+    void ensureFresh().catch((err) => console.error('Catalog snapshot refresh failed:', err));
+  }
+  if (!_db) {
+    throw new SnapshotUnavailableError('Catalog snapshot is not available');
+  }
+  return _db;
+}
+
+/** Test/diagnostic helper: drop the cached handle and state. */
+export function _resetSnapshotStoreForTest(): void {
+  if (_db) _db.close();
+  _db = null;
+  _loadedVersion = null;
+  _lastCheckedAt = 0;
+  _inflight = null;
+}
+
+export async function snapshotMeta(): Promise<{ loadedVersion: string | null; sizeBytes?: number }> {
+  const out: { loadedVersion: string | null; sizeBytes?: number } = { loadedVersion: _loadedVersion };
+  try {
+    out.sizeBytes = (await stat(dbFilePath())).size;
+  } catch {
+    // ignore
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Final phase of the self-host catalog. Self-hosted instances with `DATABASE_MODE=sqlite` and **no Supabase** now read the catalog from a downloaded SQLite snapshot (published daily in Phase 2) instead of returning 503. Hosted (Supabase) behavior is unchanged.

## What's added
- **`lib/catalog/snapshot-store.ts`** — downloads `catalog.sqlite.gz` from the `catalog-latest` release and hands the source a read-only handle. Security posture: **sha256 verified against the manifest before the gzip is unpacked or opened**; HTTPS enforced; **compressed and decompressed size caps** (zip-bomb guard); DB opened read-only + `query_only`; **atomic swap** (rename → open new → repoint → close old, no null/closed-handle window); better-sqlite3 lazy-loaded; `CATALOG_SNAPSHOT_FILE` lets a self-hoster supply a trusted local snapshot offline.
- **`lib/catalog/snapshot-source.ts`** — `SnapshotCatalogSource` implements all 22 `CatalogSource` methods over the snapshot: FTS5 search (safe MATCH builder + ILIKE fallback), popularity ordering, installer info, and the #133 SCCM mapping resolution. Degrades to each method's empty value when the snapshot is unavailable (no crash).
- **`getCatalogSource()`** returns the snapshot source via a lazy dynamic import when `!isSupabaseConfigured()`, so native deps never enter Supabase/edge bundles.
- The 7 `winget/*` routes drop `runtime='edge'` (better-sqlite3 is native) per the agreed plan; all other directives and Supabase-mode behavior are unchanged.

## Verification
- `tsc` clean, `next lint` clean, **424/424 vitest** (16 new tests build a real snapshot and exercise search/popular/detail/installer/SCCM/categories).
- Confirmed no static `better-sqlite3`/`node:fs` import is reachable from any Supabase/edge path (selector lazy-imports; no edge routes remain).
- **Adversarial security review** performed; fixed the atomic-swap concurrency race and added compressed+decompressed size caps. Remaining low-severity items (release-tag trust model, dead assert clause) accepted.

## Rollout note
The catalog routes now run as Node functions instead of Edge on hosted (they were already `fetchCache='force-no-store'`, so the practical impact is cold-start characteristics only; logic and Supabase queries are identical). The `catalog-latest` release is created by the Phase 2 daily job (or a manual `sync-manifests` dispatch).