### PR TITLE
Add public roadmap page

### DIFF
--- a/app/(marketing)/roadmap/RoadmapBoard.tsx
+++ b/app/(marketing)/roadmap/RoadmapBoard.tsx
@@ -1,0 +1,91 @@
+import { T, Var } from "gt-next";
+import {
+  categoryLabels,
+  roadmapStages,
+  type RoadmapStageId,
+} from "@/lib/data/roadmap-data";
+
+const stageStyles: Record<RoadmapStageId, { title: string; badge: string }> = {
+  shipped: {
+    title: "text-emerald-500",
+    badge: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  },
+  "in-progress": {
+    title: "text-accent-cyan",
+    badge: "bg-accent-cyan/10 text-accent-cyan",
+  },
+  "next-up": {
+    title: "text-amber-500",
+    badge: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  },
+  exploring: {
+    title: "text-violet-500",
+    badge: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+  },
+};
+
+export function RoadmapBoard() {
+  return (
+    <div className="space-y-14">
+      {roadmapStages.map((stage) => {
+        const style = stageStyles[stage.id];
+
+        return (
+          <section
+            key={stage.id}
+            id={stage.id}
+            aria-label={stage.title}
+            className="scroll-mt-28"
+          >
+            <div className="mb-4 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+              <h2 className={`text-2xl font-bold ${style.title}`}>
+                <T>{stage.title}</T>
+              </h2>
+              <span className="font-mono text-xs text-text-muted">
+                <T>{stage.timeframe}</T>
+                <span className="mx-2 text-overlay/40">/</span>
+                <Var>{stage.items.length}</Var> <T>items</T>
+              </span>
+            </div>
+
+            <div className="overflow-hidden rounded-xl border border-overlay/10 bg-bg-elevated shadow-soft">
+              <div className="hidden border-b border-overlay/10 px-5 py-3 font-mono text-[11px] uppercase tracking-wider text-text-muted md:grid md:grid-cols-[230px_160px_1fr] md:gap-4">
+                <span>
+                  <T>Feature</T>
+                </span>
+                <span>
+                  <T>Category</T>
+                </span>
+                <span>
+                  <T>Description</T>
+                </span>
+              </div>
+              <div className="divide-y divide-overlay/10">
+                {stage.items.map((item) => (
+                  <div
+                    key={item.title}
+                    className="grid grid-cols-1 gap-1.5 px-5 py-4 md:grid-cols-[230px_160px_1fr] md:items-baseline md:gap-4"
+                  >
+                    <h3 className="text-sm font-semibold text-text-primary">
+                      <T>{item.title}</T>
+                    </h3>
+                    <span>
+                      <span
+                        className={`inline-block rounded px-2 py-0.5 font-mono text-[11px] uppercase tracking-wider ${style.badge}`}
+                      >
+                        <T>{categoryLabels[item.category]}</T>
+                      </span>
+                    </span>
+                    <p className="text-sm leading-relaxed text-text-secondary">
+                      <T>{item.description}</T>
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(marketing)/roadmap/RoadmapWave.tsx
+++ b/app/(marketing)/roadmap/RoadmapWave.tsx
@@ -1,0 +1,184 @@
+import { T, Var } from "gt-next";
+import { roadmapStages } from "@/lib/data/roadmap-data";
+
+interface Station {
+  id: string;
+  title: string;
+  timeframe: string;
+  count: number;
+  dot: string;
+  line: string;
+  pill: string;
+}
+
+const stationStyles: Record<
+  string,
+  { dot: string; line: string; pill: string }
+> = {
+  shipped: {
+    dot: "bg-emerald-500",
+    line: "bg-gradient-to-b from-emerald-500/50 to-emerald-500/5",
+    pill: "border-emerald-500/30 text-emerald-500",
+  },
+  "in-progress": {
+    dot: "bg-accent-cyan",
+    line: "bg-gradient-to-b from-accent-cyan/50 to-accent-cyan/5",
+    pill: "border-accent-cyan/30 text-accent-cyan",
+  },
+  "next-up": {
+    dot: "bg-amber-500",
+    line: "bg-gradient-to-b from-amber-500/50 to-amber-500/5",
+    pill: "border-amber-500/30 text-amber-500",
+  },
+  exploring: {
+    dot: "bg-violet-500",
+    line: "bg-gradient-to-b from-violet-500/50 to-violet-500/5",
+    pill: "border-violet-500/30 text-violet-500",
+  },
+};
+
+const stations: Station[] = roadmapStages.map((stage) => ({
+  id: stage.id,
+  title: stage.title,
+  timeframe: stage.timeframe,
+  count: stage.items.length,
+  ...stationStyles[stage.id],
+}));
+
+function StationNode({ id }: { id: string }) {
+  if (id === "shipped") {
+    return (
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 ring-4 ring-emerald-500/20 transition-transform group-hover:scale-110">
+        <svg
+          className="h-3 w-3 text-white"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3.5 8.5l3 3 6-6.5"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (id === "in-progress") {
+    return (
+      <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-accent-cyan bg-bg-deepest ring-4 ring-accent-cyan/15 transition-transform group-hover:scale-110">
+        <span className="h-2.5 w-2.5 rounded-full bg-accent-cyan motion-safe:animate-pulse" />
+      </span>
+    );
+  }
+  if (id === "next-up") {
+    return (
+      <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-amber-500 bg-bg-deepest transition-transform group-hover:scale-110">
+        <span className="h-2 w-2 rounded-full border-2 border-amber-500" />
+      </span>
+    );
+  }
+  return (
+    <span className="h-6 w-6 rounded-full border-2 border-dashed border-violet-500 bg-bg-deepest transition-transform group-hover:scale-110" />
+  );
+}
+
+export function RoadmapWave() {
+  return (
+    <div aria-label="Roadmap timeline">
+      {/* Desktop wave timeline */}
+      <div className="relative hidden h-[340px] md:block">
+        <svg
+          className="absolute inset-x-0 bottom-0 h-[240px] w-full"
+          viewBox="0 0 1200 280"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient id="roadmap-wave-stroke" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0.125" stopColor="#10b981" />
+              <stop offset="0.375" stopColor="#06b6d4" />
+              <stop offset="0.625" stopColor="#f59e0b" />
+              <stop offset="0.875" stopColor="#8b5cf6" />
+            </linearGradient>
+            <linearGradient id="roadmap-wave-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#06b6d4" stopOpacity="0.16" />
+              <stop offset="1" stopColor="#06b6d4" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M 0 225 C 75 225 75 120 150 120 C 225 120 225 235 300 235 C 375 235 375 120 450 120 C 525 120 525 218 600 218 C 675 218 675 120 750 120 C 825 120 825 230 900 230 C 975 230 975 120 1050 120 C 1125 120 1125 222 1200 222 L 1200 280 L 0 280 Z"
+            fill="url(#roadmap-wave-fill)"
+          />
+          <path
+            d="M 0 225 C 75 225 75 120 150 120 C 225 120 225 235 300 235 C 375 235 375 120 450 120 C 525 120 525 218 600 218 C 675 218 675 120 750 120 C 825 120 825 230 900 230 C 975 230 975 120 1050 120 C 1125 120 1125 222 1200 222"
+            fill="none"
+            stroke="url(#roadmap-wave-stroke)"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </svg>
+
+        <div className="absolute inset-0 grid grid-cols-4">
+          {stations.map((station) => (
+            <a
+              key={station.id}
+              href={`#${station.id}`}
+              className="group relative block h-full"
+            >
+              {/* dot at the top of the connector */}
+              <span
+                className={`absolute left-1/2 top-1 h-2 w-2 -translate-x-1/2 rounded-full ${station.dot}`}
+              />
+              {/* connector line down to the wave node */}
+              <span
+                className={`absolute left-1/2 top-3 h-[179px] w-px ${station.line}`}
+              />
+              {/* label */}
+              <span className="absolute left-1/2 top-0 block pl-4 pr-2">
+                <span className="block text-lg font-bold text-text-primary transition-colors group-hover:text-accent-cyan">
+                  <T>{station.title}</T>
+                </span>
+                <span className="mt-0.5 block font-mono text-xs text-text-muted">
+                  <T>{station.timeframe}</T>
+                </span>
+                <span className="mt-1 block font-mono text-xs text-text-muted">
+                  <Var>{station.count}</Var> <T>items</T>
+                </span>
+              </span>
+              {/* node sitting on the wave crest */}
+              <span className="absolute left-1/2 top-[203px] -translate-x-1/2 -translate-y-1/2">
+                <StationNode id={station.id} />
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile fallback */}
+      <div className="grid grid-cols-2 gap-2 md:hidden">
+        {stations.map((station) => (
+          <a
+            key={station.id}
+            href={`#${station.id}`}
+            className={`flex items-center justify-between rounded-xl border bg-bg-elevated px-4 py-3 ${station.pill}`}
+          >
+            <span>
+              <span className="block text-sm font-semibold text-text-primary">
+                <T>{station.title}</T>
+              </span>
+              <span className="block font-mono text-[11px] text-text-muted">
+                <T>{station.timeframe}</T>
+              </span>
+            </span>
+            <span className="font-mono text-xs">
+              <Var>{station.count}</Var>
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(marketing)/roadmap/page.tsx
+++ b/app/(marketing)/roadmap/page.tsx
@@ -1,0 +1,135 @@
+import { Metadata } from "next";
+import { Header } from "@/components/landing/Header";
+import { Footer } from "@/components/landing/sections/Footer";
+import { T } from "gt-next";
+import { roadmapStages } from "@/lib/data/roadmap-data";
+import { RoadmapWave } from "./RoadmapWave";
+import { RoadmapBoard } from "./RoadmapBoard";
+
+export const metadata: Metadata = {
+  title: "Roadmap | IntuneGet - What's Shipped and What's Next",
+  description:
+    "See where IntuneGet is heading: shipped features, what's being built right now, and what comes next for the free, open-source Intune app deployment tool.",
+  alternates: {
+    canonical: "https://intuneget.com/roadmap",
+  },
+  openGraph: {
+    title: "IntuneGet Roadmap",
+    description:
+      "Shipped features, current work, and what comes next for IntuneGet.",
+  },
+};
+
+const roadmapJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "IntuneGet Roadmap",
+  itemListElement: roadmapStages
+    .flatMap((stage) =>
+      stage.items.map((item) => ({
+        stage: stage.title,
+        title: item.title,
+        description: item.description,
+      }))
+    )
+    .map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: `${entry.title} (${entry.stage})`,
+      description: entry.description,
+    })),
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://intuneget.com",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Roadmap",
+      item: "https://intuneget.com/roadmap",
+    },
+  ],
+};
+
+export default function RoadmapPage() {
+  return (
+    <div className="min-h-screen bg-bg-deepest flex flex-col">
+      <Header />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(roadmapJsonLd) }}
+      />
+
+      <main className="flex-1 mx-auto w-full max-w-6xl px-4 py-12 pt-24 lg:px-8 lg:py-16 lg:pt-28">
+        {/* Hero */}
+        <div className="mb-10 text-center">
+          <span className="mb-4 inline-block font-mono text-xs uppercase tracking-wider text-accent-cyan">
+            <T>Open source · AGPL-3.0</T>
+          </span>
+          <h1 className="mb-4 text-4xl font-bold text-text-primary md:text-5xl">
+            <T>Roadmap</T>
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg text-text-secondary">
+            <T>
+              Where IntuneGet is heading: what has shipped, what is being built
+              right now, and what comes next. Community priorities shape the
+              order.
+            </T>
+          </p>
+          <div className="mt-4 flex items-center justify-center gap-4 text-sm">
+            <a
+              href="https://github.com/ugurkocde/IntuneGet/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-text-muted transition-colors hover:text-accent-cyan"
+            >
+              <T>Request a feature on GitHub</T>
+              <svg
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+
+        {/* Wave timeline */}
+        <div className="mb-14">
+          <RoadmapWave />
+        </div>
+
+        {/* Filterable stages */}
+        <RoadmapBoard />
+
+        <p className="mt-14 border-t border-overlay/10 pt-6 font-mono text-xs text-text-muted">
+          <T>
+            Timelines are targets, not commitments. Sequencing follows community
+            demand.
+          </T>
+        </p>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -39,6 +39,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
+      url: `${BASE_URL}/roadmap`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
       url: `${BASE_URL}/security`,
       lastModified: now,
       changeFrequency: "monthly",

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -41,6 +41,7 @@ const secondaryNavLinks = [
   { href: "/#faq", label: "FAQ" },
   { href: "/blog", label: "Blog" },
   { href: "/changelog", label: "Changelog" },
+  { href: "/roadmap", label: "Roadmap" },
 ];
 
 export function Header() {

--- a/components/landing/sections/Footer.tsx
+++ b/components/landing/sections/Footer.tsx
@@ -63,6 +63,7 @@ const footerGroups: Array<{ title: string; links: FooterLink[] }> = [
         external: true,
       },
       { label: "Changelog", href: "/changelog" },
+      { label: "Roadmap", href: "/roadmap" },
       { label: "About", href: "/about" },
     ],
   },

--- a/lib/data/roadmap-data.ts
+++ b/lib/data/roadmap-data.ts
@@ -1,0 +1,201 @@
+export type RoadmapCategory =
+  | "package-quality"
+  | "rollout-control"
+  | "fleet-visibility"
+  | "catalog"
+  | "integrations"
+  | "msp"
+  | "trust";
+
+export type RoadmapStageId = "shipped" | "in-progress" | "next-up" | "exploring";
+
+export interface RoadmapItem {
+  title: string;
+  description: string;
+  category: RoadmapCategory;
+}
+
+export interface RoadmapStage {
+  id: RoadmapStageId;
+  title: string;
+  timeframe: string;
+  items: RoadmapItem[];
+}
+
+export const categoryLabels: Record<RoadmapCategory, string> = {
+  "package-quality": "Package quality",
+  "rollout-control": "Rollout control",
+  "fleet-visibility": "Fleet visibility",
+  catalog: "Catalog",
+  integrations: "Integrations",
+  msp: "MSP",
+  trust: "Trust",
+};
+
+export const roadmapStages: RoadmapStage[] = [
+  {
+    id: "shipped",
+    title: "Shipped",
+    timeframe: "Live today",
+    items: [
+      {
+        title: "Winget app catalog",
+        description:
+          "10,000+ apps synced hourly from winget-pkgs, with locale variants, Microsoft Store apps, and custom apps by URL.",
+        category: "catalog",
+      },
+      {
+        title: "PSADT v4 packaging",
+        description:
+          "Automated intunewin builds with generated detection rules, install commands, and a full dialog and branding surface.",
+        category: "package-quality",
+      },
+      {
+        title: "Auto-updates with policies",
+        description:
+          "Per-app auto update, notify, ignore, and pin policies with failure thresholds, cooldowns, and update history.",
+        category: "rollout-control",
+      },
+      {
+        title: "Supersedence and carry-over",
+        description:
+          "New versions supersede the old app and inherit its assignments, categories, and relationships.",
+        category: "rollout-control",
+      },
+      {
+        title: "Unmanaged app discovery",
+        description:
+          "Scan Intune discovered apps, match them to winget packages, and take over management with one click.",
+        category: "fleet-visibility",
+      },
+      {
+        title: "MSP multi-tenant",
+        description:
+          "Customer tenants with consent tracking, roles, batch cross-tenant deployments, audit logs, and webhooks.",
+        category: "msp",
+      },
+      {
+        title: "SCCM migration",
+        description:
+          "Import, match, preview, and convert ConfigMgr apps into the packaging pipeline.",
+        category: "integrations",
+      },
+      {
+        title: "ESP deployment integration",
+        description:
+          "Add newly deployed apps to Enrollment Status Page profiles during deployment.",
+        category: "integrations",
+      },
+      {
+        title: "Self-hosting",
+        description:
+          "AGPL source, Docker, SQLite mode, and a local Windows packager CLI. Run everything on your own terms.",
+        category: "trust",
+      },
+    ],
+  },
+  {
+    id: "in-progress",
+    title: "In Progress",
+    timeframe: "Q3 2026 target",
+    items: [
+      {
+        title: "Package verification pipeline",
+        description:
+          "Every package installs and uninstalls in an isolated Windows VM before release, with a published test report.",
+        category: "package-quality",
+      },
+      {
+        title: "Deployment waves",
+        description:
+          "Pilot group first, then the fleet, with configurable delays, success thresholds, and an optional approval gate.",
+        category: "rollout-control",
+      },
+      {
+        title: "Installer malware scanning",
+        description:
+          "Every downloaded installer is scanned before packaging and blocked on detections.",
+        category: "trust",
+      },
+      {
+        title: "Version retention policy",
+        description:
+          "Keep a set number of previous versions per app and clean up superseded apps in Intune automatically.",
+        category: "rollout-control",
+      },
+    ],
+  },
+  {
+    id: "next-up",
+    title: "Next Up",
+    timeframe: "Q4 2026 target",
+    items: [
+      {
+        title: "CVE visibility",
+        description:
+          "See exactly which tenants and apps are running versions with known vulnerabilities.",
+        category: "fleet-visibility",
+      },
+      {
+        title: "Rollback",
+        description:
+          "One action to redeploy the previous version and supersede a bad update.",
+        category: "rollout-control",
+      },
+      {
+        title: "PSADT script signing",
+        description:
+          "Sign generated scripts with your own certificate or a managed per-organization certificate.",
+        category: "trust",
+      },
+      {
+        title: "ESP auto version update",
+        description:
+          "Enrollment Status Page references update automatically when a new version supersedes.",
+        category: "integrations",
+      },
+      {
+        title: "Public REST API",
+        description:
+          "API keys and documented endpoints for catalog search, packaging jobs, update policies, and batch deployments.",
+        category: "integrations",
+      },
+      {
+        title: "Scheduled deployments",
+        description:
+          "Queue a deployment or update for a specific date, time, and timezone, per tenant.",
+        category: "rollout-control",
+      },
+      {
+        title: "XLSX report export",
+        description: "Export deployment and update reports as CSV, JSON, or XLSX.",
+        category: "fleet-visibility",
+      },
+    ],
+  },
+  {
+    id: "exploring",
+    title: "Exploring",
+    timeframe: "2027",
+    items: [
+      {
+        title: "Custom app binary upload",
+        description:
+          "Upload licensed or private installers directly instead of pointing at a public URL.",
+        category: "catalog",
+      },
+      {
+        title: "Maintenance windows",
+        description:
+          "Tenant-level windows that control when auto-updates are allowed to run.",
+        category: "rollout-control",
+      },
+      {
+        title: "Endpoint agent",
+        description:
+          "A lightweight agent for self-service installs and faster update enforcement on managed devices.",
+        category: "integrations",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary

Adds a public /roadmap page to the marketing site, showing what has shipped, what is being built, and what comes next.

- Wave timeline hero: the four stages (Shipped, In Progress, Next Up, Exploring) rendered as stations on a gradient wave, each with a status node (check, pulsing, outlined, dashed) and a label linking to its section. On mobile the wave collapses to a compact grid of stage links.
- Per-stage tables with Feature, Category, and Description columns and color-coded category tags (Package quality, Rollout control, Fleet visibility, Catalog, Integrations, MSP, Trust). Columns stack on mobile.
- Roadmap content lives in lib/data/roadmap-data.ts (23 items across the four stages).
- Roadmap link added to the header nav, footer Project links, and sitemap.

## Implementation notes

- Fully server-rendered, no client components, keeping the marketing bundle free of app providers.
- All strings wrapped in gt-next T/Var following the changelog page pattern.
- Uses semantic theme tokens, verified in both light and dark mode.
- Pulse animation respects prefers-reduced-motion.
- Breadcrumb and ItemList JSON-LD plus canonical URL metadata.

## Testing

- Typecheck passes (remaining errors are pre-existing test-file issues).
- Verified in the browser on desktop light and dark mode and at 390px mobile width, including anchor scrolling from the timeline stations.