### PR TITLE
Align catalog QA with production packaging

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -390,7 +390,7 @@ if ($extensionTypeMap.ContainsKey($fileExtension)) {
 
     switch ($fileExtension) {
         '.exe' {
-            if ($installerTypeLower -in 'portable', 'zip') {
+            if ($installerTypeLower -eq 'zip') {
                 $shouldOverride = $true
             }
         }
@@ -986,17 +986,26 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
         }
         'portable' {
             $lines += @(
-                "    `$zipPath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
-                "    `$extractPath = `"`$env:ProgramFiles\$displayNameEscaped`""
-                '    Write-ADTLogEntry -Message "Extracting portable app to: $extractPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                "    `$sourcePath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
+                "    `$installPath = `"`$env:ProgramFiles\$displayNameEscaped`""
+                '    Write-ADTLogEntry -Message "Installing portable app to: $installPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
                 '    try {'
-                '        if (-not (Test-Path $extractPath)) {'
-                '            New-Item -Path $extractPath -ItemType Directory -Force | Out-Null'
+                '        if (-not (Test-Path $installPath)) {'
+                '            New-Item -Path $installPath -ItemType Directory -Force | Out-Null'
                 '        }'
-                '        Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force'
-                '        Write-ADTLogEntry -Message "Portable app extracted successfully" -Severity ''Success'' -Source ''Install-ADTDeployment'''
+            )
+            if ($fileExtension -eq '.zip') {
+                $lines += '        Expand-Archive -LiteralPath $sourcePath -DestinationPath $installPath -Force'
+            } else {
+                $lines += @(
+                    "        `$targetPath = Join-Path `$installPath '$installerFileNameSingleQuoteEscaped'"
+                    '        Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force'
+                )
+            }
+            $lines += @(
+                '        Write-ADTLogEntry -Message "Portable app installed successfully" -Severity ''Success'' -Source ''Install-ADTDeployment'''
                 '    } catch {'
-                '        Write-ADTLogEntry -Message "Failed to extract portable app: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
+                '        Write-ADTLogEntry -Message "Failed to install portable app: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
                 '        throw'
                 '    }'
             )

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -37,4 +37,97 @@ describe('buildQaCatalogTestConfig', () => {
       detectionValue: '2.0.0',
     });
   });
+
+  it.each([
+    ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'],
+    ['nullsoft', '/S'],
+  ])('applies the WinGet default silent switches for %s installers', (installerType, expected) => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.Example',
+        name: 'Example',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: { InstallerType: installerType },
+      installer: { Architecture: 'x64', InstallerType: installerType },
+    });
+
+    expect(config.silentArgs).toBe(expected);
+  });
+
+  it('inherits root nested installer metadata for zip packages', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.Archive',
+        name: 'Archive',
+        publisher: 'Contoso',
+        version: '1.0.0',
+      },
+      manifest: {
+        InstallerType: 'zip',
+        NestedInstallerType: 'inno',
+        NestedInstallerFiles: [{ RelativeFilePath: 'setup\\install.exe' }],
+      },
+      installer: { Architecture: 'x64', InstallerType: 'zip' },
+    });
+
+    expect(config).toMatchObject({
+      sourceInstallerType: 'zip',
+      nestedInstallerType: 'inno',
+      nestedInstallerFiles: ['setup\\install.exe'],
+      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+    });
+  });
+
+  it('appends inherited custom switches to the derived silent default', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.Example',
+        name: 'Example',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: { InstallerType: 'inno', InstallerSwitches: { Custom: '/ALLUSERS' } },
+      installer: { Architecture: 'x64', InstallerType: 'inno' },
+    });
+
+    expect(config.silentArgs).toBe(
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS'
+    );
+  });
+
+  it('uses installer switch objects without merging root switch keys', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.Example',
+        name: 'Example',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: { InstallerType: 'nullsoft', InstallerSwitches: { Silent: '/ROOT' } },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Custom: '/CURRENTUSER' },
+      },
+    });
+
+    expect(config.silentArgs).toBe('/S /CURRENTUSER');
+  });
+
+  it('keeps portable packages argument-free', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.Portable',
+        name: 'Portable',
+        publisher: 'Contoso',
+        version: '1.0.0',
+      },
+      manifest: { InstallerType: 'portable' },
+      installer: { Architecture: 'x64', InstallerType: 'portable' },
+    });
+
+    expect(config.silentArgs).toBe('');
+  });
 });

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -1,8 +1,14 @@
 import { generateDetectionRules, generateUninstallCommand } from '@/lib/detection-rules';
+import { normalizeInstaller } from '@/lib/manifest-api';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import { normalizeQaPsadtConfig } from './package-profile';
-import type { NormalizedInstaller, WingetInstallerType, WingetScope } from '@/types/winget';
+import type {
+  WingetInstaller,
+  WingetInstallerSwitches,
+  WingetInstallerType,
+  WingetScope,
+} from '@/types/winget';
 import type { WingetInstallerCandidate } from './candidate';
 
 export interface QaCatalogTestConfig {
@@ -66,19 +72,18 @@ export function buildQaCatalogTestConfig({
   manifest: ManifestRecord;
   installer: WingetInstallerCandidate & ManifestRecord;
 }): QaCatalogTestConfig {
-  const rootSwitches = record(manifest.InstallerSwitches);
-  const installerSwitches = record(installer.InstallerSwitches);
-  const silentArgs =
-    text(installerSwitches.Silent) ||
-    text(installerSwitches.SilentWithProgress) ||
-    text(rootSwitches.Silent) ||
-    text(rootSwitches.SilentWithProgress);
-  const nestedFiles = Array.isArray(installer.NestedInstallerFiles)
+  const effectiveSwitches = isRecord(installer.InstallerSwitches)
+    ? installer.InstallerSwitches
+    : manifest.InstallerSwitches;
+  const effectiveNestedFiles = Array.isArray(installer.NestedInstallerFiles)
     ? installer.NestedInstallerFiles
-        .map((entry) => text(record(entry).RelativeFilePath))
-        .filter(Boolean)
-        .slice(0, 20)
-    : [];
+    : Array.isArray(manifest.NestedInstallerFiles)
+      ? manifest.NestedInstallerFiles
+      : [];
+  const nestedFiles = effectiveNestedFiles
+    .map((entry) => text(record(entry).RelativeFilePath))
+    .filter(Boolean)
+    .slice(0, 20);
   const rawSourceType =
     text(installer.InstallerType) || text(manifest.InstallerType) || 'exe';
   const supportedTypes = new Set<WingetInstallerType>([
@@ -97,23 +102,34 @@ export function buildQaCatalogTestConfig({
   const sourceInstallerType = supportedTypes.has(rawSourceType.toLowerCase() as WingetInstallerType)
     ? (rawSourceType.toLowerCase() as WingetInstallerType)
     : 'exe';
+  const rawNestedInstallerType =
+    text(installer.NestedInstallerType) || text(manifest.NestedInstallerType);
+  const nestedInstallerType = supportedTypes.has(
+    rawNestedInstallerType.toLowerCase() as WingetInstallerType
+  )
+    ? (rawNestedInstallerType.toLowerCase() as WingetInstallerType)
+    : undefined;
   const rawScope = text(installer.Scope) || text(manifest.Scope);
   const scope: WingetScope = rawScope.toLowerCase() === 'user' ? 'user' : 'machine';
   const productCode =
     msiProductCode(installer.ProductCode) ||
     msiProductCode(appsAndFeaturesProductCode(installer));
-  const normalizedInstaller: NormalizedInstaller = {
-    architecture: (text(installer.Architecture).toLowerCase() || 'x64') as NormalizedInstaller['architecture'],
-    url: text(installer.InstallerUrl),
-    sha256: text(installer.InstallerSha256),
-    type: sourceInstallerType,
-    nestedInstallerType: text(installer.NestedInstallerType).toLowerCase() as WingetInstallerType,
-    nestedInstallerPath: nestedFiles[0],
-    scope,
-    silentArgs,
-    productCode: productCode || undefined,
-    packageFamilyName: text(installer.PackageFamilyName) || undefined,
+  const inheritedInstaller: WingetInstaller = {
+    Architecture: (text(installer.Architecture).toLowerCase() ||
+      'x64') as WingetInstaller['Architecture'],
+    InstallerUrl: text(installer.InstallerUrl),
+    InstallerSha256: text(installer.InstallerSha256),
+    InstallerType: sourceInstallerType,
+    NestedInstallerType: nestedInstallerType,
+    NestedInstallerFiles: nestedFiles.map((relativeFilePath) => ({
+      RelativeFilePath: relativeFilePath,
+    })),
+    Scope: scope,
+    InstallerSwitches: normalizeInstallerSwitches(effectiveSwitches),
+    ProductCode: productCode || undefined,
+    PackageFamilyName: text(installer.PackageFamilyName) || undefined,
   };
+  const normalizedInstaller = normalizeInstaller(inheritedInstaller);
   const detectionRules = generateDetectionRules(
     normalizedInstaller,
     app.name,
@@ -128,15 +144,38 @@ export function buildQaCatalogTestConfig({
     displayName: app.name,
     publisher: app.publisher,
     sourceInstallerType,
-    silentArgs,
+    silentArgs: normalizedInstaller.silentArgs || '',
     productCode,
     scope,
-    nestedInstallerType:
-      text(installer.NestedInstallerType) || text(manifest.NestedInstallerType),
+    nestedInstallerType: nestedInstallerType || '',
     nestedInstallerFiles: nestedFiles,
     uninstallCommand: generateUninstallCommand(normalizedInstaller, app.name),
     psadtConfig,
     detectionRules,
     profileKind: 'catalog-default',
   };
+}
+
+function isRecord(value: unknown): value is ManifestRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeInstallerSwitches(value: unknown): WingetInstallerSwitches | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const switches: WingetInstallerSwitches = {};
+  const keys: Array<keyof WingetInstallerSwitches> = [
+    'Silent',
+    'SilentWithProgress',
+    'Interactive',
+    'InstallLocation',
+    'Log',
+    'Upgrade',
+    'Custom',
+  ];
+  for (const key of keys) {
+    const normalized = text(value[key]);
+    if (normalized) switches[key] = normalized;
+  }
+  return switches;
 }


### PR DESCRIPTION
## What changed

- derive catalog QA silent arguments through the same WinGet normalization used by production packaging
- inherit root-level nested installer metadata and preserve whole-object installer-switch precedence
- keep portable EXE packages classified as portable and copy them into the managed install directory
- add regression coverage for Inno, Nullsoft, nested ZIP, custom-switch, precedence, and portable profiles

## Why

Four real isolated PSADT QA runs produced the same failure pattern because QA profiles omitted WinGet's standard silent defaults. Portable EXEs were also reclassified as normal EXE installers and launched instead of copied.

This restores one-to-one parity between catalog QA profiles and the packages IntuneGet generates.

## Validation

- `npm.cmd test -- lib/qa/test-config.test.ts lib/qa/package-profile.test.ts` — 12/12 passed
- focused ESLint — passed
- PowerShell AST parsing — passed
- `git diff --check` — passed
- Claude Code Fable review — approved with no blocking findings

The full repository TypeScript command still reports pre-existing test-global/type errors outside these changed files; it reports no errors in the changed QA files.