### PR TITLE
Apply Auto-update / Pin version policies from the bell icon (#131)

### DIFF
--- a/app/api/update-policies/route.test.ts
+++ b/app/api/update-policies/route.test.ts
@@ -1,0 +1,310 @@
+import { NextRequest } from 'next/server';
+
+const {
+  parseAccessTokenMock,
+  createServerClientMock,
+  getCatalogSourceMock,
+  getAppForInstallerMock,
+} = vi.hoisted(() => ({
+  parseAccessTokenMock: vi.fn(),
+  createServerClientMock: vi.fn(),
+  getCatalogSourceMock: vi.fn(),
+  getAppForInstallerMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: parseAccessTokenMock,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  createServerClient: createServerClientMock,
+}));
+
+vi.mock('@/lib/catalog', () => ({
+  getCatalogSource: getCatalogSourceMock,
+}));
+
+import { POST } from '@/app/api/update-policies/route';
+
+interface TableData {
+  update_check_results?: Record<string, unknown> | null;
+  upload_history?: Record<string, unknown> | null;
+  packaging_jobs?: Record<string, unknown> | null;
+  user_settings?: Record<string, unknown> | null;
+  existing_policy?: { id: string } | null;
+}
+
+/**
+ * Builds a supabase mock whose query chain is fully thenable/awaitable at every
+ * terminal (single / maybeSingle). The chain ignores filter arguments and just
+ * resolves to the data registered for the table being queried.
+ */
+function createSupabaseMock(data: TableData) {
+  const insertPayloads: Array<Record<string, unknown>> = [];
+  const updatePayloads: Array<Record<string, unknown>> = [];
+
+  const resultFor = (table: string): { data: unknown; error: null } => {
+    switch (table) {
+      case 'update_check_results':
+        return { data: data.update_check_results ?? null, error: null };
+      case 'upload_history':
+        return { data: data.upload_history ?? null, error: null };
+      case 'packaging_jobs':
+        return { data: data.packaging_jobs ?? null, error: null };
+      case 'user_settings':
+        return { data: data.user_settings ?? null, error: null };
+      default:
+        return { data: null, error: null };
+    }
+  };
+
+  const makeChain = (table: string) => {
+    const result = resultFor(table);
+    const chain: Record<string, unknown> = {};
+    const passthrough = () => chain;
+    for (const method of ['select', 'eq', 'order', 'limit']) {
+      chain[method] = vi.fn(passthrough);
+    }
+    chain.single = vi.fn(async () => result);
+    chain.maybeSingle = vi.fn(async () => result);
+    return chain;
+  };
+
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'app_update_policies') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(function thisEq() {
+              return {
+                eq: vi.fn(() => ({
+                  eq: vi.fn(() => ({
+                    single: vi.fn(async () => ({
+                      data: data.existing_policy ?? null,
+                      error: null,
+                    })),
+                    maybeSingle: vi.fn(async () => ({
+                      data: data.existing_policy ?? null,
+                      error: null,
+                    })),
+                  })),
+                })),
+              };
+            }),
+          })),
+          insert: vi.fn((payload: Record<string, unknown>) => {
+            insertPayloads.push(payload);
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: { id: 'policy-new', ...payload },
+                  error: null,
+                })),
+              })),
+            };
+          }),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            updatePayloads.push(payload);
+            return {
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: { id: data.existing_policy?.id, ...payload },
+                    error: null,
+                  })),
+                })),
+              })),
+            };
+          }),
+        };
+      }
+
+      return makeChain(table);
+    },
+  };
+
+  return { supabase, insertPayloads, updatePayloads };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost:3000/api/update-policies', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/update-policies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parseAccessTokenMock.mockResolvedValue({
+      userId: 'user-1',
+      userEmail: 'user@example.com',
+      tenantId: 'home-tenant',
+      userName: 'User',
+    });
+    getAppForInstallerMock.mockResolvedValue(null);
+    getCatalogSourceMock.mockReturnValue({
+      getAppForInstaller: getAppForInstallerMock,
+    });
+  });
+
+  it('derives the current version for pin_version when client omits it', async () => {
+    const { supabase, insertPayloads } = createSupabaseMock({
+      update_check_results: { current_version: '1.2.3', latest_version: '1.3.0' },
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Microsoft.Edge',
+        tenant_id: 'tenant-1',
+        policy_type: 'pin_version',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(insertPayloads).toHaveLength(1);
+    expect(insertPayloads[0].pinned_version).toBe('1.2.3');
+    expect(insertPayloads[0].policy_type).toBe('pin_version');
+    expect(body.created).toBe(true);
+  });
+
+  it('returns 400 for pin_version when no current version can be derived', async () => {
+    const { supabase } = createSupabaseMock({
+      update_check_results: null,
+      upload_history: null,
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Missing.App',
+        tenant_id: 'tenant-1',
+        policy_type: 'pin_version',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('pinned_version');
+  });
+
+  it('derives a deployment_config from a prior deployment for auto_update', async () => {
+    const { supabase, insertPayloads } = createSupabaseMock({
+      update_check_results: { current_version: '1.0.0', latest_version: '2.0.0' },
+      upload_history: { id: 'upload-1', packaging_job_id: 'job-1' },
+      packaging_jobs: {
+        id: 'job-1',
+        display_name: 'Microsoft Edge',
+        publisher: 'Microsoft',
+        architecture: 'x64',
+        installer_type: 'exe',
+        install_command: 'setup.exe /silent',
+        uninstall_command: 'setup.exe /uninstall',
+        install_scope: 'system',
+        detection_rules: [],
+        package_config: { assignments: [], categories: [] },
+      },
+      user_settings: { carryOverAssignments: true },
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Microsoft.Edge',
+        tenant_id: 'tenant-1',
+        policy_type: 'auto_update',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(insertPayloads).toHaveLength(1);
+    expect(insertPayloads[0].policy_type).toBe('auto_update');
+    expect(insertPayloads[0].original_upload_history_id).toBe('upload-1');
+    const config = insertPayloads[0].deployment_config as Record<string, unknown>;
+    expect(config).toBeTruthy();
+    expect(config.displayName).toBe('Microsoft Edge');
+    expect(config.forceCreateNewApp).toBe(true);
+    expect(body.created).toBe(true);
+  });
+
+  it('returns 400 for auto_update with no prior deployment and not in catalog', async () => {
+    const { supabase } = createSupabaseMock({
+      update_check_results: { current_version: '1.0.0', latest_version: '2.0.0' },
+      upload_history: null,
+      user_settings: null,
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+    // Catalog returns no app -> buildDefaultDeploymentConfig returns null
+    getCatalogSourceMock.mockReturnValue({
+      getAppForInstaller: getAppForInstallerMock,
+      getAppNamePublisher: vi.fn(async () => null),
+      getVersionInstallerInfo: vi.fn(async () => null),
+    });
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Not.InCatalog',
+        tenant_id: 'tenant-1',
+        policy_type: 'auto_update',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Auto-update requires');
+  });
+
+  it('creates an ignore policy with just the policy type', async () => {
+    const { supabase, insertPayloads } = createSupabaseMock({
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Microsoft.Edge',
+        tenant_id: 'tenant-1',
+        policy_type: 'ignore',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(insertPayloads).toHaveLength(1);
+    expect(insertPayloads[0].policy_type).toBe('ignore');
+    expect(insertPayloads[0].pinned_version).toBeNull();
+    expect(insertPayloads[0].deployment_config).toBeNull();
+    expect(body.created).toBe(true);
+  });
+
+  it('creates a notify policy with just the policy type', async () => {
+    const { supabase, insertPayloads } = createSupabaseMock({
+      existing_policy: null,
+    });
+    createServerClientMock.mockReturnValue(supabase);
+
+    const response = await POST(
+      makeRequest({
+        winget_id: 'Microsoft.Edge',
+        tenant_id: 'tenant-1',
+        policy_type: 'notify',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(insertPayloads[0].policy_type).toBe('notify');
+    expect(body.created).toBe(true);
+  });
+});

--- a/app/api/update-policies/route.ts
+++ b/app/api/update-policies/route.ts
@@ -6,8 +6,10 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
-import type { AppUpdatePolicyInput, AppUpdatePolicy } from '@/types/update-policies';
+import { buildDeploymentConfigForApp } from '@/lib/update-policies/build-deployment-config';
+import type { AppUpdatePolicyInput, AppUpdatePolicy, DeploymentConfig } from '@/types/update-policies';
 import type { Json } from '@/types/database';
 
 /**
@@ -95,23 +97,102 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Pin version requires a version
-    if (body.policy_type === 'pin_version' && !body.pinned_version) {
-      return NextResponse.json(
-        { error: 'pinned_version is required for pin_version policy' },
-        { status: 400 }
-      );
-    }
-
-    // Auto-update requires deployment config
-    if (body.policy_type === 'auto_update' && !body.deployment_config) {
-      return NextResponse.json(
-        { error: 'deployment_config is required for auto_update policy' },
-        { status: 400 }
-      );
-    }
-
     const supabase = createServerClient();
+
+    // Fields the client may omit for pin_version / auto_update. We derive them
+    // server-side below so the bell-icon dropdown can set these policies with
+    // just { winget_id, tenant_id, policy_type }.
+    let derivedPinnedVersion = body.pinned_version || null;
+    let derivedDeploymentConfig: DeploymentConfig | null = body.deployment_config || null;
+    let derivedOriginalUploadHistoryId = body.original_upload_history_id || null;
+
+    // Pin version requires a version. If the client didn't send one, derive the
+    // currently deployed version for this app.
+    if (body.policy_type === 'pin_version' && !derivedPinnedVersion) {
+      const { data: updateRow } = await supabase
+        .from('update_check_results')
+        .select('current_version')
+        .eq('user_id', user.userId)
+        .eq('tenant_id', body.tenant_id)
+        .eq('winget_id', body.winget_id)
+        .maybeSingle();
+
+      derivedPinnedVersion = updateRow?.current_version || null;
+
+      if (!derivedPinnedVersion) {
+        const { data: latestUpload } = await supabase
+          .from('upload_history')
+          .select('version')
+          .eq('user_id', user.userId)
+          .eq('intune_tenant_id', body.tenant_id)
+          .eq('winget_id', body.winget_id)
+          .order('deployed_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        derivedPinnedVersion = latestUpload?.version || null;
+      }
+
+      if (!derivedPinnedVersion) {
+        return NextResponse.json(
+          { error: 'pinned_version is required for pin_version policy' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Auto-update requires a deployment config. If the client didn't send one,
+    // build it from the app's prior deployment or the catalog.
+    if (body.policy_type === 'auto_update' && !derivedDeploymentConfig) {
+      // Resolve the app's latest version: prefer the update check row, fall
+      // back to the catalog's latest_version.
+      const { data: updateRow } = await supabase
+        .from('update_check_results')
+        .select('latest_version')
+        .eq('user_id', user.userId)
+        .eq('tenant_id', body.tenant_id)
+        .eq('winget_id', body.winget_id)
+        .maybeSingle();
+
+      let latestVersion = updateRow?.latest_version || '';
+      if (!latestVersion) {
+        const catalogApp = await getCatalogSource().getAppForInstaller(body.winget_id);
+        latestVersion = catalogApp?.latest_version || '';
+      }
+
+      // Read the user's global carry-over setting (same source as the trigger route)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: userSettingsRow } = await (supabase as any)
+        .from('user_settings')
+        .select('settings')
+        .eq('user_id', user.userId)
+        .maybeSingle();
+      const userSettings = (userSettingsRow?.settings as Record<string, unknown> | null) || null;
+      const globalCarryOver = Boolean(userSettings?.carryOverAssignments);
+
+      const built = await buildDeploymentConfigForApp(supabase, {
+        userId: user.userId,
+        tenantId: body.tenant_id,
+        wingetId: body.winget_id,
+        latestVersion,
+        globalCarryOver,
+      });
+
+      if (built.status !== 'ok') {
+        return NextResponse.json(
+          {
+            error:
+              built.status === 'orphaned_job'
+                ? 'Could not retrieve the saved deployment configuration for this app.'
+                : 'Auto-update requires a prior deployment of this app, or the app must be in the catalog.',
+          },
+          { status: 400 }
+        );
+      }
+
+      derivedDeploymentConfig = built.deploymentConfig;
+      derivedOriginalUploadHistoryId = built.originalUploadHistoryId;
+    }
 
     // Check if policy already exists for this user/tenant/app
     const { data: existingPolicy } = await supabase
@@ -120,7 +201,7 @@ export async function POST(request: NextRequest) {
       .eq('user_id', user.userId)
       .eq('tenant_id', body.tenant_id)
       .eq('winget_id', body.winget_id)
-      .single();
+      .maybeSingle();
 
     // Build policy data - cast deployment_config to Json for database compatibility
     const policyData = {
@@ -128,9 +209,9 @@ export async function POST(request: NextRequest) {
       tenant_id: body.tenant_id,
       winget_id: body.winget_id,
       policy_type: body.policy_type,
-      pinned_version: body.policy_type === 'pin_version' ? body.pinned_version : null,
-      deployment_config: (body.deployment_config || null) as Json,
-      original_upload_history_id: body.original_upload_history_id || null,
+      pinned_version: body.policy_type === 'pin_version' ? derivedPinnedVersion : null,
+      deployment_config: (derivedDeploymentConfig || null) as Json,
+      original_upload_history_id: derivedOriginalUploadHistoryId,
       is_enabled: body.is_enabled ?? true,
       updated_at: new Date().toISOString(),
     };

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -18,8 +18,8 @@ import {
 import { getAppConfig } from '@/lib/config';
 import { getFeatureFlags } from '@/lib/features';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
-import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
 import { buildIntuneAppDescription } from '@/lib/intune-description';
+import { buildDeploymentConfigForApp } from '@/lib/update-policies/build-deployment-config';
 import type { WorkflowInputs } from '@/lib/github-actions';
 import type {
   TriggerUpdateRequest,
@@ -27,247 +27,8 @@ import type {
   AppUpdatePolicy,
   DeploymentConfig,
 } from '@/types/update-policies';
-import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
-import type { AppRelationship, DetectionRule, RequirementRule } from '@/types/intune';
-import type { NormalizedInstaller } from '@/types/winget';
 import type { Json } from '@/types/database';
 import { isSelfUpdatingApp } from '@/lib/self-updating-apps';
-
-interface PackageConfigWithAssignments {
-  assignments?: PackageAssignment[];
-  categories?: IntuneAppCategorySelection[];
-  categoryIds?: string[];
-  assignedGroups?: Array<{
-    groupId?: string;
-    groupName?: string;
-    assignmentType?: 'required' | 'available' | 'uninstall' | 'updateOnly';
-  }>;
-  requirementRules?: RequirementRule[];
-  relationships?: AppRelationship[];
-  assignmentMigration?: {
-    carryOverAssignments?: boolean;
-    removeAssignmentsFromPreviousApp?: boolean;
-  };
-  carryOverAssignments?: boolean;
-  removeAssignmentsFromPreviousApp?: boolean;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function parsePackageAssignments(packageConfig: unknown): PackageAssignment[] {
-  if (!isObject(packageConfig)) {
-    return [];
-  }
-
-  const assignments = packageConfig.assignments;
-  if (Array.isArray(assignments)) {
-    return assignments.filter((assignment): assignment is PackageAssignment => {
-      if (!isObject(assignment)) {
-        return false;
-      }
-
-      const type = assignment.type;
-      const intent = assignment.intent;
-      if (
-        type !== 'allUsers' &&
-        type !== 'allDevices' &&
-        type !== 'group'
-      ) {
-        return false;
-      }
-
-      if (
-        intent !== 'required' &&
-        intent !== 'available' &&
-        intent !== 'uninstall' &&
-        intent !== 'updateOnly'
-      ) {
-        return false;
-      }
-
-      if (type === 'group') {
-        return typeof assignment.groupId === 'string' && assignment.groupId.length > 0;
-      }
-
-      return true;
-    });
-  }
-
-  const assignedGroups = packageConfig.assignedGroups;
-  if (!Array.isArray(assignedGroups)) {
-    return [];
-  }
-
-  return assignedGroups
-    .filter((group): group is { groupId: string; groupName?: string; assignmentType?: 'required' | 'available' | 'uninstall' | 'updateOnly' } => {
-      return isObject(group) && typeof group.groupId === 'string' && group.groupId.length > 0;
-    })
-    .map((group) => ({
-      type: 'group',
-      groupId: group.groupId,
-      groupName: typeof group.groupName === 'string' ? group.groupName : undefined,
-      intent: group.assignmentType || 'required',
-    }));
-}
-
-function parseRequirementRules(packageConfig: unknown): RequirementRule[] | undefined {
-  if (!isObject(packageConfig)) {
-    return undefined;
-  }
-  const typedConfig = packageConfig as PackageConfigWithAssignments;
-  if (Array.isArray(typedConfig.requirementRules) && typedConfig.requirementRules.length > 0) {
-    return typedConfig.requirementRules as RequirementRule[];
-  }
-  return undefined;
-}
-
-function parseAppRelationships(packageConfig: unknown): AppRelationship[] {
-  if (!isObject(packageConfig)) {
-    return [];
-  }
-
-  const relationships = packageConfig.relationships;
-  if (!Array.isArray(relationships)) {
-    return [];
-  }
-
-  return relationships.filter((relationship): relationship is AppRelationship => {
-    if (!isObject(relationship)) {
-      return false;
-    }
-
-    const relationshipType = relationship.relationshipType;
-    if (relationshipType !== 'dependency' && relationshipType !== 'supersedence') {
-      return false;
-    }
-
-    if (typeof relationship.targetId !== 'string' || relationship.targetId.length === 0) {
-      return false;
-    }
-
-    if (
-      relationship.dependencyType !== undefined &&
-      relationship.dependencyType !== 'detect' &&
-      relationship.dependencyType !== 'autoInstall'
-    ) {
-      return false;
-    }
-
-    if (
-      relationship.supersedenceType !== undefined &&
-      relationship.supersedenceType !== 'update' &&
-      relationship.supersedenceType !== 'replace'
-    ) {
-      return false;
-    }
-
-    return true;
-  });
-}
-
-function parseAssignmentMigration(packageConfig: unknown): DeploymentConfig['assignmentMigration'] | undefined {
-  if (!isObject(packageConfig)) {
-    return undefined;
-  }
-
-  const typedConfig = packageConfig as PackageConfigWithAssignments;
-  const nested = typedConfig.assignmentMigration;
-
-  // If no migration config was explicitly set, return undefined so the
-  // caller can fall back to the user's global setting.
-  const hasExplicitNested = nested && (
-    nested.carryOverAssignments !== undefined ||
-    nested.removeAssignmentsFromPreviousApp !== undefined
-  );
-  const hasExplicitTop =
-    typedConfig.carryOverAssignments !== undefined ||
-    typedConfig.removeAssignmentsFromPreviousApp !== undefined;
-
-  if (!hasExplicitNested && !hasExplicitTop) {
-    return undefined;
-  }
-
-  const carryOverAssignments = Boolean(
-    nested?.carryOverAssignments ?? typedConfig.carryOverAssignments
-  );
-  const removeAssignmentsFromPreviousApp = Boolean(
-    nested?.removeAssignmentsFromPreviousApp ?? typedConfig.removeAssignmentsFromPreviousApp
-  );
-
-  return {
-    carryOverAssignments,
-    removeAssignmentsFromPreviousApp,
-  };
-}
-
-function parsePackageCategories(packageConfig: unknown): IntuneAppCategorySelection[] {
-  if (!isObject(packageConfig)) {
-    return [];
-  }
-
-  const typedConfig = packageConfig as PackageConfigWithAssignments;
-  const parsedCategories: IntuneAppCategorySelection[] = [];
-
-  if (Array.isArray(typedConfig.categories)) {
-    for (const category of typedConfig.categories) {
-      if (!isObject(category)) {
-        continue;
-      }
-
-      if (typeof category.id !== 'string' || category.id.length === 0) {
-        continue;
-      }
-
-      if (typeof category.displayName !== 'string' || category.displayName.length === 0) {
-        continue;
-      }
-
-      parsedCategories.push({
-        id: category.id,
-        displayName: category.displayName,
-      });
-    }
-  }
-
-  // Backward-compatible support for legacy shape with category IDs only
-  if (parsedCategories.length === 0 && Array.isArray(typedConfig.categoryIds)) {
-    for (const categoryId of typedConfig.categoryIds) {
-      if (typeof categoryId !== 'string' || categoryId.length === 0) {
-        continue;
-      }
-      parsedCategories.push({
-        id: categoryId,
-        displayName: categoryId,
-      });
-    }
-  }
-
-  const seen = new Set<string>();
-  return parsedCategories.filter((category) => {
-    if (seen.has(category.id)) {
-      return false;
-    }
-    seen.add(category.id);
-    return true;
-  });
-}
-
-function parseDetectionRules(value: unknown): DetectionRule[] {
-  return Array.isArray(value) ? (value as DetectionRule[]) : [];
-}
-
-function parsePsadtConfig(packageConfig: unknown): DeploymentConfig['psadtConfig'] {
-  if (!isObject(packageConfig)) {
-    return undefined;
-  }
-  const psadtConfig = packageConfig.psadtConfig;
-  if (!isObject(psadtConfig)) {
-    return undefined;
-  }
-  return psadtConfig as unknown as DeploymentConfig['psadtConfig'];
-}
 
 // Batches of up to 10 apps run sequentially (DB lookups, job creation, and a
 // workflow dispatch each); the platform default duration times out mid-batch
@@ -403,103 +164,43 @@ export async function POST(request: NextRequest) {
 
         // If no policy exists, check for prior deployment to get config
         if (!policy) {
-          // Get the original deployment config from upload_history
-          const { data: uploadHistory } = await supabase
-            .from('upload_history')
-            .select('id, packaging_job_id')
-            .eq('user_id', user.userId)
-            .eq('intune_tenant_id', req.tenant_id)
-            .eq('winget_id', req.winget_id)
-            .order('deployed_at', { ascending: false })
-            .limit(1)
-            .single();
+          const built = await buildDeploymentConfigForApp(supabase, {
+            userId: user.userId,
+            tenantId: req.tenant_id,
+            wingetId: req.winget_id,
+            latestVersion: updateResult.latest_version,
+            globalCarryOver,
+          });
 
-          let deploymentConfig: DeploymentConfig;
-          let originalUploadHistoryId: string | null = null;
-
-          if (uploadHistory?.packaging_job_id) {
-            // Has prior deployment: extract config from packaging job
-            const { data: packagingJob } = await supabase
-              .from('packaging_jobs')
-              .select('*')
-              .eq('id', uploadHistory.packaging_job_id)
-              .single();
-
-            if (!packagingJob) {
-              response.failed++;
-              response.results.push({
-                winget_id: req.winget_id,
-                tenant_id: req.tenant_id,
-                success: false,
-                error: 'Could not retrieve deployment configuration',
-              });
-              continue;
-            }
-
-            const packageConfig = packagingJob.package_config;
-            const parsedAssignments = parsePackageAssignments(packageConfig);
-            const parsedCategories = parsePackageCategories(packageConfig);
-            const parsedRequirementRules = parseRequirementRules(packageConfig);
-            const parsedRelationships = parseAppRelationships(packageConfig);
-            let assignmentMigration = parseAssignmentMigration(packageConfig);
-
-            // If no explicit migration config was stored on the packaging job,
-            // fall back to the user's global carryOverAssignments setting
-            // (read once for the whole batch above).
-            // Note: createPackagingJob() also re-reads the global setting at
-            // trigger time, so the value here is for policy record consistency.
-            if (!assignmentMigration) {
-              assignmentMigration = {
-                carryOverAssignments: globalCarryOver,
-                removeAssignmentsFromPreviousApp: globalCarryOver,
-              };
-            }
-
-            deploymentConfig = {
-              displayName: packagingJob.display_name,
-              publisher: packagingJob.publisher || 'Unknown Publisher',
-              architecture: packagingJob.architecture || 'x64',
-              installerType: packagingJob.installer_type || 'exe',
-              installCommand: packagingJob.install_command || '',
-              uninstallCommand: packagingJob.uninstall_command || '',
-              installScope: packagingJob.install_scope || 'system',
-              detectionRules: parseDetectionRules(packagingJob.detection_rules),
-              assignments: parsedAssignments,
-              categories: parsedCategories,
-              requirementRules: parsedRequirementRules,
-              relationships: parsedRelationships.length > 0 ? parsedRelationships : undefined,
-              psadtConfig: parsePsadtConfig(packageConfig),
-              forceCreateNewApp: true,
-              assignmentMigration,
-            };
-            originalUploadHistoryId = uploadHistory.id;
-          } else {
-            // No prior deployment: build config from curated catalog data
-            const defaultConfig = await buildDefaultDeploymentConfig(
-              supabase,
-              req.winget_id,
-              updateResult.latest_version
-            );
-
-            if (!defaultConfig) {
-              // Distinguish missing installer data from a missing catalog
-              // entry so the user knows whether waiting for the catalog
-              // sync can help
-              const catalogRow = await getCatalogSource().appExists(req.winget_id);
-              response.failed++;
-              response.results.push({
-                winget_id: req.winget_id,
-                tenant_id: req.tenant_id,
-                success: false,
-                error: catalogRow
-                  ? `No installer data is available for ${req.winget_id} ${updateResult.latest_version} yet - the catalog has not synced this version's manifest. Try again after the next catalog sync.`
-                  : `${req.winget_id} is not in the app catalog, so a deployment configuration cannot be built for it.`,
-              });
-              continue;
-            }
-
-            deploymentConfig = defaultConfig;
+          if (built.status === 'orphaned_job') {
+            response.failed++;
+            response.results.push({
+              winget_id: req.winget_id,
+              tenant_id: req.tenant_id,
+              success: false,
+              error: 'Could not retrieve deployment configuration',
+            });
+            continue;
           }
+
+          if (built.status === 'unavailable') {
+            // Distinguish missing installer data from a missing catalog
+            // entry so the user knows whether waiting for the catalog
+            // sync can help
+            const catalogRow = await getCatalogSource().appExists(req.winget_id);
+            response.failed++;
+            response.results.push({
+              winget_id: req.winget_id,
+              tenant_id: req.tenant_id,
+              success: false,
+              error: catalogRow
+                ? `No installer data is available for ${req.winget_id} ${updateResult.latest_version} yet - the catalog has not synced this version's manifest. Try again after the next catalog sync.`
+                : `${req.winget_id} is not in the app catalog, so a deployment configuration cannot be built for it.`,
+            });
+            continue;
+          }
+
+          const { deploymentConfig, originalUploadHistoryId } = built;
 
           // Create a policy for this manual trigger
           const { data: newPolicy, error: policyError } = await supabase
@@ -719,89 +420,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
-
-/**
- * Build a deployment config from curated catalog data for apps
- * that were never deployed through IntuneGet.
- */
-async function buildDefaultDeploymentConfig(
-  // Kept for call-site compatibility; the catalog source owns client creation.
-  _supabase: ReturnType<typeof createServerClient>,
-  wingetId: string,
-  latestVersion: string
-): Promise<DeploymentConfig | null> {
-  // Get curated app info
-  const curatedApp = await getCatalogSource().getAppNamePublisher(wingetId);
-
-  if (!curatedApp) {
-    return null;
-  }
-
-  // Get version history for installer metadata
-  const versionInfo = await getCatalogSource().getVersionInstallerInfo(
-    wingetId,
-    latestVersion
-  );
-
-  if (!versionInfo?.installer_url) {
-    return null;
-  }
-
-  // Resolve architecture-specific installer (prefer x64)
-  let installerUrl = versionInfo.installer_url;
-  let installerSha256 = versionInfo.installer_sha256 || '';
-  let installerType = versionInfo.installer_type || 'exe';
-  let architecture = 'x64';
-
-  if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
-    type InstallerEntry = { Architecture?: string; InstallerUrl?: string; InstallerSha256?: string; InstallerType?: string };
-    const installers = versionInfo.installers as InstallerEntry[];
-    const x64Installer = installers.find(
-      (i) => i.Architecture === 'x64'
-    );
-    if (x64Installer) {
-      installerUrl = x64Installer.InstallerUrl || installerUrl;
-      installerSha256 = x64Installer.InstallerSha256 || installerSha256;
-      installerType = x64Installer.InstallerType || installerType;
-    } else if (installers.length > 0) {
-      // Use first available installer's architecture
-      const first = installers[0];
-      if (first?.Architecture) {
-        architecture = first.Architecture.toLowerCase();
-      }
-    }
-  }
-
-  // Build a NormalizedInstaller for detection rule generation
-  const normalizedInstaller: NormalizedInstaller = {
-    architecture: architecture as NormalizedInstaller['architecture'],
-    url: installerUrl,
-    sha256: installerSha256,
-    type: installerType as NormalizedInstaller['type'],
-    scope: 'machine',
-  };
-
-  const installCommand = generateInstallCommand(normalizedInstaller, 'machine');
-  const uninstallCommand = generateUninstallCommand(normalizedInstaller, curatedApp.name);
-  const detectionRules = generateDetectionRules(
-    normalizedInstaller,
-    curatedApp.name,
-    wingetId,
-    latestVersion
-  );
-
-  return {
-    displayName: curatedApp.name,
-    publisher: curatedApp.publisher || 'Unknown Publisher',
-    architecture,
-    installerType,
-    installCommand,
-    uninstallCommand,
-    installScope: 'system',
-    detectionRules,
-    assignments: [],
-    categories: [],
-    forceCreateNewApp: true,
-  };
 }

--- a/app/dashboard/updates/page.tsx
+++ b/app/dashboard/updates/page.tsx
@@ -5,6 +5,7 @@ import { T, Var } from "gt-next";
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
+import { toast } from 'sonner';
 import {
   RefreshCw,
   AlertTriangle,
@@ -271,8 +272,12 @@ export default function UpdatesPage() {
         policy_type: policyType,
       });
       refetchUpdates();
-    } catch {
-      // Policy update failed; don't refetch stale data
+    } catch (err) {
+      // Surface the failure instead of silently swallowing it; don't refetch
+      // stale data on failure.
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to update the policy. Please try again.'
+      );
     }
   }, [updatePolicy, refetchUpdates]);
 

--- a/lib/update-policies/build-deployment-config.ts
+++ b/lib/update-policies/build-deployment-config.ts
@@ -1,0 +1,445 @@
+/**
+ * Shared deployment-config builder for update policies.
+ *
+ * These helpers and the orchestrator below are used by both the manual
+ * trigger route (`app/api/updates/trigger`) and the policy POST route
+ * (`app/api/update-policies`) so that pin_version / auto_update can derive a
+ * deployment configuration server-side from a prior deployment or the catalog.
+ */
+
+import { createServerClient } from '@/lib/supabase';
+import { getCatalogSource } from '@/lib/catalog';
+import {
+  generateDetectionRules,
+  generateInstallCommand,
+  generateUninstallCommand,
+} from '@/lib/detection-rules';
+import type { DeploymentConfig } from '@/types/update-policies';
+import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
+import type { AppRelationship, DetectionRule, RequirementRule } from '@/types/intune';
+import type { NormalizedInstaller } from '@/types/winget';
+
+export interface PackageConfigWithAssignments {
+  assignments?: PackageAssignment[];
+  categories?: IntuneAppCategorySelection[];
+  categoryIds?: string[];
+  assignedGroups?: Array<{
+    groupId?: string;
+    groupName?: string;
+    assignmentType?: 'required' | 'available' | 'uninstall' | 'updateOnly';
+  }>;
+  requirementRules?: RequirementRule[];
+  relationships?: AppRelationship[];
+  assignmentMigration?: {
+    carryOverAssignments?: boolean;
+    removeAssignmentsFromPreviousApp?: boolean;
+  };
+  carryOverAssignments?: boolean;
+  removeAssignmentsFromPreviousApp?: boolean;
+}
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function parsePackageAssignments(packageConfig: unknown): PackageAssignment[] {
+  if (!isObject(packageConfig)) {
+    return [];
+  }
+
+  const assignments = packageConfig.assignments;
+  if (Array.isArray(assignments)) {
+    return assignments.filter((assignment): assignment is PackageAssignment => {
+      if (!isObject(assignment)) {
+        return false;
+      }
+
+      const type = assignment.type;
+      const intent = assignment.intent;
+      if (
+        type !== 'allUsers' &&
+        type !== 'allDevices' &&
+        type !== 'group'
+      ) {
+        return false;
+      }
+
+      if (
+        intent !== 'required' &&
+        intent !== 'available' &&
+        intent !== 'uninstall' &&
+        intent !== 'updateOnly'
+      ) {
+        return false;
+      }
+
+      if (type === 'group') {
+        return typeof assignment.groupId === 'string' && assignment.groupId.length > 0;
+      }
+
+      return true;
+    });
+  }
+
+  const assignedGroups = packageConfig.assignedGroups;
+  if (!Array.isArray(assignedGroups)) {
+    return [];
+  }
+
+  return assignedGroups
+    .filter((group): group is { groupId: string; groupName?: string; assignmentType?: 'required' | 'available' | 'uninstall' | 'updateOnly' } => {
+      return isObject(group) && typeof group.groupId === 'string' && group.groupId.length > 0;
+    })
+    .map((group) => ({
+      type: 'group',
+      groupId: group.groupId,
+      groupName: typeof group.groupName === 'string' ? group.groupName : undefined,
+      intent: group.assignmentType || 'required',
+    }));
+}
+
+export function parseRequirementRules(packageConfig: unknown): RequirementRule[] | undefined {
+  if (!isObject(packageConfig)) {
+    return undefined;
+  }
+  const typedConfig = packageConfig as PackageConfigWithAssignments;
+  if (Array.isArray(typedConfig.requirementRules) && typedConfig.requirementRules.length > 0) {
+    return typedConfig.requirementRules as RequirementRule[];
+  }
+  return undefined;
+}
+
+export function parseAppRelationships(packageConfig: unknown): AppRelationship[] {
+  if (!isObject(packageConfig)) {
+    return [];
+  }
+
+  const relationships = packageConfig.relationships;
+  if (!Array.isArray(relationships)) {
+    return [];
+  }
+
+  return relationships.filter((relationship): relationship is AppRelationship => {
+    if (!isObject(relationship)) {
+      return false;
+    }
+
+    const relationshipType = relationship.relationshipType;
+    if (relationshipType !== 'dependency' && relationshipType !== 'supersedence') {
+      return false;
+    }
+
+    if (typeof relationship.targetId !== 'string' || relationship.targetId.length === 0) {
+      return false;
+    }
+
+    if (
+      relationship.dependencyType !== undefined &&
+      relationship.dependencyType !== 'detect' &&
+      relationship.dependencyType !== 'autoInstall'
+    ) {
+      return false;
+    }
+
+    if (
+      relationship.supersedenceType !== undefined &&
+      relationship.supersedenceType !== 'update' &&
+      relationship.supersedenceType !== 'replace'
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function parseAssignmentMigration(packageConfig: unknown): DeploymentConfig['assignmentMigration'] | undefined {
+  if (!isObject(packageConfig)) {
+    return undefined;
+  }
+
+  const typedConfig = packageConfig as PackageConfigWithAssignments;
+  const nested = typedConfig.assignmentMigration;
+
+  // If no migration config was explicitly set, return undefined so the
+  // caller can fall back to the user's global setting.
+  const hasExplicitNested = nested && (
+    nested.carryOverAssignments !== undefined ||
+    nested.removeAssignmentsFromPreviousApp !== undefined
+  );
+  const hasExplicitTop =
+    typedConfig.carryOverAssignments !== undefined ||
+    typedConfig.removeAssignmentsFromPreviousApp !== undefined;
+
+  if (!hasExplicitNested && !hasExplicitTop) {
+    return undefined;
+  }
+
+  const carryOverAssignments = Boolean(
+    nested?.carryOverAssignments ?? typedConfig.carryOverAssignments
+  );
+  const removeAssignmentsFromPreviousApp = Boolean(
+    nested?.removeAssignmentsFromPreviousApp ?? typedConfig.removeAssignmentsFromPreviousApp
+  );
+
+  return {
+    carryOverAssignments,
+    removeAssignmentsFromPreviousApp,
+  };
+}
+
+export function parsePackageCategories(packageConfig: unknown): IntuneAppCategorySelection[] {
+  if (!isObject(packageConfig)) {
+    return [];
+  }
+
+  const typedConfig = packageConfig as PackageConfigWithAssignments;
+  const parsedCategories: IntuneAppCategorySelection[] = [];
+
+  if (Array.isArray(typedConfig.categories)) {
+    for (const category of typedConfig.categories) {
+      if (!isObject(category)) {
+        continue;
+      }
+
+      if (typeof category.id !== 'string' || category.id.length === 0) {
+        continue;
+      }
+
+      if (typeof category.displayName !== 'string' || category.displayName.length === 0) {
+        continue;
+      }
+
+      parsedCategories.push({
+        id: category.id,
+        displayName: category.displayName,
+      });
+    }
+  }
+
+  // Backward-compatible support for legacy shape with category IDs only
+  if (parsedCategories.length === 0 && Array.isArray(typedConfig.categoryIds)) {
+    for (const categoryId of typedConfig.categoryIds) {
+      if (typeof categoryId !== 'string' || categoryId.length === 0) {
+        continue;
+      }
+      parsedCategories.push({
+        id: categoryId,
+        displayName: categoryId,
+      });
+    }
+  }
+
+  const seen = new Set<string>();
+  return parsedCategories.filter((category) => {
+    if (seen.has(category.id)) {
+      return false;
+    }
+    seen.add(category.id);
+    return true;
+  });
+}
+
+export function parseDetectionRules(value: unknown): DetectionRule[] {
+  return Array.isArray(value) ? (value as DetectionRule[]) : [];
+}
+
+export function parsePsadtConfig(packageConfig: unknown): DeploymentConfig['psadtConfig'] {
+  if (!isObject(packageConfig)) {
+    return undefined;
+  }
+  const psadtConfig = packageConfig.psadtConfig;
+  if (!isObject(psadtConfig)) {
+    return undefined;
+  }
+  return psadtConfig as unknown as DeploymentConfig['psadtConfig'];
+}
+
+/**
+ * Build a deployment config from curated catalog data for apps
+ * that were never deployed through IntuneGet.
+ */
+export async function buildDefaultDeploymentConfig(
+  // Kept for call-site compatibility; the catalog source owns client creation.
+  _supabase: ReturnType<typeof createServerClient>,
+  wingetId: string,
+  latestVersion: string
+): Promise<DeploymentConfig | null> {
+  // Get curated app info
+  const curatedApp = await getCatalogSource().getAppNamePublisher(wingetId);
+
+  if (!curatedApp) {
+    return null;
+  }
+
+  // Get version history for installer metadata
+  const versionInfo = await getCatalogSource().getVersionInstallerInfo(
+    wingetId,
+    latestVersion
+  );
+
+  if (!versionInfo?.installer_url) {
+    return null;
+  }
+
+  // Resolve architecture-specific installer (prefer x64)
+  let installerUrl = versionInfo.installer_url;
+  let installerSha256 = versionInfo.installer_sha256 || '';
+  let installerType = versionInfo.installer_type || 'exe';
+  let architecture = 'x64';
+
+  if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
+    type InstallerEntry = { Architecture?: string; InstallerUrl?: string; InstallerSha256?: string; InstallerType?: string };
+    const installers = versionInfo.installers as InstallerEntry[];
+    const x64Installer = installers.find(
+      (i) => i.Architecture === 'x64'
+    );
+    if (x64Installer) {
+      installerUrl = x64Installer.InstallerUrl || installerUrl;
+      installerSha256 = x64Installer.InstallerSha256 || installerSha256;
+      installerType = x64Installer.InstallerType || installerType;
+    } else if (installers.length > 0) {
+      // Use first available installer's architecture
+      const first = installers[0];
+      if (first?.Architecture) {
+        architecture = first.Architecture.toLowerCase();
+      }
+    }
+  }
+
+  // Build a NormalizedInstaller for detection rule generation
+  const normalizedInstaller: NormalizedInstaller = {
+    architecture: architecture as NormalizedInstaller['architecture'],
+    url: installerUrl,
+    sha256: installerSha256,
+    type: installerType as NormalizedInstaller['type'],
+    scope: 'machine',
+  };
+
+  const installCommand = generateInstallCommand(normalizedInstaller, 'machine');
+  const uninstallCommand = generateUninstallCommand(normalizedInstaller, curatedApp.name);
+  const detectionRules = generateDetectionRules(
+    normalizedInstaller,
+    curatedApp.name,
+    wingetId,
+    latestVersion
+  );
+
+  return {
+    displayName: curatedApp.name,
+    publisher: curatedApp.publisher || 'Unknown Publisher',
+    architecture,
+    installerType,
+    installCommand,
+    uninstallCommand,
+    installScope: 'system',
+    detectionRules,
+    assignments: [],
+    categories: [],
+    forceCreateNewApp: true,
+  };
+}
+
+/**
+ * Result of buildDeploymentConfigForApp.
+ *  - ok: a config was built (from a prior deployment or the catalog default).
+ *  - orphaned_job: a prior deployment exists but its packaging job is gone, so
+ *    the saved config cannot be retrieved (distinct from "no deployment").
+ *  - unavailable: no prior packaging job AND the catalog cannot produce a
+ *    default config.
+ */
+export type BuildDeploymentConfigResult =
+  | { status: 'ok'; deploymentConfig: DeploymentConfig; originalUploadHistoryId: string | null }
+  | { status: 'orphaned_job' }
+  | { status: 'unavailable' };
+
+/**
+ * Orchestrator: build a deployment config for an app, replicating the
+ * trigger route's "no policy yet" branch.
+ */
+export async function buildDeploymentConfigForApp(
+  supabase: ReturnType<typeof createServerClient>,
+  args: {
+    userId: string;
+    tenantId: string;
+    wingetId: string;
+    latestVersion: string;
+    globalCarryOver: boolean;
+  }
+): Promise<BuildDeploymentConfigResult> {
+  const { userId, tenantId, wingetId, latestVersion, globalCarryOver } = args;
+
+  // Get the original deployment config from upload_history
+  const { data: uploadHistory } = await supabase
+    .from('upload_history')
+    .select('id, packaging_job_id')
+    .eq('user_id', userId)
+    .eq('intune_tenant_id', tenantId)
+    .eq('winget_id', wingetId)
+    .order('deployed_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (uploadHistory?.packaging_job_id) {
+    // Has prior deployment: extract config from packaging job
+    const { data: packagingJob } = await supabase
+      .from('packaging_jobs')
+      .select('*')
+      .eq('id', uploadHistory.packaging_job_id)
+      .maybeSingle();
+
+    if (!packagingJob) {
+      // Prior deployment exists but its packaging job is gone.
+      return { status: 'orphaned_job' };
+    }
+
+    const packageConfig = packagingJob.package_config;
+    const parsedAssignments = parsePackageAssignments(packageConfig);
+    const parsedCategories = parsePackageCategories(packageConfig);
+    const parsedRequirementRules = parseRequirementRules(packageConfig);
+    const parsedRelationships = parseAppRelationships(packageConfig);
+    let assignmentMigration = parseAssignmentMigration(packageConfig);
+
+    // If no explicit migration config was stored on the packaging job,
+    // fall back to the user's global carryOverAssignments setting.
+    if (!assignmentMigration) {
+      assignmentMigration = {
+        carryOverAssignments: globalCarryOver,
+        removeAssignmentsFromPreviousApp: globalCarryOver,
+      };
+    }
+
+    const deploymentConfig: DeploymentConfig = {
+      displayName: packagingJob.display_name,
+      publisher: packagingJob.publisher || 'Unknown Publisher',
+      architecture: packagingJob.architecture || 'x64',
+      installerType: packagingJob.installer_type || 'exe',
+      installCommand: packagingJob.install_command || '',
+      uninstallCommand: packagingJob.uninstall_command || '',
+      installScope: packagingJob.install_scope || 'system',
+      detectionRules: parseDetectionRules(packagingJob.detection_rules),
+      assignments: parsedAssignments,
+      categories: parsedCategories,
+      requirementRules: parsedRequirementRules,
+      relationships: parsedRelationships.length > 0 ? parsedRelationships : undefined,
+      psadtConfig: parsePsadtConfig(packageConfig),
+      forceCreateNewApp: true,
+      assignmentMigration,
+    };
+
+    return { status: 'ok', deploymentConfig, originalUploadHistoryId: uploadHistory.id };
+  }
+
+  // No prior deployment: build config from curated catalog data
+  const defaultConfig = await buildDefaultDeploymentConfig(
+    supabase,
+    wingetId,
+    latestVersion
+  );
+
+  if (!defaultConfig) {
+    return { status: 'unavailable' };
+  }
+
+  return { status: 'ok', deploymentConfig: defaultConfig, originalUploadHistoryId: null };
+}


### PR DESCRIPTION
## Summary
Setting **Auto-update** or **Pin version** from the App Updates bell dropdown did nothing (only **Ignore**/**Notify** worked). `POST /api/update-policies` hard-required `pinned_version` (pin_version) and `deployment_config` (auto_update) and 400'd otherwise, but the UI only sent `{ winget_id, tenant_id, policy_type }` and its `catch {}` swallowed the error — so it looked like a no-op.

## Fix
The server now derives what a one-click toggle can't supply:
- **pin_version** without `pinned_version` → the app's current deployed version (`update_check_results.current_version`, fallback latest `upload_history` version).
- **auto_update** without `deployment_config` → built from the app's prior deployment (or the catalog default), so `triggerAutoUpdate` has a real config (it bails without one).

The deployment-config builder is **extracted from `/api/updates/trigger` into a shared `lib/update-policies/build-deployment-config.ts`** used by both routes — no behavior change to the trigger route (its tests pass unchanged; the orphaned-packaging-job error path is preserved via a typed result, and queries use `.maybeSingle()` to match convention). The updates page now shows a **toast on failure** instead of swallowing it.

## Testing
- `tsc` clean, `next lint` clean, **430 tests pass**
- 6 new `update-policies` route tests (pin derivation, auto_update derivation + `original_upload_history_id`, no-prior-deployment 400, ignore/notify)
- Trigger-route tests pass **unchanged**, confirming the extraction preserved behavior; an independent behavior-preservation review verified the config construction field-by-field

Fixes #131