### PR TITLE
ci: harden Extract App Icons workflow

### DIFF
--- a/.github/scripts/fetch-web-icons.mjs
+++ b/.github/scripts/fetch-web-icons.mjs
@@ -624,13 +624,12 @@ async function main() {
   fs.writeFileSync('web-icon-results.json', JSON.stringify(results, null, 2));
 
   if (!MISSING_SIZES_ONLY && !BINARY_GAP_FILL) {
+    // The cursor is persisted by a later workflow step, only after the fetched
+    // icons have been committed. Upserting it here would advance the cursor
+    // even when the commit fails, silently skipping these apps until the
+    // cursor wraps around.
     const nextCursor = apps.length > 0 ? apps[apps.length - 1].winget_id : null;
-    const { error: cursorError } = await supabase.from('curated_sync_status').upsert({
-      id: 'extract-icons-web-cursor',
-      metadata: { last_winget_id: nextCursor },
-      updated_at: new Date().toISOString(),
-    });
-    if (cursorError) throw new Error(`Failed to persist web icon cursor: ${cursorError.message}`);
+    fs.writeFileSync('web-icon-cursor.json', JSON.stringify({ last_winget_id: nextCursor }));
   }
 
   // Write counts for GitHub Actions output

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -81,6 +81,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify push token
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The PAT secret is not set -- icon PRs cannot be published."
+            exit 1
+          fi
+          if [ "$(gh api "repos/$GITHUB_REPOSITORY" --jq '.permissions.push' 2>/dev/null)" != "true" ]; then
+            echo "::error::The PAT cannot push to $GITHUB_REPOSITORY -- it has likely expired or lost 'Contents: write'. Rotate the PAT secret before re-running."
+            exit 1
+          fi
+          echo "PAT verified: push access to $GITHUB_REPOSITORY confirmed"
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -103,7 +118,7 @@ jobs:
 
       - name: Commit web icons
         id: commit-web-icons
-        if: steps.fetch-web-icons.outputs.total_hits != '0'
+        if: steps.fetch-web-icons.outputs.total_hits != '' && steps.fetch-web-icons.outputs.total_hits != '0'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.PAT }}
@@ -181,6 +196,38 @@ jobs:
           });
           EOF
 
+      # Advance the pagination cursor only after the fetched icons were
+      # committed (or there was nothing to commit). Default step semantics do
+      # the gating: a failed commit/database step aborts the job before this
+      # step, so the next run retries the same batch instead of skipping it.
+      - name: Persist web icon cursor
+        shell: bash
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          node << 'EOF'
+          const fs = require('fs');
+          if (!fs.existsSync('web-icon-cursor.json')) {
+            console.log('No cursor file (top-up/gap-fill mode) -- nothing to persist');
+            process.exit(0);
+          }
+          const { createClient } = require('@supabase/supabase-js');
+          const cursor = JSON.parse(fs.readFileSync('web-icon-cursor.json', 'utf8'));
+          const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+          supabase.from('curated_sync_status').upsert({
+            id: 'extract-icons-web-cursor',
+            metadata: { last_winget_id: cursor.last_winget_id },
+            updated_at: new Date().toISOString(),
+          }).then(({ error }) => {
+            if (error) {
+              console.error('Failed to persist web icon cursor:', error.message);
+              process.exit(1);
+            }
+            console.log('Web icon cursor advanced to:', cursor.last_winget_id);
+          });
+          EOF
+
       - name: Web icons summary
         if: always()
         run: |
@@ -226,6 +273,21 @@ jobs:
       - name: Pull latest (includes web icons)
         run: git pull origin main
         shell: bash
+
+      - name: Verify push token
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The PAT secret is not set -- icon PRs cannot be published."
+            exit 1
+          fi
+          if [ "$(gh api "repos/$GITHUB_REPOSITORY" --jq '.permissions.push' 2>/dev/null)" != "true" ]; then
+            echo "::error::The PAT cannot push to $GITHUB_REPOSITORY -- it has likely expired or lost 'Contents: write'. Rotate the PAT secret before re-running."
+            exit 1
+          fi
+          echo "PAT verified: push access to $GITHUB_REPOSITORY confirmed"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -803,3 +865,32 @@ jobs:
             }
           }
         shell: pwsh
+
+  # ============================================================
+  # Alert: keep a visible issue open while the pipeline is failing.
+  # Scheduled-run failure emails are easy to miss -- this workflow
+  # once failed for four weeks straight before anyone noticed.
+  # ============================================================
+  alert-on-failure:
+    runs-on: ubuntu-24.04
+    needs: [extract-web-icons, extract-binary-icons]
+    if: always() && contains(needs.*.result, 'failure')
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Extract App Icons workflow is failing"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Run failed again: $run_url"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "The Extract App Icons workflow failed: $run_url
+
+          The most common cause is the \`PAT\` secret expiring or losing write access -- check the 'Verify push token' step of the failed run, and rotate the secret if it flagged the token.
+
+          A comment is added here on every subsequent failed run. Close this issue once the workflow is green again."
+          fi


### PR DESCRIPTION
Follow-up to the PAT outage that silently broke this workflow from July 11 to August 8. Four changes:

1. **Fail-fast token preflight** — both jobs now verify at startup (via `gh api repos/... .permissions.push`) that the `PAT` secret exists and can push. A dead token now fails in seconds with an actionable error instead of after 20+ minutes of fetching.
2. **Cursor persisted only after a successful commit** — `fetch-web-icons.mjs` now writes the next pagination cursor to `web-icon-cursor.json` instead of upserting it to Supabase mid-fetch. A new workflow step persists it after the commit/DB steps, so a failed publish no longer advances the cursor past apps whose icons were never committed (this cost us ~4 weeks of fetched icons during the outage).
3. **Safer commit condition** — the commit step also skips when `total_hits` is empty, not just `'0'`.
4. **Failure alerting** — a final `alert-on-failure` job opens (or comments on) a GitHub issue titled "Extract App Icons workflow is failing" on every failed run, so scheduled failures can't go unnoticed for weeks again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)