### PR TITLE
Support nested portable PSADT packages

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -427,6 +427,35 @@ if ($extensionTypeMap.ContainsKey($fileExtension)) {
     }
 }
 
+$isNestedPortable = $installerTypeLower -eq 'zip' -and
+    -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
+    $NestedInstallerType.Trim().ToLowerInvariant() -eq 'portable'
+
+if ($installerTypeLower -eq 'zip' -and -not [string]::IsNullOrWhiteSpace($NestedInstallerPath)) {
+    $NestedInstallerPath = $NestedInstallerPath.Trim() -replace '/', '\'
+    $nestedPathSegments = @($NestedInstallerPath -split '\\')
+    $nestedPathIsUnsafe = [System.IO.Path]::IsPathRooted($NestedInstallerPath) -or
+        $NestedInstallerPath.StartsWith('\\') -or
+        $nestedPathSegments -contains '..' -or
+        $NestedInstallerPath.Contains(':') -or
+        $NestedInstallerPath -match '[\x00-\x1f]'
+    if ($nestedPathIsUnsafe) {
+        throw "Unsafe nested installer path: $NestedInstallerPath"
+    }
+}
+
+$portableFolderName = ($DisplayName -replace '[<>:"/\\|?*\x00-\x1f]', '_').Trim().TrimEnd('.')
+if ([string]::IsNullOrWhiteSpace($portableFolderName) -or
+    $portableFolderName -match '^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$') {
+    $portableFolderName = $sanitizedWingetId
+}
+$portableFolderNameSingleQuoteEscaped = $portableFolderName -replace "'", "''"
+$portableInstallPathLine = if ($IsUserScope) {
+    "    `$installPath = Join-Path `$env:LOCALAPPDATA 'Programs\$portableFolderNameSingleQuoteEscaped'"
+} else {
+    "    `$installPath = Join-Path `$env:ProgramFiles '$portableFolderNameSingleQuoteEscaped'"
+}
+
 # Check if uninstall command uses special handling
 $useRegistryUninstall = $false
 $useMsixUninstall = $false
@@ -434,7 +463,10 @@ $usePortableUninstall = $false
 $registryUninstallDisplayName = ''
 $msixPackageName = ''
 
-if ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
+if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
+    $usePortableUninstall = $true
+    Write-Host "Using portable uninstall (folder removal)"
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
     $useRegistryUninstall = $true
     $registryUninstallDisplayName = $Matches[1]
 
@@ -459,7 +491,7 @@ if ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
     $useMsixUninstall = $true
     $msixPackageName = $Matches[1]
     Write-Host "Using MSIX uninstall for package: $msixPackageName"
-} elseif ($installerTypeLower -in 'zip', 'portable') {
+} elseif ($installerTypeLower -eq 'zip') {
     $usePortableUninstall = $true
     Write-Host "Using portable uninstall (folder removal)"
 }
@@ -926,68 +958,128 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                 $nestedInstallerTypeLower = if ($NestedInstallerType) { $NestedInstallerType.ToLower() } else { '' }
                 Write-Host "Zip installer with nested installer: type='$nestedInstallerTypeLower' path='$NestedInstallerPath'"
 
-                # Build the execution line for the nested installer (dispatch on nested type)
-                switch ($nestedInstallerTypeLower) {
-                    { $_ -in 'msi', 'wix' } {
-                        $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
-                        if ($msiProperties) {
-                            $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath -AdditionalArgumentList '$msiProperties'"
-                        } else {
-                            $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath"
-                        }
-                    }
-                    'portable' {
-                        $nestedExecuteLine = '        throw "Portable nested installers are not supported yet"'
-                    }
-                    default {
-                        if ($IsUserScope) {
-                            $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
-                        } else {
-                            $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
-                        }
-                    }
-                }
-
-                $lines += @(
-                    ''
-                    '    # Extract the zip archive to a unique temp directory and run the nested installer'
-                    '    $zipExtractDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_Zip_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
-                    '    $null = New-Item -Path $zipExtractDir -ItemType Directory -Force'
-                    '    try {'
-                    '        Write-ADTLogEntry -Message "Extracting zip archive to: $zipExtractDir" -Severity ''Info'' -Source ''Install-ADTDeployment'''
-                )
-                if ($IsUserScope) {
-                    # Per-user installs: copy the zip to user temp first (consistent with the
-                    # exe branch - some installers fail when run from the IMECache directory)
+                if ($isNestedPortable) {
                     $lines += @(
-                        "        Copy-Item -LiteralPath `"`$(`$adtSession.DirFiles)\$installerFileName`" -Destination `$zipExtractDir -Force"
-                        "        Expand-Archive -Path (Join-Path `$zipExtractDir '$installerFileNameSingleQuoteEscaped') -DestinationPath `$zipExtractDir -Force"
+                        ''
+                        '    # Safely stage every portable archive entry before replacing the installed app'
+                        $portableInstallPathLine
+                        '    $portableStageDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_Portable_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
+                        '    $replacementStarted = $false'
+                        '    try {'
+                        '        $null = New-Item -Path $portableStageDir -ItemType Directory -Force'
+                        '        Add-Type -AssemblyName System.IO.Compression.FileSystem'
+                        '        $stageRoot = [System.IO.Path]::GetFullPath($portableStageDir)'
+                        '        $stageRootPrefix = $stageRoot.TrimEnd([char[]]@(''\'', ''/'')) + [System.IO.Path]::DirectorySeparatorChar'
+                        '        $archive = [System.IO.Compression.ZipFile]::OpenRead($installerPath)'
+                        '        try {'
+                        '            foreach ($entry in $archive.Entries) {'
+                        '                $entryRelativePath = $entry.FullName.Replace(''/'', [System.IO.Path]::DirectorySeparatorChar)'
+                        '                if ([string]::IsNullOrWhiteSpace($entryRelativePath)) { continue }'
+                        '                if ($entryRelativePath.Contains('':'')) { throw "Archive entry contains an unsupported path: $($entry.FullName)" }'
+                        '                $targetPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($stageRoot, $entryRelativePath))'
+                        '                if ($targetPath -ne $stageRoot -and -not $targetPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {'
+                        '                    throw "Archive entry escapes the portable staging directory: $($entry.FullName)"'
+                        '                }'
+                        '                if ([string]::IsNullOrEmpty($entry.Name)) {'
+                        '                    $null = New-Item -Path $targetPath -ItemType Directory -Force'
+                        '                    continue'
+                        '                }'
+                        '                $targetDirectory = [System.IO.Path]::GetDirectoryName($targetPath)'
+                        '                if ($targetDirectory) { $null = New-Item -Path $targetDirectory -ItemType Directory -Force }'
+                        '                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $targetPath, $true)'
+                        '            }'
+                        '        }'
+                        '        finally {'
+                        '            if ($archive) { $archive.Dispose() }'
+                        '        }'
+                        "        `$declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path `$stageRoot '$nestedInstallerPathEscaped'))"
+                        '        if (-not $declaredNestedPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {'
+                        '            throw "Nested installer path escapes the portable staging directory"'
+                        '        }'
+                        '        if (-not (Test-Path -LiteralPath $declaredNestedPath -PathType Leaf)) {'
+                        "            throw `"Nested installer not found in archive: $nestedInstallerPathEscaped`""
+                        '        }'
+                        '        $installParent = [System.IO.Path]::GetDirectoryName($installPath)'
+                        '        if ($installParent) { $null = New-Item -Path $installParent -ItemType Directory -Force }'
+                        '        $replacementStarted = $true'
+                        '        if (Test-Path -LiteralPath $installPath) { Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction Stop }'
+                        '        Move-Item -LiteralPath $portableStageDir -Destination $installPath -Force'
+                        '        Write-ADTLogEntry -Message "Portable archive installed to: $installPath" -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                        '    }'
+                        '    catch {'
+                        '        if ($replacementStarted -and (Test-Path -LiteralPath $installPath)) {'
+                        '            Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction SilentlyContinue'
+                        '        }'
+                        '        Write-ADTLogEntry -Message "Failed to install portable archive: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
+                        '        throw'
+                        '    }'
+                        '    finally {'
+                        '        if (Test-Path -LiteralPath $portableStageDir) {'
+                        '            Remove-Item -LiteralPath $portableStageDir -Recurse -Force -ErrorAction SilentlyContinue'
+                        '        }'
+                        '    }'
                     )
                 } else {
+                    # Build the execution line for a non-portable nested installer.
+                    switch ($nestedInstallerTypeLower) {
+                        { $_ -in 'msi', 'wix' } {
+                            $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
+                            if ($msiProperties) {
+                                $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath -AdditionalArgumentList '$msiProperties'"
+                            } else {
+                                $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath"
+                            }
+                        }
+                        default {
+                            if ($IsUserScope) {
+                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                            } else {
+                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                            }
+                        }
+                    }
+
                     $lines += @(
-                        "        Expand-Archive -Path `"`$(`$adtSession.DirFiles)\$installerFileName`" -DestinationPath `$zipExtractDir -Force"
+                        ''
+                        '    # Extract the zip archive to a unique temp directory and run the nested installer'
+                        '    $zipExtractDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_Zip_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
+                        '    $null = New-Item -Path $zipExtractDir -ItemType Directory -Force'
+                        '    try {'
+                        '        Write-ADTLogEntry -Message "Extracting zip archive to: $zipExtractDir" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                    )
+                    if ($IsUserScope) {
+                        # Per-user installs: copy the zip to user temp first (consistent with the
+                        # exe branch - some installers fail when run from the IMECache directory)
+                        $lines += @(
+                            "        Copy-Item -LiteralPath `"`$(`$adtSession.DirFiles)\$installerFileName`" -Destination `$zipExtractDir -Force"
+                            "        Expand-Archive -Path (Join-Path `$zipExtractDir '$installerFileNameSingleQuoteEscaped') -DestinationPath `$zipExtractDir -Force"
+                        )
+                    } else {
+                        $lines += @(
+                            "        Expand-Archive -Path `"`$(`$adtSession.DirFiles)\$installerFileName`" -DestinationPath `$zipExtractDir -Force"
+                        )
+                    }
+                    $lines += @(
+                        "        `$nestedInstallerPath = Join-Path `$zipExtractDir '$nestedInstallerPathEscaped'"
+                        '        if (-not (Test-Path -LiteralPath $nestedInstallerPath)) {'
+                        "            throw `"Nested installer not found in archive: $nestedInstallerPathEscaped`""
+                        '        }'
+                        '        Write-ADTLogEntry -Message "Running nested installer: $nestedInstallerPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                        $nestedExecuteLine
+                        '    }'
+                        '    finally {'
+                        '        if (Test-Path -LiteralPath $zipExtractDir) {'
+                        '            Remove-Item -Path $zipExtractDir -Recurse -Force -ErrorAction SilentlyContinue'
+                        '        }'
+                        '    }'
                     )
                 }
-                $lines += @(
-                    "        `$nestedInstallerPath = Join-Path `$zipExtractDir '$nestedInstallerPathEscaped'"
-                    '        if (-not (Test-Path -LiteralPath $nestedInstallerPath)) {'
-                    "            throw `"Nested installer not found in archive: $nestedInstallerPathEscaped`""
-                    '        }'
-                    '        Write-ADTLogEntry -Message "Running nested installer: $nestedInstallerPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
-                    $nestedExecuteLine
-                    '    }'
-                    '    finally {'
-                    '        if (Test-Path -LiteralPath $zipExtractDir) {'
-                    '            Remove-Item -Path $zipExtractDir -Recurse -Force -ErrorAction SilentlyContinue'
-                    '        }'
-                    '    }'
-                )
             }
         }
         'portable' {
             $lines += @(
                 "    `$sourcePath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
-                "    `$installPath = `"`$env:ProgramFiles\$displayNameEscaped`""
+                $portableInstallPathLine
                 '    Write-ADTLogEntry -Message "Installing portable app to: $installPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
                 '    try {'
                 '        if (-not (Test-Path $installPath)) {'
@@ -1229,7 +1321,7 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
     $lines += @(
         ''
         '    # Remove portable app folder'
-        "    `$installPath = `"`$env:ProgramFiles\$displayNameEscaped`""
+        $portableInstallPathLine
         '    Write-ADTLogEntry -Message "Removing portable app folder: $installPath" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
         '    try {'
         '        if (Test-Path $installPath) {'

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -584,6 +584,48 @@ catch
     };
   }
 
+  private isPortableInstaller(job: PackagingJob): boolean {
+    if (job.installer_type.toLowerCase() === 'portable') {
+      return true;
+    }
+    const nested = this.getNestedInstaller(job);
+    return job.installer_type.toLowerCase() === 'zip' && nested.type?.toLowerCase() === 'portable';
+  }
+
+  private normalizeNestedInstallerPath(nestedPath: string): string {
+    const normalized = nestedPath.trim().replace(/\//g, '\\');
+    const segments = normalized.split('\\');
+    if (
+      !normalized ||
+      /[\x00-\x1f]/.test(normalized) ||
+      normalized.includes(':') ||
+      path.win32.isAbsolute(normalized) ||
+      normalized.startsWith('\\') ||
+      segments.includes('..')
+    ) {
+      throw new Error(`Unsafe nested installer path: ${nestedPath}`);
+    }
+    return normalized;
+  }
+
+  private getPortableFolderName(job: PackagingJob): string {
+    const sanitized = job.display_name.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').trim().replace(/\.+$/, '');
+    if (
+      !sanitized ||
+      /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i.test(sanitized)
+    ) {
+      return this.sanitizeWingetId(job.winget_id);
+    }
+    return sanitized;
+  }
+
+  private getPortableInstallPathLine(job: PackagingJob): string {
+    const folderName = this.getPortableFolderName(job).replace(/'/g, "''");
+    return job.install_scope === 'user'
+      ? `$installPath = Join-Path $env:LOCALAPPDATA 'Programs\\${folderName}'`
+      : `$installPath = Join-Path $env:ProgramFiles '${folderName}'`;
+  }
+
   /**
    * Get custom install/uninstall command override from package_config.psadtConfig
    * Returns null when the override is absent, not a string, or empty/whitespace
@@ -714,6 +756,16 @@ ${steps}
       return `Start-ADTMsiProcess -Action 'Install' -FilePath '${fileName}'`;
     }
 
+    if (installerType === 'portable') {
+      const fileNameEscaped = fileName.replace(/'/g, "''");
+      return `${this.getPortableInstallPathLine(job)}
+    $sourcePath = Join-Path $adtSession.DirFiles '${fileNameEscaped}'
+    $null = New-Item -Path $installPath -ItemType Directory -Force
+    $targetPath = Join-Path $installPath '${fileNameEscaped}'
+    Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force
+    Write-ADTLogEntry -Message "Portable app installed to: $installPath" -Severity 'Success' -Source 'Install-ADTDeployment'`;
+    }
+
     return `Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\${fileName}" -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec`;
   }
 
@@ -741,8 +793,13 @@ ${steps}
       return 'throw "Zip package does not declare a nested installer; cannot install"';
     }
 
-    const nestedPathEscaped = nested.path.replace(/'/g, "''");
+    const normalizedNestedPath = this.normalizeNestedInstallerPath(nested.path);
+    const nestedPathEscaped = normalizedNestedPath.replace(/'/g, "''");
     const nestedType = (nested.type ?? '').toLowerCase();
+
+    if (nestedType === 'portable') {
+      return this.getPortableZipInstallCommand(job, fileName, nestedPathEscaped);
+    }
 
     let executeLine: string;
     if (nestedType === 'msi' || nestedType === 'wix') {
@@ -750,8 +807,6 @@ ${steps}
       executeLine = msiProperties
         ? `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath -AdditionalArgumentList '${msiProperties}'`
         : `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath`;
-    } else if (nestedType === 'portable') {
-      executeLine = 'throw "Portable nested installers are not supported yet"';
     } else {
       executeLine = `Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec`;
     }
@@ -774,6 +829,71 @@ ${steps}
     }`;
   }
 
+  private getPortableZipInstallCommand(
+    job: PackagingJob,
+    fileName: string,
+    nestedPathEscaped: string
+  ): string {
+    const fileNameEscaped = fileName.replace(/'/g, "''");
+    return `${this.getPortableInstallPathLine(job)}
+    $portableStageDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_Portable_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))
+    $replacementStarted = $false
+    try {
+        $null = New-Item -Path $portableStageDir -ItemType Directory -Force
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $stageRoot = [System.IO.Path]::GetFullPath($portableStageDir)
+        $stageRootPrefix = $stageRoot.TrimEnd([char[]]@('\\', '/')) + [System.IO.Path]::DirectorySeparatorChar
+        $archivePath = Join-Path $adtSession.DirFiles '${fileNameEscaped}'
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
+        try {
+            foreach ($entry in $archive.Entries) {
+                $entryRelativePath = $entry.FullName.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+                if ([string]::IsNullOrWhiteSpace($entryRelativePath)) { continue }
+                if ($entryRelativePath.Contains(':')) { throw "Archive entry contains an unsupported path: $($entry.FullName)" }
+                $targetPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($stageRoot, $entryRelativePath))
+                if ($targetPath -ne $stageRoot -and -not $targetPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    throw "Archive entry escapes the portable staging directory: $($entry.FullName)"
+                }
+                if ([string]::IsNullOrEmpty($entry.Name)) {
+                    $null = New-Item -Path $targetPath -ItemType Directory -Force
+                    continue
+                }
+                $targetDirectory = [System.IO.Path]::GetDirectoryName($targetPath)
+                if ($targetDirectory) { $null = New-Item -Path $targetDirectory -ItemType Directory -Force }
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $targetPath, $true)
+            }
+        }
+        finally {
+            if ($archive) { $archive.Dispose() }
+        }
+        $declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path $stageRoot '${nestedPathEscaped}'))
+        if (-not $declaredNestedPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Nested installer path escapes the portable staging directory"
+        }
+        if (-not (Test-Path -LiteralPath $declaredNestedPath -PathType Leaf)) {
+            throw "Nested installer not found in archive: ${nestedPathEscaped}"
+        }
+        $installParent = [System.IO.Path]::GetDirectoryName($installPath)
+        if ($installParent) { $null = New-Item -Path $installParent -ItemType Directory -Force }
+        $replacementStarted = $true
+        if (Test-Path -LiteralPath $installPath) { Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction Stop }
+        Move-Item -LiteralPath $portableStageDir -Destination $installPath -Force
+        Write-ADTLogEntry -Message "Portable archive installed to: $installPath" -Severity 'Success' -Source 'Install-ADTDeployment'
+    }
+    catch {
+        if ($replacementStarted -and (Test-Path -LiteralPath $installPath)) {
+            Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        Write-ADTLogEntry -Message "Failed to install portable archive: $_" -Severity 'Error' -Source 'Install-ADTDeployment'
+        throw
+    }
+    finally {
+        if (Test-Path -LiteralPath $portableStageDir) {
+            Remove-Item -LiteralPath $portableStageDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }`;
+  }
+
   /**
    * Get uninstall command (PSADT v4 cmdlets)
    * A custom uninstall command override from psadtConfig takes precedence
@@ -783,6 +903,14 @@ ${steps}
     if (uninstallOverride) {
       const overrideEscaped = uninstallOverride.replace(/'/g, "''");
       return `Start-ADTProcess -FilePath "$env:SystemRoot\\System32\\cmd.exe" -ArgumentList '/c ${overrideEscaped}' -WorkingDirectory $adtSession.DirFiles -WindowStyle Hidden`;
+    }
+
+    if (this.isPortableInstaller(job)) {
+      return `${this.getPortableInstallPathLine(job)}
+    Write-ADTLogEntry -Message "Removing portable app folder: $installPath" -Severity 'Info' -Source 'Uninstall-ADTDeployment'
+    if (Test-Path -LiteralPath $installPath) {
+        Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction Stop
+    }`;
     }
 
     if (!job.uninstall_command) {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { JobProcessor } from '../src/job-processor';
+import type { PackagingJob } from '../src/job-poller';
+
+type ScriptGenerator = {
+  getInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string;
+  getUninstallCommand(job: PackagingJob): string;
+};
+
+const generator = JobProcessor.prototype as unknown as ScriptGenerator;
+
+function packagingJob(overrides: Partial<PackagingJob> = {}): PackagingJob {
+  return {
+    id: 'candidate-1',
+    user_id: 'user-1',
+    user_email: 'qa@example.com',
+    tenant_id: 'tenant-1',
+    winget_id: 'EligianLabs.PIICrawlerCLI',
+    version: '26.0807.2256',
+    display_name: 'PIICrawler CLI',
+    publisher: 'EligianLabs',
+    architecture: 'x64',
+    installer_type: 'zip',
+    installer_url: 'https://example.com/piicrawler.zip',
+    installer_sha256: 'A'.repeat(64),
+    install_command: '',
+    uninstall_command: 'REGISTRY_UNINSTALL:PIICrawler CLI',
+    install_scope: 'machine',
+    detection_rules: [],
+    package_config: {
+      nestedInstallerType: 'portable',
+      nestedInstallerPath: 'piicrawler.exe',
+      psadtConfig: {},
+    },
+    status: 'queued',
+    progress_percent: 0,
+    created_at: '2026-08-08T11:10:00.000Z',
+    ...overrides,
+  };
+}
+
+function installScript(job: PackagingJob): string {
+  return generator.getInstallCommand.call(generator, job, 'piicrawler.zip', '');
+}
+
+function uninstallScript(job: PackagingJob): string {
+  return generator.getUninstallCommand.call(generator, job);
+}
+
+describe('nested portable PSADT generation', () => {
+  it('safely stages the full archive and never executes the nested portable file', () => {
+    const script = installScript(packagingJob());
+
+    expect(script).toContain("$installPath = Join-Path $env:ProgramFiles 'PIICrawler CLI'");
+    expect(script).toContain('[System.IO.Compression.ZipFile]::OpenRead($archivePath)');
+    expect(script).toContain('Archive entry escapes the portable staging directory');
+    expect(script).toContain("Join-Path $stageRoot 'piicrawler.exe'");
+    expect(script).toContain('Move-Item -LiteralPath $portableStageDir -Destination $installPath');
+    expect(script).not.toContain('Portable nested installers are not supported yet');
+    expect(script).not.toContain('Running nested installer');
+    expect(script).not.toContain('Expand-Archive');
+  });
+
+  it('removes the portable folder instead of using a registry uninstall sentinel', () => {
+    const script = uninstallScript(packagingJob());
+
+    expect(script).toContain("$installPath = Join-Path $env:ProgramFiles 'PIICrawler CLI'");
+    expect(script).toContain('Remove-Item -LiteralPath $installPath -Recurse -Force');
+    expect(script).not.toContain('REGISTRY_UNINSTALL');
+    expect(script).not.toContain('cmd.exe');
+  });
+
+  it('keeps a custom uninstall command ahead of synthesized portable cleanup', () => {
+    const job = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: { uninstallCommand: 'cleanup.cmd /quiet' },
+      },
+    });
+
+    const script = uninstallScript(job);
+
+    expect(script).toContain('/c cleanup.cmd /quiet');
+    expect(script).not.toContain('Remove-Item -LiteralPath $installPath');
+  });
+
+  it('uses the user programs directory for a user-scope portable package', () => {
+    const job = packagingJob({ install_scope: 'user' });
+
+    expect(installScript(job)).toContain(
+      "$installPath = Join-Path $env:LOCALAPPDATA 'Programs\\PIICrawler CLI'",
+    );
+    expect(uninstallScript(job)).toContain(
+      "$installPath = Join-Path $env:LOCALAPPDATA 'Programs\\PIICrawler CLI'",
+    );
+  });
+
+  it.each([
+    '..\\evil.exe',
+    'folder\\..\\evil.exe',
+    'C:\\evil.exe',
+    '\\\\server\\share\\evil.exe',
+    'folder\\tool.exe:payload',
+  ])('rejects an unsafe declared nested path: %s', (nestedInstallerPath) => {
+    const job = packagingJob({
+      package_config: { nestedInstallerType: 'portable', nestedInstallerPath },
+    });
+
+    expect(() => installScript(job)).toThrow('Unsafe nested installer path');
+  });
+
+  it('normalizes a valid forward-slash nested path', () => {
+    const job = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'bin/piicrawler.exe',
+      },
+    });
+
+    expect(installScript(job)).toContain("Join-Path $stageRoot 'bin\\piicrawler.exe'");
+  });
+});
+
+describe('hosted PSADT portable generator', () => {
+  it('contains the same safe nested-portable and uninstall decisions', () => {
+    const scriptPath = fileURLToPath(
+      new URL('../../.github/scripts/Create-PSADTPackage.ps1', import.meta.url),
+    );
+    const script = readFileSync(scriptPath, 'utf8');
+
+    expect(script).toContain("$isNestedPortable = $installerTypeLower -eq 'zip'");
+    expect(script).toContain("if ($installerTypeLower -eq 'portable' -or $isNestedPortable)");
+    expect(script).toContain('[System.IO.Compression.ZipFile]::OpenRead($installerPath)');
+    expect(script).toContain('Archive entry escapes the portable staging directory');
+    expect(script).not.toContain('Portable nested installers are not supported yet');
+  });
+});


### PR DESCRIPTION
## Summary
- support WinGet ZIP packages whose nested installer type is `portable`
- safely stage all archive entries with zip-slip and ADS defenses, verify the declared nested file, and copy without executing it
- make portable install/uninstall directories scope-aware and ensure portable cleanup wins over registry-uninstall sentinels
- keep GitHub-hosted and self-hosted packaging engines aligned
- add generated-script regression coverage for safety, scope, uninstall, and custom overrides

## Production evidence
QA run `31254574748` exposed the previous explicit `Portable nested installers are not supported yet` throw for `EligianLabs.PIICrawlerCLI`.

## Verification
- focused tests: 23 passed
- complete suite: 600 passed, 1 unrelated translation timeout; isolated rerun passed 2/2
- self-hosted packager TypeScript build passed
- PowerShell generator AST passed
- ESLint passed
- production Next.js build passed
- Fable final review: APPROVED