### PR TITLE
Fix confirmed bugs across app, packager, and packaging scripts

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -477,12 +477,12 @@ $deferTimes = if ($psadtConfig.deferTimes) { [int]$psadtConfig.deferTimes } else
 # Extended welcome parameters
 $blockExecution = if ($psadtConfig.blockExecution) { $true } else { $false }
 $promptToSave = if ($psadtConfig.promptToSave) { $true } else { $false }
-$deferDeadline = $psadtConfig.deferDeadline
+$deferDeadline = if ($psadtConfig.deferDeadline) { ([string]$psadtConfig.deferDeadline) -replace "'", "''" -replace '`', '``' -replace '\$', '`$' } else { $null }
 $deferDays = $psadtConfig.deferDays
 $forceCloseCountdown = $psadtConfig.forceCloseProcessesCountdown
 $persistPrompt = if ($psadtConfig.persistPrompt) { $true } else { $false }
 $minimizeWindows = if ($psadtConfig.minimizeWindows) { $true } else { $false }
-$windowLocation = if ($psadtConfig.windowLocation) { $psadtConfig.windowLocation } else { 'Default' }
+$windowLocation = if ($psadtConfig.windowLocation) { ([string]$psadtConfig.windowLocation) -replace "'", "''" -replace '`', '``' -replace '\$', '`$' } else { 'Default' }
 $checkDiskSpace = if ($psadtConfig.checkDiskSpace) { $true } else { $false }
 $requiredDiskSpace = $psadtConfig.requiredDiskSpace
 $welcomeTitle = if ([string]::IsNullOrWhiteSpace($brandingWelcomeTitle)) { "$displayNameEscaped Installation" } else { $brandingWelcomeTitle -replace "'", "''" -replace '`', '``' -replace '\$', '`$' }
@@ -570,7 +570,8 @@ if ($progressConfig -and $progressConfig.enabled) {
         $progressParams += "-StatusMessage '$statusMsgEscaped'"
     }
     if ($progressConfig.windowLocation -and $progressConfig.windowLocation -ne 'Default') {
-        $progressParams += "-WindowLocation '$($progressConfig.windowLocation)'"
+        $progressWindowLocationEscaped = ([string]$progressConfig.windowLocation) -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+        $progressParams += "-WindowLocation '$progressWindowLocationEscaped'"
     }
     $progressParamsStr = if ($progressParams.Count -gt 0) { " $($progressParams -join ' ')" } else { "" }
     $progressCall = @(

--- a/.github/workflows-reference/package-intunewin.yml
+++ b/.github/workflows-reference/package-intunewin.yml
@@ -806,14 +806,17 @@ jobs:
           }
 
           # Rename package to use display name for better identification in Intune
+          # Strip square brackets too: PowerShell treats [ ] as wildcard characters in Path
+          # parameters, so display names like "[Deprecated] Google Drive..." would silently
+          # break Get-Item / Move-Item without -LiteralPath.
           $displayName = $env:DISPLAY_NAME
-          $safeDisplayName = $displayName -replace '[\\/:*?"<>|]', '_'
+          $safeDisplayName = $displayName -replace '[\[\]\\/:*?"<>|]', '_'
           $packageFileName = "$safeDisplayName.intunewin"
           $newPath = Join-Path $outputDir $packageFileName
 
           if ($intunewinFile.Name -ne $packageFileName) {
-            Move-Item $intunewinFile.FullName $newPath -Force
-            $intunewinFile = Get-Item $newPath
+            Move-Item -LiteralPath $intunewinFile.FullName -Destination $newPath -Force
+            $intunewinFile = Get-Item -LiteralPath $newPath
           }
 
           echo "INTUNEWIN_PATH=$($intunewinFile.FullName)" >> $env:GITHUB_ENV

--- a/app/api/analytics/export/route.ts
+++ b/app/api/analytics/export/route.ts
@@ -104,17 +104,20 @@ export async function GET(request: NextRequest) {
       job.installer_type || '',
       job.status,
       job.intune_app_id || '',
-      (job.error_message || '').replace(/"/g, '""'),
+      // escapeCSV below handles quote-doubling uniformly for every column.
+      job.error_message || '',
       job.created_at,
       job.completed_at || '',
     ]);
 
     // Escape CSV values
     const escapeCSV = (value: string): string => {
-      if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-        return `"${value}"`;
+      const str = String(value);
+      if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+        // RFC 4180: wrap in quotes and double any embedded quotes.
+        return `"${str.replace(/"/g, '""')}"`;
       }
-      return value;
+      return str;
     };
 
     const csvContent = [

--- a/app/api/package/cleanup/route.ts
+++ b/app/api/package/cleanup/route.ts
@@ -96,8 +96,19 @@ export async function POST(request: NextRequest) {
 /**
  * GET handler for checking cleanup status / stats
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    // Same secret gate as POST: these are system-wide job stats, not per-user.
+    const authHeader = request.headers.get('Authorization');
+    const cleanupSecret = process.env.CLEANUP_SECRET || process.env.CALLBACK_SECRET;
+
+    if (cleanupSecret && authHeader !== `Bearer ${cleanupSecret}`) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
     const supabase = createServerClient();
 
     // Get count of jobs by status

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -604,9 +604,19 @@ export async function GET(request: NextRequest) {
 
   try {
     if (jobId) {
+      const user = await parseAccessToken(request.headers.get('Authorization'));
+      if (!user) {
+        return NextResponse.json(
+          { error: 'Authentication required' },
+          { status: 401 }
+        );
+      }
+
       const job = await db.jobs.getById(jobId);
 
-      if (!job) {
+      // Return 404 (not 403) on a foreign job so job existence isn't leaked
+      // to a caller who doesn't own it.
+      if (!job || (job as { user_id?: string }).user_id !== user.userId) {
         return NextResponse.json(
           { error: 'Job not found' },
           { status: 404 }

--- a/app/dashboard/sccm/[migrationId]/migrate/page.tsx
+++ b/app/dashboard/sccm/[migrationId]/migrate/page.tsx
@@ -113,8 +113,11 @@ export default function MigratePage({ params }: PageProps) {
   }, [getAccessToken, resolvedParams.migrationId, appIds, options]);
 
   useEffect(() => {
+    // Refetch whenever migration options change so the preview reflects the
+    // detection/command/winget-defaults toggles the user is looking at.
     fetchPreview();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options]);
 
   const handleMigrate = async () => {
     if (!preview) return;

--- a/components/msp/BatchDeploymentWizard.tsx
+++ b/components/msp/BatchDeploymentWizard.tsx
@@ -103,7 +103,12 @@ export function BatchDeploymentWizard({ initialApp, onComplete }: BatchDeploymen
   const canProceed = () => {
     switch (currentStep) {
       case 'app':
-        return selectedApp && selectedApp.winget_id && selectedApp.display_name && selectedApp.version;
+        // Accept either a picked app or a fully filled manual entry; handleNext
+        // promotes manualApp into selectedApp before advancing.
+        return Boolean(
+          (selectedApp && selectedApp.winget_id && selectedApp.display_name && selectedApp.version) ||
+          (manualApp.winget_id && manualApp.display_name && manualApp.version)
+        );
       case 'tenants':
         return selectedTenantIds.length > 0;
       case 'review':

--- a/lib/__tests__/version-compare.test.ts
+++ b/lib/__tests__/version-compare.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseVersion,
+  compareVersions,
+  hasUpdate,
+  normalizeVersion,
+} from '@/lib/version-compare';
+
+describe('parseVersion', () => {
+  it('keeps every numeric release segment', () => {
+    expect(parseVersion('1.2.3.4').segments).toEqual([1, 2, 3, 4]);
+    expect(parseVersion('v7.0.15.4').segments).toEqual([7, 0, 15, 4]);
+  });
+
+  it('still exposes major/minor/patch for existing callers', () => {
+    const v = parseVersion('24.100.1.5');
+    expect(v.major).toBe(24);
+    expect(v.minor).toBe(100);
+    expect(v.patch).toBe(1);
+  });
+
+  it('separates prerelease from the release segments', () => {
+    const v = parseVersion('1.2.3-beta.1');
+    expect(v.segments).toEqual([1, 2, 3]);
+    expect(v.prerelease).toBe('beta.1');
+  });
+});
+
+describe('compareVersions', () => {
+  it('detects a difference in the 4th segment (regression guard)', () => {
+    expect(compareVersions('1.2.3.4', '1.2.3.9')).toBe(-1);
+    expect(compareVersions('1.2.3.9', '1.2.3.4')).toBe(1);
+    expect(compareVersions('7.0.15.4', '7.0.15.4')).toBe(0);
+  });
+
+  it('treats a missing trailing segment as zero', () => {
+    expect(compareVersions('1.2.3', '1.2.3.0')).toBe(0);
+    expect(compareVersions('1.2.3', '1.2.3.1')).toBe(-1);
+  });
+
+  it('compares 3-segment versions as before', () => {
+    expect(compareVersions('1.2.3', '1.3.0')).toBe(-1);
+    expect(compareVersions('2.0.0', '1.9.9')).toBe(1);
+  });
+
+  it('ranks a release above its prerelease', () => {
+    expect(compareVersions('1.0.0', '1.0.0-rc.1')).toBe(1);
+    expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBe(-1);
+  });
+
+  it('handles date-style versions', () => {
+    expect(compareVersions('2024.09.10', '2024.10.01')).toBe(-1);
+  });
+});
+
+describe('hasUpdate', () => {
+  it('flags a newer 4-segment build (the core update-detection case)', () => {
+    expect(hasUpdate('1.2.3.4', '1.2.3.9')).toBe(true);
+    expect(hasUpdate('1.2.3.9', '1.2.3.4')).toBe(false);
+    expect(hasUpdate('1.2.3.4', '1.2.3.4')).toBe(false);
+  });
+});
+
+describe('normalizeVersion', () => {
+  it('pads short versions to three segments', () => {
+    expect(normalizeVersion('1.2')).toBe('1.2.0');
+    expect(normalizeVersion(null)).toBe('0.0.0');
+  });
+});

--- a/lib/intune-api.ts
+++ b/lib/intune-api.ts
@@ -457,6 +457,48 @@ export async function getEntraIDGroups(
 }
 
 /**
+ * Fetch every page of a Graph collection by following @odata.nextLink.
+ * Graph paginates list endpoints; reading only the first page silently
+ * truncates results (e.g. a category/filter dropdown missing entries).
+ */
+async function fetchAllGraphPages<T>(
+  initialUrl: string,
+  accessToken: string,
+  errorMessage: string,
+  extraHeaders?: Record<string, string>
+): Promise<T[]> {
+  const results: T[] = [];
+  let nextUrl: string | undefined = initialUrl;
+
+  while (nextUrl) {
+    const response: Response = await fetch(nextUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...extraHeaders,
+      },
+    });
+
+    if (!response.ok) {
+      // Carry the HTTP status so callers can distinguish a permission error
+      // (403) from a genuinely empty list and surface an actionable message.
+      const err = new Error(`${errorMessage} (${response.status})`) as Error & {
+        status?: number;
+      };
+      err.status = response.status;
+      throw err;
+    }
+
+    const data: GraphApiResponse<T> = await response.json();
+    if (data.value) {
+      results.push(...data.value);
+    }
+    nextUrl = data['@odata.nextLink'];
+  }
+
+  return results;
+}
+
+/**
  * Get Intune mobile app categories
  */
 export async function getMobileAppCategories(
@@ -465,18 +507,12 @@ export async function getMobileAppCategories(
   const url = new URL(`${GRAPH_API_BASE}/deviceAppManagement/mobileAppCategories`);
   url.searchParams.set('$select', 'id,displayName,lastModifiedDateTime');
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to get Intune app categories');
-  }
-
-  const data: GraphApiResponse<IntuneMobileAppCategory> = await response.json();
-  return (data.value || [])
+  const categories = await fetchAllGraphPages<IntuneMobileAppCategory>(
+    url.toString(),
+    accessToken,
+    'Failed to get Intune app categories'
+  );
+  return categories
     .filter((category) => Boolean(category.id && category.displayName))
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
@@ -491,24 +527,12 @@ export async function getAssignmentFilters(
   url.searchParams.set('$select', 'id,displayName,description,platform,rule');
   url.searchParams.set('$orderby', 'displayName');
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  if (!response.ok) {
-    // Carry the HTTP status so callers can distinguish a permission error (403)
-    // from a genuinely empty filter list and surface an actionable message.
-    const err = new Error(
-      `Failed to get Intune assignment filters (${response.status})`
-    ) as Error & { status?: number };
-    err.status = response.status;
-    throw err;
-  }
-
-  const data: GraphApiResponse<IntuneAssignmentFilter> = await response.json();
-  return (data.value || [])
+  const filters = await fetchAllGraphPages<IntuneAssignmentFilter>(
+    url.toString(),
+    accessToken,
+    'Failed to get Intune assignment filters'
+  );
+  return filters
     .filter((filter) => Boolean(filter.id && filter.displayName))
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
@@ -645,21 +669,11 @@ export async function getAppCategories(
   accessToken: string,
   appId: string
 ): Promise<IntuneMobileAppCategory[]> {
-  const response = await fetch(
+  return await fetchAllGraphPages<IntuneMobileAppCategory>(
     `${GRAPH_API_BASE}/deviceAppManagement/mobileApps/${appId}/categories`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
+    accessToken,
+    'Failed to get app categories'
   );
-
-  if (!response.ok) {
-    throw new Error('Failed to get app categories');
-  }
-
-  const data: GraphApiResponse<IntuneMobileAppCategory> = await response.json();
-  return data.value || [];
 }
 
 /**

--- a/lib/version-compare.ts
+++ b/lib/version-compare.ts
@@ -7,6 +7,8 @@ interface ParsedVersion {
   major: number;
   minor: number;
   patch: number;
+  /** All numeric release segments in order (e.g. [1, 2, 3, 4] for "1.2.3.4"). */
+  segments: number[];
   prerelease: string;
   build: string;
 }
@@ -18,12 +20,17 @@ export function parseVersion(version: string): ParsedVersion {
   // Remove leading 'v' if present
   const cleaned = version.replace(/^v/i, '').trim();
 
-  // Split by common separators and extract numeric parts
-  const parts = cleaned.split(/[.\-+]/);
+  // The release portion is everything before the first prerelease/build
+  // separator; keep every numeric segment (not just the first three) so that
+  // 4-part versions like "1.2.3.4" (common for winget/MSI) compare correctly.
+  const releasePart = cleaned.split(/[-+]/)[0];
+  const segments = releasePart
+    .split('.')
+    .map((p) => parseInt(p, 10) || 0);
 
-  const major = parseInt(parts[0], 10) || 0;
-  const minor = parseInt(parts[1], 10) || 0;
-  const patch = parseInt(parts[2], 10) || 0;
+  const major = segments[0] || 0;
+  const minor = segments[1] || 0;
+  const patch = segments[2] || 0;
 
   // Extract prerelease (alpha, beta, rc, etc.)
   let prerelease = '';
@@ -39,7 +46,7 @@ export function parseVersion(version: string): ParsedVersion {
     build = buildMatch[1];
   }
 
-  return { major, minor, patch, prerelease, build };
+  return { major, minor, patch, segments, prerelease, build };
 }
 
 /**
@@ -50,19 +57,15 @@ export function compareVersions(versionA: string, versionB: string): number {
   const a = parseVersion(versionA);
   const b = parseVersion(versionB);
 
-  // Compare major
-  if (a.major !== b.major) {
-    return a.major > b.major ? 1 : -1;
-  }
-
-  // Compare minor
-  if (a.minor !== b.minor) {
-    return a.minor > b.minor ? 1 : -1;
-  }
-
-  // Compare patch
-  if (a.patch !== b.patch) {
-    return a.patch > b.patch ? 1 : -1;
+  // Compare every numeric release segment in order (major.minor.patch.build...),
+  // treating a missing segment as 0 so "1.2.3" == "1.2.3.0" and "1.2.3.4" < "1.2.3.9".
+  const maxSegments = Math.max(a.segments.length, b.segments.length);
+  for (let i = 0; i < maxSegments; i++) {
+    const segA = a.segments[i] ?? 0;
+    const segB = b.segments[i] ?? 0;
+    if (segA !== segB) {
+      return segA > segB ? 1 : -1;
+    }
   }
 
   // Handle prerelease versions

--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -151,8 +151,9 @@ export class IntuneUploader {
    */
   async uploadToIntune(
     job: PackagingJob,
-    intunewinPath: string,
+    encryptedContentPath: string,
     encryptionInfo: EncryptionInfo,
+    sizes: { unencryptedSize: number; encryptedSize: number },
     onProgress?: ProgressCallback
   ): Promise<IntuneAppResult> {
     const graphClient = new GraphClient(this.config, job.tenant_id);
@@ -168,16 +169,18 @@ export class IntuneUploader {
     this.logger.info('Created content version', { contentVersionId: contentVersion.id });
 
     // Step 3: Create content file (15%)
+    // Intune's mobileAppContentFile.size is the unencrypted content size and
+    // sizeEncrypted is the encrypted payload size; the encrypted payload (not
+    // the outer .intunewin) is what gets uploaded to Azure Storage.
     await onProgress?.(15, 'Preparing file upload...');
-    const fileInfo = await fs.promises.stat(intunewinPath);
-    const encryptedSize = fileInfo.size;
 
     const contentFile = await this.createContentFile(
       graphClient,
       app.id,
       contentVersion.id,
-      path.basename(intunewinPath),
-      encryptedSize
+      path.basename(encryptedContentPath),
+      sizes.unencryptedSize,
+      sizes.encryptedSize
     );
     this.logger.info('Created content file', { contentFileId: contentFile.id });
 
@@ -194,7 +197,7 @@ export class IntuneUploader {
     // Step 5: Upload file chunks (25-80%)
     await onProgress?.(25, 'Uploading package...');
     await this.uploadFileChunks(
-      intunewinPath,
+      encryptedContentPath,
       uploadInfo.azureStorageUri,
       async (percent) => {
         // Map chunk upload progress (0-100) to overall (25-80)
@@ -417,7 +420,8 @@ export class IntuneUploader {
     appId: string,
     contentVersionId: string,
     fileName: string,
-    size: number
+    size: number,
+    sizeEncrypted: number
   ): Promise<{ id: string }> {
     const response = await graphClient.post<{ id: string }>(
       `/deviceAppManagement/mobileApps/${appId}/microsoft.graph.win32LobApp/contentVersions/${contentVersionId}/files`,
@@ -425,7 +429,7 @@ export class IntuneUploader {
         '@odata.type': '#microsoft.graph.mobileAppContentFile',
         name: fileName,
         size: size,
-        sizeEncrypted: size,
+        sizeEncrypted: sizeEncrypted,
         isDependency: false,
       }
     );

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -13,6 +13,14 @@ import { createLogger, Logger } from './logger.js';
 
 interface PackagingResult {
   intunewinPath: string;
+  // Path to the inner AES-encrypted payload extracted from the .intunewin zip.
+  // This (not the outer .intunewin) is what must be uploaded to Azure Storage.
+  encryptedContentPath: string;
+  // Size of the original unencrypted content (from Detection.xml); Intune's
+  // mobileAppContentFile.size must be this value, not the encrypted size.
+  unencryptedContentSize: number;
+  // Size of the inner encrypted payload file (mobileAppContentFile.sizeEncrypted).
+  encryptedContentSize: number;
   encryptionInfo: {
     encryptionKey: string;
     macKey: string;
@@ -85,8 +93,12 @@ export class JobProcessor {
       await poller.updateJobProgress(job.id, 75, 'Uploading to Intune...');
       const intuneApp = await this.uploader.uploadToIntune(
         job,
-        result.intunewinPath,
+        result.encryptedContentPath,
         result.encryptionInfo,
+        {
+          unencryptedSize: result.unencryptedContentSize,
+          encryptedSize: result.encryptedContentSize,
+        },
         async (percent, message) => {
           // Map upload progress (0-100) to overall progress (75-95)
           const overallPercent = 75 + Math.floor(percent * 0.2);
@@ -877,31 +889,41 @@ ${steps}
 
     const intunewinPath = path.join(outputDir, intunewinFile);
 
-    // Extract encryption info from Detection.xml inside the intunewin
-    const encryptionInfo = await this.extractEncryptionInfo(intunewinPath);
-
-    return {
-      intunewinPath,
-      encryptionInfo,
-    };
+    // Extract encryption info AND the inner encrypted payload from the intunewin
+    return await this.extractPackageContents(intunewinPath, outputDir);
   }
 
   /**
-   * Extract encryption info from .intunewin file
+   * Extract encryption info and the inner encrypted content file from a
+   * .intunewin package.
+   *
+   * A .intunewin is a ZIP containing Metadata/Detection.xml (encryption keys,
+   * digest, the unencrypted content size, and the encrypted payload's file
+   * name) plus Contents/<encrypted-payload>. Intune expects the raw encrypted
+   * payload to be uploaded to Azure Storage - never the outer .intunewin zip -
+   * with size = UnencryptedContentSize and sizeEncrypted = the payload's size.
    */
-  private async extractEncryptionInfo(
-    intunewinPath: string
-  ): Promise<PackagingResult['encryptionInfo']> {
-    // The .intunewin file is a ZIP containing Detection.xml with encryption info
-    // Use PowerShell to extract and parse it
+  private async extractPackageContents(
+    intunewinPath: string,
+    outputDir: string
+  ): Promise<PackagingResult> {
+    const extractDir = path.join(outputDir, 'intunewin-extract');
+    const escapedIntunewin = intunewinPath.replace(/'/g, "''");
+    const escapedExtractDir = extractDir.replace(/'/g, "''");
+
     const script = `
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      $zip = [System.IO.Compression.ZipFile]::OpenRead('${intunewinPath.replace(/'/g, "''")}')
-      $entry = $zip.Entries | Where-Object { $_.Name -eq 'Detection.xml' }
-      $reader = New-Object System.IO.StreamReader($entry.Open())
-      $xml = [xml]$reader.ReadToEnd()
-      $reader.Close()
-      $zip.Dispose()
+      $extractDir = '${escapedExtractDir}'
+      if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
+      [System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedIntunewin}', $extractDir)
+
+      $detection = Get-ChildItem $extractDir -Filter 'Detection.xml' -Recurse | Select-Object -First 1
+      if (-not $detection) { throw 'Detection.xml not found inside .intunewin package' }
+      [xml]$xml = Get-Content $detection.FullName
+
+      $encryptedFileName = $xml.ApplicationInfo.FileName
+      $encryptedFile = Get-ChildItem $extractDir -Filter $encryptedFileName -Recurse | Select-Object -First 1
+      if (-not $encryptedFile) { throw "Encrypted content file '$encryptedFileName' not found inside .intunewin package" }
 
       @{
         EncryptionKey = $xml.ApplicationInfo.EncryptionInfo.EncryptionKey
@@ -911,20 +933,29 @@ ${steps}
         ProfileIdentifier = $xml.ApplicationInfo.EncryptionInfo.ProfileIdentifier
         FileDigest = $xml.ApplicationInfo.EncryptionInfo.FileDigest
         FileDigestAlgorithm = $xml.ApplicationInfo.EncryptionInfo.FileDigestAlgorithm
+        EncryptedContentPath = $encryptedFile.FullName
+        EncryptedContentSize = $encryptedFile.Length
+        UnencryptedContentSize = [long]$xml.ApplicationInfo.UnencryptedContentSize
       } | ConvertTo-Json
     `;
 
     const result = await this.runPowerShell(script);
-    const encryptionData = JSON.parse(result.trim());
+    const data = JSON.parse(result.trim());
 
     return {
-      encryptionKey: encryptionData.EncryptionKey,
-      macKey: encryptionData.MacKey,
-      initializationVector: encryptionData.InitializationVector,
-      mac: encryptionData.Mac,
-      profileIdentifier: encryptionData.ProfileIdentifier,
-      fileDigest: encryptionData.FileDigest,
-      fileDigestAlgorithm: encryptionData.FileDigestAlgorithm,
+      intunewinPath,
+      encryptedContentPath: data.EncryptedContentPath,
+      unencryptedContentSize: Number(data.UnencryptedContentSize),
+      encryptedContentSize: Number(data.EncryptedContentSize),
+      encryptionInfo: {
+        encryptionKey: data.EncryptionKey,
+        macKey: data.MacKey,
+        initializationVector: data.InitializationVector,
+        mac: data.Mac,
+        profileIdentifier: data.ProfileIdentifier || 'ProfileVersion1',
+        fileDigest: data.FileDigest,
+        fileDigestAlgorithm: data.FileDigestAlgorithm,
+      },
     };
   }
 


### PR DESCRIPTION
Full-codebase review pass over the app, the self-hosted packager, and the packaging scripts. Every finding was verified against the code before fixing, and the diff was checked by an independent reviewer (which caught one regression, now fixed).

## Critical
- **packager upload**: was sending the outer `.intunewin` zip to Azure Storage with `size == sizeEncrypted ==` the outer size. Now extracts the inner AES-encrypted payload plus `UnencryptedContentSize` from `Detection.xml` and uploads with `size` = unencrypted, `sizeEncrypted` = encrypted-file size. The old behavior would fail Intune content validation (`commitFileFailed`) on every self-hosted upload. Contract confirmed against Microsoft Learn.
- **IDOR** in `GET /api/package?jobId=`: returned any user's job with no auth check. Now requires auth and 404s on non-owned jobs.
- **PSADT script injection**: `deferDeadline` / `windowLocation` were interpolated unescaped into generated PowerShell, unlike every sibling value. Now escaped.
- **Update detection for 4-segment versions**: `compareVersions` dropped the 4th segment, so `1.2.3.4` and `1.2.3.9` compared equal and updates never fired. Now compares all numeric segments, with regression tests.

## Medium
- MSP batch wizard: manual app entry could never enable the Next button.
- SCCM migration preview never refetched when options were toggled.
- Graph list calls (categories, assignment filters, app categories) never followed `@odata.nextLink`, truncating results for large tenants.
- Analytics CSV export now applies RFC 4180 quote escaping uniformly.
- `cleanup` GET leaked system-wide job counts unauthenticated; now gated behind the same secret as POST.
- Ported the bracket-safe filename rename from the live workflow into the reference copy.

## Verification
- 440 app tests pass (10 new), packager typecheck, production build.
- `Create-PSADTPackage.ps1` and the packager extraction script parse clean via `pwsh`; reference workflow YAML parses.
- Graph `mobileAppContentFile` size/sizeEncrypted contract confirmed against Microsoft Learn docs.

## Notes
- The live GitHub Actions workflow YAML is unchanged. The only hosted-path change is the escaping hardening in `Create-PSADTPackage.ps1` (the script the live workflow executes); it is byte-identical output for normal config values.
- Deferred (not in this PR): packager `cmd.exe` command hardening, packager tool-download SHA256 pinning, and the stale Azure DevOps pipeline. These are design decisions rather than clear-cut bugs.