### PR TITLE
Automate exact-candidate Intune QA release gate

### DIFF
--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -122,7 +122,11 @@ async function processAutoUpdates(
 
     try {
       // Get installer info for the new version
-      const installerInfo = await getLatestInstallerInfo(supabase, update.winget_id);
+      const installerInfo = await getLatestInstallerInfo(
+        supabase,
+        update.winget_id,
+        policy.deployment_config?.architecture
+      );
 
       if (!installerInfo) {
         result.errors.push(

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import { dispatchQaCandidate } from '@/lib/qa/dispatch';
+
+const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
+const RUN_TIMEOUT_MS = 5 * 60 * 60 * 1000;
+const MAX_ATTEMPTS = 2;
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createServerClient();
+  const now = new Date();
+  const { data: active, error: activeError } = await supabase
+    .from('qa_candidates')
+    .select('*')
+    .in('status', ['dispatched', 'running']);
+  if (activeError) throw new Error(`Could not reconcile QA candidates: ${activeError.message}`);
+
+  let reconciled = 0;
+  for (const candidate of active || []) {
+    const timestamp = candidate.status === 'running' ? candidate.started_at : candidate.dispatched_at;
+    const timeout = candidate.status === 'running' ? RUN_TIMEOUT_MS : DISPATCH_TIMEOUT_MS;
+    if (timestamp && now.getTime() - new Date(timestamp).getTime() <= timeout) continue;
+
+    const exhausted = candidate.attempts >= MAX_ATTEMPTS;
+    const { error } = await supabase
+      .from('qa_candidates')
+      .update({
+        status: exhausted ? 'error' : 'queued',
+        dispatched_at: null,
+        started_at: null,
+        github_run_id: null,
+        github_run_url: null,
+        finished_at: exhausted ? now.toISOString() : null,
+        failure_summary: exhausted ? 'QA workflow did not report completion before the safety timeout.' : null,
+        updated_at: now.toISOString(),
+      })
+      .eq('id', candidate.id)
+      .eq('status', candidate.status);
+    if (error) throw error;
+    reconciled++;
+  }
+
+  const { data: stillActive, error: stillActiveError } = await supabase
+    .from('qa_candidates')
+    .select('id')
+    .in('status', ['dispatched', 'running'])
+    .limit(1);
+  if (stillActiveError) throw stillActiveError;
+  if (stillActive?.length) {
+    return NextResponse.json({ success: true, dispatched: false, reason: 'qa_active', reconciled });
+  }
+
+  const { data: next, error: queueError } = await supabase
+    .from('qa_candidates')
+    .select('*')
+    .eq('status', 'queued')
+    .order('priority', { ascending: false })
+    .order('enqueued_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (queueError) throw queueError;
+  if (!next) {
+    return NextResponse.json({ success: true, dispatched: false, reason: 'queue_empty', reconciled });
+  }
+
+  const dispatchedAt = new Date().toISOString();
+  const { data: claimed, error: claimError } = await supabase
+    .from('qa_candidates')
+    .update({
+      status: 'dispatched',
+      attempts: next.attempts + 1,
+      dispatched_at: dispatchedAt,
+      failure_summary: null,
+      updated_at: dispatchedAt,
+    })
+    .eq('id', next.id)
+    .eq('status', 'queued')
+    .select('*')
+    .maybeSingle();
+  if (claimError?.code === '23505') {
+    return NextResponse.json({ success: true, dispatched: false, reason: 'claim_lost', reconciled });
+  }
+  if (claimError) throw claimError;
+  if (!claimed) {
+    return NextResponse.json({ success: true, dispatched: false, reason: 'claim_lost', reconciled });
+  }
+
+  try {
+    await dispatchQaCandidate(claimed);
+    return NextResponse.json({ success: true, dispatched: true, candidateId: claimed.id, reconciled });
+  } catch (error) {
+    console.error(`QA dispatch failed for candidate ${claimed.id}:`, error);
+    await supabase
+      .from('qa_candidates')
+      .update({
+        status: 'queued',
+        attempts: next.attempts,
+        dispatched_at: null,
+        failure_summary: 'QA workflow dispatch failed; retry scheduled.',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', claimed.id)
+      .eq('status', 'dispatched');
+    throw error;
+  }
+}
+
+/** Operator recovery for a terminal infrastructure error; protected by CRON_SECRET. */
+export async function POST(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = (await request.json().catch(() => null)) as { candidateId?: string } | null;
+  if (!body?.candidateId || !/^[0-9a-fA-F-]{36}$/.test(body.candidateId)) {
+    return NextResponse.json({ error: 'A candidate UUID is required' }, { status: 400 });
+  }
+
+  const supabase = createServerClient();
+  const now = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('qa_candidates')
+    .update({
+      status: 'queued',
+      attempts: 0,
+      dispatched_at: null,
+      started_at: null,
+      finished_at: null,
+      github_run_id: null,
+      github_run_url: null,
+      failure_summary: null,
+      updated_at: now,
+    })
+    .eq('id', body.candidateId)
+    .in('status', ['error', 'superseded'])
+    .select('id')
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) {
+    return NextResponse.json({ error: 'Candidate is not retryable' }, { status: 409 });
+  }
+  return NextResponse.json({ success: true, candidateId: data.id });
+}
+
+export const maxDuration = 60;

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import {
+  normalizeInstallerSha256,
+  normalizeQaInstallerType,
+  selectWingetInstaller,
+} from '@/lib/qa/candidate';
+import {
+  createWingetManifestClient,
+  resolveWingetManifest,
+} from '@/lib/winget-sync-resolution.mjs';
+
+const BATCH_SIZE = 3;
+
+function installerFileName(installerUrl: string, installerType: string): string {
+  try {
+    const decoded = decodeURIComponent(new URL(installerUrl).pathname.split('/').pop() || '');
+    if (decoded && !/[\\/:*?"<>|]/.test(decoded)) return decoded;
+  } catch {
+    // Validation below reports the malformed URL.
+  }
+  return `installer.${installerType || 'exe'}`;
+}
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createServerClient();
+  const [{ data: recipes, error: recipeError }, { data: policies, error: policyError }, { data: results, error: resultError }] =
+    await Promise.all([
+      supabase.from('qa_recipes').select('*').eq('active', true),
+      supabase
+        .from('app_update_policies')
+        .select('winget_id')
+        .eq('policy_type', 'auto_update')
+        .eq('is_enabled', true),
+      supabase
+        .from('qa_results')
+        .select('winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc'),
+    ]);
+  if (recipeError) throw new Error(`Could not read QA recipes: ${recipeError.message}`);
+  if (policyError) throw new Error(`Could not prioritize QA recipes: ${policyError.message}`);
+  if (resultError) throw new Error(`Could not read existing QA results: ${resultError.message}`);
+
+  const priorities = new Map<string, number>();
+  for (const policy of policies || []) {
+    priorities.set(policy.winget_id, (priorities.get(policy.winget_id) || 0) + 1);
+  }
+  const resultById = new Map((results || []).map((row) => [row.winget_id, row]));
+  const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
+  const summary = { checked: 0, queued: 0, alreadyKnown: 0, unavailable: 0, errors: [] as string[] };
+
+  for (let index = 0; index < (recipes || []).length; index += BATCH_SIZE) {
+    const batch = (recipes || []).slice(index, index + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (recipe) => {
+        summary.checked++;
+        try {
+          const resolution = await resolveWingetManifest({
+            client,
+            wingetId: recipe.winget_id,
+            storedVersion: undefined,
+            preferLive: true,
+          });
+          if (resolution.status !== 'resolved') {
+            summary.unavailable++;
+            return;
+          }
+
+          const manifest = resolution.manifest as Record<string, unknown>;
+          const installers = (manifest.Installers || []) as Array<Record<string, unknown>>;
+          const selected = selectWingetInstaller(installers, recipe.architecture);
+          const installerUrl = String(selected?.InstallerUrl || '');
+          const installerSha256 = normalizeInstallerSha256(String(selected?.InstallerSha256 || ''));
+          const installerType = normalizeQaInstallerType(
+            String(selected?.InstallerType || manifest.InstallerType || ''),
+            recipe.installer_type
+          );
+          if (!installerUrl.startsWith('https://') || !installerSha256) {
+            throw new Error('resolved installer is missing a valid HTTPS URL or SHA-256');
+          }
+
+          const previous = resultById.get(recipe.winget_id);
+          const previousMatches = Boolean(
+            previous &&
+              previous.tested_version === resolution.version &&
+              previous.architecture.toLowerCase() === recipe.architecture.toLowerCase() &&
+              previous.installer_sha256?.toUpperCase() === installerSha256
+          );
+          const now = new Date().toISOString();
+          const initialStatus = previousMatches
+            ? previous?.outcome === 'Passed'
+              ? 'passed'
+              : 'failed'
+            : 'queued';
+          const { data: inserted, error: insertError } = await supabase
+            .from('qa_candidates')
+            .insert({
+              winget_id: recipe.winget_id,
+              definition_path: recipe.definition_path,
+              version: resolution.version,
+              architecture: recipe.architecture,
+              installer_url: installerUrl,
+              installer_sha256: installerSha256,
+              installer_type: installerType,
+              installer_file_name: installerFileName(installerUrl, installerType),
+              status: initialStatus,
+              priority: priorities.get(recipe.winget_id) || 0,
+              finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
+              updated_at: now,
+            })
+            .select('id')
+            .single();
+
+          if (insertError?.code === '23505') {
+            summary.alreadyKnown++;
+            const { data: existing } = await supabase
+              .from('qa_candidates')
+              .select('id, status')
+              .eq('winget_id', recipe.winget_id)
+              .eq('version', resolution.version)
+              .eq('architecture', recipe.architecture)
+              .eq('installer_sha256', installerSha256)
+              .maybeSingle();
+            if (existing?.status === 'superseded') {
+              await supabase
+                .from('qa_candidates')
+                .update({
+                  status: 'queued',
+                  priority: priorities.get(recipe.winget_id) || 0,
+                  attempts: 0,
+                  finished_at: null,
+                  failure_summary: null,
+                  updated_at: now,
+                })
+                .eq('id', existing.id)
+                .eq('status', 'superseded');
+              await supabase
+                .from('qa_candidates')
+                .update({ status: 'superseded', finished_at: now, updated_at: now })
+                .eq('winget_id', recipe.winget_id)
+                .eq('architecture', recipe.architecture)
+                .eq('status', 'queued')
+                .neq('id', existing.id);
+            } else if (existing?.status === 'queued') {
+              await supabase
+                .from('qa_candidates')
+                .update({ priority: priorities.get(recipe.winget_id) || 0, updated_at: now })
+                .eq('id', existing.id)
+                .eq('status', 'queued');
+            }
+            return;
+          }
+          if (insertError) throw insertError;
+          if (initialStatus !== 'queued') {
+            summary.alreadyKnown++;
+            return;
+          }
+
+          summary.queued++;
+          await supabase
+            .from('qa_candidates')
+            .update({ status: 'superseded', finished_at: now, updated_at: now })
+            .eq('winget_id', recipe.winget_id)
+            .eq('architecture', recipe.architecture)
+            .eq('status', 'queued')
+            .neq('id', inserted.id);
+        } catch (error) {
+          summary.errors.push(`${recipe.winget_id}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      })
+    );
+  }
+
+  return NextResponse.json(
+    { success: summary.errors.length === 0, ...summary },
+    { status: summary.errors.length === 0 ? 200 : 207 }
+  );
+}
+
+export const maxDuration = 300;

--- a/app/api/qa/status/route.test.ts
+++ b/app/api/qa/status/route.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const { getQaStatusesMock, applyRateLimitMock } = vi.hoisted(() => ({
+const { getQaStatusesMock, getQaCandidateStatusesMock, applyRateLimitMock } = vi.hoisted(() => ({
   getQaStatusesMock: vi.fn(),
+  getQaCandidateStatusesMock: vi.fn(),
   applyRateLimitMock: vi.fn(),
 }));
 vi.mock('@/lib/catalog', () => ({
-  getCatalogSource: () => ({ getQaStatuses: getQaStatusesMock }),
+  getCatalogSource: () => ({
+    getQaStatuses: getQaStatusesMock,
+    getQaCandidateStatuses: getQaCandidateStatusesMock,
+  }),
 }));
 vi.mock('@/lib/rate-limit', () => ({
   applyRateLimit: applyRateLimitMock,
@@ -19,6 +23,7 @@ import { GET } from './route';
 describe('GET /api/qa/status', () => {
   beforeEach(() => {
     getQaStatusesMock.mockReset();
+    getQaCandidateStatusesMock.mockReset().mockResolvedValue([]);
     applyRateLimitMock.mockReset().mockResolvedValue(null);
   });
 
@@ -38,7 +43,7 @@ describe('GET /api/qa/status', () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('cache-control')).toContain('s-maxage=300');
+    expect(response.headers.get('cache-control')).toContain('s-maxage=60');
     expect(body.statuses['OpenJS.NodeJS']).toMatchObject({ outcome: 'Passed', testedVersion: '26.7.0' });
     expect(body.statuses['Mozilla.Firefox']).toBeNull();
   });
@@ -54,6 +59,28 @@ describe('GET /api/qa/status', () => {
     expect(mixed.status).toBe(200);
     expect((await mixed.json()).statuses['9NBLGGH4NNS1']).toBeNull();
     expect(getQaStatusesMock).toHaveBeenCalledWith(['OpenJS.NodeJS']);
+  });
+
+  it('overlays an active candidate on the last completed result', async () => {
+    getQaStatusesMock.mockResolvedValue([]);
+    getQaCandidateStatusesMock.mockResolvedValue([
+      {
+        winget_id: 'OpenJS.NodeJS',
+        version: '27.0.0',
+        architecture: 'x64',
+        installer_sha256: 'A'.repeat(64),
+        status: 'running',
+        enqueued_at: '2026-08-07T12:00:00Z',
+        started_at: '2026-08-07T12:01:00Z',
+      },
+    ]);
+    const response = await GET(
+      new NextRequest('http://localhost/api/qa/status?ids=OpenJS.NodeJS')
+    );
+    expect((await response.json()).statuses['OpenJS.NodeJS']).toMatchObject({
+      outcome: 'Running',
+      testedVersion: '27.0.0',
+    });
   });
 
   it('rejects oversized ID sets before querying the catalog', async () => {

--- a/app/api/qa/status/route.ts
+++ b/app/api/qa/status/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCatalogSource } from '@/lib/catalog';
-import { toQaStatus } from '@/lib/qa/status';
+import { toQaCandidateStatus, toQaStatus } from '@/lib/qa/status';
 import { applyRateLimit, getIpKey, PUBLIC_RATE_LIMIT } from '@/lib/rate-limit';
 import type { QaStatus } from '@/types/qa';
 
 const APP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]*\.[A-Za-z0-9][A-Za-z0-9._+-]*$/;
-const CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=600';
+const CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=120';
 
 export async function GET(request: NextRequest) {
   const rateLimitResponse = await applyRateLimit(getIpKey(request), PUBLIC_RATE_LIMIT);
@@ -25,13 +25,20 @@ export async function GET(request: NextRequest) {
     // Store product IDs share the catalog but are not WinGet IDs. Treat any
     // unsupported identifier as untested instead of failing the entire batch.
     const validIds = ids.filter((id) => APP_ID_PATTERN.test(id));
-    const rows = validIds.length > 0
-      ? await getCatalogSource().getQaStatuses(validIds)
-      : [];
+    const catalog = getCatalogSource();
+    const [rows, candidates] = validIds.length > 0
+      ? await Promise.all([
+          catalog.getQaStatuses(validIds),
+          catalog.getQaCandidateStatuses(validIds),
+        ])
+      : [[], []];
     const statuses: Record<string, QaStatus | null> = Object.fromEntries(
       ids.map((id) => [id, null])
     );
     for (const row of rows) statuses[row.winget_id] = toQaStatus(row);
+    for (const candidate of candidates) {
+      statuses[candidate.winget_id] = toQaCandidateStatus(candidate);
+    }
 
     return NextResponse.json({ statuses }, { headers: { 'Cache-Control': CACHE_CONTROL } });
   } catch (error) {

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -29,7 +29,7 @@ import type {
 } from '@/types/update-policies';
 import type { Json } from '@/types/database';
 import { isSelfUpdatingApp } from '@/lib/self-updating-apps';
-import { describeQaGateError, QaGateError } from '@/lib/qa/gate';
+import { describeQaGateError, isQaGateError } from '@/lib/qa/gate';
 
 // Batches of up to 10 apps run sequentially (DB lookups, job creation, and a
 // workflow dispatch each); the platform default duration times out mid-batch
@@ -272,7 +272,11 @@ export async function POST(request: NextRequest) {
         }
 
         // Get installer info
-        const installerInfo = await getLatestInstallerInfo(supabase, req.winget_id);
+        const installerInfo = await getLatestInstallerInfo(
+          supabase,
+          req.winget_id,
+          (policy.deployment_config as unknown as DeploymentConfig | null)?.architecture
+        );
 
         if (!installerInfo) {
           response.failed++;
@@ -384,9 +388,10 @@ export async function POST(request: NextRequest) {
             try {
               await triggerPackagingWorkflow(workflowInputs, undefined, {
                 skipRunCapture: isBatch,
+                requireQaPass: true,
               });
             } catch (error) {
-              if (!(error instanceof QaGateError)) throw error;
+              if (!isQaGateError(error)) throw error;
 
               // The status can change between the pre-job auto-update gate and
               // the final dispatch gate. Make that race an explicit safety
@@ -397,7 +402,7 @@ export async function POST(request: NextRequest) {
                 .from('packaging_jobs')
                 .update({
                   status: 'cancelled',
-                  status_message: 'Skipped because current QA failed',
+                  status_message: 'Skipped while awaiting exact QA pass',
                   error_message: message,
                   cancelled_at: completedAt,
                   completed_at: completedAt,

--- a/components/qa/QaBadge.tsx
+++ b/components/qa/QaBadge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ShieldAlert, ShieldCheck, ShieldX } from 'lucide-react';
+import { Clock3, LoaderCircle, ShieldAlert, ShieldCheck, ShieldX } from 'lucide-react';
 import { getStatusToneClasses } from '@/components/ui/status-badge';
 import { cn } from '@/lib/utils';
 import { deriveQaBadgeState } from '@/lib/qa/status';
@@ -18,6 +18,23 @@ export function QaBadge({ wingetId, catalogVersion, status }: QaBadgeProps) {
   const [open, setOpen] = useState(false);
   const state = deriveQaBadgeState(status, catalogVersion);
   if (!status || state === 'untested') return null;
+
+  if (state === 'queued' || state === 'running') {
+    const running = state === 'running';
+    const Icon = running ? LoaderCircle : Clock3;
+    return (
+      <span
+        aria-label={`QA ${state} for version ${status.testedVersion}.`}
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium',
+          getStatusToneClasses(running ? 'info' : 'neutral')
+        )}
+      >
+        <Icon className={cn('h-3 w-3', running && 'animate-spin')} aria-hidden="true" />
+        QA {running ? 'Running' : 'Queued'} v{status.testedVersion}
+      </span>
+    );
+  }
 
   const stale = state === 'stale_passed' || state === 'stale_failed';
   const failed = state === 'failed' || state === 'stale_failed';

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -27,7 +27,8 @@ export function useQaStatuses(ids: string[]) {
       };
     },
     enabled: stableIds.length > 0,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
   });
 }
 

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -99,6 +99,7 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       tested_version: '2.0.0',
       architecture: 'x64',
       outcome: 'Failed',
+      installer_sha256: 'A'.repeat(64),
       tested_at_utc: '2026-08-07T12:00:00Z',
       overall_duration_seconds: 30,
       installer_type: 'zip',
@@ -135,9 +136,9 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     expect(result).toMatchObject({
       success: false,
       skipped: true,
-      code: 'QA_FAILED_CURRENT_VERSION',
+      code: 'QA_NOT_PASSED_CURRENT_VERSION',
     });
-    expect(result.skipReason).toContain('uninstall command');
+    expect(result.skipReason).toContain('exact QA pass');
     expect(createHistorySpy).not.toHaveBeenCalled();
   });
 

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -15,7 +15,8 @@ import {
 } from '@/types/update-policies';
 import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
 import { getCatalogSource } from '@/lib/catalog';
-import { describeQaGateError, enforceQaGate, QaGateError } from '@/lib/qa/gate';
+import { describeQaGateError, enforceQaGate, isQaGateError } from '@/lib/qa/gate';
+import { normalizeInstallerSha256, selectWingetInstaller } from '@/lib/qa/candidate';
 
 interface TriggerResult {
   success: boolean;
@@ -24,7 +25,7 @@ interface TriggerResult {
   error?: string;
   skipped?: boolean;
   skipReason?: string;
-  code?: 'QA_FAILED_CURRENT_VERSION';
+  code?: 'QA_FAILED_CURRENT_VERSION' | 'QA_NOT_PASSED_CURRENT_VERSION';
 }
 
 interface UpdateInfo {
@@ -180,9 +181,11 @@ export class AutoUpdateTrigger {
           wingetId: updateInfo.wingetId,
           version: updateInfo.latestVersion,
           architecture: deploymentConfig.architecture,
+          installerSha256: updateInfo.installerSha256,
+          requirePassed: true,
         });
       } catch (error) {
-        if (error instanceof QaGateError) {
+        if (isQaGateError(error)) {
           return {
             success: false,
             skipped: true,
@@ -703,7 +706,8 @@ export function createAutoUpdateTrigger(): AutoUpdateTrigger | null {
 export async function getLatestInstallerInfo(
   // Kept for call-site compatibility; the catalog source owns client creation.
   _supabase: SupabaseClient,
-  wingetId: string
+  wingetId: string,
+  architecture?: string
 ): Promise<UpdateInfo | null> {
   const catalog = getCatalogSource();
 
@@ -724,31 +728,30 @@ export async function getLatestInstallerInfo(
     return null;
   }
 
-  // Extract installer details (prefer x64 architecture)
+  // Bind the selected installer to the deployment's requested architecture.
   let installerUrl = versionInfo.installer_url;
   let installerSha256 = versionInfo.installer_sha256;
   let installerType = versionInfo.installer_type;
   let nestedInstallerType: string | undefined;
   let nestedInstallerPath: string | undefined;
 
-  // If there are architecture-specific installers, prefer x64
-  // Note: The installers JSONB uses PascalCase from winget manifests
+  // The installers JSONB uses PascalCase from WinGet manifests.
   if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
-    const x64Installer = versionInfo.installers.find(
-      (i: { Architecture?: string }) => i.Architecture === 'x64'
-    );
-    if (x64Installer) {
-      installerUrl = x64Installer.InstallerUrl || installerUrl;
-      installerSha256 = x64Installer.InstallerSha256 || installerSha256;
-      installerType = x64Installer.InstallerType || installerType;
-      nestedInstallerType = x64Installer.NestedInstallerType || undefined;
-      nestedInstallerPath = Array.isArray(x64Installer.NestedInstallerFiles)
-        ? x64Installer.NestedInstallerFiles[0]?.RelativeFilePath
-        : undefined;
-    }
+    const selectedInstaller = selectWingetInstaller(versionInfo.installers, architecture);
+    if (!selectedInstaller) return null;
+    installerUrl = selectedInstaller.InstallerUrl || installerUrl;
+    installerSha256 = selectedInstaller.InstallerSha256 || installerSha256;
+    installerType = selectedInstaller.InstallerType || installerType;
+    nestedInstallerType = selectedInstaller.NestedInstallerType || undefined;
+    nestedInstallerPath = Array.isArray(selectedInstaller.NestedInstallerFiles)
+      ? selectedInstaller.NestedInstallerFiles[0]?.RelativeFilePath
+      : undefined;
+  } else if (architecture) {
+    return null;
   }
 
-  if (!installerUrl) {
+  const normalizedSha256 = normalizeInstallerSha256(installerSha256);
+  if (!installerUrl || !normalizedSha256) {
     return null;
   }
 
@@ -758,7 +761,7 @@ export async function getLatestInstallerInfo(
     latestVersion: curatedApp.latest_version,
     displayName: curatedApp.name,
     installerUrl,
-    installerSha256: installerSha256 || '',
+    installerSha256: normalizedSha256,
     installerType: installerType || 'exe',
     nestedInstallerType,
     nestedInstallerPath,

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -118,6 +118,7 @@ const qaResults = [
     tested_version: '120.0',
     architecture: 'x64',
     outcome: 'Passed',
+    installer_sha256: 'A'.repeat(64),
     tested_at_utc: '2026-01-03T00:00:00Z',
     overall_duration_seconds: 12.5,
     installer_type: 'msi',

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -20,6 +20,7 @@ import type { LocaleVariant } from '@/types/winget';
 import type { CuratedAppMatch } from '@/lib/app-mappings';
 import type { InstallationSnapshot } from '@/lib/winget-api';
 import type {
+  QaCandidateStatusRow,
   QaChanges,
   QaDetectionRule,
   QaEnvironment,
@@ -583,6 +584,11 @@ export class SnapshotCatalogSource implements CatalogSource {
       },
       () => null
     );
+  }
+
+  async getQaCandidateStatuses(_ids: string[]): Promise<QaCandidateStatusRow[]> {
+    // Candidate state is operational and intentionally absent from snapshots.
+    return [];
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -18,7 +18,7 @@ import { getLocaleDisplay } from '@/lib/locale-utils';
 import type { LocaleVariant } from '@/types/winget';
 import type { CuratedAppMatch } from '@/lib/app-mappings';
 import type { InstallationSnapshot } from '@/lib/winget-api';
-import type { QaResultRow, QaStatusRow } from '@/types/qa';
+import type { QaCandidateStatusRow, QaResultRow, QaStatusRow } from '@/types/qa';
 import type {
   CatalogSource,
   CategoryCount,
@@ -382,7 +382,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     const { data, error } = await supabase
       .from('qa_results')
       .select(
-        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, qa_schema_version, synced_at'
+        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, installer_sha256, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, qa_schema_version, synced_at'
       )
       .eq('winget_id', wingetId)
       .maybeSingle();
@@ -393,6 +393,29 @@ export class SupabaseCatalogSource implements CatalogSource {
     }
 
     return (data as QaResultRow | null) || null;
+  }
+
+  async getQaCandidateStatuses(ids: string[]): Promise<QaCandidateStatusRow[]> {
+    if (ids.length === 0) return [];
+    const supabase = serviceOrAnonClient();
+    if (!supabase) return [];
+
+    const { data, error } = await supabase
+      .from('qa_candidates')
+      .select('winget_id, version, architecture, installer_sha256, status, enqueued_at, started_at')
+      .in('winget_id', ids)
+      .in('status', ['queued', 'dispatched', 'running'])
+      .order('enqueued_at', { ascending: false });
+    if (error) {
+      console.error('Failed to read QA candidate statuses:', error.message);
+      return [];
+    }
+
+    const latest = new Map<string, QaCandidateStatusRow>();
+    for (const row of (data || []) as QaCandidateStatusRow[]) {
+      if (!latest.has(row.winget_id)) latest.set(row.winget_id, row);
+    }
+    return [...latest.values()];
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -16,7 +16,7 @@ import type { LocaleVariant } from '@/types/winget';
 import type { SccmMatchResult } from '@/lib/matching/sccm-matcher';
 import type { CuratedAppMatch } from '@/lib/app-mappings';
 import type { InstallationSnapshot } from '@/lib/winget-api';
-import type { QaResultRow, QaStatusRow } from '@/types/qa';
+import type { QaCandidateStatusRow, QaResultRow, QaStatusRow } from '@/types/qa';
 
 /**
  * Raw row returned by the search_curated_apps / get_popular_curated_apps RPCs.
@@ -213,6 +213,9 @@ export interface CatalogSource {
 
   /** Compact QA badge rows for a visible set of catalog apps. */
   getQaStatuses(ids: string[]): Promise<QaStatusRow[]>;
+
+  /** Latest active queued/running candidate for each requested app. */
+  getQaCandidateStatuses(ids: string[]): Promise<QaCandidateStatusRow[]>;
 
   /** Latest compact QA result for one catalog app. */
   getQaResult(wingetId: string): Promise<QaResultRow | null>;

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -129,6 +129,20 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('binds a required QA pass to the dispatched installer SHA', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const sha = 'A'.repeat(64);
+    await triggerPackagingWorkflow(
+      workflowInputs({ wingetId: 'Example.App', installerSha256: sha, sourceType: 'winget' }),
+      config,
+      { skipRunCapture: true, requireQaPass: true }
+    );
+    expect(enforceQaGateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ installerSha256: sha, requirePassed: true })
+    );
+  });
+
   it('uses qaOverride only at the server gate and does not forward it to GitHub', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -104,7 +104,7 @@ export interface TriggerResult {
 export async function triggerPackagingWorkflow(
   inputs: WorkflowInputs,
   config?: GitHubActionsConfig,
-  options?: { skipRunCapture?: boolean }
+  options?: { skipRunCapture?: boolean; requireQaPass?: boolean }
 ): Promise<TriggerResult> {
   const cfg = config || getGitHubActionsConfig();
 
@@ -131,6 +131,8 @@ export async function triggerPackagingWorkflow(
     wingetId: inputs.wingetId,
     version: inputs.version,
     architecture: inputs.architecture,
+    installerSha256: inputs.installerSha256,
+    requirePassed: options?.requireQaPass,
     qaOverride: inputs.qaOverride,
     sourceType: inputs.sourceType,
   });

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeInstallerSha256,
+  normalizeQaArchitecture,
+  normalizeQaInstallerType,
+  selectWingetInstaller,
+} from './candidate';
+
+describe('QA candidate normalization', () => {
+  const installers = [
+    { Architecture: 'x86', InstallerUrl: 'https://example.test/x86.exe' },
+    { Architecture: 'x64', InstallerUrl: 'https://example.test/x64.exe' },
+  ];
+
+  it('selects the exact requested architecture', () => {
+    expect(selectWingetInstaller(installers, 'x86')?.InstallerUrl).toContain('x86');
+    expect(selectWingetInstaller(installers, 'x64')?.InstallerUrl).toContain('x64');
+  });
+
+  it('does not silently substitute a different architecture', () => {
+    expect(selectWingetInstaller(installers, 'arm64')).toBeNull();
+    expect(normalizeQaArchitecture(undefined)).toBe('x64');
+  });
+
+  it('accepts and uppercases only complete SHA-256 values', () => {
+    expect(normalizeInstallerSha256('a'.repeat(64))).toBe('A'.repeat(64));
+    expect(normalizeInstallerSha256('abc')).toBe('');
+  });
+
+  it('maps WinGet technology-specific types to supported package types', () => {
+    expect(normalizeQaInstallerType('inno', 'exe')).toBe('exe');
+    expect(normalizeQaInstallerType('nullsoft', 'exe')).toBe('exe');
+    expect(normalizeQaInstallerType('wix', 'exe')).toBe('msi');
+    expect(normalizeQaInstallerType('portable', 'exe')).toBe('exe');
+  });
+});

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -1,0 +1,52 @@
+export interface WingetInstallerCandidate {
+  Architecture?: string;
+  InstallerUrl?: string;
+  InstallerSha256?: string;
+  InstallerType?: string;
+  NestedInstallerType?: string;
+  NestedInstallerFiles?: Array<{ RelativeFilePath?: string }>;
+}
+
+const SUPPORTED_ARCHITECTURES = new Set(['x64', 'x86', 'arm64']);
+
+export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 'arm64' {
+  const normalized = value?.trim().toLowerCase();
+  return SUPPORTED_ARCHITECTURES.has(normalized || '')
+    ? (normalized as 'x64' | 'x86' | 'arm64')
+    : 'x64';
+}
+
+/** Select the exact architecture requested by a deployment or QA recipe. */
+export function selectWingetInstaller(
+  installers: WingetInstallerCandidate[] | null | undefined,
+  architecture?: string | null
+): WingetInstallerCandidate | null {
+  if (!installers?.length) return null;
+  const target = normalizeQaArchitecture(architecture);
+  return (
+    installers.find((installer) => installer.Architecture?.toLowerCase() === target) ||
+    installers.find((installer) => installer.Architecture?.toLowerCase() === 'neutral') ||
+    null
+  );
+}
+
+export function normalizeInstallerSha256(value?: string | null): string {
+  const normalized = value?.trim().toUpperCase() || '';
+  return /^[A-F0-9]{64}$/.test(normalized) ? normalized : '';
+}
+
+export function normalizeQaInstallerType(
+  wingetType?: string | null,
+  recipeType: string = 'exe'
+): 'exe' | 'msi' | 'msix' | 'appx' | 'zip' {
+  const normalized = wingetType?.trim().toLowerCase();
+  if (normalized === 'wix' || normalized === 'msi') return 'msi';
+  if (['inno', 'nullsoft', 'burn', 'exe'].includes(normalized || '')) return 'exe';
+  if (normalized === 'msix') return 'msix';
+  if (normalized === 'appx') return 'appx';
+  if (normalized === 'zip') return 'zip';
+  const fallback = recipeType.trim().toLowerCase();
+  return ['exe', 'msi', 'msix', 'appx', 'zip'].includes(fallback)
+    ? (fallback as 'exe' | 'msi' | 'msix' | 'appx' | 'zip')
+    : 'exe';
+}

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { dispatchQaCandidate } from './dispatch';
+
+vi.mock('@/lib/github-actions', () => ({
+  getGitHubActionsConfig: () => ({
+    token: 'secret-token',
+    owner: 'example',
+    workflowsRepo: 'workflows',
+    ref: 'main',
+  }),
+}));
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('dispatchQaCandidate', () => {
+  it('dispatches only exact public candidate metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await dispatchQaCandidate({
+      id: '11111111-1111-4111-8111-111111111111',
+      definition_path: 'qa/apps/example.app.json',
+      version: '2.0.0',
+      installer_url: 'https://example.test/setup.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_file_name: 'setup.exe',
+      installer_type: 'exe',
+    });
+
+    const [url, request] = fetchMock.mock.calls[0];
+    expect(url).toContain('/actions/workflows/intune-qa.yml/dispatches');
+    const body = JSON.parse(String((request as RequestInit).body));
+    expect(body.inputs).toMatchObject({
+      app_definition: 'qa/apps/example.app.json',
+    });
+    expect(JSON.parse(body.inputs.candidate_payload)).toMatchObject({
+      version: '2.0.0',
+      installerSha256: 'A'.repeat(64),
+    });
+    expect(JSON.stringify(body)).not.toContain('secret-token');
+  });
+
+  it('surfaces a rejected GitHub dispatch', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('denied', { status: 403 })));
+    await expect(
+      dispatchQaCandidate({
+        id: '11111111-1111-4111-8111-111111111111',
+        definition_path: 'qa/apps/example.app.json',
+        version: '2.0.0',
+        installer_url: 'https://example.test/setup.exe',
+        installer_sha256: 'A'.repeat(64),
+        installer_file_name: 'setup.exe',
+        installer_type: 'exe',
+      })
+    ).rejects.toThrow('403');
+  });
+});

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -1,0 +1,46 @@
+import { getGitHubActionsConfig } from '@/lib/github-actions';
+
+export interface QaDispatchCandidate {
+  id: string;
+  definition_path: string;
+  version: string;
+  installer_url: string;
+  installer_sha256: string;
+  installer_file_name: string;
+  installer_type: string;
+}
+
+export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promise<void> {
+  const config = getGitHubActionsConfig();
+  const url = `https://api.github.com/repos/${config.owner}/${config.workflowsRepo}/actions/workflows/intune-qa.yml/dispatches`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      ref: config.ref,
+      inputs: {
+        smoke_test: 'false',
+        app_definition: candidate.definition_path,
+        candidate_payload: JSON.stringify({
+          id: candidate.id,
+          version: candidate.version,
+          installerUrl: candidate.installer_url,
+          installerSha256: candidate.installer_sha256,
+          installerFileName: candidate.installer_file_name,
+          installerType: candidate.installer_type,
+        }),
+        timeout_minutes: '60',
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 1000);
+    throw new Error(`QA workflow dispatch failed (${response.status}): ${detail}`);
+  }
+}

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -6,7 +6,9 @@ vi.mock('@/lib/catalog', () => ({
   getCatalogSource: () => ({ getQaResult: getQaResultMock }),
 }));
 
-import { enforceQaGate, QaGateError } from './gate';
+import { enforceQaGate, QaGateError, QaGateNotPassedError } from './gate';
+
+const installerSha256 = 'A'.repeat(64);
 
 const failedRow = {
   winget_id: 'OpenJS.NodeJS',
@@ -15,6 +17,7 @@ const failedRow = {
   tested_version: '26.7.0',
   architecture: 'x64',
   outcome: 'Failed',
+  installer_sha256: installerSha256,
   tested_at_utc: '2026-08-07T12:00:00Z',
   overall_duration_seconds: 30,
   installer_type: 'msi',
@@ -59,5 +62,51 @@ describe('enforceQaGate', () => {
     ).resolves.toBeUndefined();
     getQaResultMock.mockResolvedValue(null);
     await expect(enforceQaGate({ wingetId: 'Unknown.App', version: '1.0' })).resolves.toBeUndefined();
+  });
+
+  it('allows only an exact passed candidate when requirePassed is enabled', async () => {
+    getQaResultMock.mockResolvedValue({ ...failedRow, outcome: 'Passed' });
+    await expect(
+      enforceQaGate({
+        wingetId: 'OpenJS.NodeJS',
+        version: '26.7.0',
+        architecture: 'x64',
+        installerSha256: installerSha256.toLowerCase(),
+        requirePassed: true,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['missing', null, '26.7.0', 'x64', installerSha256],
+    ['failed', failedRow, '26.7.0', 'x64', installerSha256],
+    ['stale version', { ...failedRow, outcome: 'Passed' }, '26.8.0', 'x64', installerSha256],
+    ['wrong architecture', { ...failedRow, outcome: 'Passed' }, '26.7.0', 'arm64', installerSha256],
+    ['wrong SHA', { ...failedRow, outcome: 'Passed' }, '26.7.0', 'x64', 'B'.repeat(64)],
+  ])('blocks a %s candidate in strict mode', async (_label, row, version, architecture, sha) => {
+    getQaResultMock.mockResolvedValue(row);
+    await expect(
+      enforceQaGate({
+        wingetId: 'OpenJS.NodeJS',
+        version: String(version),
+        architecture: String(architecture),
+        installerSha256: String(sha),
+        requirePassed: true,
+      })
+    ).rejects.toBeInstanceOf(QaGateNotPassedError);
+  });
+
+  it('does not allow a manual override to bypass strict automatic QA', async () => {
+    getQaResultMock.mockResolvedValue(null);
+    await expect(
+      enforceQaGate({
+        wingetId: 'OpenJS.NodeJS',
+        version: '26.7.0',
+        architecture: 'x64',
+        installerSha256,
+        requirePassed: true,
+        qaOverride: true,
+      })
+    ).rejects.toBeInstanceOf(QaGateNotPassedError);
   });
 });

--- a/lib/qa/gate.ts
+++ b/lib/qa/gate.ts
@@ -21,7 +21,35 @@ export class QaGateError extends Error {
   }
 }
 
-export function describeQaGateError(error: QaGateError): string {
+export class QaGateNotPassedError extends Error {
+  readonly code = 'QA_NOT_PASSED_CURRENT_VERSION' as const;
+
+  constructor(
+    readonly details: {
+      wingetId: string;
+      version: string;
+      architecture: string;
+      installerSha256: string;
+      reason: 'missing' | 'failed' | 'version' | 'architecture' | 'installer_sha256';
+    }
+  ) {
+    super(
+      `Awaiting an exact QA pass for ${details.wingetId} ${details.version} (${details.architecture}, ${details.installerSha256.slice(0, 8) || 'no hash'})`
+    );
+    this.name = 'QaGateNotPassedError';
+  }
+}
+
+export type AnyQaGateError = QaGateError | QaGateNotPassedError;
+
+export function isQaGateError(error: unknown): error is AnyQaGateError {
+  return error instanceof QaGateError || error instanceof QaGateNotPassedError;
+}
+
+export function describeQaGateError(error: AnyQaGateError): string {
+  if (error instanceof QaGateNotPassedError) {
+    return `${error.message}. Automatic deployment will resume after that exact installer has passed isolated QA.`;
+  }
   const { classification, testedAtUtc } = error.details;
   return [
     error.message,
@@ -35,12 +63,39 @@ export async function enforceQaGate(input: {
   wingetId: string;
   version: string;
   architecture?: string;
+  installerSha256?: string;
+  requirePassed?: boolean;
   qaOverride?: boolean;
   sourceType?: 'winget' | 'custom';
 }): Promise<void> {
-  if (input.qaOverride || input.sourceType === 'custom') return;
+  if (input.sourceType === 'custom' || (!input.requirePassed && input.qaOverride)) return;
 
   const row = await getCatalogSource().getQaResult(input.wingetId);
+  if (input.requirePassed) {
+    const architecture = (input.architecture || 'x64').toLowerCase();
+    const installerSha256 = input.installerSha256?.trim().toUpperCase() || '';
+    const reason = !row
+      ? 'missing'
+      : row.outcome !== 'Passed'
+        ? 'failed'
+        : row.tested_version !== input.version
+          ? 'version'
+          : row.architecture.toLowerCase() !== architecture
+            ? 'architecture'
+            : !installerSha256 || row.installer_sha256?.toUpperCase() !== installerSha256
+              ? 'installer_sha256'
+              : null;
+
+    if (!reason) return;
+    throw new QaGateNotPassedError({
+      wingetId: input.wingetId,
+      version: input.version,
+      architecture,
+      installerSha256,
+      reason,
+    });
+  }
+
   if (
     !row ||
     row.outcome !== 'Failed' ||

--- a/lib/qa/status.test.ts
+++ b/lib/qa/status.test.ts
@@ -23,4 +23,11 @@ describe('deriveQaBadgeState', () => {
     expect(deriveQaBadgeState(passed, '8.9.70')).toBe('stale_passed');
     expect(deriveQaBadgeState({ ...passed, outcome: 'Failed' }, '8.9.8')).toBe('stale_failed');
   });
+
+  it('shows active candidate states even while the catalog version catches up', () => {
+    const running: QaStatus = { ...passed, outcome: 'Running', testedVersion: '9.0.0' };
+    expect(deriveQaBadgeState(running, '9.0.0')).toBe('running');
+    expect(deriveQaBadgeState({ ...running, outcome: 'Queued' }, '9.0.0')).toBe('queued');
+    expect(deriveQaBadgeState(running, '8.9.7')).toBe('running');
+  });
 });

--- a/lib/qa/status.ts
+++ b/lib/qa/status.ts
@@ -11,6 +11,10 @@ export function deriveQaBadgeState(
 ): QaBadgeState {
   if (!qa) return 'untested';
 
+  if (qa.outcome === 'Queued' || qa.outcome === 'Running') {
+    return qa.outcome.toLowerCase() as 'queued' | 'running';
+  }
+
   const stale = !catalogVersion || qa.testedVersion !== catalogVersion;
   if (stale) {
     return qa.outcome === 'Passed' ? 'stale_passed' : 'stale_failed';
@@ -19,7 +23,7 @@ export function deriveQaBadgeState(
 }
 
 export function toQaStatus(row: {
-  outcome: QaStatus['outcome'];
+  outcome: 'Passed' | 'Failed';
   tested_version: string;
   architecture: QaStatus['architecture'];
   tested_at_utc: string;
@@ -29,5 +33,22 @@ export function toQaStatus(row: {
     testedVersion: row.tested_version,
     architecture: row.architecture,
     testedAtUtc: row.tested_at_utc,
+  };
+}
+
+export function toQaCandidateStatus(row: {
+  status: 'queued' | 'dispatched' | 'running';
+  version: string;
+  architecture: QaStatus['architecture'];
+  installer_sha256: string;
+  enqueued_at: string;
+  started_at: string | null;
+}): QaStatus {
+  return {
+    outcome: row.status === 'running' ? 'Running' : 'Queued',
+    testedVersion: row.version,
+    architecture: row.architecture,
+    testedAtUtc: row.started_at || row.enqueued_at,
+    installerSha256: row.installer_sha256,
   };
 }

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -51,7 +51,7 @@ const SCCM_COLUMNS = [
 ];
 const QA_COLUMNS = [
   'winget_id', 'display_name', 'publisher', 'tested_version', 'architecture',
-  'outcome', 'tested_at_utc', 'overall_duration_seconds', 'installer_type',
+  'outcome', 'installer_sha256', 'tested_at_utc', 'overall_duration_seconds', 'installer_type',
   'install_command', 'uninstall_command', 'detection', 'phase_results', 'changes',
   'relevant_event_count', 'environment', 'qa_schema_version', 'synced_at',
 ];
@@ -117,6 +117,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       CREATE TABLE qa_results (
         winget_id TEXT PRIMARY KEY, display_name TEXT NOT NULL, publisher TEXT NOT NULL,
         tested_version TEXT NOT NULL, architecture TEXT NOT NULL, outcome TEXT NOT NULL,
+        installer_sha256 TEXT,
         tested_at_utc TEXT NOT NULL, overall_duration_seconds REAL, installer_type TEXT,
         install_command TEXT NOT NULL, uninstall_command TEXT NOT NULL,
         detection TEXT NOT NULL, phase_results TEXT NOT NULL, changes TEXT,
@@ -146,11 +147,11 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
        VALUES (@id,@sccm_display_name_normalized,@sccm_ci_id,@sccm_product_code,@winget_package_id,
        @winget_package_name,@confidence,@is_verified)`);
     const insQa = db.prepare(`INSERT OR REPLACE INTO qa_results
-      (winget_id, display_name, publisher, tested_version, architecture, outcome,
+      (winget_id, display_name, publisher, tested_version, architecture, outcome, installer_sha256,
        tested_at_utc, overall_duration_seconds, installer_type, install_command,
        uninstall_command, detection, phase_results, changes, relevant_event_count,
        environment, qa_schema_version, synced_at)
-      VALUES (@winget_id,@display_name,@publisher,@tested_version,@architecture,@outcome,
+      VALUES (@winget_id,@display_name,@publisher,@tested_version,@architecture,@outcome,@installer_sha256,
        @tested_at_utc,@overall_duration_seconds,@installer_type,@install_command,
        @uninstall_command,@detection,@phase_results,@changes,@relevant_event_count,
        @environment,@qa_schema_version,@synced_at)`);
@@ -198,6 +199,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           tested_version: q.tested_version,
           architecture: q.architecture,
           outcome: q.outcome,
+          installer_sha256: q.installer_sha256 ?? null,
           tested_at_utc: q.tested_at_utc,
           overall_duration_seconds: q.overall_duration_seconds ?? null,
           installer_type: q.installer_type ?? null,

--- a/supabase/migrations/20260807193111_qa_release_gate.sql
+++ b/supabase/migrations/20260807193111_qa_release_gate.sql
@@ -1,0 +1,227 @@
+-- Bind public QA results to the exact installer payload and add the small,
+-- idempotent release-candidate queue used by the 10-minute QA automation.
+alter table public.qa_results
+  add column if not exists installer_sha256 text
+  check (installer_sha256 is null or installer_sha256 ~ '^[A-F0-9]{64}$');
+
+create table public.qa_recipes (
+  winget_id text primary key,
+  definition_path text not null check (
+    definition_path ~ '^qa/apps/[A-Za-z0-9._+-]+\.json$'
+  ),
+  architecture text not null check (architecture in ('x64', 'x86', 'arm64')),
+  installer_type text not null,
+  active boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.qa_recipes is
+  'Public, non-secret index of the application definitions supported by isolated QA automation.';
+
+create table public.qa_candidates (
+  id uuid primary key default gen_random_uuid(),
+  winget_id text not null references public.qa_recipes(winget_id),
+  definition_path text not null,
+  version text not null,
+  architecture text not null check (architecture in ('x64', 'x86', 'arm64')),
+  installer_url text not null check (installer_url ~ '^https://'),
+  installer_sha256 text not null check (installer_sha256 ~ '^[A-F0-9]{64}$'),
+  installer_type text not null,
+  installer_file_name text not null check (
+    installer_file_name <> '' and installer_file_name !~ '[\\/:*?"<>|]'
+  ),
+  status text not null default 'queued' check (
+    status in ('queued', 'dispatched', 'running', 'passed', 'failed', 'error', 'superseded')
+  ),
+  priority integer not null default 0,
+  attempts integer not null default 0 check (attempts >= 0),
+  enqueued_at timestamptz not null default now(),
+  dispatched_at timestamptz,
+  started_at timestamptz,
+  finished_at timestamptz,
+  github_run_id text,
+  github_run_url text,
+  failure_summary text,
+  updated_at timestamptz not null default now(),
+  unique (winget_id, version, architecture, installer_sha256)
+);
+
+create index qa_candidates_dispatch_idx
+  on public.qa_candidates(priority desc, enqueued_at asc)
+  where status = 'queued';
+create index qa_candidates_active_idx
+  on public.qa_candidates(updated_at asc)
+  where status in ('dispatched', 'running');
+create unique index qa_candidates_single_active_idx
+  on public.qa_candidates ((true))
+  where status in ('dispatched', 'running');
+create index qa_candidates_app_idx
+  on public.qa_candidates(winget_id, architecture, enqueued_at desc);
+
+comment on table public.qa_candidates is
+  'Exact WinGet release candidates awaiting or completing isolated Hyper-V QA.';
+
+alter table public.qa_recipes enable row level security;
+alter table public.qa_candidates enable row level security;
+
+revoke all on table public.qa_recipes from public, anon, authenticated;
+revoke all on table public.qa_candidates from public, anon, authenticated;
+grant select on table public.qa_recipes to anon, authenticated;
+grant select on table public.qa_candidates to anon, authenticated;
+grant select, insert, update, delete on table public.qa_recipes to service_role;
+grant select, insert, update, delete on table public.qa_candidates to service_role;
+
+create policy "QA recipes are publicly readable"
+  on public.qa_recipes for select to anon, authenticated using (true);
+create policy "QA candidate states are publicly readable"
+  on public.qa_candidates for select to anon, authenticated using (true);
+
+-- Keep the original three-argument sync RPC working during the coordinated
+-- rollout. V2 delegates its reconciliation to that function, then adds the
+-- exact SHA and recipe mirror in the same transaction.
+create or replace function public.sync_qa_results_v2(
+  p_secret text,
+  p_rows jsonb,
+  p_recipes jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  sync_result jsonb;
+begin
+  sync_result := public.sync_qa_results(p_secret, p_rows, p_allow_large_delete);
+
+  update public.qa_results result
+  set installer_sha256 = upper(row_data.installer_sha256)
+  from jsonb_to_recordset(p_rows) as row_data(
+    winget_id text,
+    installer_sha256 text
+  )
+  where result.winget_id = row_data.winget_id;
+
+  if jsonb_typeof(p_recipes) <> 'array' or jsonb_array_length(p_recipes) = 0 then
+    raise exception 'At least one canonical QA recipe is required';
+  end if;
+
+  update public.qa_recipes set active = false, updated_at = now();
+
+  insert into public.qa_recipes (
+    winget_id,
+    definition_path,
+    architecture,
+    installer_type,
+    active,
+    updated_at
+  )
+  select
+    recipe.winget_id,
+    recipe.definition_path,
+    recipe.architecture,
+    recipe.installer_type,
+    true,
+    now()
+  from jsonb_to_recordset(p_recipes) as recipe(
+    winget_id text,
+    definition_path text,
+    architecture text,
+    installer_type text
+  )
+  on conflict (winget_id) do update set
+    definition_path = excluded.definition_path,
+    architecture = excluded.architecture,
+    installer_type = excluded.installer_type,
+    active = true,
+    updated_at = excluded.updated_at;
+
+  return sync_result || jsonb_build_object('recipes', jsonb_array_length(p_recipes));
+end;
+$$;
+
+create or replace function public.mark_qa_candidate_running(
+  p_secret text,
+  p_candidate_id uuid,
+  p_run_id text,
+  p_run_url text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  update public.qa_candidates
+  set status = 'running',
+      started_at = now(),
+      github_run_id = p_run_id,
+      github_run_url = p_run_url,
+      failure_summary = null,
+      updated_at = now()
+  where id = p_candidate_id and status = 'dispatched';
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+create or replace function public.report_qa_candidate_result(
+  p_secret text,
+  p_candidate_id uuid,
+  p_outcome text,
+  p_summary text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  normalized_outcome text := lower(coalesce(p_outcome, ''));
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if normalized_outcome not in ('passed', 'failed', 'error', 'retry') then
+    raise exception 'Invalid QA candidate outcome';
+  end if;
+
+  update public.qa_candidates
+  set status = case
+        when normalized_outcome = 'retry' and attempts < 2 then 'queued'
+        when normalized_outcome = 'retry' then 'error'
+        else normalized_outcome
+      end,
+      dispatched_at = case when normalized_outcome = 'retry' then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' then null else github_run_url end,
+      finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
+      failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
+      updated_at = now()
+  where id = p_candidate_id and status in ('dispatched', 'running');
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  from public, authenticated, service_role;
+revoke all on function public.mark_qa_candidate_running(text, uuid, text, text)
+  from public, authenticated, service_role;
+revoke all on function public.report_qa_candidate_result(text, uuid, text, text)
+  from public, authenticated, service_role;
+
+grant execute on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean) to anon;
+grant execute on function public.mark_qa_candidate_running(text, uuid, text, text) to anon;
+grant execute on function public.report_qa_candidate_result(text, uuid, text, text) to anon;

--- a/supabase/migrations/20260807193111_qa_release_gate.sql
+++ b/supabase/migrations/20260807193111_qa_release_gate.sql
@@ -107,7 +107,7 @@ begin
     raise exception 'At least one canonical QA recipe is required';
   end if;
 
-  update public.qa_recipes set active = false, updated_at = now();
+  update public.qa_recipes set active = false, updated_at = now() where active = true;
 
   insert into public.qa_recipes (
     winget_id,

--- a/supabase/migrations/20260807201023_qa_release_gate_sync_fix.sql
+++ b/supabase/migrations/20260807201023_qa_release_gate_sync_fix.sql
@@ -1,0 +1,69 @@
+-- Production enables safe-update protection, which requires an explicit WHERE
+-- clause even for an intentional full-table recipe deactivation.
+create or replace function public.sync_qa_results_v2(
+  p_secret text,
+  p_rows jsonb,
+  p_recipes jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  sync_result jsonb;
+begin
+  sync_result := public.sync_qa_results(p_secret, p_rows, p_allow_large_delete);
+
+  update public.qa_results result
+  set installer_sha256 = upper(row_data.installer_sha256)
+  from jsonb_to_recordset(p_rows) as row_data(
+    winget_id text,
+    installer_sha256 text
+  )
+  where result.winget_id = row_data.winget_id;
+
+  if jsonb_typeof(p_recipes) <> 'array' or jsonb_array_length(p_recipes) = 0 then
+    raise exception 'At least one canonical QA recipe is required';
+  end if;
+
+  update public.qa_recipes
+  set active = false, updated_at = now()
+  where active = true;
+
+  insert into public.qa_recipes (
+    winget_id,
+    definition_path,
+    architecture,
+    installer_type,
+    active,
+    updated_at
+  )
+  select
+    recipe.winget_id,
+    recipe.definition_path,
+    recipe.architecture,
+    recipe.installer_type,
+    true,
+    now()
+  from jsonb_to_recordset(p_recipes) as recipe(
+    winget_id text,
+    definition_path text,
+    architecture text,
+    installer_type text
+  )
+  on conflict (winget_id) do update set
+    definition_path = excluded.definition_path,
+    architecture = excluded.architecture,
+    installer_type = excluded.installer_type,
+    active = true,
+    updated_at = excluded.updated_at;
+
+  return sync_result || jsonb_build_object('recipes', jsonb_array_length(p_recipes));
+end;
+$$;
+
+revoke all on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  from public, authenticated, service_role;
+grant execute on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean) to anon;

--- a/types/database.ts
+++ b/types/database.ts
@@ -30,6 +30,7 @@ export interface Database {
           publisher: string;
           tested_version: string;
           architecture: string;
+          installer_sha256: string | null;
           outcome: string;
           tested_at_utc: string;
           overall_duration_seconds: number | null;
@@ -53,6 +54,7 @@ export interface Database {
           publisher: string;
           tested_version: string;
           architecture: string;
+          installer_sha256?: string | null;
           outcome: string;
           tested_at_utc: string;
           overall_duration_seconds?: number | null;
@@ -76,6 +78,7 @@ export interface Database {
           publisher?: string;
           tested_version?: string;
           architecture?: string;
+          installer_sha256?: string | null;
           outcome?: string;
           tested_at_utc?: string;
           overall_duration_seconds?: number | null;
@@ -93,6 +96,81 @@ export interface Database {
           qa_schema_version?: number;
           synced_at?: string;
         };
+        Relationships: GenericRelationship[];
+      };
+      qa_recipes: {
+        Row: {
+          winget_id: string;
+          definition_path: string;
+          architecture: string;
+          installer_type: string;
+          active: boolean;
+          updated_at: string;
+        };
+        Insert: {
+          winget_id: string;
+          definition_path: string;
+          architecture: string;
+          installer_type: string;
+          active?: boolean;
+          updated_at?: string;
+        };
+        Update: {
+          winget_id?: string;
+          definition_path?: string;
+          architecture?: string;
+          installer_type?: string;
+          active?: boolean;
+          updated_at?: string;
+        };
+        Relationships: GenericRelationship[];
+      };
+      qa_candidates: {
+        Row: {
+          id: string;
+          winget_id: string;
+          definition_path: string;
+          version: string;
+          architecture: string;
+          installer_url: string;
+          installer_sha256: string;
+          installer_type: string;
+          installer_file_name: string;
+          status: string;
+          priority: number;
+          attempts: number;
+          enqueued_at: string;
+          dispatched_at: string | null;
+          started_at: string | null;
+          finished_at: string | null;
+          github_run_id: string | null;
+          github_run_url: string | null;
+          failure_summary: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          winget_id: string;
+          definition_path: string;
+          version: string;
+          architecture: string;
+          installer_url: string;
+          installer_sha256: string;
+          installer_type: string;
+          installer_file_name: string;
+          status?: string;
+          priority?: number;
+          attempts?: number;
+          enqueued_at?: string;
+          dispatched_at?: string | null;
+          started_at?: string | null;
+          finished_at?: string | null;
+          github_run_id?: string | null;
+          github_run_url?: string | null;
+          failure_summary?: string | null;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['qa_candidates']['Insert']>;
         Relationships: GenericRelationship[];
       };
       user_profiles: {

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -59,10 +59,21 @@ export interface QaStatusRow {
   tested_at_utc: string;
 }
 
+export interface QaCandidateStatusRow {
+  winget_id: string;
+  version: string;
+  architecture: QaArchitecture;
+  installer_sha256: string;
+  status: 'queued' | 'dispatched' | 'running';
+  enqueued_at: string;
+  started_at: string | null;
+}
+
 /** Full compact database row used only when details or the gate are requested. */
 export interface QaResultRow extends QaStatusRow {
   display_name: string;
   publisher: string;
+  installer_sha256: string | null;
   overall_duration_seconds: number | null;
   installer_type: string | null;
   install_command: string;
@@ -77,10 +88,11 @@ export interface QaResultRow extends QaStatusRow {
 }
 
 export interface QaStatus {
-  outcome: QaOutcome;
+  outcome: QaOutcome | 'Queued' | 'Running';
   testedVersion: string;
   architecture: QaArchitecture;
   testedAtUtc: string;
+  installerSha256?: string;
 }
 
 export type QaBadgeState =
@@ -88,6 +100,8 @@ export type QaBadgeState =
   | 'failed'
   | 'stale_passed'
   | 'stale_failed'
+  | 'queued'
+  | 'running'
   | 'untested';
 
 export type QaFailureBucket =

--- a/types/update-policies.ts
+++ b/types/update-policies.ts
@@ -213,7 +213,7 @@ export interface TriggerUpdateResponse {
     tenant_id: string;
     success: boolean;
     skipped?: boolean;
-    code?: 'QA_FAILED_CURRENT_VERSION';
+    code?: 'QA_FAILED_CURRENT_VERSION' | 'QA_NOT_PASSED_CURRENT_VERSION';
     packaging_job_id?: string;
     error?: string;
   }[];

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,14 @@
       "schedule": "30 3 * * *"
     },
     {
+      "path": "/api/cron/qa-enqueue",
+      "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/qa-dispatch",
+      "schedule": "5-59/10 * * * *"
+    },
+    {
       "path": "/api/cron/send-notifications",
       "schedule": "0 4 * * *"
     },


### PR DESCRIPTION
## What changed

- Fail closed for automatic WinGet updates unless the exact package ID, version, architecture, and installer SHA-256 has Passed isolated QA.
- Treat missing/stale/mismatched QA as an “awaiting QA” skip before job/history creation, so policy circuit breakers are not incremented.
- Add the additive `qa_candidates` state machine and `qa_recipes` index with RLS and secret-pinned candidate RPCs.
- Poll supported WinGet recipes every 10 minutes, including same-version hash changes; prioritize apps used by enabled auto-update policies.
- Dispatch one QA candidate at a time, retry an interrupted run once, and provide CRON-secret-protected operator recovery.
- Show Queued and Running on app cards, then Passed/Failed from the compact result.
- Carry installer SHA into Supabase and public catalog snapshots.

## Why

The former gate blocked only a known exact Failed result. Missing, stale, architecture-mismatched, and same-version/different-binary results all passed through, so an automatic customer update could deploy before the tested payload was known to be safe.

## Product impact

All WinGet update actions—including user-initiated **Update now**—now wait for an exact QA pass. Apps outside the current six canonical recipes therefore pause safely until recipe coverage is added. Fresh/manual app deployments and custom installers retain their existing behavior.

## Coordinated rollout

1. Apply the additive `20260807193111_qa_release_gate.sql` migration.
2. Merge companion workflow PR ugurkocde/IntuneGet-Workflows#28.
3. Run **Sync QA Results** once to populate recipe/SHA data.
4. Merge this PR so the strict gate and 10-minute crons deploy only after their dependencies exist.

## Validation

- Claude Code Fable planned the architecture and performed two final diff reviews; no high findings remain.
- Production Next.js build and TypeScript check passed.
- ESLint passed.
- Focused QA suite: 55/55 tests passed.
- Full suite: 551/552 initially passed; the sole unrelated translation timeout passed immediately in isolation.
- Workflow Node tests/dry-run/definition validation passed.
- Local YAML validation confirmed 9 workflow-dispatch inputs.