### PR TITLE
Use packaging pipeline in deployment errors

### DIFF
--- a/components/UploadCart.tsx
+++ b/components/UploadCart.tsx
@@ -471,7 +471,7 @@ export function UploadCart() {
                       <p className="text-status-error/70 mt-1">{error.message}</p>
                       {error.blockedBeforeDispatch && (
                         <p className="text-text-muted mt-2">
-                          No GitHub Action was started and no changes were made in Intune.
+                          No packaging pipeline was started and no changes were made in Intune.
                         </p>
                       )}
                       {!error.retryable && (

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -91,6 +91,7 @@ describe('installer dispatch preflight', () => {
       code: 'HASH_MISMATCH',
       retryable: false,
       actualSha256,
+      message: 'The publisher currently serves different bytes for Example.App 1.2.3. The deployment was quarantined before the packaging pipeline started.',
     });
     await expect(enforceInstallerPreflight(request)).rejects.toMatchObject({
       code: 'HASH_MISMATCH',

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -293,7 +293,7 @@ async function performLivePreflight(
     if (!hashesEqual(downloaded.sha256, input.installerSha256)) {
       const error = new InstallerPreflightError(
         'HASH_MISMATCH',
-        `The publisher currently serves different bytes for ${input.wingetId} ${input.version}. The deployment was quarantined before GitHub Actions dispatch.`,
+        `The publisher currently serves different bytes for ${input.wingetId} ${input.version}. The deployment was quarantined before the packaging pipeline started.`,
         false,
         downloaded.sha256,
       );


### PR DESCRIPTION
## What changed

- Replaced the deployment quarantine reference to GitHub Actions with the product-facing term "packaging pipeline"
- Updated the cart confirmation to say that no packaging pipeline was started
- Added a regression assertion for the hash mismatch message

## Why

Users should see product behavior, not the implementation detail behind hosted packaging. The message now stays accurate for every packaging backend.

## Validation

- Installer preflight unit tests
- ESLint on the touched files
- Full repository lint through the pre-push hook
