### PR TITLE
Pin QA profiles to reviewed packager

### DIFF
--- a/.github/workflows-reference/package-intunewin.yml
+++ b/.github/workflows-reference/package-intunewin.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: ugurkocde/IntuneGet
           # Update only after reviewing the referenced scripts in this commit.
-          ref: 22ab5995b4347804ed0730e0da380bcffb63f895
+          ref: de6ff2636a446ff69a222811d4057dd92b452a71
           path: intuneget
           persist-credentials: false
 

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '22ab5995b4347804ed0730e0da380bcffb63f895',
+  packagerCommit: 'de6ff2636a446ff69a222811d4057dd92b452a71',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## What changed

- pin canonical QA package profiles to IntuneGet commit `de6ff2636a446ff69a222811d4057dd92b452a71`
- keep the production workflow reference mirror on the same immutable commit

## Why

The packager commit is part of the exact package profile identity. Profiles generated after the catalog-parity fix must bind to the reviewed implementation that produced them.

## Validation

- QA profile tests: 12/12 passed
- focused ESLint: passed
- coordinated pin review by Claude Code Fable: approved
- hash-bound historical QA JSON is intentionally unchanged until a new VM run replaces it