### PR TITLE
Backfill QA after PSADT toolchain updates

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -29,7 +29,17 @@ type QueryResult = {
 
 function query(result: QueryResult) {
   const builder: Record<string, unknown> = {};
-  for (const method of ['select', 'eq', 'neq', 'in', 'order', 'limit']) {
+  for (const method of [
+    'select',
+    'eq',
+    'neq',
+    'not',
+    'in',
+    'order',
+    'limit',
+    'or',
+    'contains',
+  ]) {
     builder[method] = vi.fn(() => builder);
   }
   builder.single = vi.fn(async () => result);
@@ -46,10 +56,14 @@ function createSupabaseStub(options: {
   coverageError?: string;
   supportedApps?: Array<Record<string, unknown>>;
   recipes?: Array<Record<string, unknown>>;
+  candidates?: Array<Record<string, unknown>>;
+  candidatePages?: Array<Array<Record<string, unknown>>>;
 }) {
   const pollRunInserts: Array<Record<string, unknown>> = [];
   const pollRunUpdates: Array<Record<string, unknown>> = [];
   const cursorUpdates: Array<Record<string, unknown>> = [];
+  const candidateInserts: Array<Record<string, unknown>> = [];
+  let candidatePageIndex = 0;
 
   const client = {
     from: vi.fn((table: string) => {
@@ -97,15 +111,65 @@ function createSupabaseStub(options: {
       }
       if (table === 'qa_candidates') {
         return {
-          insert: vi.fn(() => query({ data: { id: 'candidate-1' }, error: null })),
+          insert: vi.fn((row: Record<string, unknown>) => {
+            candidateInserts.push(row);
+            return query({ data: { id: `candidate-${candidateInserts.length}` }, error: null });
+          }),
           update: vi.fn(() => query({ data: null, error: null })),
-          select: vi.fn(() => query({ data: null, error: null })),
+          select: vi.fn(() =>
+            query({
+              data: options.candidatePages
+                ? options.candidatePages[candidatePageIndex++] || []
+                : options.candidates || [],
+              error: null,
+            })
+          ),
         };
       }
       throw new Error(`Unexpected table: ${table}`);
     }),
   };
-  return { client, pollRunInserts, pollRunUpdates, cursorUpdates };
+  return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
+}
+
+const CURRENT_PACKAGER_COMMIT = 'de6ff2636a446ff69a222811d4057dd92b452a71';
+
+function profileCandidate(options: {
+  id: string;
+  wingetId: string;
+  packagerCommit: string;
+  enqueuedAt?: string;
+  profileKind?: string;
+}): Record<string, unknown> {
+  return {
+    id: options.id,
+    winget_id: options.wingetId,
+    enqueued_at: options.enqueuedAt || '2026-08-08T10:00:00.000Z',
+    test_config: {
+      profileKind: options.profileKind || 'catalog-default',
+      packageProfileCanonicalJson: JSON.stringify({
+        toolchain: { packagerCommit: options.packagerCommit },
+      }),
+    },
+  };
+}
+
+function resolvedManifest() {
+  return {
+    status: 'resolved',
+    version: '1.0.0',
+    manifest: {
+      InstallerType: 'nullsoft',
+      Installers: [
+        {
+          Architecture: 'x64',
+          InstallerUrl: 'https://example.com/setup.exe',
+          InstallerSha256: 'A'.repeat(64),
+          InstallerType: 'nullsoft',
+        },
+      ],
+    },
+  };
 }
 
 function cronRequest(): Request {
@@ -205,5 +269,184 @@ describe('GET /api/cron/qa-enqueue', () => {
       'system: Could not count the supported QA catalog: database unavailable',
     ]);
     expect(pollRunUpdates[0]).toMatchObject({ status: 'failed', error_count: 1 });
+  });
+
+  it('queues a catalog app when its most recent QA profile used an older packager', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'old-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: '1'.repeat(40),
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      checked: 1,
+      queued: 1,
+      toolchainBackfillCount: 1,
+      toolchainBackfillPagesScanned: 1,
+    });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({
+      winget_id: 'Example.App',
+      status: 'queued',
+      test_level: 'psadt-package',
+      test_config: {
+        profileKind: 'catalog-default',
+        silentArgs: '/S',
+      },
+    });
+    const canonical = JSON.parse(
+      String((candidateInserts[0].test_config as Record<string, unknown>).packageProfileCanonicalJson)
+    );
+    expect(canonical.toolchain.packagerCommit).toBe(CURRENT_PACKAGER_COMMIT);
+  });
+
+  it('does not backfill an app that already has a current catalog profile', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'current-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: CURRENT_PACKAGER_COMMIT,
+          enqueuedAt: '2026-08-08T10:01:00.000Z',
+        }),
+        profileCandidate({
+          id: 'old-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: '1'.repeat(40),
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 0, queued: 0, toolchainBackfillCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveManifestMock).not.toHaveBeenCalled();
+  });
+
+  it('uses only the newest catalog profile when deciding whether an app is stale', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'newest-stale-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: '1'.repeat(40),
+          enqueuedAt: '2026-08-08T10:01:00.000Z',
+        }),
+        profileCandidate({
+          id: 'older-current-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: CURRENT_PACKAGER_COMMIT,
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 1, toolchainBackfillCount: 1 });
+    expect(candidateInserts[0]).toMatchObject({ winget_id: 'Example.App' });
+  });
+
+  it('continues keyset pagination until it finds a stale catalog profile', async () => {
+    const firstPage = Array.from({ length: 1_000 }, (_, index) =>
+      profileCandidate({
+        id: `irrelevant-${String(1_000 - index).padStart(4, '0')}`,
+        wingetId: `Irrelevant.App.${index}`,
+        packagerCommit: '1'.repeat(40),
+        enqueuedAt: '2026-08-08T10:00:00.000Z',
+        profileKind: 'deployment-config',
+      })
+    );
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Paged.App', name: 'Paged', publisher: 'Contoso' }],
+      candidatePages: [
+        firstPage,
+        [
+          profileCandidate({
+            id: 'paged-old-candidate',
+            wingetId: 'Paged.App',
+            packagerCommit: '1'.repeat(40),
+            enqueuedAt: '2026-08-08T09:59:59.000Z',
+          }),
+        ],
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      toolchainBackfillCount: 1,
+      toolchainBackfillPagesScanned: 2,
+    });
+    expect(candidateInserts[0]).toMatchObject({ winget_id: 'Paged.App' });
+  });
+
+  it('does not let unsupported stale apps consume the backfill batch', async () => {
+    const unsupportedPage = Array.from({ length: 1_000 }, (_, index) =>
+      profileCandidate({
+        id: `unsupported-${String(1_000 - index).padStart(4, '0')}`,
+        wingetId: `Unsupported.App.${index}`,
+        packagerCommit: '1'.repeat(40),
+        enqueuedAt: '2026-08-08T10:00:00.000Z',
+      })
+    );
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [
+        { winget_id: 'Supported.App', name: 'Supported', publisher: 'Contoso' },
+      ],
+      candidatePages: [
+        unsupportedPage,
+        [
+          profileCandidate({
+            id: 'supported-old-candidate',
+            wingetId: 'Supported.App',
+            packagerCommit: '1'.repeat(40),
+            enqueuedAt: '2026-08-08T09:59:59.000Z',
+          }),
+        ],
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      toolchainBackfillCount: 1,
+      toolchainBackfillPagesScanned: 2,
+    });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({ winget_id: 'Supported.App' });
   });
 });

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -15,7 +15,7 @@ import {
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
-import { buildQaPackageIdentity } from '@/lib/qa/package-profile';
+import { buildQaPackageIdentity, QA_PSADT_TOOLCHAIN } from '@/lib/qa/package-profile';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
@@ -27,6 +27,108 @@ const POLL_STATE_ID = 'microsoft/winget-pkgs';
 const INITIAL_LOOKBACK_MINUTES = 30;
 const MAX_RECORDED_ERRORS = 100;
 const MAX_ERROR_LENGTH = 1_000;
+const TOOLCHAIN_BACKFILL_BATCH_SIZE = 3;
+const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
+
+interface QaCandidateProfileRow {
+  id: string;
+  winget_id: string;
+  enqueued_at: string;
+  test_config: unknown;
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function catalogProfilePackagerCommit(testConfig: unknown): string {
+  const config = object(testConfig);
+  if (config.profileKind !== 'catalog-default') return '';
+  if (typeof config.packageProfileCanonicalJson !== 'string') return '';
+
+  try {
+    const profile = object(JSON.parse(config.packageProfileCanonicalJson));
+    const toolchain = object(profile.toolchain);
+    return typeof toolchain.packagerCommit === 'string' ? toolchain.packagerCommit : '';
+  } catch {
+    return '';
+  }
+}
+
+async function findToolchainBackfillIds(
+  supabase: ReturnType<typeof createServerClient>
+): Promise<{ ids: string[]; pagesScanned: number }> {
+  const decidedIds = new Set<string>();
+  const supportedStaleIds: string[] = [];
+  let cursor: { enqueuedAt: string; id: string } | null = null;
+  let pagesScanned = 0;
+
+  while (true) {
+    let candidateQuery = supabase
+      .from('qa_candidates')
+      .select('id, winget_id, enqueued_at, test_config')
+      .eq('test_level', 'psadt-package')
+      .not('package_profile_sha256', 'is', null)
+      .order('enqueued_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(TOOLCHAIN_BACKFILL_PAGE_SIZE);
+    if (cursor) {
+      candidateQuery = candidateQuery.or(
+        `enqueued_at.lt.${cursor.enqueuedAt},and(enqueued_at.eq.${cursor.enqueuedAt},id.lt.${cursor.id})`
+      );
+    }
+
+    const { data, error } = await candidateQuery;
+    if (error) throw new Error(`Could not scan prior QA toolchains: ${error.message}`);
+    const rows = (data || []) as QaCandidateProfileRow[];
+    pagesScanned++;
+
+    const pageStaleIds: string[] = [];
+    for (const row of rows) {
+      const commit = catalogProfilePackagerCommit(row.test_config);
+      if (!commit || decidedIds.has(row.winget_id)) continue;
+      decidedIds.add(row.winget_id);
+      if (commit !== QA_PSADT_TOOLCHAIN.packagerCommit) pageStaleIds.push(row.winget_id);
+    }
+
+    if (pageStaleIds.length > 0) {
+      const { data: supported, error: supportedError } = await supabase
+        .from('curated_apps')
+        .select('winget_id')
+        .in('winget_id', pageStaleIds)
+        .eq('is_verified', true)
+        .eq('is_winget_verified', true)
+        .eq('app_source', 'win32')
+        .eq('is_locale_variant', false)
+        .eq('psadt_supported', true);
+      if (supportedError) {
+        throw new Error(`Could not filter QA toolchain backfill apps: ${supportedError.message}`);
+      }
+      const supportedIds = new Set((supported || []).map((app) => app.winget_id));
+      for (const wingetId of pageStaleIds) {
+        if (supportedIds.has(wingetId)) supportedStaleIds.push(wingetId);
+      }
+    }
+
+    if (supportedStaleIds.length >= TOOLCHAIN_BACKFILL_BATCH_SIZE) {
+      return {
+        ids: supportedStaleIds.slice(0, TOOLCHAIN_BACKFILL_BATCH_SIZE),
+        pagesScanned,
+      };
+    }
+    if (rows.length < TOOLCHAIN_BACKFILL_PAGE_SIZE) {
+      return { ids: supportedStaleIds, pagesScanned };
+    }
+
+    const last = rows.at(-1);
+    if (!last?.enqueued_at || !last.id) {
+      throw new Error('Could not advance the QA toolchain backfill cursor.');
+    }
+    cursor = { enqueuedAt: last.enqueued_at, id: last.id };
+  }
+}
 
 function installerFileName(installerUrl: string, installerType: string): string {
   try {
@@ -70,6 +172,8 @@ export async function GET(request: Request) {
   let recipeCount = 0;
   let changedPackageCount = 0;
   let supportedChangedCount = 0;
+  let toolchainBackfillCount = 0;
+  let toolchainBackfillPagesScanned = 0;
   let baseSha: string | null = null;
   let headSha: string | null = null;
   let runId: string | null = null;
@@ -149,6 +253,11 @@ export async function GET(request: Request) {
     baseSha = changes.baseSha;
     headSha = changes.headSha;
     changedPackageCount = changes.changedPackageIds.length;
+    const backfill = await findToolchainBackfillIds(supabase);
+    toolchainBackfillPagesScanned = backfill.pagesScanned;
+    const changedIds = new Set(changes.changedPackageIds);
+    const backfillIds = new Set(backfill.ids);
+    const targetPackageIds = Array.from(new Set([...changedIds, ...backfillIds]));
 
     structuredQaPollLog('info', 'qa_poll_started', {
       runId,
@@ -158,6 +267,8 @@ export async function GET(request: Request) {
       baseSha,
       headSha,
       changedPackageCount,
+      toolchainBackfillRequestedCount: backfill.ids.length,
+      toolchainBackfillPagesScanned,
     });
 
     let supportedApps: Array<{
@@ -165,11 +276,11 @@ export async function GET(request: Request) {
       name: string;
       publisher: string;
     }> = [];
-    if (changes.changedPackageIds.length > 0) {
+    if (targetPackageIds.length > 0) {
       const { data, error } = await supabase
         .from('curated_apps')
         .select('winget_id, name, publisher')
-        .in('winget_id', changes.changedPackageIds)
+        .in('winget_id', targetPackageIds)
         .eq('is_verified', true)
         .eq('is_winget_verified', true)
         .eq('app_source', 'win32')
@@ -177,7 +288,8 @@ export async function GET(request: Request) {
       if (error) throw new Error(`Could not filter changed WinGet packages: ${error.message}`);
       supportedApps = data || [];
     }
-    supportedChangedCount = supportedApps.length;
+    supportedChangedCount = supportedApps.filter((app) => changedIds.has(app.winget_id)).length;
+    toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
 
     const supportedIds = supportedApps.map((app) => app.winget_id);
     let recipes: Array<{
@@ -472,6 +584,8 @@ export async function GET(request: Request) {
       headSha,
       changedPackageCount,
       supportedChangedCount,
+      toolchainBackfillCount,
+      toolchainBackfillPagesScanned,
       ...summary,
     });
 
@@ -486,6 +600,8 @@ export async function GET(request: Request) {
         headSha,
         changedPackageCount,
         supportedChangedCount,
+        toolchainBackfillCount,
+        toolchainBackfillPagesScanned,
         ...summary,
       },
       { status: status === 'succeeded' ? 200 : 207 }
@@ -522,6 +638,8 @@ export async function GET(request: Request) {
         headSha,
         changedPackageCount,
         supportedChangedCount,
+        toolchainBackfillCount,
+        toolchainBackfillPagesScanned,
         ...summary,
       },
       { status: 500 }

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -101,8 +101,7 @@ async function findToolchainBackfillIds(
         .eq('is_verified', true)
         .eq('is_winget_verified', true)
         .eq('app_source', 'win32')
-        .eq('is_locale_variant', false)
-        .eq('psadt_supported', true);
+        .eq('is_locale_variant', false);
       if (supportedError) {
         throw new Error(`Could not filter QA toolchain backfill apps: ${supportedError.message}`);
       }


### PR DESCRIPTION
## Summary
- backfill up to three supported catalog apps after a pinned PSADT packager change
- use the newest catalog profile per app and keyset pagination through candidate history
- skip delisted or unsupported apps without starving eligible candidates
- report backfill counts and scan depth in cron telemetry

## Verification
- `npm test -- app/api/cron/qa-enqueue/route.test.ts lib/qa/test-config.test.ts lib/qa/package-profile.test.ts` (20 tests passed)
- ESLint passed for both changed files
- `git diff --check` passed
- no TypeScript errors reference the changed files
- Fable final review: APPROVED