### PR TITLE
Pin QA to nested portable packager fix

### DIFF
--- a/.github/workflows-reference/package-intunewin.yml
+++ b/.github/workflows-reference/package-intunewin.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: ugurkocde/IntuneGet
           # Update only after reviewing the referenced scripts in this commit.
-          ref: de6ff2636a446ff69a222811d4057dd92b452a71
+          ref: 70685a9a689b7cdeb4edba8ec5eadd1cc8bb2cc5
           path: intuneget
           persist-credentials: false
 

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -132,7 +132,7 @@ function createSupabaseStub(options: {
   return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
 }
 
-const CURRENT_PACKAGER_COMMIT = 'de6ff2636a446ff69a222811d4057dd92b452a71';
+const CURRENT_PACKAGER_COMMIT = '70685a9a689b7cdeb4edba8ec5eadd1cc8bb2cc5';
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'de6ff2636a446ff69a222811d4057dd92b452a71',
+  packagerCommit: '70685a9a689b7cdeb4edba8ec5eadd1cc8bb2cc5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Pins catalog QA package identities and the reference packaging workflow to reviewed packager commit `70685a9a689b7cdeb4edba8ec5eadd1cc8bb2cc5` from #241. Updates the backfill test's current-commit fixture so older profiles are re-enqueued.

Verification: 13 focused tests passed, ESLint passed, Fable coordinated-pin review APPROVED.