### PR TITLE
Let catalog browse/search use the snapshot in sqlite mode

### DIFF
--- a/app/api/winget/categories/route.ts
+++ b/app/api/winget/categories/route.ts
@@ -7,19 +7,6 @@ export const fetchCache = 'force-no-store';
 
 export async function GET() {
   try {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseKey) {
-      return NextResponse.json(
-        {
-          error:
-            'App catalog requires a configured Supabase database. See docs/SELF_HOSTING.md - the catalog is not available in standalone SQLite mode.',
-        },
-        { status: 503, headers: { 'Cache-Control': 'no-store, max-age=0' } }
-      );
-    }
-
     const categories = await getCategories();
 
     // Get actual total count of verified apps (not just sum of categories)

--- a/app/api/winget/popular/route.ts
+++ b/app/api/winget/popular/route.ts
@@ -7,19 +7,6 @@ type SortBy = 'popular' | 'name' | 'newest';
 
 export async function GET(request: NextRequest) {
   try {
-    if (
-      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-      !(process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
-    ) {
-      return NextResponse.json(
-        {
-          error:
-            'App catalog requires a configured Supabase database. See docs/SELF_HOSTING.md - the catalog is not available in standalone SQLite mode.',
-        },
-        { status: 503, headers: { 'Cache-Control': 'no-store, max-age=0' } }
-      );
-    }
-
     const searchParams = request.nextUrl.searchParams;
     const requestedLimit = parseInt(searchParams.get('limit') || '20', 10);
     const requestedOffset = parseInt(searchParams.get('offset') || '0', 10);

--- a/app/api/winget/search/route.ts
+++ b/app/api/winget/search/route.ts
@@ -28,13 +28,6 @@ async function searchCachedPackages(
   category?: string | null,
   sort: string = 'popular'
 ) {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!supabaseUrl || !supabaseServiceKey) {
-    return null;
-  }
-
   const { data: curatedData, error: curatedError } = await getCatalogSource().searchApps(
     query,
     { limit, category: category || null }
@@ -67,16 +60,6 @@ async function searchCachedPackages(
 
 export async function GET(request: NextRequest) {
   try {
-    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return NextResponse.json(
-        {
-          error:
-            'App catalog requires a configured Supabase database. See docs/SELF_HOSTING.md - the catalog is not available in standalone SQLite mode.',
-        },
-        { status: 503, headers: { 'Cache-Control': 'no-store, max-age=0' } }
-      );
-    }
-
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q') || searchParams.get('query');
     const limit = parseInt(searchParams.get('limit') || '50', 10);

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -131,12 +131,26 @@ If `DATABASE_MODE=sqlite`, also set:
 |----------|-------------|
 | `PACKAGER_API_KEY` | Shared key between web app and local packager API mode |
 
-> **Important**: `DATABASE_MODE=sqlite` covers packaging jobs and upload
-> history only. The app catalog (the `curated_apps` and `version_history`
-> tables) requires a Supabase database, which is seeded by the
-> `build-app-list` and `sync-manifests` GitHub Actions workflows. Without
-> Supabase, catalog browsing and search are unavailable and the catalog API
-> routes return `503`.
+Optional catalog snapshot overrides (sensible defaults, normally unset):
+
+| Variable | Description |
+|----------|-------------|
+| `CATALOG_SNAPSHOT_BASE_URL` | HTTPS base URL to fetch `manifest.json` + `catalog.sqlite.gz` from. Defaults to the public `catalog-latest` GitHub release. |
+| `CATALOG_SNAPSHOT_DIR` | Directory to store the downloaded snapshot. Defaults to the directory of `DATABASE_PATH` (e.g. `./data`). |
+| `CATALOG_SNAPSHOT_FILE` | Path to a trusted local `catalog.sqlite` to use directly, skipping all downloading (fully offline). |
+
+> **App catalog in SQLite mode**: when `DATABASE_MODE=sqlite` and Supabase is
+> not configured, the app catalog (browse, search, categories, update detection,
+> SCCM matching) is served from a **downloaded SQLite snapshot** instead of
+> Supabase. On first use the app downloads `catalog.sqlite.gz` from the public
+> `catalog-latest` GitHub release, verifies its sha256 against the published
+> manifest, opens it read-only, and re-checks daily. Requirements: the optional
+> `better-sqlite3` package installed (it is in the Docker image), a writable data
+> directory, and outbound HTTPS to `github.com`. For a fully offline install,
+> point `CATALOG_SNAPSHOT_FILE` at a snapshot you fetched yourself.
+>
+> Note: other Supabase-backed surfaces (dashboard history, notifications, MSP
+> features) still require Supabase; only the catalog runs Supabase-less.
 
 ### Pipeline Configuration
 


### PR DESCRIPTION
## Summary
Closes the remaining gap for Supabase-less self-hosting. After Phase 3, the catalog *source* selected the downloaded snapshot in sqlite mode, but the user-facing `winget/{search,popular,categories}` routes still had a hard `503` guard ('catalog requires a configured Supabase database') that returned early when Supabase env was absent — so browse/search never reached the snapshot. (The deploy-path reads — update detection, SCCM — had no such guard and already worked.)

This removes those Supabase-only guards (and the duplicate one inside search's helper). The routes now call `getCatalogSource()` unconditionally: it resolves to the verified snapshot when Supabase is absent, or degrades to empty results (logged server-side) if the snapshot is genuinely unavailable, instead of hard-blocking. `winget-api` is already source-backed, so package/variants/changelog/manifest work too.

Also updates `docs/SELF_HOSTING.md`: the catalog is now available in sqlite mode via the snapshot, with requirements (better-sqlite3, writable data dir, outbound HTTPS to github.com) and the optional `CATALOG_SNAPSHOT_BASE_URL`/`_DIR`/`_FILE` overrides. Only dashboard/notifications/MSP still require Supabase.

## Testing
- 424/424 vitest, tsc clean, next lint clean
- No 'requires a configured Supabase' guard remains in app/api (grep)
- End-to-end: verified the live `catalog-latest` snapshot downloads, sha256-matches, and answers search/popular/SCCM queries correctly