### PR TITLE
Restrict QA sync RPC execution

### DIFF
--- a/supabase/migrations/20260807181755_restrict_qa_sync_rpc_execution.sql
+++ b/supabase/migrations/20260807181755_restrict_qa_sync_rpc_execution.sql
@@ -1,0 +1,10 @@
+-- Supabase default privileges can retain explicit function grants for API
+-- roles across CREATE OR REPLACE. Keep the QA synchronization surface scoped
+-- to the anonymous role used with the dedicated QA-only secret.
+revoke all on function public.sync_qa_results(text, jsonb, boolean)
+  from public, authenticated, service_role;
+revoke all on function public.record_qa_sync_failure(text)
+  from public, authenticated, service_role;
+
+grant execute on function public.sync_qa_results(text, jsonb, boolean) to anon;
+grant execute on function public.record_qa_sync_failure(text) to anon;


### PR DESCRIPTION
## Summary
- revoke retained QA sync RPC execution grants from authenticated and service roles
- keep execution scoped to the anon API role plus the dedicated QA-only secret
- align the checked-in migration history with production

## Verification
- production ACL now contains only postgres and anon
- signed-in and service roles no longer have EXECUTE
- canonical QA sync will be rerun after this change