### PR TITLE
Monitor the full supported app catalog for QA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,12 @@ GITHUB_WORKFLOWS_REPO=IntuneGet-Workflows
 # Generate with: openssl rand -hex 16
 CALLBACK_SECRET=your-32-char-random-secret
 
+# Operational QA alerts. Every partial or failed poll is always emitted to
+# Vercel runtime logs. Configure either destination for direct notifications.
+QA_ALERT_EMAIL=                    # Requires RESEND_API_KEY
+QA_ALERT_WEBHOOK_URL=              # HTTPS endpoint
+QA_ALERT_WEBHOOK_BEARER_TOKEN=     # Optional Authorization bearer token
+
 # ===========================================
 # Application URL
 # ===========================================

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createServerClientMock,
+  createManifestClientMock,
+  detectWingetChangesMock,
+  resolveManifestMock,
+} = vi.hoisted(() => ({
+  createServerClientMock: vi.fn(),
+  createManifestClientMock: vi.fn(() => ({ kind: 'manifest-client' })),
+  detectWingetChangesMock: vi.fn(),
+  resolveManifestMock: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
+vi.mock('@/lib/qa/winget-changes', () => ({ detectWingetChanges: detectWingetChangesMock }));
+vi.mock('@/lib/winget-sync-resolution.mjs', () => ({
+  createWingetManifestClient: createManifestClientMock,
+  resolveWingetManifest: resolveManifestMock,
+}));
+
+import { GET } from './route';
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string; code?: string } | null;
+  count?: number | null;
+};
+
+function query(result: QueryResult) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'neq', 'in', 'order', 'limit']) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.single = vi.fn(async () => result);
+  builder.maybeSingle = vi.fn(async () => result);
+  builder.then = (
+    onFulfilled?: (value: QueryResult) => unknown,
+    onRejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return builder;
+}
+
+function createSupabaseStub(options: {
+  coverage?: number;
+  coverageError?: string;
+  supportedApps?: Array<Record<string, unknown>>;
+  recipes?: Array<Record<string, unknown>>;
+}) {
+  const pollRunInserts: Array<Record<string, unknown>> = [];
+  const pollRunUpdates: Array<Record<string, unknown>> = [];
+  const cursorUpdates: Array<Record<string, unknown>> = [];
+
+  const client = {
+    from: vi.fn((table: string) => {
+      if (table === 'qa_poll_runs') {
+        return {
+          insert: vi.fn((row: Record<string, unknown>) => {
+            pollRunInserts.push(row);
+            return query({ data: { id: 'poll-run-1' }, error: null });
+          }),
+          update: vi.fn((row: Record<string, unknown>) => {
+            pollRunUpdates.push(row);
+            return query({ data: null, error: null });
+          }),
+        };
+      }
+      if (table === 'curated_apps') {
+        return {
+          select: vi.fn((_columns: string, selectOptions?: { head?: boolean }) =>
+            query(
+              selectOptions?.head
+                ? {
+                    data: null,
+                    count: options.coverage ?? 14_062,
+                    error: options.coverageError ? { message: options.coverageError } : null,
+                  }
+                : { data: options.supportedApps || [], error: null }
+            )
+          ),
+        };
+      }
+      if (table === 'qa_winget_poll_state') {
+        return {
+          select: vi.fn(() => query({ data: { head_sha: 'a'.repeat(40), last_checked_at: null }, error: null })),
+          update: vi.fn((row: Record<string, unknown>) => {
+            cursorUpdates.push(row);
+            return query({ data: null, error: null });
+          }),
+        };
+      }
+      if (table === 'qa_recipes') {
+        return query({ data: options.recipes || [], error: null });
+      }
+      if (table === 'app_update_policies' || table === 'qa_results') {
+        return query({ data: [], error: null });
+      }
+      if (table === 'qa_candidates') {
+        return {
+          insert: vi.fn(() => query({ data: { id: 'candidate-1' }, error: null })),
+          update: vi.fn(() => query({ data: null, error: null })),
+          select: vi.fn(() => query({ data: null, error: null })),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+  };
+  return { client, pollRunInserts, pollRunUpdates, cursorUpdates };
+}
+
+function cronRequest(): Request {
+  return new Request('https://intuneget.com/api/cron/qa-enqueue', {
+    headers: {
+      authorization: 'Bearer test-cron-secret',
+      'x-vercel-id': 'fra1::request-1',
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  process.env.CRON_SECRET = 'test-cron-secret';
+  detectWingetChangesMock.mockResolvedValue({
+    baseSha: 'a'.repeat(40),
+    headSha: 'b'.repeat(40),
+    changedFiles: 0,
+    changedPackageIds: [],
+    initialized: false,
+  });
+});
+
+afterEach(() => {
+  delete process.env.CRON_SECRET;
+  vi.restoreAllMocks();
+});
+
+describe('GET /api/cron/qa-enqueue', () => {
+  it('persists a successful full-catalog poll and advances its cursor', async () => {
+    const { client, pollRunInserts, pollRunUpdates, cursorUpdates } = createSupabaseStub({});
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      runId: 'poll-run-1',
+      coveredApps: 14_062,
+      checked: 0,
+      errorCount: 0,
+    });
+    expect(pollRunInserts).toEqual([expect.objectContaining({ request_id: 'fra1::request-1' })]);
+    expect(cursorUpdates).toEqual([expect.objectContaining({ head_sha: 'b'.repeat(40) })]);
+    expect(pollRunUpdates).toEqual([
+      expect.objectContaining({
+        status: 'succeeded',
+        recipe_count: 14_062,
+        changed_package_count: 0,
+        supported_changed_count: 0,
+      }),
+    ]);
+  });
+
+  it('records a changed supported app failure without advancing the cursor', async () => {
+    detectWingetChangesMock.mockResolvedValue({
+      baseSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+      changedFiles: 2,
+      changedPackageIds: ['Example.App'],
+      initialized: false,
+    });
+    const { client, pollRunUpdates, cursorUpdates } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockRejectedValue(new Error('GitHub returned HTTP 503'));
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(207);
+    expect(body).toMatchObject({
+      success: false,
+      checked: 1,
+      supportedChangedCount: 1,
+      errorCount: 1,
+      errors: ['Example.App: GitHub returned HTTP 503'],
+    });
+    expect(cursorUpdates).toHaveLength(0);
+    expect(pollRunUpdates[0]).toMatchObject({ status: 'partial', error_count: 1 });
+  });
+
+  it('persists systemic catalog failures with a 500 response', async () => {
+    const { client, pollRunUpdates } = createSupabaseStub({ coverageError: 'database unavailable' });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.errors).toEqual([
+      'system: Could not count the supported QA catalog: database unavailable',
+    ]);
+    expect(pollRunUpdates[0]).toMatchObject({ status: 'failed', error_count: 1 });
+  });
+});

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -1,16 +1,31 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import {
+  emitQaPollAlert,
+  qaPollRunStatus,
+  structuredQaPollLog,
+  type QaPollAlertDelivery,
+  type QaPollRunStatus,
+  type QaPollSummary,
+} from '@/lib/qa/poll-observability';
+import {
   normalizeInstallerSha256,
   normalizeQaInstallerType,
+  selectQaVmInstaller,
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
+import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
+import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
   resolveWingetManifest,
 } from '@/lib/winget-sync-resolution.mjs';
 
 const BATCH_SIZE = 3;
+const POLL_STATE_ID = 'microsoft/winget-pkgs';
+const INITIAL_LOOKBACK_MINUTES = 30;
+const MAX_RECORDED_ERRORS = 100;
+const MAX_ERROR_LENGTH = 1_000;
 
 function installerFileName(installerUrl: string, installerType: string): string {
   try {
@@ -22,163 +37,460 @@ function installerFileName(installerUrl: string, installerType: string): string 
   return `installer.${installerType || 'exe'}`;
 }
 
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, MAX_ERROR_LENGTH);
+}
+
+function recordPollError(summary: QaPollSummary, scope: string, error: unknown): void {
+  summary.errorCount++;
+  if (summary.errors.length < MAX_RECORDED_ERRORS) {
+    summary.errors.push(`${scope}: ${errorMessage(error)}`);
+  }
+}
+
 export async function GET(request: Request) {
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const supabase = createServerClient();
-  const [{ data: recipes, error: recipeError }, { data: policies, error: policyError }, { data: results, error: resultError }] =
-    await Promise.all([
-      supabase.from('qa_recipes').select('*').eq('active', true),
-      supabase
-        .from('app_update_policies')
-        .select('winget_id')
-        .eq('policy_type', 'auto_update')
-        .eq('is_enabled', true),
-      supabase
-        .from('qa_results')
-        .select('winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc'),
-    ]);
-  if (recipeError) throw new Error(`Could not read QA recipes: ${recipeError.message}`);
-  if (policyError) throw new Error(`Could not prioritize QA recipes: ${policyError.message}`);
-  if (resultError) throw new Error(`Could not read existing QA results: ${resultError.message}`);
+  const startedAt = new Date().toISOString();
+  const startedAtMs = Date.now();
+  const requestId = request.headers.get('x-vercel-id');
+  const summary: QaPollSummary = {
+    checked: 0,
+    updatesFound: 0,
+    queued: 0,
+    alreadyKnown: 0,
+    unavailable: 0,
+    errorCount: 0,
+    errors: [],
+  };
+  let recipeCount = 0;
+  let changedPackageCount = 0;
+  let supportedChangedCount = 0;
+  let baseSha: string | null = null;
+  let headSha: string | null = null;
+  let runId: string | null = null;
+  let supabase: ReturnType<typeof createServerClient> | null = null;
 
-  const priorities = new Map<string, number>();
-  for (const policy of policies || []) {
-    priorities.set(policy.winget_id, (priorities.get(policy.winget_id) || 0) + 1);
-  }
-  const resultById = new Map((results || []).map((row) => [row.winget_id, row]));
-  const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
-  const summary = { checked: 0, queued: 0, alreadyKnown: 0, unavailable: 0, errors: [] as string[] };
-
-  for (let index = 0; index < (recipes || []).length; index += BATCH_SIZE) {
-    const batch = (recipes || []).slice(index, index + BATCH_SIZE);
-    await Promise.all(
-      batch.map(async (recipe) => {
-        summary.checked++;
-        try {
-          const resolution = await resolveWingetManifest({
-            client,
-            wingetId: recipe.winget_id,
-            storedVersion: undefined,
-            preferLive: true,
-          });
-          if (resolution.status !== 'resolved') {
-            summary.unavailable++;
-            return;
-          }
-
-          const manifest = resolution.manifest as Record<string, unknown>;
-          const installers = (manifest.Installers || []) as Array<Record<string, unknown>>;
-          const selected = selectWingetInstaller(installers, recipe.architecture);
-          const installerUrl = String(selected?.InstallerUrl || '');
-          const installerSha256 = normalizeInstallerSha256(String(selected?.InstallerSha256 || ''));
-          const installerType = normalizeQaInstallerType(
-            String(selected?.InstallerType || manifest.InstallerType || ''),
-            recipe.installer_type
-          );
-          if (!installerUrl.startsWith('https://') || !installerSha256) {
-            throw new Error('resolved installer is missing a valid HTTPS URL or SHA-256');
-          }
-
-          const previous = resultById.get(recipe.winget_id);
-          const previousMatches = Boolean(
-            previous &&
-              previous.tested_version === resolution.version &&
-              previous.architecture.toLowerCase() === recipe.architecture.toLowerCase() &&
-              previous.installer_sha256?.toUpperCase() === installerSha256
-          );
-          const now = new Date().toISOString();
-          const initialStatus = previousMatches
-            ? previous?.outcome === 'Passed'
-              ? 'passed'
-              : 'failed'
-            : 'queued';
-          const { data: inserted, error: insertError } = await supabase
-            .from('qa_candidates')
-            .insert({
-              winget_id: recipe.winget_id,
-              definition_path: recipe.definition_path,
-              version: resolution.version,
-              architecture: recipe.architecture,
-              installer_url: installerUrl,
-              installer_sha256: installerSha256,
-              installer_type: installerType,
-              installer_file_name: installerFileName(installerUrl, installerType),
-              status: initialStatus,
-              priority: priorities.get(recipe.winget_id) || 0,
-              finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
-              updated_at: now,
-            })
-            .select('id')
-            .single();
-
-          if (insertError?.code === '23505') {
-            summary.alreadyKnown++;
-            const { data: existing } = await supabase
-              .from('qa_candidates')
-              .select('id, status')
-              .eq('winget_id', recipe.winget_id)
-              .eq('version', resolution.version)
-              .eq('architecture', recipe.architecture)
-              .eq('installer_sha256', installerSha256)
-              .maybeSingle();
-            if (existing?.status === 'superseded') {
-              await supabase
-                .from('qa_candidates')
-                .update({
-                  status: 'queued',
-                  priority: priorities.get(recipe.winget_id) || 0,
-                  attempts: 0,
-                  finished_at: null,
-                  failure_summary: null,
-                  updated_at: now,
-                })
-                .eq('id', existing.id)
-                .eq('status', 'superseded');
-              await supabase
-                .from('qa_candidates')
-                .update({ status: 'superseded', finished_at: now, updated_at: now })
-                .eq('winget_id', recipe.winget_id)
-                .eq('architecture', recipe.architecture)
-                .eq('status', 'queued')
-                .neq('id', existing.id);
-            } else if (existing?.status === 'queued') {
-              await supabase
-                .from('qa_candidates')
-                .update({ priority: priorities.get(recipe.winget_id) || 0, updated_at: now })
-                .eq('id', existing.id)
-                .eq('status', 'queued');
-            }
-            return;
-          }
-          if (insertError) throw insertError;
-          if (initialStatus !== 'queued') {
-            summary.alreadyKnown++;
-            return;
-          }
-
-          summary.queued++;
-          await supabase
-            .from('qa_candidates')
-            .update({ status: 'superseded', finished_at: now, updated_at: now })
-            .eq('winget_id', recipe.winget_id)
-            .eq('architecture', recipe.architecture)
-            .eq('status', 'queued')
-            .neq('id', inserted.id);
-        } catch (error) {
-          summary.errors.push(`${recipe.winget_id}: ${error instanceof Error ? error.message : String(error)}`);
-        }
+  const persistRun = async (
+    status: QaPollRunStatus,
+    durationMs: number,
+    alertDelivery: QaPollAlertDelivery | null
+  ) => {
+    if (!supabase || !runId) return;
+    const { error } = await supabase
+      .from('qa_poll_runs')
+      .update({
+        status,
+        finished_at: new Date().toISOString(),
+        duration_ms: durationMs,
+        recipe_count: recipeCount,
+        checked_count: summary.checked,
+        updates_found_count: summary.updatesFound,
+        queued_count: summary.queued,
+        already_known_count: summary.alreadyKnown,
+        unavailable_count: summary.unavailable,
+        error_count: summary.errorCount,
+        errors: summary.errors,
+        alert_delivery: alertDelivery,
+        base_sha: baseSha,
+        head_sha: headSha,
+        changed_package_count: changedPackageCount,
+        supported_changed_count: supportedChangedCount,
       })
+      .eq('id', runId);
+    if (error) throw new Error(`Could not finalize QA poll run ${runId}: ${error.message}`);
+  };
+
+  try {
+    supabase = createServerClient();
+    const { data: pollRun, error: pollRunError } = await supabase
+      .from('qa_poll_runs')
+      .insert({ request_id: requestId, started_at: startedAt })
+      .select('id')
+      .single();
+    if (pollRunError) throw new Error(`Could not create QA poll run: ${pollRunError.message}`);
+    runId = pollRun.id;
+
+    const [coverageResult, stateResult] = await Promise.all([
+      supabase
+        .from('curated_apps')
+        .select('winget_id', { count: 'exact', head: true })
+        .eq('is_verified', true)
+        .eq('is_winget_verified', true)
+        .eq('app_source', 'win32')
+        .eq('is_locale_variant', false),
+      supabase
+        .from('qa_winget_poll_state')
+        .select('head_sha, last_checked_at')
+        .eq('id', POLL_STATE_ID)
+        .maybeSingle(),
+    ]);
+    if (coverageResult.error) {
+      throw new Error(`Could not count the supported QA catalog: ${coverageResult.error.message}`);
+    }
+    if (stateResult.error) {
+      throw new Error(`Could not read the WinGet poll cursor: ${stateResult.error.message}`);
+    }
+    recipeCount = coverageResult.count || 0;
+    baseSha = stateResult.data?.head_sha || null;
+
+    const lookbackStart = new Date(
+      Date.now() - INITIAL_LOOKBACK_MINUTES * 60 * 1000
+    ).toISOString();
+    const changes = await detectWingetChanges({
+      token: process.env.GITHUB_PAT,
+      baseSha,
+      since: stateResult.data?.last_checked_at || lookbackStart,
+    });
+    baseSha = changes.baseSha;
+    headSha = changes.headSha;
+    changedPackageCount = changes.changedPackageIds.length;
+
+    structuredQaPollLog('info', 'qa_poll_started', {
+      runId,
+      requestId,
+      startedAt,
+      coveredApps: recipeCount,
+      baseSha,
+      headSha,
+      changedPackageCount,
+    });
+
+    let supportedApps: Array<{
+      winget_id: string;
+      name: string;
+      publisher: string;
+    }> = [];
+    if (changes.changedPackageIds.length > 0) {
+      const { data, error } = await supabase
+        .from('curated_apps')
+        .select('winget_id, name, publisher')
+        .in('winget_id', changes.changedPackageIds)
+        .eq('is_verified', true)
+        .eq('is_winget_verified', true)
+        .eq('app_source', 'win32')
+        .eq('is_locale_variant', false);
+      if (error) throw new Error(`Could not filter changed WinGet packages: ${error.message}`);
+      supportedApps = data || [];
+    }
+    supportedChangedCount = supportedApps.length;
+
+    const supportedIds = supportedApps.map((app) => app.winget_id);
+    let recipes: Array<{
+      winget_id: string;
+      definition_path: string;
+      architecture: string;
+      installer_type: string;
+    }> = [];
+    let policies: Array<{ winget_id: string }> = [];
+    let results: Array<{
+      winget_id: string;
+      tested_version: string;
+      architecture: string;
+      installer_sha256: string | null;
+      outcome: string;
+      tested_at_utc: string;
+    }> = [];
+    if (supportedIds.length > 0) {
+      const [recipeResult, policyResult, resultResult] = await Promise.all([
+        supabase
+          .from('qa_recipes')
+          .select('winget_id, definition_path, architecture, installer_type')
+          .in('winget_id', supportedIds)
+          .eq('active', true),
+        supabase
+          .from('app_update_policies')
+          .select('winget_id')
+          .in('winget_id', supportedIds)
+          .eq('policy_type', 'auto_update')
+          .eq('is_enabled', true),
+        supabase
+          .from('qa_results')
+          .select(
+            'winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc'
+          )
+          .in('winget_id', supportedIds),
+      ]);
+      if (recipeResult.error) {
+        throw new Error(`Could not read optional QA recipes: ${recipeResult.error.message}`);
+      }
+      if (policyResult.error) {
+        throw new Error(`Could not prioritize QA candidates: ${policyResult.error.message}`);
+      }
+      if (resultResult.error) {
+        throw new Error(`Could not read existing QA results: ${resultResult.error.message}`);
+      }
+      recipes = recipeResult.data || [];
+      policies = policyResult.data || [];
+      results = resultResult.data || [];
+    }
+
+    const priorities = new Map<string, number>();
+    for (const policy of policies) {
+      priorities.set(policy.winget_id, (priorities.get(policy.winget_id) || 0) + 1);
+    }
+    const recipeById = new Map(recipes.map((row) => [row.winget_id, row]));
+    const resultById = new Map(results.map((row) => [row.winget_id, row]));
+    const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
+
+    for (let index = 0; index < supportedApps.length; index += BATCH_SIZE) {
+      const batch = supportedApps.slice(index, index + BATCH_SIZE);
+      await Promise.all(
+        batch.map(async (app) => {
+          summary.checked++;
+          try {
+            const recipe = recipeById.get(app.winget_id);
+            const resolution = await resolveWingetManifest({
+              client,
+              wingetId: app.winget_id,
+              storedVersion: undefined,
+              preferLive: true,
+            });
+            if (resolution.status !== 'resolved') {
+              summary.unavailable++;
+              return;
+            }
+
+            const manifest = resolution.manifest as Record<string, unknown>;
+            const installers = (manifest.Installers || []) as Array<Record<string, unknown>>;
+            const selectedForVm = recipe
+              ? (() => {
+                  const installer = selectWingetInstaller(installers, recipe.architecture);
+                  return installer
+                    ? { installer, architecture: recipe.architecture as 'x64' | 'x86' | 'arm64' }
+                    : null;
+                })()
+              : selectQaVmInstaller(installers);
+            if (!selectedForVm) {
+              summary.unavailable++;
+              return;
+            }
+            const selected = selectedForVm.installer as Record<string, unknown>;
+            const installerUrl = String(selected.InstallerUrl || '');
+            const installerSha256 = normalizeInstallerSha256(
+              String(selected.InstallerSha256 || '')
+            );
+            const sourceInstallerType = String(
+              selected.InstallerType || manifest.InstallerType || ''
+            );
+            const installerType = normalizeQaInstallerType(
+              sourceInstallerType,
+              recipe?.installer_type || 'exe'
+            );
+            if (!installerUrl.startsWith('https://') || !installerSha256) {
+              throw new Error('resolved installer is missing a valid HTTPS URL or SHA-256');
+            }
+
+            const previous = resultById.get(app.winget_id);
+            const architecture = selectedForVm.architecture;
+            const previousMatches = Boolean(
+              previous &&
+                previous.tested_version === resolution.version &&
+                previous.architecture.toLowerCase() === architecture.toLowerCase() &&
+                previous.installer_sha256?.toUpperCase() === installerSha256
+            );
+            const now = new Date().toISOString();
+            const initialStatus = previousMatches
+              ? previous?.outcome === 'Passed'
+                ? 'passed'
+                : 'failed'
+              : 'queued';
+            const testConfig = buildQaCatalogTestConfig({
+              app,
+              manifest,
+              installer: selectedForVm.installer as never,
+            });
+            const { data: inserted, error: insertError } = await supabase!
+              .from('qa_candidates')
+              .insert({
+                winget_id: app.winget_id,
+                definition_path: recipe?.definition_path || null,
+                version: resolution.version,
+                architecture,
+                installer_url: installerUrl,
+                installer_sha256: installerSha256,
+                installer_type: installerType,
+                installer_file_name: installerFileName(installerUrl, installerType),
+                test_config: testConfig,
+                status: initialStatus,
+                priority: priorities.get(app.winget_id) || 0,
+                finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
+                updated_at: now,
+              })
+              .select('id')
+              .single();
+
+            if (insertError?.code === '23505') {
+              summary.alreadyKnown++;
+              const { data: existing, error: existingError } = await supabase!
+                .from('qa_candidates')
+                .select('id, status')
+                .eq('winget_id', app.winget_id)
+                .eq('version', resolution.version)
+                .eq('architecture', architecture)
+                .eq('installer_sha256', installerSha256)
+                .maybeSingle();
+              if (existingError) {
+                throw new Error(`Could not read the existing QA candidate: ${existingError.message}`);
+              }
+              if (existing?.status === 'superseded') {
+                const { error: reactivateError } = await supabase!
+                  .from('qa_candidates')
+                  .update({
+                    status: 'queued',
+                    priority: priorities.get(app.winget_id) || 0,
+                    attempts: 0,
+                    finished_at: null,
+                    failure_summary: null,
+                    test_config: testConfig,
+                    updated_at: now,
+                  })
+                  .eq('id', existing.id)
+                  .eq('status', 'superseded');
+                if (reactivateError) throw reactivateError;
+                const { error: supersedeError } = await supabase!
+                  .from('qa_candidates')
+                  .update({ status: 'superseded', finished_at: now, updated_at: now })
+                  .eq('winget_id', app.winget_id)
+                  .eq('architecture', architecture)
+                  .eq('status', 'queued')
+                  .neq('id', existing.id);
+                if (supersedeError) throw supersedeError;
+                summary.queued++;
+              } else if (existing?.status === 'queued') {
+                const { error: priorityError } = await supabase!
+                  .from('qa_candidates')
+                  .update({
+                    priority: priorities.get(app.winget_id) || 0,
+                    test_config: testConfig,
+                    updated_at: now,
+                  })
+                  .eq('id', existing.id)
+                  .eq('status', 'queued');
+                if (priorityError) throw priorityError;
+              }
+              return;
+            }
+            if (insertError) throw insertError;
+
+            summary.updatesFound++;
+            if (initialStatus !== 'queued') {
+              summary.alreadyKnown++;
+              return;
+            }
+
+            summary.queued++;
+            const { error: supersedeError } = await supabase!
+              .from('qa_candidates')
+              .update({ status: 'superseded', finished_at: now, updated_at: now })
+              .eq('winget_id', app.winget_id)
+              .eq('architecture', architecture)
+              .eq('status', 'queued')
+              .neq('id', inserted.id);
+            if (supersedeError) throw supersedeError;
+          } catch (error) {
+            recordPollError(summary, app.winget_id, error);
+          }
+        })
+      );
+    }
+
+    if (summary.errorCount === 0) {
+      const { error: cursorError } = await supabase
+        .from('qa_winget_poll_state')
+        .update({
+          head_sha: headSha,
+          last_checked_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', POLL_STATE_ID);
+      if (cursorError) throw new Error(`Could not advance the WinGet poll cursor: ${cursorError.message}`);
+    }
+
+    const status = qaPollRunStatus(summary);
+    const durationMs = Date.now() - startedAtMs;
+    const alertDelivery =
+      status === 'partial'
+        ? await emitQaPollAlert({
+            runId,
+            requestId,
+            status,
+            startedAt,
+            durationMs,
+            recipeCount,
+            summary,
+          })
+        : null;
+
+    await persistRun(status, durationMs, alertDelivery);
+    structuredQaPollLog('info', 'qa_poll_completed', {
+      runId,
+      requestId,
+      status,
+      durationMs,
+      coveredApps: recipeCount,
+      baseSha,
+      headSha,
+      changedPackageCount,
+      supportedChangedCount,
+      ...summary,
+    });
+
+    return NextResponse.json(
+      {
+        success: status === 'succeeded',
+        runId,
+        coveredApps: recipeCount,
+        recipeCount,
+        durationMs,
+        baseSha,
+        headSha,
+        changedPackageCount,
+        supportedChangedCount,
+        ...summary,
+      },
+      { status: status === 'succeeded' ? 200 : 207 }
+    );
+  } catch (error) {
+    recordPollError(summary, 'system', error);
+    const durationMs = Date.now() - startedAtMs;
+    const alertDelivery = await emitQaPollAlert({
+      runId,
+      requestId,
+      status: 'failed',
+      startedAt,
+      durationMs,
+      recipeCount,
+      summary,
+    });
+    try {
+      await persistRun('failed', durationMs, alertDelivery);
+    } catch (persistError) {
+      structuredQaPollLog('error', 'qa_poll_persistence_failed', {
+        runId,
+        requestId,
+        error: errorMessage(persistError),
+      });
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        runId,
+        coveredApps: recipeCount,
+        recipeCount,
+        durationMs,
+        baseSha,
+        headSha,
+        changedPackageCount,
+        supportedChangedCount,
+        ...summary,
+      },
+      { status: 500 }
     );
   }
-
-  return NextResponse.json(
-    { success: summary.errors.length === 0, ...summary },
-    { status: summary.errors.length === 0 ? 200 : 207 }
-  );
 }
 
 export const maxDuration = 300;

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -147,7 +147,11 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
                   <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-overlay/10 bg-bg-base p-3 text-xs text-text-secondary">{data.commands.uninstall}</pre>
                 </div>
                 <p className="text-xs text-text-secondary">
-                  Detection: file version at <code className="rounded bg-bg-base px-1 py-0.5">{data.detection.path}</code> must be at least {data.detection.minimumVersion}.
+                  {data.detection.type === 'fileVersion' ? (
+                    <>Detection: file version at <code className="rounded bg-bg-base px-1 py-0.5">{data.detection.path}</code> must be at least {data.detection.minimumVersion}.</>
+                  ) : (
+                    <>Detection: {data.detection.description}.</>
+                  )}
                 </p>
               </section>
 

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeInstallerSha256,
   normalizeQaArchitecture,
   normalizeQaInstallerType,
+  selectQaVmInstaller,
   selectWingetInstaller,
 } from './candidate';
 
@@ -20,6 +21,12 @@ describe('QA candidate normalization', () => {
   it('does not silently substitute a different architecture', () => {
     expect(selectWingetInstaller(installers, 'arm64')).toBeNull();
     expect(normalizeQaArchitecture(undefined)).toBe('x64');
+  });
+
+  it('uses x86 only as an explicit fallback supported by the x64 QA VM', () => {
+    expect(selectQaVmInstaller(installers)).toMatchObject({ architecture: 'x64' });
+    expect(selectQaVmInstaller([installers[0]])).toMatchObject({ architecture: 'x86' });
+    expect(selectQaVmInstaller([{ Architecture: 'arm64' }])).toBeNull();
   });
 
   it('accepts and uppercases only complete SHA-256 values', () => {

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -7,6 +7,11 @@ export interface WingetInstallerCandidate {
   NestedInstallerFiles?: Array<{ RelativeFilePath?: string }>;
 }
 
+export interface QaInstallerSelection {
+  installer: WingetInstallerCandidate;
+  architecture: 'x64' | 'x86';
+}
+
 const SUPPORTED_ARCHITECTURES = new Set(['x64', 'x86', 'arm64']);
 
 export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 'arm64' {
@@ -28,6 +33,21 @@ export function selectWingetInstaller(
     installers.find((installer) => installer.Architecture?.toLowerCase() === 'neutral') ||
     null
   );
+}
+
+/** Select an installer executable by the x64 QA VM (x64/neutral first, then x86). */
+export function selectQaVmInstaller(
+  installers: WingetInstallerCandidate[] | null | undefined
+): QaInstallerSelection | null {
+  if (!installers?.length) return null;
+  const x64 = installers.find((installer) => installer.Architecture?.toLowerCase() === 'x64');
+  if (x64) return { installer: x64, architecture: 'x64' };
+  const neutral = installers.find(
+    (installer) => installer.Architecture?.toLowerCase() === 'neutral'
+  );
+  if (neutral) return { installer: neutral, architecture: 'x64' };
+  const x86 = installers.find((installer) => installer.Architecture?.toLowerCase() === 'x86');
+  return x86 ? { installer: x86, architecture: 'x86' } : null;
 }
 
 export function normalizeInstallerSha256(value?: string | null): string {

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -18,12 +18,15 @@ describe('dispatchQaCandidate', () => {
     vi.stubGlobal('fetch', fetchMock);
     await dispatchQaCandidate({
       id: '11111111-1111-4111-8111-111111111111',
+      winget_id: 'Example.App',
       definition_path: 'qa/apps/example.app.json',
       version: '2.0.0',
+      architecture: 'x64',
       installer_url: 'https://example.test/setup.exe',
       installer_sha256: 'A'.repeat(64),
       installer_file_name: 'setup.exe',
       installer_type: 'exe',
+      test_config: { mode: 'catalog' },
     });
 
     const [url, request] = fetchMock.mock.calls[0];
@@ -34,6 +37,8 @@ describe('dispatchQaCandidate', () => {
     });
     expect(JSON.parse(body.inputs.candidate_payload)).toMatchObject({
       version: '2.0.0',
+      wingetId: 'Example.App',
+      architecture: 'x64',
       installerSha256: 'A'.repeat(64),
     });
     expect(JSON.stringify(body)).not.toContain('secret-token');
@@ -44,12 +49,15 @@ describe('dispatchQaCandidate', () => {
     await expect(
       dispatchQaCandidate({
         id: '11111111-1111-4111-8111-111111111111',
+        winget_id: 'Example.App',
         definition_path: 'qa/apps/example.app.json',
         version: '2.0.0',
+        architecture: 'x64',
         installer_url: 'https://example.test/setup.exe',
         installer_sha256: 'A'.repeat(64),
         installer_file_name: 'setup.exe',
         installer_type: 'exe',
+        test_config: { mode: 'catalog' },
       })
     ).rejects.toThrow('403');
   });

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -1,13 +1,17 @@
 import { getGitHubActionsConfig } from '@/lib/github-actions';
+import type { Json } from '@/types/database';
 
 export interface QaDispatchCandidate {
   id: string;
-  definition_path: string;
+  winget_id: string;
+  definition_path: string | null;
   version: string;
+  architecture: string;
   installer_url: string;
   installer_sha256: string;
   installer_file_name: string;
   installer_type: string;
+  test_config: Json;
 }
 
 export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promise<void> {
@@ -25,14 +29,17 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
       ref: config.ref,
       inputs: {
         smoke_test: 'false',
-        app_definition: candidate.definition_path,
+        app_definition: candidate.definition_path || '',
         candidate_payload: JSON.stringify({
           id: candidate.id,
+          wingetId: candidate.winget_id,
           version: candidate.version,
+          architecture: candidate.architecture,
           installerUrl: candidate.installer_url,
           installerSha256: candidate.installer_sha256,
           installerFileName: candidate.installer_file_name,
           installerType: candidate.installer_type,
+          testConfig: candidate.test_config,
         }),
         timeout_minutes: '60',
       },

--- a/lib/qa/poll-observability.test.ts
+++ b/lib/qa/poll-observability.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  emitQaPollAlert,
+  qaPollRunStatus,
+  type QaPollAlertPayload,
+  type QaPollSummary,
+} from './poll-observability';
+
+const summary: QaPollSummary = {
+  checked: 6,
+  updatesFound: 1,
+  queued: 1,
+  alreadyKnown: 5,
+  unavailable: 0,
+  errorCount: 1,
+  errors: ['Example.App: upstream unavailable'],
+};
+
+const payload: QaPollAlertPayload = {
+  runId: 'run-1',
+  requestId: 'fra1::request-1',
+  status: 'partial',
+  startedAt: '2026-08-08T01:01:17.000Z',
+  durationMs: 1_234,
+  recipeCount: 6,
+  summary,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('qaPollRunStatus', () => {
+  it('uses the full error count rather than the sampled error list', () => {
+    expect(qaPollRunStatus({ ...summary, errorCount: 2, errors: [] })).toBe('partial');
+    expect(qaPollRunStatus({ ...summary, errorCount: 0, errors: [] })).toBe('succeeded');
+  });
+});
+
+describe('emitQaPollAlert', () => {
+  it('always emits a structured Vercel error log without configured destinations', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const sendEmail = vi.fn();
+    const fetch = vi.fn();
+
+    const result = await emitQaPollAlert(
+      payload,
+      { email: null, webhookUrl: null, webhookBearerToken: null },
+      { sendEmail, fetch }
+    );
+
+    expect(result).toEqual({
+      vercelLog: 'emitted',
+      email: 'not_configured',
+      webhook: 'not_configured',
+      failures: [],
+    });
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(consoleError.mock.calls[0][0]))).toMatchObject({
+      level: 'error',
+      message: 'qa_poll_requires_attention',
+      runId: 'run-1',
+      errorCount: 1,
+    });
+  });
+
+  it('delivers configured email and webhook alerts', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const sendEmail = vi.fn().mockResolvedValue({ success: true, messageId: 'email-1' });
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+
+    const result = await emitQaPollAlert(
+      payload,
+      {
+        email: 'ops@example.com',
+        webhookUrl: 'https://alerts.example.com/qa',
+        webhookBearerToken: 'secret-token',
+      },
+      { sendEmail, fetch }
+    );
+
+    expect(result).toEqual({
+      vercelLog: 'emitted',
+      email: 'sent',
+      webhook: 'sent',
+      failures: [],
+    });
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'ops@example.com',
+        subject: '[IntuneGet QA] WinGet poll partial',
+      })
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://alerts.example.com/qa'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer secret-token',
+        },
+      })
+    );
+  });
+
+  it('records alert delivery failures without hiding the poll failure', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const sendEmail = vi.fn().mockResolvedValue({ success: false, error: 'rate limited' });
+    const fetch = vi.fn();
+
+    const result = await emitQaPollAlert(
+      payload,
+      {
+        email: 'ops@example.com',
+        webhookUrl: 'http://alerts.example.com/qa',
+        webhookBearerToken: null,
+      },
+      { sendEmail, fetch }
+    );
+
+    expect(result.email).toBe('failed');
+    expect(result.webhook).toBe('failed');
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        'webhook: QA_ALERT_WEBHOOK_URL must use HTTPS',
+        'email: rate limited',
+      ])
+    );
+    expect(fetch).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/qa/poll-observability.ts
+++ b/lib/qa/poll-observability.ts
@@ -1,0 +1,212 @@
+import { sendEmail } from '@/lib/email/service';
+import type { Json } from '@/types/database';
+
+export type QaPollRunStatus = 'succeeded' | 'partial' | 'failed';
+
+export interface QaPollSummary {
+  checked: number;
+  updatesFound: number;
+  queued: number;
+  alreadyKnown: number;
+  unavailable: number;
+  errorCount: number;
+  errors: string[];
+}
+
+export interface QaPollAlertPayload {
+  runId: string | null;
+  requestId: string | null;
+  status: Exclude<QaPollRunStatus, 'succeeded'>;
+  startedAt: string;
+  durationMs: number;
+  recipeCount: number;
+  summary: QaPollSummary;
+}
+
+export interface QaPollAlertConfig {
+  email: string | null;
+  webhookUrl: string | null;
+  webhookBearerToken: string | null;
+}
+
+export interface QaPollAlertDelivery extends Record<string, Json> {
+  vercelLog: 'emitted';
+  email: 'not_configured' | 'sent' | 'failed';
+  webhook: 'not_configured' | 'sent' | 'failed';
+  failures: string[];
+}
+
+interface QaPollAlertDependencies {
+  sendEmail: typeof sendEmail;
+  fetch: typeof fetch;
+}
+
+const DEFAULT_DEPENDENCIES: QaPollAlertDependencies = {
+  sendEmail,
+  fetch,
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function alertText(payload: QaPollAlertPayload): string {
+  const lines = [
+    `QA WinGet poll ${payload.status}`,
+    `Run: ${payload.runId || 'not persisted'}`,
+    `Request: ${payload.requestId || 'unknown'}`,
+    `Started: ${payload.startedAt}`,
+    `Duration: ${payload.durationMs} ms`,
+    `Recipes: ${payload.recipeCount}`,
+    `Checked: ${payload.summary.checked}`,
+    `Updates found: ${payload.summary.updatesFound}`,
+    `Queued: ${payload.summary.queued}`,
+    `Already known: ${payload.summary.alreadyKnown}`,
+    `Unavailable: ${payload.summary.unavailable}`,
+    `Errors: ${payload.summary.errorCount}`,
+  ];
+
+  if (payload.summary.errors.length > 0) {
+    lines.push('', ...payload.summary.errors.map((error) => `- ${error}`));
+    if (payload.summary.errorCount > payload.summary.errors.length) {
+      lines.push(
+        `- ${payload.summary.errorCount - payload.summary.errors.length} additional error(s) are stored only as a count`
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function qaPollAlertConfigFromEnvironment(): QaPollAlertConfig {
+  return {
+    email: process.env.QA_ALERT_EMAIL?.trim() || null,
+    webhookUrl: process.env.QA_ALERT_WEBHOOK_URL?.trim() || null,
+    webhookBearerToken: process.env.QA_ALERT_WEBHOOK_BEARER_TOKEN?.trim() || null,
+  };
+}
+
+export function qaPollRunStatus(summary: QaPollSummary): QaPollRunStatus {
+  return summary.errorCount > 0 ? 'partial' : 'succeeded';
+}
+
+export function structuredQaPollLog(
+  level: 'info' | 'error',
+  message: string,
+  context: Record<string, unknown>
+): void {
+  const entry = JSON.stringify({
+    level,
+    message,
+    route: '/api/cron/qa-enqueue',
+    ...context,
+  });
+
+  if (level === 'error') {
+    console.error(entry);
+  } else {
+    console.log(entry);
+  }
+}
+
+export async function emitQaPollAlert(
+  payload: QaPollAlertPayload,
+  config: QaPollAlertConfig = qaPollAlertConfigFromEnvironment(),
+  dependencies: QaPollAlertDependencies = DEFAULT_DEPENDENCIES
+): Promise<QaPollAlertDelivery> {
+  structuredQaPollLog('error', 'qa_poll_requires_attention', {
+    runId: payload.runId,
+    requestId: payload.requestId,
+    status: payload.status,
+    durationMs: payload.durationMs,
+    recipeCount: payload.recipeCount,
+    checked: payload.summary.checked,
+    updatesFound: payload.summary.updatesFound,
+    queued: payload.summary.queued,
+    alreadyKnown: payload.summary.alreadyKnown,
+    unavailable: payload.summary.unavailable,
+    errorCount: payload.summary.errorCount,
+    errors: payload.summary.errors,
+  });
+
+  const delivery: QaPollAlertDelivery = {
+    vercelLog: 'emitted',
+    email: config.email ? 'failed' : 'not_configured',
+    webhook: config.webhookUrl ? 'failed' : 'not_configured',
+    failures: [],
+  };
+  const text = alertText(payload);
+  const deliveries: Promise<void>[] = [];
+
+  if (config.email) {
+    deliveries.push(
+      dependencies
+        .sendEmail({
+          to: config.email,
+          subject: `[IntuneGet QA] WinGet poll ${payload.status}`,
+          text,
+          html: `<pre style="font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap">${escapeHtml(text)}</pre>`,
+        })
+        .then((result) => {
+          if (result.success) {
+            delivery.email = 'sent';
+            return;
+          }
+          delivery.failures.push(`email: ${result.error || 'delivery failed'}`);
+        })
+        .catch((error) => {
+          delivery.failures.push(
+            `email: ${error instanceof Error ? error.message : String(error)}`
+          );
+        })
+    );
+  }
+
+  if (config.webhookUrl) {
+    deliveries.push(
+      (async () => {
+        try {
+          const url = new URL(config.webhookUrl!);
+          if (url.protocol !== 'https:') {
+            throw new Error('QA_ALERT_WEBHOOK_URL must use HTTPS');
+          }
+          const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+          if (config.webhookBearerToken) {
+            headers.Authorization = `Bearer ${config.webhookBearerToken}`;
+          }
+          const response = await dependencies.fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ event: 'qa.poll.requires_attention', ...payload }),
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          delivery.webhook = 'sent';
+        } catch (error) {
+          delivery.failures.push(
+            `webhook: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      })()
+    );
+  }
+
+  await Promise.all(deliveries);
+
+  if (delivery.failures.length > 0) {
+    structuredQaPollLog('error', 'qa_poll_alert_delivery_failed', {
+      runId: payload.runId,
+      requestId: payload.requestId,
+      failures: delivery.failures,
+    });
+  }
+
+  return delivery;
+}

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildQaCatalogTestConfig } from './test-config';
+
+describe('buildQaCatalogTestConfig', () => {
+  it('prefers installer-specific silent switches and product metadata', () => {
+    const config = buildQaCatalogTestConfig({
+      app: { name: 'Example', publisher: 'Contoso' },
+      manifest: { InstallerType: 'exe', InstallerSwitches: { Silent: '/quiet-root' } },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'inno',
+        InstallerSwitches: { Silent: '/VERYSILENT' },
+        AppsAndFeaturesEntries: [{ ProductCode: '{00000000-0000-0000-0000-000000000001}' }],
+      },
+    });
+
+    expect(config).toMatchObject({
+      mode: 'catalog',
+      displayName: 'Example',
+      publisher: 'Contoso',
+      sourceInstallerType: 'inno',
+      silentArgs: '/VERYSILENT',
+      productCode: '{00000000-0000-0000-0000-000000000001}',
+    });
+  });
+});

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -1,0 +1,86 @@
+import type { WingetInstallerCandidate } from './candidate';
+
+export interface QaCatalogTestConfig {
+  [key: string]: string | string[];
+  mode: 'catalog';
+  displayName: string;
+  publisher: string;
+  sourceInstallerType: string;
+  silentArgs: string;
+  productCode: string;
+  scope: string;
+  nestedInstallerType: string;
+  nestedInstallerFiles: string[];
+}
+
+type ManifestRecord = Record<string, unknown>;
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function record(value: unknown): ManifestRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as ManifestRecord)
+    : {};
+}
+
+function appsAndFeaturesProductCode(installer: ManifestRecord): string {
+  const entries = Array.isArray(installer.AppsAndFeaturesEntries)
+    ? installer.AppsAndFeaturesEntries
+    : [];
+  for (const entry of entries) {
+    const productCode = text(record(entry).ProductCode);
+    if (productCode) return productCode;
+  }
+  return '';
+}
+
+function msiProductCode(value: unknown): string {
+  const candidate = text(value);
+  return /^\{?[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}?$/.test(
+    candidate
+  )
+    ? candidate
+    : '';
+}
+
+export function buildQaCatalogTestConfig({
+  app,
+  manifest,
+  installer,
+}: {
+  app: { name: string; publisher: string };
+  manifest: ManifestRecord;
+  installer: WingetInstallerCandidate & ManifestRecord;
+}): QaCatalogTestConfig {
+  const rootSwitches = record(manifest.InstallerSwitches);
+  const installerSwitches = record(installer.InstallerSwitches);
+  const silentArgs =
+    text(installerSwitches.Silent) ||
+    text(installerSwitches.SilentWithProgress) ||
+    text(rootSwitches.Silent) ||
+    text(rootSwitches.SilentWithProgress);
+  const nestedFiles = Array.isArray(installer.NestedInstallerFiles)
+    ? installer.NestedInstallerFiles
+        .map((entry) => text(record(entry).RelativeFilePath))
+        .filter(Boolean)
+        .slice(0, 20)
+    : [];
+
+  return {
+    mode: 'catalog',
+    displayName: app.name,
+    publisher: app.publisher,
+    sourceInstallerType:
+      text(installer.InstallerType) || text(manifest.InstallerType) || 'exe',
+    silentArgs,
+    productCode:
+      msiProductCode(installer.ProductCode) ||
+      msiProductCode(appsAndFeaturesProductCode(installer)),
+    scope: text(installer.Scope) || text(manifest.Scope),
+    nestedInstallerType:
+      text(installer.NestedInstallerType) || text(manifest.NestedInstallerType),
+    nestedInstallerFiles: nestedFiles,
+  };
+}

--- a/lib/qa/winget-changes.test.ts
+++ b/lib/qa/winget-changes.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { detectWingetChanges, wingetIdFromManifestPath } from './winget-changes';
+
+const BASE = 'a'.repeat(40);
+const HEAD = 'b'.repeat(40);
+
+describe('wingetIdFromManifestPath', () => {
+  it('extracts installer and singleton manifest package ids', () => {
+    expect(
+      wingetIdFromManifestPath('manifests/g/Google/Chrome/152.0/Google.Chrome.installer.yaml')
+    ).toBe('Google.Chrome');
+    expect(wingetIdFromManifestPath('manifests/v/VideoLAN/VLC/4.0/VideoLAN.VLC.yaml')).toBe(
+      'VideoLAN.VLC'
+    );
+  });
+
+  it('ignores locale and non-manifest paths', () => {
+    expect(
+      wingetIdFromManifestPath('manifests/g/Google/Chrome/152.0/Google.Chrome.locale.en-US.yaml')
+    ).toBeNull();
+    expect(wingetIdFromManifestPath('README.md')).toBeNull();
+  });
+});
+
+describe('detectWingetChanges', () => {
+  it('compares a durable cursor and returns unique changed package ids', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ sha: HEAD }]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'ahead',
+            total_commits: 2,
+            files: [
+              { status: 'added', filename: 'manifests/g/Google/Chrome/2/Google.Chrome.installer.yaml' },
+              { status: 'modified', filename: 'manifests/g/Google/Chrome/2/Google.Chrome.yaml' },
+              { status: 'removed', filename: 'manifests/o/Old/App/1/Old.App.installer.yaml' },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
+
+    await expect(detectWingetChanges({ baseSha: BASE, fetchImpl })).resolves.toMatchObject({
+      baseSha: BASE,
+      headSha: HEAD,
+      changedFiles: 3,
+      changedPackageIds: ['Google.Chrome'],
+      initialized: false,
+    });
+  });
+
+  it('uses a bounded lookback when no cursor exists', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ sha: HEAD }]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ sha: HEAD, parents: [{ sha: BASE }] }]), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'ahead',
+            total_commits: 1,
+            files: [
+              { status: 'added', filename: 'manifests/m/Mozilla/Firefox/2/Mozilla.Firefox.yaml' },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
+
+    const changes = await detectWingetChanges({ since: '2026-08-08T00:00:00Z', fetchImpl });
+    expect(changes.initialized).toBe(true);
+    expect(changes.changedPackageIds).toEqual(['Mozilla.Firefox']);
+  });
+
+  it('refuses to advance a truncated comparison', async () => {
+    const files = Array.from({ length: 300 }, (_, index) => ({
+      status: 'modified',
+      filename: `manifests/e/Example/App/${index}/Example.App.yaml`,
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ sha: HEAD }]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'ahead', total_commits: 10, files }), { status: 200 })
+      );
+
+    await expect(detectWingetChanges({ baseSha: BASE, fetchImpl })).rejects.toThrow(
+      'compare limits'
+    );
+  });
+});

--- a/lib/qa/winget-changes.ts
+++ b/lib/qa/winget-changes.ts
@@ -1,0 +1,146 @@
+const GITHUB_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs';
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const APP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]*\.[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+
+interface GitHubCommitSummary {
+  sha?: string;
+  parents?: Array<{ sha?: string }>;
+}
+
+interface GitHubChangedFile {
+  filename?: string;
+  status?: string;
+}
+
+interface GitHubComparison {
+  status?: string;
+  total_commits?: number;
+  files?: GitHubChangedFile[];
+}
+
+export interface WingetChangeSet {
+  baseSha: string | null;
+  headSha: string;
+  changedFiles: number;
+  changedPackageIds: string[];
+  initialized: boolean;
+}
+
+export interface DetectWingetChangesOptions {
+  token?: string;
+  baseSha?: string | null;
+  since?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function githubHeaders(token?: string): HeadersInit {
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'IntuneGet-QA-Poller',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function githubJson<T>(
+  fetchImpl: typeof fetch,
+  path: string,
+  token?: string
+): Promise<T> {
+  const response = await fetchImpl(`${GITHUB_API_BASE}${path}`, {
+    headers: githubHeaders(token),
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 500);
+    throw new Error(`WinGet change feed failed (${response.status}): ${detail || path}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function wingetIdFromManifestPath(path: string): string | null {
+  if (!path.toLowerCase().startsWith('manifests/')) return null;
+  const fileName = path.split('/').pop() || '';
+  if (!/\.ya?ml$/i.test(fileName) || /\.locale\.[^.]+\.ya?ml$/i.test(fileName)) {
+    return null;
+  }
+
+  const id = fileName
+    .replace(/\.installer\.ya?ml$/i, '')
+    .replace(/\.ya?ml$/i, '');
+  return APP_ID_PATTERN.test(id) ? id : null;
+}
+
+function changedPackageIds(files: GitHubChangedFile[]): string[] {
+  const ids = new Set<string>();
+  for (const file of files) {
+    if (!file.filename || file.status === 'removed') continue;
+    const id = wingetIdFromManifestPath(file.filename);
+    if (id) ids.add(id);
+  }
+  return [...ids].sort((a, b) => a.localeCompare(b));
+}
+
+async function compare(
+  fetchImpl: typeof fetch,
+  baseSha: string,
+  headSha: string,
+  token?: string
+): Promise<{ changedFiles: number; changedPackageIds: string[] }> {
+  if (baseSha === headSha) return { changedFiles: 0, changedPackageIds: [] };
+  const result = await githubJson<GitHubComparison>(
+    fetchImpl,
+    `/compare/${baseSha}...${headSha}`,
+    token
+  );
+  if (result.status === 'diverged' || result.status === 'behind') {
+    throw new Error(`WinGet change cursor is not an ancestor of ${headSha}`);
+  }
+  const files = result.files || [];
+  if ((result.total_commits || 0) >= 250 || files.length >= 300) {
+    throw new Error('WinGet change window exceeded GitHub compare limits; cursor was not advanced');
+  }
+  return { changedFiles: files.length, changedPackageIds: changedPackageIds(files) };
+}
+
+export async function detectWingetChanges({
+  token,
+  baseSha,
+  since = new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  fetchImpl = fetch,
+}: DetectWingetChangesOptions = {}): Promise<WingetChangeSet> {
+  const latest = await githubJson<GitHubCommitSummary[]>(fetchImpl, '/commits?per_page=1', token);
+  const headSha = latest[0]?.sha?.toLowerCase() || '';
+  if (!SHA_PATTERN.test(headSha)) throw new Error('WinGet change feed returned an invalid head SHA');
+
+  if (baseSha) {
+    const normalizedBase = baseSha.toLowerCase();
+    if (!SHA_PATTERN.test(normalizedBase)) throw new Error('Stored WinGet cursor SHA is invalid');
+    const changes = await compare(fetchImpl, normalizedBase, headSha, token);
+    return { baseSha: normalizedBase, headSha, ...changes, initialized: false };
+  }
+
+  const recent = await githubJson<GitHubCommitSummary[]>(
+    fetchImpl,
+    `/commits?per_page=100&since=${encodeURIComponent(since)}`,
+    token
+  );
+  if (recent.length === 0) {
+    return {
+      baseSha: null,
+      headSha,
+      changedFiles: 0,
+      changedPackageIds: [],
+      initialized: true,
+    };
+  }
+  if (recent.length >= 100) {
+    throw new Error('Initial WinGet lookback exceeded 100 commits; cursor was not initialized');
+  }
+  const oldestParent = recent[recent.length - 1]?.parents?.[0]?.sha?.toLowerCase() || '';
+  if (!SHA_PATTERN.test(oldestParent)) {
+    throw new Error('Initial WinGet change feed did not include a valid parent SHA');
+  }
+  const changes = await compare(fetchImpl, oldestParent, headSha, token);
+  return { baseSha: oldestParent, headSha, ...changes, initialized: true };
+}

--- a/supabase/migrations/20260808054131_qa_poll_observability.sql
+++ b/supabase/migrations/20260808054131_qa_poll_observability.sql
@@ -1,0 +1,43 @@
+-- Keep a durable, service-only audit trail for every WinGet QA polling cycle.
+-- Recipe-level errors can contain upstream details, so this table is not
+-- exposed to anonymous or authenticated Data API clients.
+create table public.qa_poll_runs (
+  id uuid primary key default gen_random_uuid(),
+  request_id text,
+  status text not null default 'running' check (
+    status in ('running', 'succeeded', 'partial', 'failed')
+  ),
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  duration_ms integer check (duration_ms is null or duration_ms >= 0),
+  recipe_count integer not null default 0 check (recipe_count >= 0),
+  checked_count integer not null default 0 check (checked_count >= 0),
+  updates_found_count integer not null default 0 check (updates_found_count >= 0),
+  queued_count integer not null default 0 check (queued_count >= 0),
+  already_known_count integer not null default 0 check (already_known_count >= 0),
+  unavailable_count integer not null default 0 check (unavailable_count >= 0),
+  error_count integer not null default 0 check (error_count >= 0),
+  errors jsonb not null default '[]'::jsonb check (jsonb_typeof(errors) = 'array'),
+  alert_delivery jsonb,
+  created_at timestamptz not null default now(),
+  check (
+    (status = 'running' and finished_at is null and duration_ms is null)
+    or
+    (status <> 'running' and finished_at is not null and duration_ms is not null)
+  )
+);
+
+create index qa_poll_runs_started_at_idx
+  on public.qa_poll_runs(started_at desc);
+
+create index qa_poll_runs_attention_idx
+  on public.qa_poll_runs(started_at desc)
+  where status in ('partial', 'failed');
+
+comment on table public.qa_poll_runs is
+  'Service-only operational history for each scheduled WinGet QA polling invocation.';
+
+alter table public.qa_poll_runs enable row level security;
+
+revoke all on table public.qa_poll_runs from public, anon, authenticated;
+grant select, insert, update, delete on table public.qa_poll_runs to service_role;

--- a/supabase/migrations/20260808061746_full_catalog_qa.sql
+++ b/supabase/migrations/20260808061746_full_catalog_qa.sql
@@ -1,0 +1,71 @@
+-- Monitor the complete supported WinGet catalog without duplicating every app
+-- as a hand-authored QA recipe. Catalog candidates carry a small, validated
+-- test configuration and may omit a repository definition path.
+
+alter table public.qa_candidates
+  drop constraint if exists qa_candidates_winget_id_fkey;
+
+alter table public.qa_candidates
+  alter column definition_path drop not null,
+  add column if not exists test_config jsonb not null default '{}'::jsonb;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'qa_candidates_test_config_object_check'
+      and conrelid = 'public.qa_candidates'::regclass
+  ) then
+    alter table public.qa_candidates
+      add constraint qa_candidates_test_config_object_check
+      check (jsonb_typeof(test_config) = 'object');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'qa_candidates_winget_id_fkey'
+      and conrelid = 'public.qa_candidates'::regclass
+  ) then
+    alter table public.qa_candidates
+      add constraint qa_candidates_winget_id_fkey
+      foreign key (winget_id)
+      references public.curated_apps(winget_id)
+      on update cascade;
+  end if;
+end $$;
+
+create index if not exists curated_apps_qa_eligible_idx
+  on public.curated_apps(winget_id)
+  where is_verified = true
+    and is_winget_verified = true
+    and app_source = 'win32'
+    and is_locale_variant = false;
+
+create table if not exists public.qa_winget_poll_state (
+  id text primary key check (id = 'microsoft/winget-pkgs'),
+  head_sha text check (head_sha is null or head_sha ~ '^[a-f0-9]{40}$'),
+  last_checked_at timestamptz,
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.qa_winget_poll_state is
+  'Private durable cursor for the WinGet repository change feed used by catalog-wide QA.';
+
+insert into public.qa_winget_poll_state(id)
+values ('microsoft/winget-pkgs')
+on conflict (id) do nothing;
+
+alter table public.qa_winget_poll_state enable row level security;
+revoke all on table public.qa_winget_poll_state from public, anon, authenticated;
+grant select, insert, update on table public.qa_winget_poll_state to service_role;
+
+alter table public.qa_poll_runs
+  add column if not exists base_sha text,
+  add column if not exists head_sha text,
+  add column if not exists changed_package_count integer not null default 0,
+  add column if not exists supported_changed_count integer not null default 0;
+
+comment on column public.qa_poll_runs.recipe_count is
+  'Count of canonical Win32 catalog apps covered by QA monitoring for this poll.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -129,13 +129,14 @@ export interface Database {
         Row: {
           id: string;
           winget_id: string;
-          definition_path: string;
+          definition_path: string | null;
           version: string;
           architecture: string;
           installer_url: string;
           installer_sha256: string;
           installer_type: string;
           installer_file_name: string;
+          test_config: Json;
           status: string;
           priority: number;
           attempts: number;
@@ -151,13 +152,14 @@ export interface Database {
         Insert: {
           id?: string;
           winget_id: string;
-          definition_path: string;
+          definition_path?: string | null;
           version: string;
           architecture: string;
           installer_url: string;
           installer_sha256: string;
           installer_type: string;
           installer_file_name: string;
+          test_config?: Json;
           status?: string;
           priority?: number;
           attempts?: number;
@@ -171,6 +173,70 @@ export interface Database {
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_candidates']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
+      qa_poll_runs: {
+        Row: {
+          id: string;
+          request_id: string | null;
+          status: 'running' | 'succeeded' | 'partial' | 'failed';
+          started_at: string;
+          finished_at: string | null;
+          duration_ms: number | null;
+          recipe_count: number;
+          checked_count: number;
+          updates_found_count: number;
+          queued_count: number;
+          already_known_count: number;
+          unavailable_count: number;
+          error_count: number;
+          errors: Json;
+          alert_delivery: Json | null;
+          base_sha: string | null;
+          head_sha: string | null;
+          changed_package_count: number;
+          supported_changed_count: number;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          request_id?: string | null;
+          status?: 'running' | 'succeeded' | 'partial' | 'failed';
+          started_at?: string;
+          finished_at?: string | null;
+          duration_ms?: number | null;
+          recipe_count?: number;
+          checked_count?: number;
+          updates_found_count?: number;
+          queued_count?: number;
+          already_known_count?: number;
+          unavailable_count?: number;
+          error_count?: number;
+          errors?: Json;
+          alert_delivery?: Json | null;
+          base_sha?: string | null;
+          head_sha?: string | null;
+          changed_package_count?: number;
+          supported_changed_count?: number;
+          created_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['qa_poll_runs']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
+      qa_winget_poll_state: {
+        Row: {
+          id: string;
+          head_sha: string | null;
+          last_checked_at: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          id: string;
+          head_sha?: string | null;
+          last_checked_at?: string | null;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['qa_winget_poll_state']['Insert']>;
         Relationships: GenericRelationship[];
       };
       user_profiles: {
@@ -1265,6 +1331,9 @@ export interface Database {
           curation_notes: string | null;
           manually_mapped: boolean;
           is_verified: boolean;
+          is_winget_verified: boolean | null;
+          is_locale_variant: boolean | null;
+          app_source: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -1288,6 +1357,9 @@ export interface Database {
           curation_notes?: string | null;
           manually_mapped?: boolean;
           is_verified?: boolean;
+          is_winget_verified?: boolean | null;
+          is_locale_variant?: boolean | null;
+          app_source?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -1311,6 +1383,9 @@ export interface Database {
           curation_notes?: string | null;
           manually_mapped?: boolean;
           is_verified?: boolean;
+          is_winget_verified?: boolean | null;
+          is_locale_variant?: boolean | null;
+          app_source?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -41,9 +41,10 @@ export interface QaChanges {
 }
 
 export interface QaDetectionRule {
-  type: 'fileVersion';
-  path: string;
-  minimumVersion: string;
+  type: 'fileVersion' | 'installationEvidence';
+  path?: string;
+  minimumVersion?: string;
+  description?: string;
 }
 
 export interface QaEnvironment {


### PR DESCRIPTION
## Summary
- poll the WinGet repository every ten minutes using a durable commit cursor
- cover every verified canonical Win32 app in the catalog while resolving only changed packages
- dispatch generic VM-only QA tests for catalog apps and preserve tailored recipes
- add poll observability and support generic installation evidence in the existing QA details UI

## Safety
- only one QA test runs at a time
- app installers execute only inside the checkpointed Hyper-V VM
- the poll cursor is service-role-only and does not expose credentials to the guest
- truncated GitHub comparisons and package-resolution errors do not advance the cursor

## Verification
- npm test (573 tests)
- npm run build:ci
- live Supabase migration applied and verified
- full eligible catalog count: 14,062