### PR TITLE
Fix WinGet manifest sync failures

### DIFF
--- a/.github/workflows/build-app-list.yml
+++ b/.github/workflows/build-app-list.yml
@@ -227,6 +227,7 @@ jobs:
                 winget_last_update: pkg.LastUpdate || null,
                 is_verified: true, // Source is authoritative (winget-pkgs)
                 is_winget_verified: true,
+                app_source: 'win32',
                 parent_winget_id: isVariant ? localeInfo.parentId : null,
                 locale_code: isVariant ? localeInfo.locale : null,
                 is_locale_variant: isVariant,

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -37,7 +37,6 @@ concurrency:
 
 env:
   NODE_VERSION: "26.5.0"
-  GITHUB_RAW_BASE: "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests"
 
 permissions:
   contents: read
@@ -90,7 +89,7 @@ jobs:
               total = requestedIds.length;
             } else {
               // Query count via Supabase REST API (no npm needed)
-              let url = `${SUPABASE_URL}/rest/v1/curated_apps?select=winget_id`;
+              let url = `${SUPABASE_URL}/rest/v1/curated_apps?select=winget_id&app_source=eq.win32&is_winget_verified=eq.true`;
               const res = await fetch(url, {
                 headers: {
                   'apikey': SUPABASE_KEY,
@@ -215,9 +214,9 @@ jobs:
         run: |
           node << 'EOF'
           const fs = require('fs');
-          const https = require('https');
           const { createClient } = require('@supabase/supabase-js');
           const yaml = require('yaml');
+          const resolverModule = import('./lib/winget-sync-resolution.mjs');
 
           const supabaseUrl = process.env.SUPABASE_URL;
           const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
@@ -228,176 +227,15 @@ jobs:
           }
 
           const supabase = createClient(supabaseUrl, supabaseKey);
-          const GITHUB_RAW_BASE = process.env.GITHUB_RAW_BASE;
           const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-          const MAX_MANIFEST_BYTES = 5 * 1024 * 1024;
-
-          function fetchUrl(url, retries = 5) {
-            return new Promise((resolve, reject) => {
-              const attempt = (retriesLeft) => {
-                const headers = { 'User-Agent': 'IntuneGet-Manifest-Sync' };
-                if (GITHUB_TOKEN && url.includes('api.github.com')) {
-                  headers['Authorization'] = `token ${GITHUB_TOKEN}`;
-                }
-                https.get(url, { headers }, (res) => {
-                  if (res.statusCode === 404) {
-                    resolve(null);
-                    return;
-                  }
-                  if (res.statusCode === 403 || res.statusCode === 429) {
-                    // Use Retry-After header, cap at 30s to avoid extremely long waits
-                    const retryAfter = Math.min(parseInt(res.headers['retry-after'] || '3', 10), 30);
-                    if (retriesLeft > 0) {
-                      res.resume();
-                      setTimeout(() => attempt(retriesLeft - 1), retryAfter * 1000);
-                      return;
-                    }
-                    // Drain response body before rejecting
-                    res.resume();
-                    reject(new Error(`HTTP ${res.statusCode} (rate limited, retries exhausted)`));
-                    return;
-                  }
-                  if (res.statusCode !== 200) {
-                    if (retriesLeft > 0 && res.statusCode >= 500) {
-                      res.resume();
-                      setTimeout(() => attempt(retriesLeft - 1), 1000);
-                      return;
-                    }
-                    res.resume();
-                    reject(new Error(`HTTP ${res.statusCode}`));
-                    return;
-                  }
-
-                  let data = '';
-                  let bytes = 0;
-                  res.on('data', chunk => {
-                    bytes += chunk.length;
-                    if (bytes > MAX_MANIFEST_BYTES) {
-                      res.destroy();
-                      reject(new Error(`Response exceeded ${MAX_MANIFEST_BYTES} bytes`));
-                      return;
-                    }
-                    data += chunk;
-                  });
-                  res.on('end', () => resolve(data));
-                }).on('error', (err) => {
-                  if (retriesLeft > 0) {
-                    setTimeout(() => attempt(retriesLeft - 1), 1000);
-                  } else {
-                    reject(err);
-                  }
-                });
-              };
-              attempt(retries);
-            });
-          }
-
-          function buildManifestUrl(wingetId, version, type = 'installer') {
-            const parts = wingetId.split('.');
-            if (parts.length < 2) return null;
-            const publisher = parts[0];
-            const namePath = parts.slice(1).join('/');
-            const firstLetter = publisher.charAt(0).toLowerCase();
-            return `${GITHUB_RAW_BASE}/${firstLetter}/${publisher}/${namePath}/${version}/${wingetId}.${type}.yaml`;
-          }
-
-          function buildVersionListUrl(wingetId) {
-            const parts = wingetId.split('.');
-            if (parts.length < 2) return null;
-            const publisher = parts[0];
-            const namePath = parts.slice(1).map(p => encodeURIComponent(p)).join('/');
-            const firstLetter = publisher.charAt(0).toLowerCase();
-            return `https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/${firstLetter}/${encodeURIComponent(publisher)}/${namePath}`;
-          }
-
-          let versionFetchErrors = 0;
-          async function fetchVersions(wingetId) {
-            const url = buildVersionListUrl(wingetId);
-            if (!url) return [];
-            try {
-              const response = await fetchUrl(url);
-              if (!response) return [];
-              const dirs = JSON.parse(response);
-              return dirs
-                .filter(d => d.type === 'dir')
-                .map(d => d.name)
-                .filter(name => /^\d/.test(name))
-                .filter(name => /^\d+[\d._-]*\d*$/.test(name) || name.includes('.'))
-                .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
-            } catch (e) {
-              versionFetchErrors++;
-              // Log first few errors to help diagnose rate limiting
-              if (versionFetchErrors <= 5) {
-                console.error(`  [DEBUG] fetchVersions failed for ${wingetId}: ${e.message}`);
-              }
-              return [];
-            }
-          }
-
-          async function fetchInstallerManifest(wingetId, version) {
-            const url = buildManifestUrl(wingetId, version, 'installer');
-            if (!url) return null;
-            try {
-              const content = await fetchUrl(url);
-              if (!content) return null;
-              return yaml.parse(content);
-            } catch (e) {
-              return null;
-            }
-          }
-
-          function buildVersionManifestUrl(wingetId, version) {
-            const parts = wingetId.split('.');
-            if (parts.length < 2) return null;
-            const publisher = parts[0];
-            const namePath = parts.slice(1).join('/');
-            const firstLetter = publisher.charAt(0).toLowerCase();
-            return `${GITHUB_RAW_BASE}/${firstLetter}/${publisher}/${namePath}/${version}/${wingetId}.yaml`;
-          }
 
           function localeText(value) {
             return typeof value === 'string' ? value.trim() : '';
           }
 
-          function hasLocaleDescription(manifest) {
-            return Boolean(manifest && (localeText(manifest.ShortDescription) || localeText(manifest.Description)));
-          }
-
-          async function fetchYamlManifest(url) {
-            if (!url) return null;
-            try {
-              const content = await fetchUrl(url);
-              if (content) return yaml.parse(content);
-            } catch (e) {
-              // Treat as missing; fetchUrl already retried transient failures
-            }
-            return null;
-          }
-
-          // en-US is preferred, but when it is absent or carries no
-          // description the DefaultLocale declared in <id>.yaml is fetched
-          // instead (e.g. zh-CN-only packages). Singleton manifests carry
-          // the locale fields directly in <id>.yaml and are handled by the
-          // same lookup.
-          async function fetchLocaleManifest(wingetId, version) {
-            const enUS = await fetchYamlManifest(buildManifestUrl(wingetId, version, 'locale.en-US'));
-            if (hasLocaleDescription(enUS)) return enUS;
-
-            const versionManifest = await fetchYamlManifest(buildVersionManifestUrl(wingetId, version));
-            if (hasLocaleDescription(versionManifest)) return versionManifest;
-
-            const defaultLocale = localeText(versionManifest?.DefaultLocale);
-            if (defaultLocale && defaultLocale.toLowerCase() !== 'en-us') {
-              const defaultManifest = await fetchYamlManifest(buildManifestUrl(wingetId, version, `locale.${defaultLocale}`));
-              if (hasLocaleDescription(defaultManifest) || (defaultManifest && !enUS)) {
-                return defaultManifest;
-              }
-            }
-
-            return enUS;
-          }
-
           async function syncManifests() {
+            const { createWingetManifestClient, resolveWingetManifest } = await resolverModule;
+            const manifestClient = createWingetManifestClient({ token: GITHUB_TOKEN });
             const appIds = process.env.APP_IDS;
             const appOffset = parseInt(process.env.APP_OFFSET || '0', 10);
             const chunkSize = parseInt(process.env.APP_LIMIT || '2000', 10);
@@ -412,7 +250,8 @@ jobs:
               if (chunkSize === 0) {
                 console.log('No apps to sync in this shard.');
                 fs.writeFileSync('./sync-results.json', JSON.stringify({
-                  synced: 0, failed: 0, skipped: 0, newVersions: []
+                  synced: 0, failed: 0, skipped: 0, skippedExisting: 0,
+                  unavailable: 0, unavailableItems: [], failedItems: [], newVersions: []
                 }));
                 return;
               }
@@ -421,6 +260,8 @@ jobs:
               let query = supabase
                 .from('curated_apps')
                 .select('winget_id, latest_version, description')
+                .eq('app_source', 'win32')
+                .eq('is_winget_verified', true)
                 .order('popularity_rank', { ascending: true, nullsFirst: false })
                 .range(appOffset, appOffset + chunkSize - 1);
 
@@ -432,13 +273,15 @@ jobs:
               const { data, error } = await supabase
                 .from('curated_apps')
                 .select('winget_id, latest_version, description')
-                .in('winget_id', targetIds);
+                .in('winget_id', targetIds)
+                .eq('app_source', 'win32')
+                .eq('is_winget_verified', true);
               if (error) throw error;
               apps = data || [];
             }
 
-            // Versions come from the trusted package index stored in curated_apps,
-            // so GitHub API enumeration is only a fallback for legacy null rows.
+            // Try the stored catalog version first. GitHub API enumeration is
+            // reserved for missing or pruned versions and legacy null rows.
             const batchSize = 10;
             const batchDelay = 750;
             const delay = ms => new Promise(r => setTimeout(r, ms));
@@ -478,12 +321,11 @@ jobs:
 
             let synced = 0;
             let failed = 0;
-            let skipped = 0;
             let healed = 0;
             let failedApps = [];
-            let skippedNoVersions = 0;
+            let unavailable = 0;
+            let unavailableApps = [];
             let skippedExisting = 0;
-            let skippedNoManifest = 0;
             let newVersions = [];
             const startTime = Date.now();
 
@@ -492,18 +334,27 @@ jobs:
 
               await Promise.all(batch.map(async (app) => {
                 try {
-                  let latestVersion = app.latest_version;
-                  if (!latestVersion) {
-                    const versions = await fetchVersions(app.winget_id);
-                    latestVersion = versions[0];
-                  }
-                  if (!latestVersion) throw new Error('No latest version available from index or upstream');
-
                   if (syncMode === 'new_only' && previousVersionByApp.has(app.winget_id)) {
-                    skipped++;
                     skippedExisting++;
                     return;
                   }
+
+                  const resolution = await resolveWingetManifest({
+                    client: manifestClient,
+                    wingetId: app.winget_id,
+                    storedVersion: app.latest_version,
+                  });
+                  if (resolution.status === 'unavailable') {
+                    unavailable++;
+                    unavailableApps.push({
+                      id: app.winget_id,
+                      reason: resolution.reason || 'upstream_unavailable'
+                    });
+                    return;
+                  }
+
+                  const latestVersion = resolution.version;
+                  const installerManifest = resolution.manifest;
 
                   if (!forceRefresh && syncMode !== 'all') {
                     if (existingVersions.has(`${app.winget_id}\u0000${latestVersion}`)) {
@@ -513,7 +364,7 @@ jobs:
                       // next version bump. The DB-side null filter makes the
                       // write a no-op when a description appeared meanwhile.
                       if (!localeText(app.description)) {
-                        const healManifest = await fetchLocaleManifest(app.winget_id, latestVersion);
+                        const healManifest = await manifestClient.fetchLocaleManifest(app.winget_id, latestVersion);
                         const healDescription = localeText(healManifest?.ShortDescription) ||
                                                 localeText(healManifest?.Description);
                         if (healDescription) {
@@ -525,22 +376,12 @@ jobs:
                           if (!healError) healed++;
                         }
                       }
-                      skipped++;
                       skippedExisting++;
                       return;
                     }
                   }
 
-                  const installerManifest = await fetchInstallerManifest(app.winget_id, latestVersion);
-
-                  if (!installerManifest) {
-                    failed++;
-                    skippedNoManifest++;
-                    failedApps.push({ id: app.winget_id, reason: 'no installer manifest' });
-                    return;
-                  }
-
-                  const localeManifest = await fetchLocaleManifest(app.winget_id, latestVersion);
+                  const localeManifest = await manifestClient.fetchLocaleManifest(app.winget_id, latestVersion);
 
                   const rawInstallers = installerManifest.Installers || [];
                   const defaultInstaller = rawInstallers[0] || {};
@@ -641,7 +482,7 @@ jobs:
               if ((i / batchSize) % 5 === 0 || processed >= apps.length) {
                 const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
                 const rate = (processed / (Date.now() - startTime) * 1000).toFixed(1);
-                console.log(`  [${elapsed}s] ${processed}/${apps.length} | synced: ${synced} | failed: ${failed} | skipped: ${skipped} (no-versions: ${skippedNoVersions}, existing: ${skippedExisting}, no-manifest: ${skippedNoManifest}) | ${rate} apps/s`);
+                console.log(`  [${elapsed}s] ${processed}/${apps.length} | synced: ${synced} | unavailable: ${unavailable} | failed: ${failed} | existing: ${skippedExisting} | ${rate} apps/s`);
               }
             }
 
@@ -653,12 +494,20 @@ jobs:
             console.log(`  Duration:    ${totalTime}s`);
             console.log(`  Synced:      ${synced}`);
             console.log(`  Failed:      ${failed}`);
-            console.log(`  Skipped:     ${skipped}`);
+            console.log(`  Unavailable: ${unavailable}`);
+            console.log(`  Existing:    ${skippedExisting}`);
             console.log(`  Healed descriptions: ${healed}`);
-            console.log(`    - No versions found: ${skippedNoVersions}`);
-            console.log(`    - Already up to date: ${skippedExisting}`);
-            console.log(`    - No manifest found:  ${skippedNoManifest}`);
             console.log(`========================================`);
+
+            if (unavailableApps.length > 0) {
+              console.log(`\nUnavailable upstream packages (showing first 30):`);
+              for (const item of unavailableApps.slice(0, 30)) {
+                console.log(`  - ${item.id}: ${item.reason}`);
+              }
+              if (unavailableApps.length > 30) {
+                console.log(`  ... and ${unavailableApps.length - 30} more`);
+              }
+            }
 
             if (failedApps.length > 0) {
               console.log(`\nFailed apps (showing first 30):`);
@@ -681,7 +530,15 @@ jobs:
             }
 
             fs.writeFileSync('./sync-results.json', JSON.stringify({
-              synced, failed, skipped, healed, newVersions
+              synced,
+              failed,
+              skipped: skippedExisting,
+              skippedExisting,
+              unavailable,
+              unavailableItems: unavailableApps,
+              failedItems: failedApps,
+              healed,
+              newVersions
             }));
           }
 
@@ -693,7 +550,10 @@ jobs:
             const fs = require('fs');
             if (!require('fs').existsSync('./sync-results.json')) {
               fs.writeFileSync('./sync-results.json', JSON.stringify({
-                synced: 0, failed: 1, skipped: 0, newVersions: []
+                synced: 0, failed: 1, skipped: 0, skippedExisting: 0,
+                unavailable: 0, unavailableItems: [],
+                failedItems: [{ id: 'shard', reason: err.message || String(err) }],
+                newVersions: []
               }));
             }
             process.exit(1);
@@ -749,58 +609,79 @@ jobs:
           const fs = require('fs');
           const path = require('path');
 
-          const resultsDir = './results';
-          const expectedShards = Number.parseInt(process.env.EXPECTED_SHARDS || '0', 10);
-          let totalSynced = 0, totalFailed = 0, totalSkipped = 0, totalHealed = 0;
-          let allNewVersions = [];
-          let shardsFound = 0;
+          async function main() {
+            const { classifyWingetSyncRun } = await import('./lib/winget-sync-resolution.mjs');
+            const resultsDir = './results';
+            const expectedShards = Number.parseInt(process.env.EXPECTED_SHARDS || '0', 10);
+            let totalSynced = 0, totalFailed = 0, totalSkippedExisting = 0;
+            let totalUnavailable = 0, totalHealed = 0, shardsFound = 0;
+            let allNewVersions = [], unavailableItems = [], failedItems = [];
 
-          if (fs.existsSync(resultsDir)) {
-            const dirs = fs.readdirSync(resultsDir);
-            for (const dir of dirs) {
-              const filePath = path.join(resultsDir, dir, 'sync-results.json');
-              if (fs.existsSync(filePath)) {
-                const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-                totalSynced += data.synced || 0;
-                totalFailed += data.failed || 0;
-                totalSkipped += data.skipped || 0;
-                totalHealed += data.healed || 0;
-                allNewVersions = allNewVersions.concat(data.newVersions || []);
-                shardsFound++;
+            if (fs.existsSync(resultsDir)) {
+              const dirs = fs.readdirSync(resultsDir);
+              for (const dir of dirs) {
+                const filePath = path.join(resultsDir, dir, 'sync-results.json');
+                if (fs.existsSync(filePath)) {
+                  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+                  totalSynced += data.synced || 0;
+                  totalFailed += data.failed || 0;
+                  totalSkippedExisting += data.skippedExisting ?? data.skipped ?? 0;
+                  totalUnavailable += data.unavailable || 0;
+                  totalHealed += data.healed || 0;
+                  allNewVersions = allNewVersions.concat(data.newVersions || []);
+                  unavailableItems = unavailableItems.concat(data.unavailableItems || []);
+                  failedItems = failedItems.concat(data.failedItems || []);
+                  shardsFound++;
+                }
               }
             }
-          }
 
-          console.log(`\n========================================`);
-          console.log(`  Sync Complete (${shardsFound} shards)`);
-          console.log(`========================================`);
-          console.log(`  Synced:      ${totalSynced}`);
-          console.log(`  Failed:      ${totalFailed}`);
-          console.log(`  Skipped:     ${totalSkipped}`);
-          console.log(`  Healed descriptions: ${totalHealed}`);
-          console.log(`  New versions: ${allNewVersions.length}`);
-          console.log(`========================================`);
+            const complete = expectedShards > 0 && shardsFound === expectedShards;
+            if (!complete) {
+              totalFailed += Math.max(1, expectedShards - shardsFound);
+              failedItems.push({ id: 'shards', reason: `Expected ${expectedShards}, found ${shardsFound}` });
+              console.error(`Incomplete sync: expected ${expectedShards} shard artifacts, found ${shardsFound}`);
+            }
+            const classification = classifyWingetSyncRun({
+              complete,
+              failed: totalFailed,
+              unavailable: totalUnavailable,
+            });
 
-          fs.writeFileSync('./aggregate-results.json', JSON.stringify({
-            synced: totalSynced,
-            failed: totalFailed,
-            skipped: totalSkipped,
-            healed: totalHealed,
-            newVersions: allNewVersions
-          }));
+            console.log(`\n========================================`);
+            console.log(`  Sync Complete (${shardsFound} shards)`);
+            console.log(`========================================`);
+            console.log(`  Synced:      ${totalSynced}`);
+            console.log(`  Failed:      ${totalFailed}`);
+            console.log(`  Unavailable: ${totalUnavailable}`);
+            console.log(`  Existing:    ${totalSkippedExisting}`);
+            console.log(`  Healed descriptions: ${totalHealed}`);
+            console.log(`  New versions: ${allNewVersions.length}`);
+            console.log(`  Status:      ${classification.status}`);
+            console.log(`========================================`);
 
-          const complete = expectedShards > 0 && shardsFound === expectedShards;
-          if (!complete) {
-            totalFailed += Math.max(1, expectedShards - shardsFound);
-            console.error(`Incomplete sync: expected ${expectedShards} shard artifacts, found ${shardsFound}`);
-          }
+            fs.writeFileSync('./aggregate-results.json', JSON.stringify({
+              synced: totalSynced,
+              failed: totalFailed,
+              skipped: totalSkippedExisting,
+              skippedExisting: totalSkippedExisting,
+              unavailable: totalUnavailable,
+              unavailableItems,
+              failedItems,
+              healed: totalHealed,
+              newVersions: allNewVersions,
+              complete,
+              status: classification.status,
+            }));
 
-          // Update sync status in Supabase
-          const SUPABASE_URL = process.env.SUPABASE_URL;
-          const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY;
-          const syncMode = process.env.SYNC_MODE || 'all';
-
-          async function updateStatus() {
+            const SUPABASE_URL = process.env.SUPABASE_URL;
+            const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY;
+            const syncMode = process.env.SYNC_MODE || 'all';
+            const errorMessage = totalFailed > 0
+              ? `${totalFailed} operational sync failures`
+              : totalUnavailable > 0
+                ? `${totalUnavailable} upstream packages unavailable`
+                : null;
             const response = await fetch(`${SUPABASE_URL}/rest/v1/curated_sync_status`, {
               method: 'POST',
               headers: {
@@ -812,14 +693,16 @@ jobs:
               body: JSON.stringify({
                 id: 'sync-manifests',
                 last_run_completed_at: new Date().toISOString(),
-                last_run_status: complete && totalFailed === 0 ? 'success' : (totalSynced > 0 ? 'partial' : 'failed'),
+                last_run_status: classification.status,
                 items_processed: totalSynced,
-                error_message: totalFailed > 0 ? `${totalFailed} apps failed to sync` : null,
+                error_message: errorMessage,
                 metadata: {
                   mode: syncMode,
                   synced: totalSynced,
                   failed: totalFailed,
-                  skipped: totalSkipped,
+                  unavailable: totalUnavailable,
+                  unavailable_samples: unavailableItems.slice(0, 20),
+                  skipped_existing: totalSkippedExisting,
                   shards: shardsFound,
                   expected_shards: expectedShards,
                   new_versions: allNewVersions.length
@@ -830,33 +713,49 @@ jobs:
             if (!response.ok) {
               throw new Error(`Sync status update failed: ${response.status} ${await response.text()}`);
             }
+            if (classification.shouldFail) process.exit(1);
           }
 
-          updateStatus()
-            .then(() => {
-              if (!complete || totalFailed > 0) process.exit(1);
-            })
-            .catch(err => {
-              console.error('Failed to update sync status:', err);
-              process.exit(1);
-            });
+          main().catch(err => {
+            console.error('Failed to aggregate sync results:', err);
+            process.exit(1);
+          });
           SUMMARYEOF
 
       - name: Create summary
+        if: always()
         run: |
           if [ -f aggregate-results.json ]; then
             SYNCED=$(jq -r '.synced' aggregate-results.json)
             FAILED=$(jq -r '.failed' aggregate-results.json)
-            SKIPPED=$(jq -r '.skipped' aggregate-results.json)
+            UNAVAILABLE=$(jq -r '.unavailable' aggregate-results.json)
+            SKIPPED=$(jq -r '.skippedExisting' aggregate-results.json)
+            STATUS=$(jq -r '.status' aggregate-results.json)
             NEW_VERSIONS=$(jq -r '.newVersions | length' aggregate-results.json)
 
             echo "## Manifest Sync Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Mode:** ${{ github.event.inputs.mode || 'all' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status:** $STATUS" >> $GITHUB_STEP_SUMMARY
             echo "- **Synced:** $SYNCED" >> $GITHUB_STEP_SUMMARY
             echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY
-            echo "- **Skipped:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
+            echo "- **Unavailable upstream:** $UNAVAILABLE" >> $GITHUB_STEP_SUMMARY
+            echo "- **Already up to date:** $SKIPPED" >> $GITHUB_STEP_SUMMARY
             echo "- **New versions detected:** $NEW_VERSIONS" >> $GITHUB_STEP_SUMMARY
+
+            if [ "$UNAVAILABLE" -gt 0 ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Unavailable Upstream (first 20)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              jq -r '.unavailableItems[:20][] | "- **\(.id):** \(.reason)"' aggregate-results.json >> $GITHUB_STEP_SUMMARY
+            fi
+
+            if [ "$FAILED" -gt 0 ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Operational Failures (first 20)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              jq -r '.failedItems[:20][] | "- **\(.id):** \(.reason)"' aggregate-results.json >> $GITHUB_STEP_SUMMARY
+            fi
 
             if [ "$NEW_VERSIONS" -gt 0 ]; then
               echo "" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# The production container runs the standalone server directly and does not
+# need npm. Remove the package manager and its bundled dependencies from the
+# runtime image to reduce attack surface and avoid shipping vulnerable tools.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/app/api/cron/sync-packages/route.ts
+++ b/app/api/cron/sync-packages/route.ts
@@ -1,21 +1,14 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import YAML from 'yaml';
+import {
+  classifyWingetSyncRun,
+  createWingetManifestClient,
+  resolveWingetManifest,
+} from '@/lib/winget-sync-resolution.mjs';
 import { selectAppsToSync } from './select-apps';
 
-const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests';
-const GITHUB_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests';
 const BATCH_SIZE = 10;
-
-function githubHeaders(accept: string): Record<string, string> {
-  const headers: Record<string, string> = {
-    'User-Agent': 'IntuneGet',
-    Accept: accept,
-  };
-  const token = process.env.GITHUB_PAT;
-  if (token) headers.Authorization = `Bearer ${token}`;
-  return headers;
-}
+const SYNC_STATUS_ID = 'sync-manifests-hot';
 
 interface VersionHistoryRecord {
   winget_id: string;
@@ -56,16 +49,21 @@ export async function GET(request: Request) {
   }
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const manifestClient = createWingetManifestClient({
+    token: process.env.GITHUB_PAT,
+    maxRetries: 2,
+  });
 
   try {
     // Mark sync as started
-    await supabase.from('curated_sync_status').upsert({
-      id: 'sync-manifests',
+    const { error: startStatusError } = await supabase.from('curated_sync_status').upsert({
+      id: SYNC_STATUS_ID,
       last_run_started_at: new Date().toISOString(),
       last_run_status: 'running',
       error_message: null,
       updated_at: new Date().toISOString(),
     });
+    if (startStatusError) throw startStatusError;
 
     // Get curated apps that need syncing (top ranked apps plus apps that
     // have never been synced, which NULL popularity_rank would push past
@@ -74,18 +72,24 @@ export async function GET(request: Request) {
 
     if (curatedApps.length === 0) {
       // No curated apps yet, update sync status
-      await supabase.from('curated_sync_status').upsert({
-        id: 'sync-manifests',
+      const { error: emptyStatusError } = await supabase.from('curated_sync_status').upsert({
+        id: SYNC_STATUS_ID,
         last_run_completed_at: new Date().toISOString(),
         last_run_status: 'success',
         items_processed: 0,
         error_message: 'No curated apps to sync',
         updated_at: new Date().toISOString(),
       });
+      if (emptyStatusError) throw emptyStatusError;
 
       return NextResponse.json({
         success: true,
         count: 0,
+        synced: 0,
+        failed: 0,
+        skipped: 0,
+        unavailable: 0,
+        newVersions: 0,
         message: 'No curated apps to sync. Run build-app-list workflow first.',
       });
     }
@@ -93,6 +97,9 @@ export async function GET(request: Request) {
     let synced = 0;
     let failed = 0;
     let skipped = 0;
+    let unavailable = 0;
+    const unavailableItems: Array<{ id: string; reason: string }> = [];
+    const failedItems: Array<{ id: string; reason: string }> = [];
     const newVersions: { wingetId: string; oldVersion: string; newVersion: string }[] = [];
 
     // Process apps in batches
@@ -104,25 +111,26 @@ export async function GET(request: Request) {
           try {
             const { winget_id, latest_version } = app;
 
-            // Fetch available versions from GitHub
-            const versions = await fetchVersions(winget_id);
-            if (versions.length === 0) {
-              skipped++;
+            const resolution = await resolveWingetManifest({
+              client: manifestClient,
+              wingetId: winget_id,
+              storedVersion: latest_version,
+              preferLive: true,
+            });
+            if (resolution.status === 'unavailable') {
+              unavailable++;
+              unavailableItems.push({
+                id: winget_id,
+                reason: resolution.reason || 'upstream_unavailable',
+              });
               return;
             }
 
-            const latestVersion = versions[0];
-
-            // Always refresh the current version. Publishers and winget-pkgs
-            // can correct a URL or SHA256 without changing the version.
-            const installerManifest = await fetchInstallerManifest(winget_id, latestVersion);
-            if (!installerManifest) {
-              failed++;
-              return;
-            }
+            const latestVersion = resolution.version;
+            const installerManifest = resolution.manifest;
 
             // Fetch locale manifest for metadata
-            const localeManifest = await fetchLocaleManifest(winget_id, latestVersion);
+            const localeManifest = await manifestClient.fetchLocaleManifest(winget_id, latestVersion);
 
             // Extract installer data
             const installers = (installerManifest.Installers as Array<Record<string, unknown>>) || [];
@@ -153,8 +161,7 @@ export async function GET(request: Request) {
               .upsert(versionRecord, { onConflict: 'winget_id,version' });
 
             if (vhError) {
-              failed++;
-              return;
+              throw new Error(`version_history upsert failed: ${vhError.message}`);
             }
 
             // Update curated_apps with latest version and metadata.
@@ -180,10 +187,13 @@ export async function GET(request: Request) {
             const license = localeText(localeManifest?.License);
             if (license) appUpdate.license = license;
 
-            await supabase
+            const { error: appUpdateError } = await supabase
               .from('curated_apps')
               .update(appUpdate)
               .eq('winget_id', winget_id);
+            if (appUpdateError) {
+              throw new Error(`curated_apps update failed: ${appUpdateError.message}`);
+            }
 
             // Track new versions
             if (latest_version && latest_version !== latestVersion) {
@@ -195,8 +205,12 @@ export async function GET(request: Request) {
             }
 
             synced++;
-          } catch {
+          } catch (error) {
             failed++;
+            failedItems.push({
+              id: app.winget_id,
+              reason: error instanceof Error ? error.message : String(error),
+            });
           }
         })
       );
@@ -207,36 +221,47 @@ export async function GET(request: Request) {
       }
     }
 
-    // Update sync status
-    await supabase.from('curated_sync_status').upsert({
-      id: 'sync-manifests',
+    const classification = classifyWingetSyncRun({ complete: true, failed, unavailable });
+    const errorMessage = failed > 0
+      ? `${failed} operational sync failures`
+      : unavailable > 0
+        ? `${unavailable} upstream packages unavailable`
+        : null;
+
+    const { error: completionStatusError } = await supabase.from('curated_sync_status').upsert({
+      id: SYNC_STATUS_ID,
       last_run_completed_at: new Date().toISOString(),
-      last_run_status: failed > 0 && synced === 0 ? 'failed' : 'success',
+      last_run_status: classification.status,
       items_processed: synced,
-      error_message: failed > 0 ? `${failed} apps failed to sync` : null,
+      error_message: errorMessage,
       metadata: {
         synced,
         failed,
         skipped,
+        unavailable,
+        unavailable_samples: unavailableItems.slice(0, 20),
+        failed_samples: failedItems.slice(0, 20),
         new_versions: newVersions.length,
       },
       updated_at: new Date().toISOString(),
     });
+    if (completionStatusError) throw completionStatusError;
 
     return NextResponse.json({
-      success: true,
+      success: !classification.shouldFail,
       synced,
       failed,
       skipped,
+      unavailable,
       newVersions: newVersions.length,
-      message: `Synced ${synced} apps, ${failed} failed, ${skipped} skipped`,
-    });
+      message: `Synced ${synced} apps, ${unavailable} unavailable, ${failed} failed, ${skipped} skipped`,
+    }, { status: classification.shouldFail ? 500 : 200 });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
     // Update sync status to failed
     await supabase.from('curated_sync_status').upsert({
-      id: 'sync-manifests',
+      id: SYNC_STATUS_ID,
       last_run_status: 'failed',
       error_message: errorMessage,
       updated_at: new Date().toISOString(),
@@ -246,154 +271,8 @@ export async function GET(request: Request) {
   }
 }
 
-// Helper functions
-
-/**
- * Build the manifest directory path for a winget ID. Every dot-separated
- * segment of the ID is a directory in winget-pkgs (e.g. MongoDB.Compass.Full
- * -> m/MongoDB/Compass/Full), so multi-part IDs must not keep their dots.
- */
-function manifestBasePath(wingetId: string): string | null {
-  const parts = wingetId.split('.');
-  if (parts.length < 2) return null;
-  const firstLetter = parts[0].charAt(0).toLowerCase();
-  return `${firstLetter}/${parts.join('/')}`;
-}
-
 function localeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
-}
-
-function hasLocaleDescription(manifest: Record<string, unknown> | null): boolean {
-  return Boolean(
-    manifest &&
-      (localeText(manifest.ShortDescription) || localeText(manifest.Description))
-  );
-}
-
-async function fetchVersions(wingetId: string): Promise<string[]> {
-  const basePath = manifestBasePath(wingetId);
-  if (!basePath) return [];
-
-  try {
-    const response = await fetch(
-      `${GITHUB_API_BASE}/${basePath}`,
-      {
-        headers: githubHeaders('application/vnd.github.v3+json'),
-      }
-    );
-
-    if (!response.ok) return [];
-
-    const dirs = await response.json();
-    // Keep only version-like directory names (same filter as the
-    // sync-manifests GitHub Actions workflow) so non-version directories
-    // such as ".validation" or named subfolders are never picked as latest
-    return dirs
-      .filter((d: { type: string }) => d.type === 'dir')
-      .map((d: { name: string }) => d.name)
-      .filter((name: string) => /^\d/.test(name))
-      .filter((name: string) => /^\d+[\d._-]*\d*$/.test(name) || name.includes('.'))
-      .sort((a: string, b: string) =>
-        b.localeCompare(a, undefined, { numeric: true })
-      );
-  } catch {
-    return [];
-  }
-}
-
-async function fetchInstallerManifest(
-  wingetId: string,
-  version: string
-): Promise<Record<string, unknown> | null> {
-  const basePath = manifestBasePath(wingetId);
-  if (!basePath) return null;
-
-  const url = `${GITHUB_RAW_BASE}/${basePath}/${version}/${wingetId}.installer.yaml`;
-
-  try {
-    const response = await fetch(url, {
-      headers: githubHeaders('text/plain'),
-    });
-
-    if (!response.ok) return null;
-
-    const yamlContent = await response.text();
-    return YAML.parse(yamlContent);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Fetch and parse a manifest YAML with one retry on transient failures
- * (network errors, 429/5xx). 404 means the file does not exist and is
- * not retried.
- */
-async function fetchManifestYaml(
-  url: string
-): Promise<Record<string, unknown> | null> {
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const response = await fetch(url, {
-        headers: githubHeaders('text/plain'),
-      });
-
-      if (response.status === 404) return null;
-
-      if (response.ok) {
-        return YAML.parse(await response.text());
-      }
-    } catch {
-      // Network or parse error: fall through to the retry
-    }
-
-    if (attempt === 0) {
-      // Short backoff: this route runs many fetches inside Vercel's
-      // maxDuration budget, so retries must stay cheap.
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-  }
-
-  return null;
-}
-
-/**
- * Resolve the locale manifest for a package version. en-US is preferred,
- * but when it is absent or carries no description (packages whose
- * DefaultLocale is not en-US name their locale file accordingly, e.g.
- * <id>.locale.zh-CN.yaml), the DefaultLocale declared in <id>.yaml is
- * fetched instead. Singleton manifests carry the locale fields directly
- * in <id>.yaml and are handled by the same lookup.
- */
-async function fetchLocaleManifest(
-  wingetId: string,
-  version: string
-): Promise<Record<string, unknown> | null> {
-  const basePath = manifestBasePath(wingetId);
-  if (!basePath) return null;
-
-  const versionDir = `${GITHUB_RAW_BASE}/${basePath}/${version}`;
-
-  const enUS = await fetchManifestYaml(
-    `${versionDir}/${wingetId}.locale.en-US.yaml`
-  );
-  if (hasLocaleDescription(enUS)) return enUS;
-
-  const versionManifest = await fetchManifestYaml(`${versionDir}/${wingetId}.yaml`);
-  if (hasLocaleDescription(versionManifest)) return versionManifest;
-
-  const defaultLocale = localeText(versionManifest?.DefaultLocale);
-  if (defaultLocale && defaultLocale.toLowerCase() !== 'en-us') {
-    const defaultManifest = await fetchManifestYaml(
-      `${versionDir}/${wingetId}.locale.${defaultLocale}.yaml`
-    );
-    if (hasLocaleDescription(defaultManifest) || (defaultManifest && !enUS)) {
-      return defaultManifest;
-    }
-  }
-
-  return enUS;
 }
 
 // Allow up to 5 minutes for the sync to complete

--- a/app/api/cron/sync-packages/select-apps.test.ts
+++ b/app/api/cron/sync-packages/select-apps.test.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
 import { selectAppsToSync } from '@/app/api/cron/sync-packages/select-apps';
 
 interface AppRow {
@@ -14,9 +15,13 @@ function createSupabaseMock(options: {
 }) {
   const from = vi.fn(() => {
     let isUnsyncedQuery = false;
+    const filters: Array<[string, unknown]> = [];
     const chain: Record<string, unknown> = {};
     chain.select = vi.fn(() => chain);
-    chain.eq = vi.fn(() => chain);
+    chain.eq = vi.fn((column: string, value: unknown) => {
+      filters.push([column, value]);
+      return chain;
+    });
     chain.is = vi.fn(() => {
       // .is('latest_version', null) only appears on the never-synced query
       isUnsyncedQuery = true;
@@ -24,9 +29,12 @@ function createSupabaseMock(options: {
     });
     chain.order = vi.fn(() => chain);
     chain.limit = vi.fn(async () =>
-      isUnsyncedQuery
-        ? { data: options.unsyncedRows || [], error: options.unsyncedError || null }
-        : { data: options.rankedRows || [], error: options.rankedError || null }
+      ({
+        ...(isUnsyncedQuery
+          ? { data: options.unsyncedRows || [], error: options.unsyncedError || null }
+          : { data: options.rankedRows || [], error: options.rankedError || null }),
+        filters,
+      })
     );
     return chain;
   });
@@ -77,6 +85,22 @@ describe('selectAppsToSync', () => {
     const apps = await selectAppsToSync(supabase);
 
     expect(apps).toEqual([]);
+  });
+
+  it('restricts both selections to verified Win32 WinGet packages', async () => {
+    const supabase = createSupabaseMock({});
+
+    await selectAppsToSync(supabase);
+
+    const fromMock = supabase.from as unknown as ReturnType<typeof vi.fn>;
+    const queryChains = fromMock.mock.results
+      .map((result: { value: unknown }) => result.value as { eq: ReturnType<typeof vi.fn> });
+    expect(queryChains).toHaveLength(2);
+    for (const chain of queryChains) {
+      expect(chain.eq).toHaveBeenCalledWith('is_verified', true);
+      expect(chain.eq).toHaveBeenCalledWith('is_winget_verified', true);
+      expect(chain.eq).toHaveBeenCalledWith('app_source', 'win32');
+    }
   });
 
   it('throws when a query fails', async () => {

--- a/app/api/cron/sync-packages/select-apps.ts
+++ b/app/api/cron/sync-packages/select-apps.ts
@@ -26,6 +26,8 @@ export async function selectAppsToSync(
     .from('curated_apps')
     .select('winget_id, latest_version, description')
     .eq('is_verified', true)
+    .eq('is_winget_verified', true)
+    .eq('app_source', 'win32')
     .order('popularity_rank', { ascending: true })
     .limit(RANKED_SYNC_LIMIT);
 
@@ -38,6 +40,8 @@ export async function selectAppsToSync(
     .from('curated_apps')
     .select('winget_id, latest_version, description')
     .eq('is_verified', true)
+    .eq('is_winget_verified', true)
+    .eq('app_source', 'win32')
     .is('latest_version', null)
     .order('created_at', { ascending: false })
     .limit(UNSYNCED_SYNC_LIMIT);

--- a/lib/winget-sync-resolution.mjs
+++ b/lib/winget-sync-resolution.mjs
@@ -1,0 +1,236 @@
+import YAML from 'yaml';
+
+const DEFAULT_RAW_BASE = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests';
+const DEFAULT_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests';
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+
+export class WingetSyncOperationalError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = 'WingetSyncOperationalError';
+    this.code = code;
+  }
+}
+
+export function manifestBasePath(wingetId) {
+  const parts = String(wingetId || '').split('.');
+  if (parts.length < 2 || parts.some((part) => !part)) return null;
+  return `${parts[0].charAt(0).toLowerCase()}/${parts.map(encodeURIComponent).join('/')}`;
+}
+
+function retryDelayMs(response, attempt) {
+  const retryAfter = Number.parseInt(response.headers.get('retry-after') || '', 10);
+  if (Number.isFinite(retryAfter)) return Math.min(retryAfter, 30) * 1000;
+  return Math.min(1000 * (attempt + 1), 5000);
+}
+
+function operationalError(code, message, cause) {
+  return new WingetSyncOperationalError(code, message, cause ? { cause } : undefined);
+}
+
+export function createWingetManifestClient(options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const sleepImpl = options.sleepImpl || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const token = options.token || '';
+  const rawBase = options.rawBase || DEFAULT_RAW_BASE;
+  const apiBase = options.apiBase || DEFAULT_API_BASE;
+  const maxBytes = options.maxBytes || DEFAULT_MAX_BYTES;
+  const maxRetries = options.maxRetries ?? 5;
+
+  if (typeof fetchImpl !== 'function') {
+    throw operationalError('FETCH_UNAVAILABLE', 'A fetch implementation is required for WinGet manifest sync');
+  }
+
+  async function requestText(url, { accept = 'text/plain', allowNotFound = true } = {}) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      let response;
+      try {
+        const headers = {
+          Accept: accept,
+          'User-Agent': 'IntuneGet-Manifest-Sync',
+        };
+        if (token && url.startsWith('https://api.github.com/')) {
+          headers.Authorization = `Bearer ${token}`;
+        }
+        response = await fetchImpl(url, { headers, cache: 'no-store' });
+      } catch (error) {
+        if (attempt < maxRetries) {
+          await sleepImpl(Math.min(1000 * (attempt + 1), 5000));
+          continue;
+        }
+        throw operationalError('NETWORK_ERROR', `Network request failed for ${url}`, error);
+      }
+
+      if (response.status === 404 && allowNotFound) return null;
+
+      const retryable = response.status === 403 || response.status === 429 || response.status >= 500;
+      if (retryable && attempt < maxRetries) {
+        await sleepImpl(retryDelayMs(response, attempt));
+        continue;
+      }
+
+      if (!response.ok) {
+        throw operationalError(`HTTP_${response.status}`, `GitHub request failed with HTTP ${response.status} for ${url}`);
+      }
+
+      const declaredLength = Number.parseInt(response.headers.get('content-length') || '0', 10);
+      if (declaredLength > maxBytes) {
+        throw operationalError('RESPONSE_TOO_LARGE', `GitHub response exceeded ${maxBytes} bytes for ${url}`);
+      }
+
+      const text = await response.text();
+      if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+        throw operationalError('RESPONSE_TOO_LARGE', `GitHub response exceeded ${maxBytes} bytes for ${url}`);
+      }
+      return text;
+    }
+
+    throw operationalError('RETRY_EXHAUSTED', `GitHub retries were exhausted for ${url}`);
+  }
+
+  async function fetchContentsFile(relativePath) {
+    const url = `${apiBase}/${relativePath}`;
+    const text = await requestText(url, { accept: 'application/vnd.github+json' });
+    if (text === null) return null;
+
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch (error) {
+      throw operationalError('INVALID_GITHUB_RESPONSE', `GitHub returned invalid JSON for ${relativePath}`, error);
+    }
+
+    if (!payload || typeof payload !== 'object' || payload.encoding !== 'base64' || typeof payload.content !== 'string') {
+      throw operationalError('INVALID_GITHUB_RESPONSE', `GitHub returned malformed file content for ${relativePath}`);
+    }
+
+    try {
+      return Buffer.from(payload.content.replace(/\s/g, ''), 'base64').toString('utf8');
+    } catch (error) {
+      throw operationalError('INVALID_GITHUB_RESPONSE', `GitHub returned invalid base64 content for ${relativePath}`, error);
+    }
+  }
+
+  async function fetchYamlFile(relativePath) {
+    let text = await requestText(`${rawBase}/${relativePath}`);
+    if (text === null) {
+      text = await fetchContentsFile(relativePath);
+    }
+    if (text === null) return null;
+
+    try {
+      const manifest = YAML.parse(text);
+      if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+        throw new Error('Manifest root must be an object');
+      }
+      return manifest;
+    } catch (error) {
+      throw operationalError('INVALID_YAML', `WinGet manifest contains invalid YAML at ${relativePath}`, error);
+    }
+  }
+
+  async function fetchVersions(wingetId) {
+    const basePath = manifestBasePath(wingetId);
+    if (!basePath) return [];
+    const text = await requestText(`${apiBase}/${basePath}`, { accept: 'application/vnd.github+json' });
+    if (text === null) return [];
+
+    let entries;
+    try {
+      entries = JSON.parse(text);
+    } catch (error) {
+      throw operationalError('INVALID_GITHUB_RESPONSE', `GitHub returned invalid version data for ${wingetId}`, error);
+    }
+    if (!Array.isArray(entries)) {
+      throw operationalError('INVALID_GITHUB_RESPONSE', `GitHub returned malformed version data for ${wingetId}`);
+    }
+
+    return entries
+      .filter((entry) => entry && entry.type === 'dir' && typeof entry.name === 'string')
+      .map((entry) => entry.name)
+      .filter((name) => /^\d/.test(name))
+      .filter((name) => /^\d+[\d._-]*\d*$/.test(name) || name.includes('.'))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  }
+
+  async function fetchInstallerManifest(wingetId, version) {
+    const basePath = manifestBasePath(wingetId);
+    if (!basePath || !version) return null;
+    const versionPath = `${basePath}/${encodeURIComponent(version)}`;
+    const installer = await fetchYamlFile(`${versionPath}/${wingetId}.installer.yaml`);
+    if (installer) return installer;
+
+    const singleton = await fetchYamlFile(`${versionPath}/${wingetId}.yaml`);
+    if (singleton && Array.isArray(singleton.Installers) && singleton.Installers.length > 0) {
+      return singleton;
+    }
+    return null;
+  }
+
+  async function fetchLocaleManifest(wingetId, version) {
+    const basePath = manifestBasePath(wingetId);
+    if (!basePath || !version) return null;
+    const versionPath = `${basePath}/${encodeURIComponent(version)}`;
+    const localeText = (value) => typeof value === 'string' ? value.trim() : '';
+    const hasDescription = (manifest) => Boolean(
+      manifest && (localeText(manifest.ShortDescription) || localeText(manifest.Description))
+    );
+
+    const enUS = await fetchYamlFile(`${versionPath}/${wingetId}.locale.en-US.yaml`);
+    if (hasDescription(enUS)) return enUS;
+
+    const versionManifest = await fetchYamlFile(`${versionPath}/${wingetId}.yaml`);
+    if (hasDescription(versionManifest)) return versionManifest;
+
+    const defaultLocale = localeText(versionManifest?.DefaultLocale);
+    if (defaultLocale && defaultLocale.toLowerCase() !== 'en-us') {
+      const fallback = await fetchYamlFile(`${versionPath}/${wingetId}.locale.${defaultLocale}.yaml`);
+      if (hasDescription(fallback) || (fallback && !enUS)) return fallback;
+    }
+    return enUS;
+  }
+
+  return {
+    fetchInstallerManifest,
+    fetchLocaleManifest,
+    fetchVersions,
+  };
+}
+
+export async function resolveWingetManifest({ client, wingetId, storedVersion, preferLive = false }) {
+  if (!client || typeof client.fetchInstallerManifest !== 'function' || typeof client.fetchVersions !== 'function') {
+    throw operationalError('INVALID_CLIENT', 'A WinGet manifest client is required');
+  }
+
+  if (!preferLive && storedVersion) {
+    const storedManifest = await client.fetchInstallerManifest(wingetId, storedVersion);
+    if (storedManifest) {
+      return { status: 'resolved', version: storedVersion, manifest: storedManifest, source: 'stored' };
+    }
+  }
+
+  const versions = await client.fetchVersions(wingetId);
+  if (versions.length === 0) {
+    return { status: 'unavailable', reason: 'package_or_version_missing' };
+  }
+
+  const liveVersion = versions[0];
+  if (!preferLive && storedVersion === liveVersion) {
+    return { status: 'unavailable', reason: 'installer_manifest_missing', version: liveVersion };
+  }
+
+  const liveManifest = await client.fetchInstallerManifest(wingetId, liveVersion);
+  if (!liveManifest) {
+    return { status: 'unavailable', reason: 'installer_manifest_missing', version: liveVersion };
+  }
+
+  return { status: 'resolved', version: liveVersion, manifest: liveManifest, source: 'live' };
+}
+
+export function classifyWingetSyncRun({ complete, failed = 0, unavailable = 0 }) {
+  const shouldFail = !complete || failed > 0;
+  return {
+    shouldFail,
+    status: shouldFail ? 'failed' : unavailable > 0 ? 'partial' : 'success',
+  };
+}

--- a/lib/winget-sync-resolution.test.ts
+++ b/lib/winget-sync-resolution.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  WingetSyncOperationalError,
+  classifyWingetSyncRun,
+  createWingetManifestClient,
+  resolveWingetManifest,
+} from './winget-sync-resolution.mjs';
+
+const installerManifest = {
+  PackageIdentifier: 'Example.App',
+  PackageVersion: '2.0.0',
+  Installers: [{ InstallerUrl: 'https://example.test/app.exe' }],
+};
+
+describe('resolveWingetManifest', () => {
+  it('uses a valid stored version without enumerating GitHub versions', async () => {
+    const client = {
+      fetchInstallerManifest: vi.fn().mockResolvedValue(installerManifest),
+      fetchVersions: vi.fn(),
+    };
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '1.0.0', source: 'stored' });
+    expect(client.fetchVersions).not.toHaveBeenCalled();
+  });
+
+  it('heals a pruned stored version to the current live version', async () => {
+    const client = {
+      fetchInstallerManifest: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(installerManifest),
+      fetchVersions: vi.fn().mockResolvedValue(['2.0.0', '1.5.0']),
+    };
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '2.0.0', source: 'live' });
+  });
+
+  it('classifies a removed package as unavailable', async () => {
+    const client = {
+      fetchInstallerManifest: vi.fn().mockResolvedValue(null),
+      fetchVersions: vi.fn().mockResolvedValue([]),
+    };
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Removed.App', storedVersion: '1.0.0' }))
+      .resolves.toEqual({ status: 'unavailable', reason: 'package_or_version_missing' });
+  });
+
+  it('uses a singleton version manifest when no installer file exists', async () => {
+    const singletonYaml = [
+      'PackageIdentifier: Example.App',
+      'PackageVersion: 1.0.0',
+      'ManifestType: singleton',
+      'Installers:',
+      '- Architecture: x64',
+      '  InstallerUrl: https://example.test/app.exe',
+      '  InstallerSha256: ABC123',
+    ].join('\n');
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response(singletonYaml, { status: 200 }));
+    const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
+  });
+
+  it('verifies a raw 404 through the GitHub Contents API', async () => {
+    const yaml = [
+      'PackageIdentifier: Example.App',
+      'PackageVersion: 1.0.0',
+      'ManifestType: installer',
+      'Installers:',
+      '- Architecture: x64',
+      '  InstallerUrl: https://example.test/app.exe',
+    ].join('\n');
+    const apiPayload = JSON.stringify({ encoding: 'base64', content: Buffer.from(yaml).toString('base64') });
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response(apiPayload, { status: 200 }));
+    const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
+  });
+
+  it('treats exhausted rate limits as operational errors', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
+    const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .rejects.toMatchObject({ name: 'WingetSyncOperationalError', code: 'HTTP_429' });
+  });
+
+  it('treats invalid YAML as an operational error', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('[unclosed', { status: 200 }));
+    const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .rejects.toBeInstanceOf(WingetSyncOperationalError);
+  });
+});
+
+describe('classifyWingetSyncRun', () => {
+  it('keeps source unavailability non-fatal while recording partial status', () => {
+    expect(classifyWingetSyncRun({ complete: true, unavailable: 3 })).toEqual({
+      shouldFail: false,
+      status: 'partial',
+    });
+  });
+
+  it('fails for operational or database errors', () => {
+    expect(classifyWingetSyncRun({ complete: true, failed: 1 })).toEqual({
+      shouldFail: true,
+      status: 'failed',
+    });
+  });
+
+  it('fails when shard output is incomplete', () => {
+    expect(classifyWingetSyncRun({ complete: false })).toEqual({
+      shouldFail: true,
+      status: 'failed',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix false failure notifications from the WinGet manifest synchronization workflow.

## What changed

- Restrict daily, manual, weekly, and hourly manifest processing to verified Win32 WinGet catalog rows.
- Resolve stale stored versions against the live Microsoft winget-pkgs repository.
- Support singleton manifests and authenticated Contents API fallback.
- Classify removed upstream packages as non-fatal unavailable results.
- Preserve hard failures for network, parsing, database, and incomplete-shard errors.
- Isolate hourly synchronization status under sync-manifests-hot.
- Add resolver, aggregation, and hourly selection coverage.

## Impact

Scheduled synchronization no longer sends failure emails solely because Microsoft removed a package or pruned an old version directory. Existing database history remains intact for unavailable packages.

## Validation

- Full unit suite: 515 tests passed
- ESLint passed
- Production build passed
- GitHub Actions workflow lint passed
- Diff integrity check passed