### PR TITLE
Fix the Win32 app create payload in the local packager

### DIFF
--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -187,6 +187,7 @@ export class IntuneUploader {
     encryptedContentPath: string,
     encryptionInfo: EncryptionInfo,
     sizes: { unencryptedSize: number; encryptedSize: number },
+    packageFileName: string,
     onProgress?: ProgressCallback
   ): Promise<IntuneAppResult> {
     const graphClient = new GraphClient(this.config, job.tenant_id);
@@ -202,7 +203,7 @@ export class IntuneUploader {
 
     // Step 1: Create Win32 LOB App (5%)
     await onProgress?.(5, 'Creating app in Intune...');
-    const app = await this.createWin32App(graphClient, job);
+    const app = await this.createWin32App(graphClient, job, packageFileName);
     this.logger.info('Created Win32 LOB App', { appId: app.id });
 
     // Step 2: Create content version (10%)
@@ -333,7 +334,8 @@ export class IntuneUploader {
    */
   private async createWin32App(
     graphClient: GraphClient,
-    job: PackagingJob
+    job: PackagingJob,
+    packageFileName: string
   ): Promise<{ id: string }> {
     const commands = this.buildCommandLines(job);
     const baseDescription = extractPackageDescription(
@@ -364,6 +366,11 @@ export class IntuneUploader {
       applicableArchitectures: this.mapArchitecture(job.architecture),
       minimumSupportedWindowsRelease: 'v10_1903',
       runAs32Bit: false,
+      // Graph rejects the create call with "FileName for Win32 LOB app cannot
+      // be empty" when this is missing. It is the name of the uploaded package
+      // file (the .intunewin we just built) and is distinct from
+      // setupFilePath, which names the entry point inside that package.
+      fileName: packageFileName,
       setupFilePath: 'Invoke-AppDeployToolkit.exe',
       installExperience: {
         runAsAccount: job.install_scope === 'user' ? 'user' : 'system',

--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -275,10 +275,10 @@ export class IntuneUploader {
     await this.commitContentVersion(graphClient, app.id, contentVersion.id);
     this.logger.info('Content version committed');
 
-    // Step 9: Add detection rules (98%)
-    await onProgress?.(98, 'Adding detection rules...');
-    await this.addDetectionRules(graphClient, app.id, job);
-    this.logger.info('Detection rules added');
+    // Step 9: Add requirement rules, if any (98%)
+    await onProgress?.(98, 'Adding requirement rules...');
+    await this.addRequirementRules(graphClient, app.id, job);
+    this.logger.info('Requirement rules added');
 
     // Step 10: Apply assignment configuration (99%)
     await onProgress?.(99, 'Applying assignments...');
@@ -348,6 +348,11 @@ export class IntuneUploader {
       ? baseDescription
       : `${baseDescription}\n${INTUNE_APP_SOURCE_MARKER}`;
     const largeIcon = await this.fetchLargeIcon(job);
+    // Graph rejects the create call with "The Win32LobApp must have at least
+    // one detection rule specified" if `rules` is empty at creation time, so
+    // detection rules must be sent here rather than added via a later PATCH
+    // (addRequirementRules still runs afterwards, for requirement rules only).
+    const detectionRules = this.buildDetectionRules(job);
     const appBody: Record<string, unknown> = {
       '@odata.type': '#microsoft.graph.win32LobApp',
       displayName: job.display_name,
@@ -371,7 +376,7 @@ export class IntuneUploader {
         { returnCode: 1641, type: 'hardReboot' },
         { returnCode: 1618, type: 'retry' },
       ],
-      rules: [], // Will add detection/requirement rules later
+      rules: detectionRules,
     };
 
     if (largeIcon) {
@@ -672,28 +677,20 @@ export class IntuneUploader {
   }
 
   /**
-   * Add detection rules (and requirement rules if present) to the app
+   * Add requirement rules (for "Update Only" mode), if present, to the app.
+   * Detection rules are set at creation time in createWin32App() - Graph
+   * rejects an app created with an empty rules array.
    */
-  private async addDetectionRules(
+  private async addRequirementRules(
     graphClient: GraphClient,
     appId: string,
     job: PackagingJob
   ): Promise<void> {
-    const detectionRules = this.buildDetectionRules(job);
     const requirementRules = this.extractRequirementRules(job);
 
-    // Set detection rules using the detectionRules property (old format,
-    // compatible with the win32LobAppDetection type names used by buildDetectionRules)
-    if (detectionRules.length > 0) {
-      await graphClient.patch(`/deviceAppManagement/mobileApps/${appId}`, {
-        '@odata.type': '#microsoft.graph.win32LobApp',
-        detectionRules: detectionRules,
-      });
-    }
-
     // If requirement rules exist (for "Update Only" mode), read the current
-    // unified rules array (which now includes the detection rules set above,
-    // converted to win32LobAppRule format by Graph internally), append the
+    // unified rules array (which already holds the detection rules sent at
+    // create time, in the same win32LobAppRule format), append the
     // requirement rules, and PATCH back the complete set.
     if (requirementRules.length > 0) {
       const app = await graphClient.get<{ rules?: unknown[] }>(
@@ -1211,7 +1208,17 @@ export class IntuneUploader {
   }
 
   /**
-   * Build detection rules from job configuration
+   * Build detection rules from job configuration, in the unified
+   * win32LobAppRule format that the `rules` collection expects.
+   *
+   * The shape here must match convertToGraphDetectionRule() in
+   * lib/intune-api.ts and the PowerShell equivalent in
+   * .github/workflows-reference/package-intunewin.yml: type names end in
+   * `Rule` (not `DetectionRule`), every entry carries ruleType: 'detection',
+   * and the comparison fields are operationType/comparisonValue - not the
+   * detectionType/detectionValue names of the deprecated `detectionRules`
+   * property. Requirement rules (extractRequirementRules) already arrive in
+   * this format and land in the same array.
    */
   private buildDetectionRules(job: PackagingJob): unknown[] {
     const rules: unknown[] = [];
@@ -1222,37 +1229,42 @@ export class IntuneUploader {
 
         if (ruleObj.type === 'file') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppFileSystemDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+            ruleType: 'detection',
             path: ruleObj.path,
             fileOrFolderName: ruleObj.fileOrFolderName,
             check32BitOn64System: ruleObj.check32BitOn64System || false,
-            detectionType: ruleObj.detectionType || 'exists',
-            operator: ruleObj.operator,
-            detectionValue: ruleObj.detectionValue,
+            operationType: this.mapFileDetectionType(ruleObj.detectionType as string),
+            operator: ruleObj.operator || 'notConfigured',
+            comparisonValue: ruleObj.detectionValue ?? null,
           });
         } else if (ruleObj.type === 'registry') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppRegistryDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppRegistryRule',
+            ruleType: 'detection',
             keyPath: ruleObj.keyPath,
             valueName: ruleObj.valueName,
             check32BitOn64System: ruleObj.check32BitOn64System || false,
-            detectionType: ruleObj.detectionType || 'exists',
-            operator: ruleObj.operator,
-            detectionValue: ruleObj.detectionValue,
+            operationType: this.mapRegistryDetectionType(ruleObj.detectionType as string),
+            operator: ruleObj.operator || 'notConfigured',
+            comparisonValue: ruleObj.detectionValue ?? null,
           });
         } else if (ruleObj.type === 'msi') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppProductCodeDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppProductCodeRule',
+            ruleType: 'detection',
             productCode: ruleObj.productCode,
             productVersionOperator: ruleObj.productVersionOperator || 'notConfigured',
-            productVersion: ruleObj.productVersion,
+            productVersion: ruleObj.productVersion ?? null,
           });
         } else if (ruleObj.type === 'script') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppPowerShellScriptDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppPowerShellScriptRule',
+            ruleType: 'detection',
             scriptContent: Buffer.from(ruleObj.scriptContent as string).toString('base64'),
             enforceSignatureCheck: ruleObj.enforceSignatureCheck || false,
             runAs32Bit: ruleObj.runAs32Bit || false,
+            operationType: 'notConfigured',
           });
         }
       }
@@ -1261,15 +1273,50 @@ export class IntuneUploader {
     // Add default detection rule if none specified
     if (rules.length === 0) {
       rules.push({
-        '@odata.type': '#microsoft.graph.win32LobAppFileSystemDetectionRule',
+        '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+        ruleType: 'detection',
         path: '%ProgramFiles%',
         fileOrFolderName: job.display_name.replace(/[^a-zA-Z0-9]/g, ''),
         check32BitOn64System: false,
-        detectionType: 'exists',
+        operationType: 'exists',
+        operator: 'notConfigured',
+        comparisonValue: null,
       });
     }
 
     return rules;
+  }
+
+  /**
+   * Map our file detection type to the Graph win32LobAppRuleOperationType
+   * enum. Mirrors mapFileDetectionType() in lib/intune-api.ts.
+   */
+  private mapFileDetectionType(type: string): string {
+    const mapping: Record<string, string> = {
+      exists: 'exists',
+      notExists: 'doesNotExist',
+      version: 'version',
+      dateModified: 'modifiedDate',
+      dateCreated: 'createdDate',
+      string: 'string',
+      sizeInMB: 'sizeInMB',
+    };
+    return mapping[type] || 'exists';
+  }
+
+  /**
+   * Map our registry detection type to the Graph win32LobAppRuleOperationType
+   * enum. Mirrors mapRegistryDetectionType() in lib/intune-api.ts.
+   */
+  private mapRegistryDetectionType(type: string): string {
+    const mapping: Record<string, string> = {
+      exists: 'exists',
+      notExists: 'doesNotExist',
+      string: 'string',
+      integer: 'integer',
+      version: 'version',
+    };
+    return mapping[type] || 'exists';
   }
 
   /**

--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -364,7 +364,13 @@ export class IntuneUploader {
       installCommandLine: commands.install,
       uninstallCommandLine: commands.uninstall,
       applicableArchitectures: this.mapArchitecture(job.architecture),
-      minimumSupportedWindowsRelease: 'v10_1903',
+      // Graph has two ways to express this and they take different values:
+      // minimumSupportedOperatingSystem is an object of v10_* booleans (what
+      // lib/intune-api.ts uses), minimumSupportedWindowsRelease is a bare
+      // release string. Passing the object form's 'v10_1903' to the string
+      // property is rejected with "Unknown MinimumSupportedWindowsRelease".
+      // Matches package-intunewin.yml, which creates the app the same way.
+      minimumSupportedWindowsRelease: '1903',
       runAs32Bit: false,
       // Graph rejects the create call with "FileName for Win32 LOB app cannot
       // be empty" when this is missing. It is the name of the uploaded package

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -101,6 +101,9 @@ export class JobProcessor {
             unencryptedSize: result.unencryptedContentSize,
             encryptedSize: result.encryptedContentSize,
           },
+          // Intune's win32LobApp.fileName is the name of the package file we
+          // built, not the installer inside it.
+          path.basename(result.intunewinPath),
           async (percent, message) => {
             // Map upload progress (0-100) to overall progress (75-95)
             const overallPercent = 75 + Math.floor(percent * 0.2);

--- a/packager/tests/intune-uploader.test.ts
+++ b/packager/tests/intune-uploader.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import { IntuneUploader } from '../src/intune-uploader';
+import type { PackagingJob } from '../src/job-poller';
+import type { PackagerConfig } from '../src/config';
+
+function makeJob(overrides: Partial<PackagingJob> = {}): PackagingJob {
+  return {
+    id: 'job-1',
+    user_id: 'user-1',
+    user_email: 'user@example.com',
+    tenant_id: 'tenant-1',
+    winget_id: 'Mozilla.Firefox',
+    version: '152.0.5',
+    display_name: 'Firefox',
+    publisher: 'Mozilla',
+    architecture: 'x64',
+    installer_type: 'exe',
+    installer_url: 'https://example.com/firefox.exe',
+    installer_sha256: 'a'.repeat(64),
+    install_command: 'setup.exe /S',
+    uninstall_command: 'uninstall.exe /S',
+    install_scope: 'system',
+    detection_rules: [
+      {
+        type: 'registry',
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Mozilla_Firefox',
+        valueName: 'Version',
+        check32BitOn64System: false,
+        detectionType: 'version',
+        operator: 'greaterThanOrEqual',
+        detectionValue: '152.0.5',
+      },
+    ],
+    package_config: {},
+    status: 'uploading',
+    progress_percent: 90,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeConfig(): PackagerConfig {
+  return {
+    packagerId: 'packager-1',
+    mode: 'api',
+    supabase: { url: '', serviceRoleKey: '' },
+    api: { url: 'https://intuneget.example.com', key: 'api-key' },
+    azure: { clientId: 'client-1', clientSecret: 'secret', useManagedIdentity: false },
+    polling: { interval: 5000, staleJobTimeout: 300000 },
+    paths: { work: '/tmp/work', tools: '/tmp/tools' },
+  };
+}
+
+describe('IntuneUploader.createWin32App (accessed via private-method cast)', () => {
+  it('sends a non-empty rules array on the initial create call, not an empty array', async () => {
+    // Regression: Graph rejects POST /deviceAppManagement/mobileApps with
+    // "The Win32LobApp must have at least one detection rule specified" when
+    // `rules` is empty at creation time. Detection rules were previously only
+    // added via a PATCH several steps later (addDetectionRules), which is too
+    // late - the create call itself must carry them.
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-1' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    const job = makeJob();
+    const result = await uploaderInternal.createWin32App(graphClientStub, job);
+
+    expect(result.id).toBe('app-1');
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [path, body] = postMock.mock.calls[0];
+    expect(path).toBe('/deviceAppManagement/mobileApps');
+    const rules = (body as { rules: unknown[] }).rules;
+    expect(Array.isArray(rules)).toBe(true);
+    expect(rules.length).toBeGreaterThan(0);
+    // The unified `rules` collection takes win32LobAppRule types with an
+    // explicit ruleType and operationType/comparisonValue - not the
+    // win32LobApp*DetectionRule names or detectionType/detectionValue fields
+    // of the deprecated `detectionRules` property. Same shape as
+    // convertToGraphDetectionRule() in lib/intune-api.ts.
+    expect(rules[0]).toEqual({
+      '@odata.type': '#microsoft.graph.win32LobAppRegistryRule',
+      ruleType: 'detection',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Mozilla_Firefox',
+      valueName: 'Version',
+      check32BitOn64System: false,
+      operationType: 'version',
+      operator: 'greaterThanOrEqual',
+      comparisonValue: '152.0.5',
+    });
+  });
+
+  it('maps notExists to the doesNotExist operation type Graph expects', async () => {
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-3' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    const job = makeJob({
+      detection_rules: [
+        {
+          type: 'file',
+          path: 'C:\\Program Files\\Mozilla Firefox',
+          fileOrFolderName: 'firefox.exe',
+          detectionType: 'notExists',
+        },
+      ],
+    });
+    await uploaderInternal.createWin32App(graphClientStub, job);
+
+    const [, body] = postMock.mock.calls[0];
+    expect((body as { rules: unknown[] }).rules[0]).toMatchObject({
+      '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+      ruleType: 'detection',
+      operationType: 'doesNotExist',
+      operator: 'notConfigured',
+    });
+  });
+
+  it('base64-encodes script detection rules and marks them notConfigured', async () => {
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-4' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    const job = makeJob({
+      detection_rules: [{ type: 'script', scriptContent: 'Write-Output "ok"' }],
+    });
+    await uploaderInternal.createWin32App(graphClientStub, job);
+
+    const [, body] = postMock.mock.calls[0];
+    expect((body as { rules: unknown[] }).rules[0]).toEqual({
+      '@odata.type': '#microsoft.graph.win32LobAppPowerShellScriptRule',
+      ruleType: 'detection',
+      scriptContent: Buffer.from('Write-Output "ok"').toString('base64'),
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+      operationType: 'notConfigured',
+    });
+  });
+
+  it('falls back to a default file-system detection rule when the job has none', async () => {
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-2' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    const job = makeJob({ detection_rules: [] });
+    await uploaderInternal.createWin32App(graphClientStub, job);
+
+    const [, body] = postMock.mock.calls[0];
+    const rules = (body as { rules: unknown[] }).rules;
+    expect(rules.length).toBeGreaterThan(0);
+    expect(rules[0]).toEqual({
+      '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+      ruleType: 'detection',
+      path: '%ProgramFiles%',
+      fileOrFolderName: 'Firefox',
+      check32BitOn64System: false,
+      operationType: 'exists',
+      operator: 'notConfigured',
+      comparisonValue: null,
+    });
+  });
+});

--- a/packager/tests/intune-uploader.test.ts
+++ b/packager/tests/intune-uploader.test.ts
@@ -135,6 +135,37 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
     });
   });
 
+  it('sends minimumSupportedWindowsRelease as a bare release string', async () => {
+    // Regression: 'v10_1903' belongs to the minimumSupportedOperatingSystem
+    // object form; the minimumSupportedWindowsRelease string property takes
+    // '1903' and rejects the prefixed value with "Unknown
+    // MinimumSupportedWindowsRelease: v10_1903". package-intunewin.yml sends
+    // the bare string.
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-6' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob,
+        packageFileName: string
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    await uploaderInternal.createWin32App(
+      graphClientStub,
+      makeJob(),
+      'Invoke-AppDeployToolkit.intunewin'
+    );
+
+    const [, body] = postMock.mock.calls[0];
+    expect(body).toMatchObject({ minimumSupportedWindowsRelease: '1903' });
+    expect(body).not.toHaveProperty('minimumSupportedOperatingSystem');
+  });
+
   it('maps notExists to the doesNotExist operation type Graph expects', async () => {
     const postMock = vi.fn().mockResolvedValue({ id: 'app-3' });
     const graphClientStub = { post: postMock };

--- a/packager/tests/intune-uploader.test.ts
+++ b/packager/tests/intune-uploader.test.ts
@@ -66,13 +66,18 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
       fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
       createWin32App: (
         graphClient: typeof graphClientStub,
-        job: PackagingJob
+        job: PackagingJob,
+        packageFileName: string
       ) => Promise<{ id: string }>;
     };
     vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
 
     const job = makeJob();
-    const result = await uploaderInternal.createWin32App(graphClientStub, job);
+    const result = await uploaderInternal.createWin32App(
+      graphClientStub,
+      job,
+      'Invoke-AppDeployToolkit.intunewin'
+    );
 
     expect(result.id).toBe('app-1');
     expect(postMock).toHaveBeenCalledTimes(1);
@@ -98,6 +103,38 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
     });
   });
 
+  it('sends the package file name as fileName, separate from setupFilePath', async () => {
+    // Regression: Graph rejects the create call with "FileName for Win32 LOB
+    // app cannot be empty" when the body carries setupFilePath but no
+    // fileName. The two are different fields - fileName names the uploaded
+    // .intunewin, setupFilePath the entry point inside it.
+    const postMock = vi.fn().mockResolvedValue({ id: 'app-5' });
+    const graphClientStub = { post: postMock };
+
+    const uploader = new IntuneUploader(makeConfig());
+    const uploaderInternal = uploader as unknown as {
+      fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
+      createWin32App: (
+        graphClient: typeof graphClientStub,
+        job: PackagingJob,
+        packageFileName: string
+      ) => Promise<{ id: string }>;
+    };
+    vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
+
+    await uploaderInternal.createWin32App(
+      graphClientStub,
+      makeJob(),
+      'Invoke-AppDeployToolkit.intunewin'
+    );
+
+    const [, body] = postMock.mock.calls[0];
+    expect(body).toMatchObject({
+      fileName: 'Invoke-AppDeployToolkit.intunewin',
+      setupFilePath: 'Invoke-AppDeployToolkit.exe',
+    });
+  });
+
   it('maps notExists to the doesNotExist operation type Graph expects', async () => {
     const postMock = vi.fn().mockResolvedValue({ id: 'app-3' });
     const graphClientStub = { post: postMock };
@@ -107,7 +144,8 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
       fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
       createWin32App: (
         graphClient: typeof graphClientStub,
-        job: PackagingJob
+        job: PackagingJob,
+        packageFileName: string
       ) => Promise<{ id: string }>;
     };
     vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
@@ -122,7 +160,11 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
         },
       ],
     });
-    await uploaderInternal.createWin32App(graphClientStub, job);
+    await uploaderInternal.createWin32App(
+      graphClientStub,
+      job,
+      'Invoke-AppDeployToolkit.intunewin'
+    );
 
     const [, body] = postMock.mock.calls[0];
     expect((body as { rules: unknown[] }).rules[0]).toMatchObject({
@@ -142,7 +184,8 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
       fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
       createWin32App: (
         graphClient: typeof graphClientStub,
-        job: PackagingJob
+        job: PackagingJob,
+        packageFileName: string
       ) => Promise<{ id: string }>;
     };
     vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
@@ -150,7 +193,11 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
     const job = makeJob({
       detection_rules: [{ type: 'script', scriptContent: 'Write-Output "ok"' }],
     });
-    await uploaderInternal.createWin32App(graphClientStub, job);
+    await uploaderInternal.createWin32App(
+      graphClientStub,
+      job,
+      'Invoke-AppDeployToolkit.intunewin'
+    );
 
     const [, body] = postMock.mock.calls[0];
     expect((body as { rules: unknown[] }).rules[0]).toEqual({
@@ -172,13 +219,18 @@ describe('IntuneUploader.createWin32App (accessed via private-method cast)', () 
       fetchLargeIcon: (job: PackagingJob) => Promise<unknown>;
       createWin32App: (
         graphClient: typeof graphClientStub,
-        job: PackagingJob
+        job: PackagingJob,
+        packageFileName: string
       ) => Promise<{ id: string }>;
     };
     vi.spyOn(uploaderInternal, 'fetchLargeIcon').mockResolvedValue(null);
 
     const job = makeJob({ detection_rules: [] });
-    await uploaderInternal.createWin32App(graphClientStub, job);
+    await uploaderInternal.createWin32App(
+      graphClientStub,
+      job,
+      'Invoke-AppDeployToolkit.intunewin'
+    );
 
     const [, body] = postMock.mock.calls[0];
     const rules = (body as { rules: unknown[] }).rules;


### PR DESCRIPTION
Three validation errors from Microsoft Graph, all on the same `POST /deviceAppManagement/mobileApps` call in the local packager. Each only became reachable once the previous one was fixed, so they surfaced one at a time.

**1. Detection rules were not sent at creation.** `createWin32App()` posted `rules: []` and relied on a PATCH several upload steps later. Graph rejects that immediately:

```
400 BadRequest - "The Win32LobApp must have at least one detection rule specified."
```

Rules are now computed before the body is built. `addDetectionRules()` becomes `addRequirementRules()` and only handles requirement rules for "Update Only" mode.

The payload itself was also wrong for that field. `buildDetectionRules()` produced the shape of the deprecated `detectionRules` property - type names ending in `DetectionRule`, fields `detectionType`/`detectionValue`. The unified `rules` collection takes `win32LobAppRule` subtypes with an explicit `ruleType: 'detection'` and `operationType`/`comparisonValue`. Every other code path in this repo already agrees on that shape: `convertToGraphDetectionRule()` in `lib/intune-api.ts`, the PowerShell conversion in `.github/workflows-reference/package-intunewin.yml`, the requirement rules from `lib/requirement-rules.ts` (which pass through untouched into the same array), and `types/intune.ts`. The mapping is ported from `lib/intune-api.ts`, including `notExists -> doesNotExist`.

**2. `fileName` was missing.**

```
400 BadRequest - "FileName for Win32 LOB app cannot be empty."
```

The body set `setupFilePath` but never `fileName`. They are different properties: `fileName` names the uploaded package file, `setupFilePath` the entry point inside it. The real `.intunewin` name is already known at the call site, so it is threaded through `uploadToIntune()` rather than hardcoded.

**3. `minimumSupportedWindowsRelease` had the wrong value form.**

```
400 BadRequest - "Unknown MinimumSupportedWindowsRelease: v10_1903"
```

Graph offers two ways to express the minimum OS and they take different values: `minimumSupportedOperatingSystem` is an object of `v10_*` booleans, `minimumSupportedWindowsRelease` is a bare release string. The packager combined the string property with the object form's prefixed value. Changed to `'1903'`, matching `package-intunewin.yml`, which creates the app through the same property.

Verified end to end against a live tenant: packaging, upload and app creation now complete.