### PR TITLE
Preserve terminal QA run evidence

### DIFF
--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { dispatchQaCandidate } from '@/lib/qa/dispatch';
+import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
 const RUN_TIMEOUT_MS = 5 * 60 * 60 * 1000;
@@ -26,19 +27,10 @@ export async function GET(request: Request) {
     const timeout = candidate.status === 'running' ? RUN_TIMEOUT_MS : DISPATCH_TIMEOUT_MS;
     if (timestamp && now.getTime() - new Date(timestamp).getTime() <= timeout) continue;
 
-    const exhausted = candidate.attempts >= MAX_ATTEMPTS;
+    const recovery = qaTimeoutRecoveryUpdate(candidate, now.toISOString(), MAX_ATTEMPTS);
     const { error } = await supabase
       .from('qa_candidates')
-      .update({
-        status: exhausted ? 'error' : 'queued',
-        dispatched_at: null,
-        started_at: null,
-        github_run_id: null,
-        github_run_url: null,
-        finished_at: exhausted ? now.toISOString() : null,
-        failure_summary: exhausted ? 'QA workflow did not report completion before the safety timeout.' : null,
-        updated_at: now.toISOString(),
-      })
+      .update(recovery)
       .eq('id', candidate.id)
       .eq('status', candidate.status);
     if (error) throw error;

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationPaths = [
+  'supabase/migrations/20260807193111_qa_release_gate.sql',
+  'supabase/migrations/20260807205000_qa_candidate_terminal_evidence.sql',
+];
+
+describe.each(migrationPaths)('QA candidate migration contract: %s', (migrationPath) => {
+  const sql = readFileSync(resolve(process.cwd(), migrationPath), 'utf8');
+
+  it('only clears per-attempt evidence when another retry will run', () => {
+    for (const column of ['dispatched_at', 'started_at', 'github_run_id', 'github_run_url']) {
+      expect(sql).toContain(
+        `${column} = case when normalized_outcome = 'retry' and attempts < 2 then null else ${column} end`
+      );
+    }
+  });
+
+  it('keeps terminal retry exhaustion distinct from a re-queued retry', () => {
+    expect(sql).toContain("when normalized_outcome = 'retry' and attempts < 2 then 'queued'");
+    expect(sql).toContain("when normalized_outcome = 'retry' then 'error'");
+  });
+});

--- a/lib/qa/recovery.test.ts
+++ b/lib/qa/recovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { qaTimeoutRecoveryUpdate } from './recovery';
+
+const execution = {
+  attempts: 1,
+  dispatched_at: '2026-08-07T20:35:20.000Z',
+  started_at: '2026-08-07T20:35:37.000Z',
+  github_run_id: '31216520295',
+  github_run_url: 'https://github.com/example/workflows/actions/runs/31216520295',
+};
+
+describe('qaTimeoutRecoveryUpdate', () => {
+  it('clears per-attempt evidence when the candidate will be retried', () => {
+    expect(qaTimeoutRecoveryUpdate(execution, '2026-08-07T20:50:00.000Z', 2)).toMatchObject({
+      status: 'queued',
+      dispatched_at: null,
+      started_at: null,
+      github_run_id: null,
+      github_run_url: null,
+      finished_at: null,
+      failure_summary: null,
+    });
+  });
+
+  it('preserves final-run evidence when the timeout exhausts retries', () => {
+    expect(
+      qaTimeoutRecoveryUpdate(
+        { ...execution, attempts: 2 },
+        '2026-08-07T20:50:00.000Z',
+        2
+      )
+    ).toEqual({
+      status: 'error',
+      dispatched_at: execution.dispatched_at,
+      started_at: execution.started_at,
+      github_run_id: execution.github_run_id,
+      github_run_url: execution.github_run_url,
+      finished_at: '2026-08-07T20:50:00.000Z',
+      failure_summary: 'QA workflow did not report completion before the safety timeout.',
+      updated_at: '2026-08-07T20:50:00.000Z',
+    });
+  });
+});

--- a/lib/qa/recovery.ts
+++ b/lib/qa/recovery.ts
@@ -1,0 +1,27 @@
+interface QaExecutionEvidence {
+  attempts: number;
+  dispatched_at: string | null;
+  started_at: string | null;
+  github_run_id: string | null;
+  github_run_url: string | null;
+}
+
+export function qaTimeoutRecoveryUpdate(
+  candidate: QaExecutionEvidence,
+  now: string,
+  maxAttempts: number
+) {
+  const exhausted = candidate.attempts >= maxAttempts;
+  return {
+    status: exhausted ? ('error' as const) : ('queued' as const),
+    dispatched_at: exhausted ? candidate.dispatched_at : null,
+    started_at: exhausted ? candidate.started_at : null,
+    github_run_id: exhausted ? candidate.github_run_id : null,
+    github_run_url: exhausted ? candidate.github_run_url : null,
+    finished_at: exhausted ? now : null,
+    failure_summary: exhausted
+      ? 'QA workflow did not report completion before the safety timeout.'
+      : null,
+    updated_at: now,
+  };
+}

--- a/supabase/migrations/20260807193111_qa_release_gate.sql
+++ b/supabase/migrations/20260807193111_qa_release_gate.sql
@@ -202,10 +202,10 @@ begin
         when normalized_outcome = 'retry' then 'error'
         else normalized_outcome
       end,
-      dispatched_at = case when normalized_outcome = 'retry' then null else dispatched_at end,
-      started_at = case when normalized_outcome = 'retry' then null else started_at end,
-      github_run_id = case when normalized_outcome = 'retry' then null else github_run_id end,
-      github_run_url = case when normalized_outcome = 'retry' then null else github_run_url end,
+      dispatched_at = case when normalized_outcome = 'retry' and attempts < 2 then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_url end,
       finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
       failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
       updated_at = now()

--- a/supabase/migrations/20260807205000_qa_candidate_terminal_evidence.sql
+++ b/supabase/migrations/20260807205000_qa_candidate_terminal_evidence.sql
@@ -1,0 +1,48 @@
+-- Preserve the final protected workflow reference when an infrastructure
+-- retry exhausts its two attempts. A retry that is actually re-queued still
+-- clears per-attempt execution metadata before the next dispatch.
+create or replace function public.report_qa_candidate_result(
+  p_secret text,
+  p_candidate_id uuid,
+  p_outcome text,
+  p_summary text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  normalized_outcome text := lower(coalesce(p_outcome, ''));
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if normalized_outcome not in ('passed', 'failed', 'error', 'retry') then
+    raise exception 'Invalid QA candidate outcome';
+  end if;
+
+  update public.qa_candidates
+  set status = case
+        when normalized_outcome = 'retry' and attempts < 2 then 'queued'
+        when normalized_outcome = 'retry' then 'error'
+        else normalized_outcome
+      end,
+      dispatched_at = case when normalized_outcome = 'retry' and attempts < 2 then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_url end,
+      finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
+      failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
+      updated_at = now()
+  where id = p_candidate_id and status in ('dispatched', 'running');
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.report_qa_candidate_result(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.report_qa_candidate_result(text, uuid, text, text) to anon;


### PR DESCRIPTION
## What changed

- Preserve the final GitHub run ID, URL, and timestamps when an automated QA retry exhausts its two attempts.
- Keep clearing per-attempt evidence when a candidate is genuinely re-queued.
- Apply the same policy to the scheduled timeout reconciler.
- Add an additive Supabase migration plus regression tests for the SQL and TypeScript paths.

## Production observation

The first live automatic candidate correctly blocked Google Chrome 151.0.7922.76 because the installer served by Google did not match the SHA-256 declared by WinGet. After the second attempt, the candidate correctly became `error`, but the retry RPC cleared its final run link. This PR fixes only that evidence-loss defect; it does not weaken SHA verification or retry limits.

## Review and validation

- Claude Code Fable reviewed the SQL hotfix and timeout parity change: no high or medium findings.
- Focused tests: 6/6 passed.
- Focused and full pre-commit ESLint passed.
- Next.js production build and application TypeScript check passed.
- The standalone `tsc --noEmit` command still reports pre-existing test-global/test-fixture errors; project CI uses the passing production build path.

## Rollout

The additive database migration was applied first. The terminal Chrome record was repaired with its final run link. Merge this PR to deploy the timeout-reconciler parity fix and track the migration.