### PR TITLE
Pin UI locale via gt-next middleware to stop the locale flip (#136)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createNextMiddleware } from 'gt-next/middleware';
 
 const PROTECTED_ROUTES = ['/dashboard'];
+
+// gt-next locale middleware in cookie-only mode (no path-based locale routing).
+// It resolves the UI locale once per request and writes it to the gt locale
+// cookie, so the server-rendered locale and the client provider read the same
+// value. Without this the locale was re-derived independently on the server
+// (Accept-Language) and the client, which showed up as a brief German->English
+// flip in client-rendered sections like Uploads (issue #136).
+const gtMiddleware = createNextMiddleware({ localeRouting: false });
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -16,7 +25,11 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  const response = NextResponse.next();
+  // Pin the UI locale on page requests. API requests are skipped: their locale
+  // is irrelevant and must not drive the shared cookie.
+  const response = pathname.startsWith('/api')
+    ? NextResponse.next()
+    : gtMiddleware(request);
 
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('X-Frame-Options', 'SAMEORIGIN');


### PR DESCRIPTION
## Summary
Reporter saw inconsistent translations: the UI loaded in German then switched to English a second later, notably in the Uploads section, plus German in Edge vs English in Firefox.

Root cause: the app uses gt-next (App Router) **without its locale middleware**, so the locale was derived independently on the server (from `Accept-Language`) and again on the client, with no shared cookie to keep them in sync. When a client-rendered section re-rendered (Uploads loads its data client-side), it flipped from the server-rendered locale to the client-resolved one — the visible German→English flash.

## Fix
Add gt-next's `createNextMiddleware({ localeRouting: false })` to the existing middleware. In cookie-only mode it resolves the locale once per page request and writes the gt locale cookie, so the server render and the client provider read the **same** value → no flip. No path-based locale routing is introduced (no `/de/` prefixes); API routes are skipped so they can't drive the cookie; the dashboard auth redirect and security headers are preserved.

The separate "German in Edge, English in Firefox" is the browser sending `de` in its `Accept-Language` list (the reporter can check `edge://settings/languages`); with the cookie pinned it's at least consistent within a session.

## Testing
- `tsc` clean, `next lint` clean, **430 tests pass**, `createNextMiddleware` export verified
- The locale flip needs a German-`Accept-Language` browser to reproduce, so the CI **Build** job (edge-runtime bundling of the middleware with the injected gt config) is the key automated check; behavioral confirmation will come from the reporter

Fixes #136