### PR TITLE
Show older activity in the Uploads tab + fix its user scoping (#134)

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -97,6 +97,13 @@ function minutesAgo(minutes: number): string {
 describe('GET /api/package (userId listing)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The list path now authenticates and uses the token's userId.
+    parseAccessTokenMock.mockResolvedValue({
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      userEmail: 'user@example.com',
+      userName: 'User One',
+    });
     getDatabaseMock.mockReturnValue({
       jobs: {
         getByUserId: getByUserIdMock,

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -599,14 +599,6 @@ async function healStaleJobs(
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const jobId = searchParams.get('jobId');
-  const userId = searchParams.get('userId');
-
-  if (!jobId && !userId) {
-    return NextResponse.json(
-      { error: 'jobId or userId parameter required' },
-      { status: 400 }
-    );
-  }
 
   const db = getDatabase();
 
@@ -624,8 +616,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ job });
     }
 
-    // Get all jobs for a user
-    const jobs = await db.jobs.getByUserId(userId!, 50);
+    // List the signed-in user's jobs. Use the token's userId (the same value
+    // jobs are stored under and the dashboard reads) instead of trusting a
+    // client-supplied id, so older completed activity shows here too.
+    const user = await parseAccessToken(request.headers.get('Authorization'));
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const jobs = await db.jobs.getByUserId(user.userId, 50);
 
     // Self-heal jobs stuck in intermediate states (safety net for
     // deployments where the cleanup cron is not running)

--- a/app/dashboard/uploads/page.tsx
+++ b/app/dashboard/uploads/page.tsx
@@ -129,7 +129,10 @@ export default function UploadsPage() {
     }
 
     try {
-      const response = await fetch(`/api/package?userId=${user.id}`);
+      const accessToken = await getAccessToken();
+      const response = await fetch('/api/package', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
 
       if (!response.ok) {
         const contentType = response.headers.get('content-type');
@@ -150,7 +153,7 @@ export default function UploadsPage() {
       setIsLoading(false);
       setIsRefreshing(false);
     }
-  }, [user?.id]);
+  }, [user?.id, getAccessToken]);
 
   // Initial load
   useEffect(() => {

--- a/lib/db/sqlite.ts
+++ b/lib/db/sqlite.ts
@@ -170,18 +170,15 @@ export const sqliteDb: DatabaseAdapter = {
      */
     async getByUserId(userId: string, limit: number = 50): Promise<PackagingJob[]> {
       const database = getDb();
-      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+      // Return the most recent jobs for the user with no age cutoff, so the
+      // Uploads (all activities) view shows older completed deployments too.
       const stmt = database.prepare(`
         SELECT * FROM packaging_jobs
         WHERE user_id = ?
-        AND (
-          status IN ('queued', 'packaging', 'uploading')
-          OR created_at >= ?
-        )
         ORDER BY created_at DESC
         LIMIT ?
       `);
-      const rows = stmt.all(userId, sevenDaysAgo, limit) as Record<string, unknown>[];
+      const rows = stmt.all(userId, limit) as Record<string, unknown>[];
       return rows.map(parseJobRow);
     },
 

--- a/lib/db/supabase-adapter.ts
+++ b/lib/db/supabase-adapter.ts
@@ -154,16 +154,13 @@ export const supabaseDb: DatabaseAdapter = {
      */
     async getByUserId(userId: string, limit: number = 50): Promise<PackagingJob[]> {
       const supabase = createServerClient();
-      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-      const terminalStatuses = ['completed', 'deployed', 'failed', 'cancelled', 'duplicate_skipped'];
-      const activeStatuses = ['queued', 'packaging', 'uploading'];
 
-      // Fetch jobs: either active (any age) or terminal within last 7 days
+      // Return the most recent jobs for the user with no age cutoff, so the
+      // Uploads (all activities) view shows older completed deployments too.
       const { data, error } = await supabase
         .from('packaging_jobs')
         .select('*')
         .eq('user_id', userId)
-        .or(`status.in.(${activeStatuses.join(',')}),created_at.gte.${sevenDaysAgo}`)
         .order('created_at', { ascending: false })
         .limit(limit);
 


### PR DESCRIPTION
## Summary
The Uploads ("all activities") tab was empty even though the dashboard **Last Activities** widget and **MSP Reports** showed deployments. Two causes:

1. **7-day cutoff.** `db.jobs.getByUserId` — the only source for the Uploads tab — returned active jobs OR terminal jobs `created_at >= 7 days ago`, so deployments older than a week were hidden. The dashboard widget queries `packaging_jobs` with no cutoff, which is why it still showed the old test apps. Removed the 7-day window in both the sqlite and supabase adapters; the tab now lists the most recent jobs for the user regardless of age.
2. **User scoping.** The `GET /api/package` list path trusted a client-supplied `userId` query param (the MSAL `localAccountId`) and was unauthenticated. It now authenticates and uses the **token's userId** — the same value jobs are stored under and the dashboard reads — so the list always matches, and the unauthenticated read is closed. The uploads page sends its access token (as its other calls already do). The `jobId` lookup path is unchanged.

## Testing
- `tsc` clean, `next lint` clean, **430 tests pass**
- The existing `GET /api/package` stale-job-healing tests were updated for the new auth requirement
- Confirmed the Uploads page is the only caller of the list path; `getByUserId` has no other callers

Fixes #134