### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intuneget",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "private": true,
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Version bump for the v0.7.0 release (Supabase-less self-hosting: catalog snapshot + consent fix, plus the accumulated work since v0.6.4).