### PR TITLE
Remove private workflow link from uploads

### DIFF
--- a/app/(app)/dashboard/uploads/page.tsx
+++ b/app/(app)/dashboard/uploads/page.tsx
@@ -921,17 +921,6 @@ function UploadJobCard({
 
           <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
             <span title={job.id} translate="no">Support ID: {job.id.slice(0, 8)}</span>
-            {job.github_run_url && (
-              <a
-                href={job.github_run_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 rounded text-accent-cyan hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
-              >
-                <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                <T>View workflow run</T>
-              </a>
-            )}
           </div>
 
           {/* Error message */}


### PR DESCRIPTION
## Summary

Removes the workflow-run link from deployment progress cards because the packaging workflow repository is private and unavailable to users.

The Support ID remains visible so support can correlate a deployment with internal job records, callbacks, and logs.

## Validation

- Full ESLint check passed through the pre-commit hook
- Diff check passed