### PR TITLE
Fix multi-arch Docker build (arm64 native modules need a toolchain)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Toolchain for native node modules that have no prebuilt binary for the target
+# arch (notably tree-sitter-python from the gt translation tooling, and
+# better-sqlite3 used by sqlite mode). Required for the linux/arm64 multi-arch
+# build, where these compile from source via node-gyp.
+RUN apk add --no-cache python3 make g++
+
 # Install dependencies
 # Use npm install (not npm ci) so Sharp's platform-specific transitive deps
 # (@emnapi/runtime, @emnapi/core, etc.) resolve correctly even when


### PR DESCRIPTION
The v0.7.0 release Docker build failed on linux/arm64: `npm install` compiles `tree-sitter-python` (transitive dev dep from the `gt` translation CLI) with node-gyp, but the alpine builder had no Python/C++ toolchain. amd64 used prebuilt binaries (so CI's amd64 Docker Build passed); arm64 has no prebuild and compiles from source. Adds `python3 make g++` to the builder stage (also covers `better-sqlite3`). Build tools stay in the builder; the runner image is unchanged.