### PR TITLE
Honor HTTP(S)_PROXY in the local packager

### DIFF
--- a/packager/package-lock.json
+++ b/packager/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@ugurkocde/intuneget-packager",
   "version": "1.3.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -14,6 +14,8 @@
         "@supabase/supabase-js": "^2.110.2",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "node-fetch": "^3.3.2",
         "uuid": "^14.0.1"
       },
@@ -1151,6 +1153,642 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
+  "dependencies": {
+    "@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
+      "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "requires": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/msal-browser": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
+      "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
+      "requires": {
+        "@azure/msal-common": "16.11.1"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
+      "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw=="
+    },
+    "@azure/msal-node": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.0.tgz",
+      "integrity": "sha512-6EZEParwHRlnSSIikw8FNAnAzwmh71uhveUXdPNFeZFviJ9SH+rwFiurhjzXqICYTrpm3E+dj693QOwfPbJXAQ==",
+      "requires": {
+        "@azure/msal-common": "16.11.1",
+        "jsonwebtoken": "^9.0.0"
+      }
+    },
+    "@supabase/auth-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.4.tgz",
+      "integrity": "sha512-nD+gsHRX7/qCCKzpX8Lch/NUi0rmg4YereGTFzUT0BkPJ0ObDLkhCfjfiloRNLky1oHkb+QLA45Vx2zAsQ6iIQ==",
+      "requires": {
+        "tslib": "2.8.1"
+      }
+    },
+    "@supabase/functions-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.4.tgz",
+      "integrity": "sha512-661Bg5VeEDv6twzQhXzoBpPV4xswuwGGDzmBkpa1wmpwu5/veHqT2lURNxCowCiUOWIkj8fJ9LLjq0sgwBIA4A==",
+      "requires": {
+        "tslib": "2.8.1"
+      }
+    },
+    "@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    },
+    "@supabase/postgrest-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.4.tgz",
+      "integrity": "sha512-TVTPrB8Ee/0dqA6B1fieMnCS32TYi5IRgIFuW5jL5DWGtw/y9XIojVkgLROdm8mhfpkiwt51lEtKYb3jl5cx1w==",
+      "requires": {
+        "tslib": "2.8.1"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.4.tgz",
+      "integrity": "sha512-nPtV06SuJXA+iAMUFBRrhjReayDICIzM8qi0TbsOXlPhn3GK5sDchwidHDtw9VPVOgKeF3xyXlrjIxeA0YdpuA==",
+      "requires": {
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.4.tgz",
+      "integrity": "sha512-s7e6KGY3KQQTLWz93xd8qJQpSZMqHQR8Yvigk4aqxdCc/XEzNhF/FiEEUO8bwZ2RrFxCe4rmPlHHd+/OyTATMw==",
+      "requires": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.110.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.4.tgz",
+      "integrity": "sha512-RErQw3rYFu/t23oli4q7Zb+PUiyAv2h2/aoGLJqaY35eBGugmo+Bb7ZByqxssoFcrxT6xVz3hQde53O/6/+HWA==",
+      "requires": {
+        "@supabase/auth-js": "2.110.4",
+        "@supabase/functions-js": "2.110.4",
+        "@supabase/postgrest-js": "2.110.4",
+        "@supabase/realtime-js": "2.110.4",
+        "@supabase/storage-js": "2.110.4"
+      }
+    },
+    "@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@typespec/ts-http-runtime": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.2.tgz",
+      "integrity": "sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==",
+      "requires": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "requires": {
+        "run-applescript": "^7.0.0"
+      }
+    },
+    "commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "default-browser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+      "requires": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      }
+    },
+    "default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="
+    },
+    "define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
+    },
+    "dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      }
+    },
+    "iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
+    },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "requires": {
+        "is-docker": "^3.0.0"
+      }
+    },
+    "is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "requires": {
+        "is-inside-container": "^1.0.0"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "requires": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      }
+    },
+    "jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "requires": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "requires": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
+    },
+    "open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "requires": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      }
+    },
+    "run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "requires": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
+    },
+    "wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "requires": {
+        "is-wsl": "^3.1.0"
       }
     }
   }

--- a/packager/package.json
+++ b/packager/package.json
@@ -46,6 +46,8 @@
     "@supabase/supabase-js": "^2.110.2",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
     "uuid": "^14.0.1"
   },

--- a/packager/src/fetch-with-proxy.ts
+++ b/packager/src/fetch-with-proxy.ts
@@ -16,7 +16,7 @@ const agentPromises: { http: Promise<unknown> | null; https: Promise<unknown> | 
   https: null,
 };
 
-async function resolveProxyAgent(targetUrl: string): Promise<unknown> {
+export async function resolveProxyAgent(targetUrl: string): Promise<unknown> {
   const isHttps = targetUrl.startsWith('https:');
   const proxyUrl = isHttps
     ? process.env.HTTPS_PROXY || process.env.https_proxy

--- a/packager/src/fetch-with-proxy.ts
+++ b/packager/src/fetch-with-proxy.ts
@@ -1,0 +1,56 @@
+/**
+ * Proxy-aware wrapper around node-fetch.
+ *
+ * node-fetch does not read HTTP_PROXY/HTTPS_PROXY (unlike Node's built-in
+ * fetch/undici with NODE_USE_ENV_PROXY=1), so every outbound call - Graph
+ * API, installer/tool downloads, Azure Storage uploads - bypassed the proxy
+ * and failed with ECONNREFUSED on hosts that only have proxied internet
+ * access. This resolves a single proxy agent from the environment once and
+ * reuses it for every request.
+ */
+
+import type { RequestInit, Response } from 'node-fetch';
+
+const agentPromises: { http: Promise<unknown> | null; https: Promise<unknown> | null } = {
+  http: null,
+  https: null,
+};
+
+async function resolveProxyAgent(targetUrl: string): Promise<unknown> {
+  const isHttps = targetUrl.startsWith('https:');
+  const proxyUrl = isHttps
+    ? process.env.HTTPS_PROXY || process.env.https_proxy
+    : process.env.HTTP_PROXY || process.env.http_proxy;
+
+  if (!proxyUrl) {
+    return undefined;
+  }
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
+  const host = new URL(targetUrl).hostname;
+  const bypassed = noProxy
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .some((entry) => host === entry || host.endsWith(`.${entry.replace(/^\./, '')}`));
+
+  if (bypassed) {
+    return undefined;
+  }
+
+  const protocol = isHttps ? 'https' : 'http';
+  if (!agentPromises[protocol]) {
+    agentPromises[protocol] = isHttps
+      ? import('https-proxy-agent').then((mod) => new mod.HttpsProxyAgent(proxyUrl))
+      : import('http-proxy-agent').then((mod) => new mod.HttpProxyAgent(proxyUrl));
+  }
+
+  return agentPromises[protocol];
+}
+
+export async function fetchWithProxy(url: string, init: RequestInit = {}): Promise<Response> {
+  const fetch = (await import('node-fetch')).default;
+  const agent = init.agent ?? (await resolveProxyAgent(url));
+
+  return fetch(url, agent ? { ...init, agent: agent as never } : init);
+}

--- a/packager/src/graph-client.ts
+++ b/packager/src/graph-client.ts
@@ -8,6 +8,7 @@ import { ManagedIdentityCredential, type TokenCredential } from '@azure/identity
 import { PackagerConfig } from './config.js';
 import { createLogger, Logger } from './logger.js';
 import { fetchWithProxy } from './fetch-with-proxy.js';
+import { ProxyHttpClient } from './msal-proxy-http-client.js';
 
 const GRAPH_ENDPOINT = 'https://graph.microsoft.com/beta';
 const GRAPH_SCOPE = 'https://graph.microsoft.com/.default';
@@ -43,6 +44,9 @@ export class GraphClient {
           clientId: config.azure.clientId,
           clientSecret: config.azure.clientSecret,
           authority: `https://login.microsoftonline.com/${tenantId}`,
+        },
+        system: {
+          networkClient: new ProxyHttpClient(),
         },
       });
     }

--- a/packager/src/graph-client.ts
+++ b/packager/src/graph-client.ts
@@ -7,6 +7,7 @@ import { ConfidentialClientApplication } from '@azure/msal-node';
 import { ManagedIdentityCredential, type TokenCredential } from '@azure/identity';
 import { PackagerConfig } from './config.js';
 import { createLogger, Logger } from './logger.js';
+import { fetchWithProxy } from './fetch-with-proxy.js';
 
 const GRAPH_ENDPOINT = 'https://graph.microsoft.com/beta';
 const GRAPH_SCOPE = 'https://graph.microsoft.com/.default';
@@ -97,8 +98,7 @@ export class GraphClient {
     const token = await this.getAccessToken();
     const url = `${GRAPH_ENDPOINT}${path}`;
 
-    const fetch = (await import('node-fetch')).default;
-    const response = await fetch(url, {
+    const response = await fetchWithProxy(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -126,8 +126,7 @@ export class GraphClient {
     const token = await this.getAccessToken();
     const url = `${GRAPH_ENDPOINT}${path}`;
 
-    const fetch = (await import('node-fetch')).default;
-    const response = await fetch(url, {
+    const response = await fetchWithProxy(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -162,8 +161,7 @@ export class GraphClient {
     const token = await this.getAccessToken();
     const url = `${GRAPH_ENDPOINT}${path}`;
 
-    const fetch = (await import('node-fetch')).default;
-    const response = await fetch(url, {
+    const response = await fetchWithProxy(url, {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -198,8 +196,7 @@ export class GraphClient {
     const token = await this.getAccessToken();
     const url = `${GRAPH_ENDPOINT}${path}`;
 
-    const fetch = (await import('node-fetch')).default;
-    const response = await fetch(url, {
+    const response = await fetchWithProxy(url, {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -8,6 +8,7 @@ import { PackagerConfig } from './config.js';
 import { PackagingJob } from './job-poller.js';
 import { GraphClient } from './graph-client.js';
 import { createLogger, Logger } from './logger.js';
+import { fetchWithProxy } from './fetch-with-proxy.js';
 import {
   findDuplicateIntuneApp,
   INTUNE_APP_SOURCE_MARKER,
@@ -400,8 +401,7 @@ export class IntuneUploader {
     }
 
     try {
-      const fetch = (await import('node-fetch')).default;
-      const response = await fetch(iconUrl);
+      const response = await fetchWithProxy(iconUrl);
 
       if (!response.ok) {
         this.logger.warn('Failed to download app icon, creating app without icon', {
@@ -529,7 +529,6 @@ export class IntuneUploader {
     azureStorageUri: string,
     onProgress?: (percent: number) => Promise<void>
   ): Promise<void> {
-    const fetch = (await import('node-fetch')).default;
     const fileHandle = await fs.promises.open(filePath, 'r');
     const stats = await fileHandle.stat();
     const fileSize = stats.size;
@@ -552,7 +551,7 @@ export class IntuneUploader {
 
         // Upload block
         const blockUrl = `${azureStorageUri}&comp=block&blockid=${encodeURIComponent(blockId)}`;
-        const response = await fetch(blockUrl, {
+        const response = await fetchWithProxy(blockUrl, {
           method: 'PUT',
           headers: {
             'Content-Length': chunk.length.toString(),
@@ -572,7 +571,7 @@ export class IntuneUploader {
       // Commit blocks
       const blockListXml = this.createBlockListXml(blockIds);
       const commitUrl = `${azureStorageUri}&comp=blocklist`;
-      const commitResponse = await fetch(commitUrl, {
+      const commitResponse = await fetchWithProxy(commitUrl, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/xml',

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -10,6 +10,7 @@ import { PackagerConfig } from './config.js';
 import { PackagingJob, JobPoller } from './job-poller.js';
 import { IntuneUploader, IntuneAppResult, DuplicateAppError } from './intune-uploader.js';
 import { createLogger, Logger } from './logger.js';
+import { fetchWithProxy } from './fetch-with-proxy.js';
 
 interface PackagingResult {
   intunewinPath: string;
@@ -242,15 +243,14 @@ export class JobProcessor {
    * when the server refuses the request outright.
    */
   private async downloadFile(url: string, destPath: string): Promise<void> {
-    const fetch = (await import('node-fetch')).default;
-    let response = await fetch(url);
+    let response = await fetchWithProxy(url);
 
     if (response.status === 403 || response.status === 406) {
       this.logger.warn('Download refused, retrying with browser User-Agent', {
         url,
         status: response.status,
       });
-      response = await fetch(url, {
+      response = await fetchWithProxy(url, {
         headers: {
           'User-Agent':
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',

--- a/packager/src/msal-proxy-http-client.ts
+++ b/packager/src/msal-proxy-http-client.ts
@@ -1,0 +1,55 @@
+/**
+ * Proxy-aware INetworkModule for msal-node.
+ *
+ * msal-node's default HttpClient calls Node's built-in fetch directly with
+ * no agent. That only honors HTTP_PROXY/HTTPS_PROXY when NODE_USE_ENV_PROXY=1
+ * is set on the process *before* the Node runtime initializes its network
+ * stack - setting it via a .env file loaded at startup (dotenv.config(), which
+ * runs after Node has already started) is too late and gets silently ignored,
+ * so token acquisition fails with "Network request failed: fetch failed"
+ * even with the proxy vars set. Route it through the same node-fetch +
+ * proxy-agent path used by fetchWithProxy() instead, which resolves the
+ * agent from the environment at call time regardless of when it was set.
+ */
+
+import type { INetworkModule, NetworkRequestOptions, NetworkResponse } from '@azure/msal-node';
+import { fetchWithProxy } from './fetch-with-proxy.js';
+
+export class ProxyHttpClient implements INetworkModule {
+  async sendGetRequestAsync<T>(
+    url: string,
+    options?: NetworkRequestOptions
+  ): Promise<NetworkResponse<T>> {
+    return this.sendRequest<T>(url, 'GET', options);
+  }
+
+  async sendPostRequestAsync<T>(
+    url: string,
+    options?: NetworkRequestOptions
+  ): Promise<NetworkResponse<T>> {
+    return this.sendRequest<T>(url, 'POST', options);
+  }
+
+  private async sendRequest<T>(
+    url: string,
+    method: 'GET' | 'POST',
+    options?: NetworkRequestOptions
+  ): Promise<NetworkResponse<T>> {
+    const response = await fetchWithProxy(url, {
+      method,
+      headers: options?.headers,
+      body: method === 'POST' ? options?.body || '' : undefined,
+    });
+
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    return {
+      headers,
+      body: (await response.json()) as T,
+      status: response.status,
+    };
+  }
+}

--- a/packager/tests/fetch-with-proxy.test.ts
+++ b/packager/tests/fetch-with-proxy.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock('node-fetch', () => ({
+  default: fetchMock,
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function freshFetchWithProxy() {
+  // The module caches resolved proxy agents in module-level state, so each
+  // test needs its own fresh import to observe a clean cache.
+  vi.resetModules();
+  return (await import('../src/fetch-with-proxy.js')).fetchWithProxy;
+}
+
+describe('fetchWithProxy', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.no_proxy;
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('does not pass an agent when no proxy env vars are set', async () => {
+    const fetchWithProxy = await freshFetchWithProxy();
+
+    await fetchWithProxy('https://graph.microsoft.com/beta/deviceAppManagement');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://graph.microsoft.com/beta/deviceAppManagement',
+      {}
+    );
+  });
+
+  it('attaches an HttpsProxyAgent for https URLs when HTTPS_PROXY is set', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+    const fetchWithProxy = await freshFetchWithProxy();
+
+    await fetchWithProxy('https://graph.microsoft.com/beta/deviceAppManagement');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as { agent?: unknown })?.agent).toBeDefined();
+  });
+
+  it('bypasses the proxy for hosts covered by NO_PROXY', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+    process.env.NO_PROXY = 'internal.example.com';
+    const fetchWithProxy = await freshFetchWithProxy();
+
+    await fetchWithProxy('https://packager-api.internal.example.com/api/packager/jobs');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://packager-api.internal.example.com/api/packager/jobs',
+      {}
+    );
+  });
+
+  it('reuses the same agent instance across calls to the same protocol', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+    const fetchWithProxy = await freshFetchWithProxy();
+
+    await fetchWithProxy('https://graph.microsoft.com/beta/a');
+    await fetchWithProxy('https://graph.microsoft.com/beta/b');
+
+    const agentA = (fetchMock.mock.calls[0][1] as { agent?: unknown })?.agent;
+    const agentB = (fetchMock.mock.calls[1][1] as { agent?: unknown })?.agent;
+    expect(agentA).toBe(agentB);
+  });
+
+  it('lets an explicitly passed agent override proxy resolution', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+    const fetchWithProxy = await freshFetchWithProxy();
+    const explicitAgent = { custom: true };
+
+    await fetchWithProxy('https://graph.microsoft.com/beta/a', { agent: explicitAgent as never });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://graph.microsoft.com/beta/a', {
+      agent: explicitAgent,
+    });
+  });
+});

--- a/packager/tests/msal-proxy-http-client.test.ts
+++ b/packager/tests/msal-proxy-http-client.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock('node-fetch', () => ({
+  default: fetchMock,
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    status,
+    headers: new Map([['content-type', 'application/json']]),
+    json: async () => body,
+  };
+}
+
+async function freshProxyHttpClient() {
+  // fetch-with-proxy.ts caches resolved agents at module scope.
+  vi.resetModules();
+  const { ProxyHttpClient } = await import('../src/msal-proxy-http-client.js');
+  return new ProxyHttpClient();
+}
+
+describe('ProxyHttpClient', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('routes msal token requests through the proxy agent, unlike native fetch with a runtime-set NODE_USE_ENV_PROXY', async () => {
+    // This mirrors the actual bug: NODE_USE_ENV_PROXY=1 loaded from .env at
+    // runtime (after Node's network stack already initialized) is silently
+    // ignored by undici, so a raw fetch() would bypass the proxy and fail
+    // with ECONNREFUSED on a proxy-only host. Verify our client attaches
+    // the proxy agent regardless of when the env var was set.
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+    process.env.NODE_USE_ENV_PROXY = '1'; // set at runtime, same as dotenv would
+
+    fetchMock.mockResolvedValue(jsonResponse({ access_token: 'token' }));
+    const client = await freshProxyHttpClient();
+
+    const response = await client.sendPostRequestAsync(
+      'https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token',
+      { body: 'grant_type=client_credentials' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as { agent?: unknown })?.agent).toBeDefined();
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ access_token: 'token' });
+  });
+
+  it('sends GET requests without a body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ value: [] }));
+    const client = await freshProxyHttpClient();
+
+    await client.sendGetRequestAsync('https://graph.microsoft.com/beta/deviceAppManagement');
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as { method?: string }).method).toBe('GET');
+    expect((init as { body?: unknown }).body).toBeUndefined();
+  });
+
+  it('forwards response headers as a plain dict', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}));
+    const client = await freshProxyHttpClient();
+
+    const response = await client.sendGetRequestAsync('https://graph.microsoft.com/beta/x');
+
+    expect(response.headers).toEqual({ 'content-type': 'application/json' });
+  });
+});


### PR DESCRIPTION
On a host whose only internet access is an HTTP proxy, every packaging job failed before it started. Two separate reasons, both invisible from the outside because the symptom was a generic network error.

**Downloads and Graph calls** go through `node-fetch`, which does not read `HTTP_PROXY`/`HTTPS_PROXY` at all (unlike Node's built-in fetch with `NODE_USE_ENV_PROXY=1`):

```
request to https://.../Firefox%20Setup%20152.0.5.exe failed,
reason: connect ECONNREFUSED <ip>:443
```

Added `fetchWithProxy()`, which resolves a proxy agent from the environment once (with `NO_PROXY` support) and reuses it. All seven direct `node-fetch` call sites now go through it: Graph API GET/POST/PATCH/DELETE, installer download, tool download, icon download and the Azure Storage block upload.

**Token acquisition** goes through `msal-node`, which calls Node's built-in fetch with no agent. That honors the proxy variables only when `NODE_USE_ENV_PROXY=1` is set *before* the runtime initializes its network stack - setting it from a `.env` file is too late and is silently ignored, so the variable looks correct and does nothing:

```
[ERROR] [GraphClient] Failed to acquire access token
{"error":"network_error: Network request failed: fetch failed"}
```

Added `ProxyHttpClient`, implementing msal-node's `INetworkModule` on top of the same `fetchWithProxy()` path, wired in through `system.networkClient` so the agent is resolved at call time regardless of when the environment was set.

New dependencies: `http-proxy-agent`, `https-proxy-agent`.

Tests cover agent selection per protocol, `NO_PROXY` bypass, the no-proxy-configured case, and the msal client's GET/POST shapes.