### PR TITLE
Harden QA package profile dispatch

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createServerClientMock, dispatchQaCandidateMock } = vi.hoisted(() => ({
+  createServerClientMock: vi.fn(),
+  dispatchQaCandidateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
+vi.mock('@/lib/qa/dispatch', () => ({ dispatchQaCandidate: dispatchQaCandidateMock }));
+
+import { GET } from './route';
+import { buildQaPackageIdentity } from '@/lib/qa/package-profile';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string; code?: string } | null;
+};
+
+const CATALOG_ID = '00000000-0000-4000-8000-000000000001';
+const DEPLOYMENT_ID = '00000000-0000-4000-8000-000000000002';
+
+function testUuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+}
+
+function query(result: QueryResult) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ['eq', 'in', 'order', 'limit', 'or', 'select']) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.maybeSingle = vi.fn(async () => result);
+  builder.then = (
+    onFulfilled?: (value: QueryResult) => unknown,
+    onRejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return builder;
+}
+
+function candidate(profileKind: 'catalog-default' | 'deployment-config') {
+  const profileInput = {
+    profileKind,
+    wingetId: 'Example.App',
+    displayName: 'Example',
+    publisher: 'Contoso',
+    version: '1.2.3',
+    architecture: 'x64',
+    installerSha256: 'A'.repeat(64),
+    sourceInstallerType: 'nullsoft',
+    silentArgs: '/S',
+    uninstallCommand: 'REGISTRY_UNINSTALL:Example:/S',
+    installScope: 'machine',
+    nestedInstallerType: '',
+    nestedInstallerFiles: [],
+    psadtConfig: DEFAULT_PSADT_CONFIG,
+    detectionRules: [],
+  } as const;
+  const identity = buildQaPackageIdentity(profileInput);
+  return {
+    id: profileKind === 'deployment-config' ? DEPLOYMENT_ID : CATALOG_ID,
+    winget_id: profileInput.wingetId,
+    version: profileInput.version,
+    architecture: profileInput.architecture,
+    installer_sha256: profileInput.installerSha256,
+    package_profile_sha256: identity.packageProfileSha256,
+    test_config: {
+      profileKind,
+      packageProfileCanonicalJson: identity.canonicalJson,
+      packageProfileSha256: identity.packageProfileSha256,
+    },
+    priority: profileKind === 'deployment-config' ? 1000 : 0,
+    enqueued_at: '2026-08-08T12:00:00.000Z',
+    attempts: 0,
+    status: 'queued',
+    test_level: 'psadt-package',
+  };
+}
+
+function createSupabaseStub(
+  queued: Array<ReturnType<typeof candidate>>,
+  additionalPages: Array<Array<ReturnType<typeof candidate>>> = [],
+  options: {
+    claimNullIds?: string[];
+    claimErrorById?: Record<string, { message: string; code?: string }>;
+    supersedeError?: { message: string; code?: string };
+  } = {}
+) {
+  const supersededIds: string[] = [];
+  const claimedIds: string[] = [];
+  const claimAttemptIds: string[] = [];
+  const rollbackIds: string[] = [];
+  const orFilters: string[] = [];
+  const supersedePayloads: Array<Record<string, unknown>> = [];
+  const queuePages = [queued, ...additionalPages];
+  const allQueued = queuePages.flat();
+  let queuePageIndex = 0;
+
+  const client = {
+    from: vi.fn((table: string) => {
+      if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
+      return {
+        select: vi.fn((columns: string) => {
+          if (columns === '*') return query({ data: [], error: null });
+          if (columns === 'id') return query({ data: [], error: null });
+          if (columns.includes('package_profile_sha256')) {
+            const data = queuePages[queuePageIndex++] || [];
+            const builder = query({ data, error: null }) as Record<string, unknown>;
+            builder.or = vi.fn((filter: string) => {
+              orFilters.push(filter);
+              return builder;
+            });
+            return builder;
+          }
+          throw new Error(`Unexpected select: ${columns}`);
+        }),
+        update: vi.fn((values: Record<string, unknown>) => {
+          if (values.status === 'superseded') {
+            supersedePayloads.push(values);
+            let ids: string[] = [];
+            const builder = query({ data: [], error: null }) as Record<string, unknown>;
+            builder.in = vi.fn((_column: string, value: string[]) => {
+              ids = value;
+              return builder;
+            });
+            builder.select = vi.fn(() => {
+              if (options.supersedeError) {
+                return query({ data: null, error: options.supersedeError });
+              }
+              supersededIds.push(...ids);
+              return query({ data: ids.map((id) => ({ id })), error: null });
+            });
+            return builder;
+          }
+
+          if (values.status === 'dispatched') {
+            let id = '';
+            const builder = query({ data: null, error: null }) as Record<string, unknown>;
+            builder.eq = vi.fn((column: string, value: string) => {
+              if (column === 'id') id = value;
+              return builder;
+            });
+            builder.maybeSingle = vi.fn(async () => {
+              claimAttemptIds.push(id);
+              const claimError = options.claimErrorById?.[id];
+              if (claimError) return { data: null, error: claimError };
+              if (options.claimNullIds?.includes(id)) return { data: null, error: null };
+              const row = allQueued.find((entry) => entry.id === id) || null;
+              if (row) claimedIds.push(id);
+              return { data: row ? { ...row, ...values } : null, error: null };
+            });
+            return builder;
+          }
+
+          if (values.status === 'queued') {
+            const builder = query({ data: null, error: null }) as Record<string, unknown>;
+            builder.eq = vi.fn((column: string, value: string) => {
+              if (column === 'id') rollbackIds.push(value);
+              return builder;
+            });
+            return builder;
+          }
+
+          throw new Error(`Unexpected update: ${JSON.stringify(values)}`);
+        }),
+      };
+    }),
+  };
+  return {
+    client,
+    supersededIds,
+    supersedePayloads,
+    claimedIds,
+    claimAttemptIds,
+    rollbackIds,
+    orFilters,
+  };
+}
+
+function cronRequest(): Request {
+  return new Request('https://intuneget.com/api/cron/qa-dispatch', {
+    headers: { authorization: 'Bearer test-cron-secret' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CRON_SECRET = 'test-cron-secret';
+  dispatchQaCandidateMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe('GET /api/cron/qa-dispatch', () => {
+  it('supersedes an invalid row and dispatches the valid row behind it', async () => {
+    const invalid = candidate('catalog-default');
+    invalid.id = testUuid(10);
+    invalid.priority = 1000;
+    invalid.test_config.profileKind = 'legacy' as never;
+    const valid = candidate('catalog-default');
+    const { client, supersededIds, supersedePayloads, claimedIds } = createSupabaseStub([
+      invalid,
+      valid,
+    ]);
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      dispatched: true,
+      candidateId: valid.id,
+      scanned: 2,
+      superseded: 1,
+    });
+    expect(supersededIds).toEqual([invalid.id]);
+    expect(supersedePayloads).toEqual([
+      expect.objectContaining({
+        status: 'superseded',
+        finished_at: expect.any(String),
+        failure_summary: 'Superseded before dispatch: wrong-profile-kind.',
+        updated_at: expect.any(String),
+      }),
+    ]);
+    expect(claimedIds).toEqual([valid.id]);
+    expect(dispatchQaCandidateMock).toHaveBeenCalledOnce();
+  });
+
+  it('dispatches a current deployment-config profile', async () => {
+    const deploymentConfig = candidate('deployment-config');
+    const { client, supersededIds, claimedIds } = createSupabaseStub([deploymentConfig]);
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: true, candidateId: deploymentConfig.id });
+    expect(supersededIds).toEqual([]);
+    expect(claimedIds).toEqual([deploymentConfig.id]);
+  });
+
+  it('supersedes a row whose canonical profile does not match its installer', async () => {
+    const invalid = candidate('catalog-default');
+    invalid.installer_sha256 = 'B'.repeat(64);
+    const { client, supersededIds, claimedIds } = createSupabaseStub([invalid]);
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: false, reason: 'queue_empty', superseded: 1 });
+    expect(supersededIds).toEqual([invalid.id]);
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('uses keyset pages to reach a valid row behind a full stale page', async () => {
+    const stalePage = Array.from({ length: 100 }, (_, index) => {
+      const row = candidate('catalog-default');
+      row.id = testUuid(100 + index);
+      row.test_config.profileKind = 'legacy' as never;
+      return row;
+    });
+    const valid = candidate('catalog-default');
+    valid.id = testUuid(999);
+    const { client, supersededIds, claimedIds, orFilters } = createSupabaseStub(
+      stalePage,
+      [[valid]]
+    );
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      dispatched: true,
+      candidateId: valid.id,
+      scanned: 101,
+      superseded: 100,
+    });
+    expect(supersededIds).toHaveLength(100);
+    expect(claimedIds).toEqual([valid.id]);
+    expect(orFilters).toEqual([
+      `priority.lt.0,and(priority.eq.0,enqueued_at.gt."2026-08-08T12:00:00.000Z"),and(priority.eq.0,enqueued_at.eq."2026-08-08T12:00:00.000Z",id.gt."${testUuid(199)}")`,
+    ]);
+  });
+
+  it('stops when a compare-and-set claim is lost instead of claiming another row', async () => {
+    const first = candidate('catalog-default');
+    first.id = testUuid(20);
+    const second = candidate('catalog-default');
+    second.id = testUuid(21);
+    const { client, claimAttemptIds, claimedIds } = createSupabaseStub([first, second], [], {
+      claimNullIds: [first.id],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: false, reason: 'claim_lost' });
+    expect(claimAttemptIds).toEqual([first.id]);
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('treats the single-active unique-index race as a lost claim', async () => {
+    const row = candidate('catalog-default');
+    const { client, claimAttemptIds } = createSupabaseStub([row], [], {
+      claimErrorById: {
+        [row.id]: { message: 'duplicate key', code: '23505' },
+      },
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: false, reason: 'claim_lost' });
+    expect(claimAttemptIds).toEqual([row.id]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('supersedes invalid queue metadata without blocking a valid row', async () => {
+    const invalid = candidate('catalog-default');
+    invalid.id = testUuid(30);
+    invalid.priority = Number.NaN;
+    const valid = candidate('catalog-default');
+    valid.id = testUuid(31);
+    const { client, supersededIds, claimedIds } = createSupabaseStub([invalid, valid]);
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: true, candidateId: valid.id, superseded: 1 });
+    expect(supersededIds).toEqual([invalid.id]);
+    expect(claimedIds).toEqual([valid.id]);
+  });
+
+  it('rolls a claim back to queued when workflow dispatch fails', async () => {
+    const row = candidate('catalog-default');
+    const { client, rollbackIds } = createSupabaseStub([row]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock.mockRejectedValueOnce(new Error('GitHub unavailable'));
+
+    await expect(GET(cronRequest())).rejects.toThrow('GitHub unavailable');
+
+    expect(rollbackIds).toEqual([row.id]);
+  });
+
+  it('does not claim anything when superseding an invalid profile fails', async () => {
+    const invalid = candidate('catalog-default');
+    invalid.test_config.profileKind = 'legacy' as never;
+    const { client, claimAttemptIds } = createSupabaseStub([invalid], [], {
+      supersedeError: { message: 'database unavailable' },
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    await expect(GET(cronRequest())).rejects.toMatchObject({
+      message: 'database unavailable',
+    });
+    expect(claimAttemptIds).toEqual([]);
+  });
+});

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -1,11 +1,40 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { dispatchQaCandidate } from '@/lib/qa/dispatch';
+import { validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
 const RUN_TIMEOUT_MS = 5 * 60 * 60 * 1000;
 const MAX_ATTEMPTS = 2;
+const QUEUE_SCAN_PAGE_SIZE = 100;
+const MAX_QUEUE_SCAN_PAGES = 10;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function queueCursor(candidate: {
+  id: unknown;
+  priority: unknown;
+  enqueued_at: unknown;
+}): { priority: number; enqueuedAt: string; id: string } | null {
+  if (!Number.isInteger(candidate.priority)) return null;
+  if (typeof candidate.id !== 'string' || !UUID_PATTERN.test(candidate.id)) return null;
+  if (
+    typeof candidate.enqueued_at !== 'string' ||
+    !candidate.enqueued_at ||
+    Number.isNaN(Date.parse(candidate.enqueued_at))
+  ) {
+    return null;
+  }
+  return {
+    priority: candidate.priority as number,
+    enqueuedAt: candidate.enqueued_at,
+    id: candidate.id,
+  };
+}
+
+function postgrestQuoted(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
 
 export async function GET(request: Request) {
   const cronSecret = process.env.CRON_SECRET;
@@ -49,60 +78,173 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: true, dispatched: false, reason: 'qa_active', reconciled });
   }
 
-  const { data: next, error: queueError } = await supabase
-    .from('qa_candidates')
-    .select('*')
-    .eq('test_level', 'psadt-package')
-    .eq('status', 'queued')
-    .order('priority', { ascending: false })
-    .order('enqueued_at', { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  if (queueError) throw queueError;
-  if (!next) {
-    return NextResponse.json({ success: true, dispatched: false, reason: 'queue_empty', reconciled });
-  }
+  let cursor: { priority: number; enqueuedAt: string; id: string } | null = null;
+  let scanned = 0;
+  let superseded = 0;
+  const supersededAt = new Date().toISOString();
 
-  const dispatchedAt = new Date().toISOString();
-  const { data: claimed, error: claimError } = await supabase
-    .from('qa_candidates')
-    .update({
-      status: 'dispatched',
-      attempts: next.attempts + 1,
-      dispatched_at: dispatchedAt,
-      failure_summary: null,
-      updated_at: dispatchedAt,
-    })
-    .eq('id', next.id)
-    .eq('status', 'queued')
-    .select('*')
-    .maybeSingle();
-  if (claimError?.code === '23505') {
-    return NextResponse.json({ success: true, dispatched: false, reason: 'claim_lost', reconciled });
-  }
-  if (claimError) throw claimError;
-  if (!claimed) {
-    return NextResponse.json({ success: true, dispatched: false, reason: 'claim_lost', reconciled });
-  }
-
-  try {
-    await dispatchQaCandidate(claimed);
-    return NextResponse.json({ success: true, dispatched: true, candidateId: claimed.id, reconciled });
-  } catch (error) {
-    console.error(`QA dispatch failed for candidate ${claimed.id}:`, error);
-    await supabase
+  for (let pageIndex = 0; pageIndex < MAX_QUEUE_SCAN_PAGES; pageIndex++) {
+    let queueQuery = supabase
       .from('qa_candidates')
-      .update({
-        status: 'queued',
-        attempts: next.attempts,
-        dispatched_at: null,
-        failure_summary: 'QA workflow dispatch failed; retry scheduled.',
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', claimed.id)
-      .eq('status', 'dispatched');
-    throw error;
+      .select(
+        'id, winget_id, version, architecture, installer_sha256, package_profile_sha256, test_config, priority, enqueued_at, attempts'
+      )
+      .eq('test_level', 'psadt-package')
+      .eq('status', 'queued')
+      .order('priority', { ascending: false })
+      .order('enqueued_at', { ascending: true })
+      .order('id', { ascending: true })
+      .limit(QUEUE_SCAN_PAGE_SIZE);
+    if (cursor) {
+      const enqueuedAt = postgrestQuoted(cursor.enqueuedAt);
+      const id = postgrestQuoted(cursor.id);
+      queueQuery = queueQuery.or(
+        `priority.lt.${cursor.priority},and(priority.eq.${cursor.priority},enqueued_at.gt.${enqueuedAt}),and(priority.eq.${cursor.priority},enqueued_at.eq.${enqueuedAt},id.gt.${id})`
+      );
+    }
+
+    const { data: page, error: queueError } = await queueQuery;
+    if (queueError) throw queueError;
+    if (!page?.length) break;
+    scanned += page.length;
+
+    const eligible = [];
+    const invalidByReason = new Map<string, string[]>();
+    const addInvalid = (reason: string, id: string) => {
+      const ids = invalidByReason.get(reason) || [];
+      ids.push(id);
+      invalidByReason.set(reason, ids);
+    };
+    for (const candidate of page) {
+      if (!queueCursor(candidate)) {
+        addInvalid('queue-metadata-invalid', candidate.id);
+        continue;
+      }
+      const validation = validateCurrentQaPackageProfile({
+        testConfig: candidate.test_config,
+        candidatePackageProfileSha256: candidate.package_profile_sha256,
+        candidateWingetId: candidate.winget_id,
+        candidateVersion: candidate.version,
+        candidateArchitecture: candidate.architecture,
+        candidateInstallerSha256: candidate.installer_sha256,
+      });
+      if (validation.valid) {
+        eligible.push(candidate);
+        continue;
+      }
+      addInvalid(validation.reason, candidate.id);
+    }
+
+    for (const [reason, ids] of invalidByReason) {
+      const { data: updated, error: supersedeError } = await supabase
+        .from('qa_candidates')
+        .update({
+          status: 'superseded',
+          finished_at: supersededAt,
+          failure_summary: `Superseded before dispatch: ${reason}.`,
+          updated_at: supersededAt,
+        })
+        .in('id', ids)
+        .eq('status', 'queued')
+        .select('id');
+      if (supersedeError) throw supersedeError;
+      superseded += updated?.length || 0;
+    }
+
+    let nextCursor: { priority: number; enqueuedAt: string; id: string } | null = null;
+    for (let index = page.length - 1; index >= 0; index--) {
+      nextCursor = queueCursor(page[index]);
+      if (nextCursor) break;
+    }
+    if (!nextCursor) {
+      return NextResponse.json({
+        success: true,
+        dispatched: false,
+        reason: 'queue_metadata_invalid',
+        reconciled,
+        scanned,
+        superseded,
+      });
+    }
+    cursor = nextCursor;
+
+    for (const candidate of eligible) {
+      const dispatchedAt = new Date().toISOString();
+      const { data: claimed, error: claimError } = await supabase
+        .from('qa_candidates')
+        .update({
+          status: 'dispatched',
+          attempts: candidate.attempts + 1,
+          dispatched_at: dispatchedAt,
+          failure_summary: null,
+          updated_at: dispatchedAt,
+        })
+        .eq('id', candidate.id)
+        .eq('status', 'queued')
+        .select('*')
+        .maybeSingle();
+      if (claimError?.code === '23505') {
+        return NextResponse.json({
+          success: true,
+          dispatched: false,
+          reason: 'claim_lost',
+          reconciled,
+          scanned,
+          superseded,
+        });
+      }
+      if (claimError) throw claimError;
+      // A lost compare-and-set means another dispatcher is already making
+      // progress. Do not move on to a second row and violate single-flight QA.
+      if (!claimed) {
+        return NextResponse.json({
+          success: true,
+          dispatched: false,
+          reason: 'claim_lost',
+          reconciled,
+          scanned,
+          superseded,
+        });
+      }
+
+      try {
+        await dispatchQaCandidate(claimed);
+        return NextResponse.json({
+          success: true,
+          dispatched: true,
+          candidateId: claimed.id,
+          reconciled,
+          scanned,
+          superseded,
+        });
+      } catch (error) {
+        console.error(`QA dispatch failed for candidate ${claimed.id}:`, error);
+        await supabase
+          .from('qa_candidates')
+          .update({
+            status: 'queued',
+            attempts: candidate.attempts,
+            dispatched_at: null,
+            failure_summary: 'QA workflow dispatch failed; retry scheduled.',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', claimed.id)
+          .eq('status', 'dispatched');
+        throw error;
+      }
+    }
+
+    if (page.length < QUEUE_SCAN_PAGE_SIZE) break;
   }
+
+  return NextResponse.json({
+    success: true,
+    dispatched: false,
+    reason: scanned >= QUEUE_SCAN_PAGE_SIZE * MAX_QUEUE_SCAN_PAGES ? 'scan_limit' : 'queue_empty',
+    reconciled,
+    scanned,
+    superseded,
+  });
 }
 
 /** Operator recovery for a terminal infrastructure error; protected by CRON_SECRET. */

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -20,6 +20,13 @@ vi.mock('@/lib/winget-sync-resolution.mjs', () => ({
 }));
 
 import { GET } from './route';
+import {
+  buildQaPackageIdentity,
+  canonicalQaJson,
+  QA_PSADT_TOOLCHAIN,
+  qaSha256,
+} from '@/lib/qa/package-profile';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 type QueryResult = {
   data: unknown;
@@ -140,16 +147,50 @@ function profileCandidate(options: {
   packagerCommit: string;
   enqueuedAt?: string;
   profileKind?: string;
+  toolchainOverrides?: Record<string, unknown>;
 }): Record<string, unknown> {
+  const profileKind = options.profileKind || 'catalog-default';
+  const version = '1.0.0';
+  const architecture = 'x64';
+  const installerSha256 = 'A'.repeat(64);
+  const identity = buildQaPackageIdentity({
+    profileKind: profileKind as 'catalog-default' | 'deployment-config',
+    wingetId: options.wingetId,
+    displayName: 'Example',
+    publisher: 'Contoso',
+    version,
+    architecture,
+    installerSha256,
+    sourceInstallerType: 'nullsoft',
+    silentArgs: '/S',
+    uninstallCommand: '',
+    installScope: 'machine',
+    nestedInstallerType: '',
+    nestedInstallerFiles: [],
+    psadtConfig: DEFAULT_PSADT_CONFIG,
+    detectionRules: [],
+  });
+  const canonicalJson = canonicalQaJson({
+    ...identity.profile,
+    toolchain: {
+      ...QA_PSADT_TOOLCHAIN,
+      packagerCommit: options.packagerCommit,
+      ...(options.toolchainOverrides || {}),
+    },
+  });
+  const packageProfileSha256 = qaSha256(canonicalJson);
   return {
     id: options.id,
     winget_id: options.wingetId,
+    version,
+    architecture,
+    installer_sha256: installerSha256,
     enqueued_at: options.enqueuedAt || '2026-08-08T10:00:00.000Z',
+    package_profile_sha256: packageProfileSha256,
     test_config: {
-      profileKind: options.profileKind || 'catalog-default',
-      packageProfileCanonicalJson: JSON.stringify({
-        toolchain: { packagerCommit: options.packagerCommit },
-      }),
+      profileKind,
+      packageProfileCanonicalJson: canonicalJson,
+      packageProfileSha256,
     },
   };
 }
@@ -338,6 +379,29 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(body).toMatchObject({ checked: 0, queued: 0, toolchainBackfillCount: 0 });
     expect(candidateInserts).toHaveLength(0);
     expect(resolveManifestMock).not.toHaveBeenCalled();
+  });
+
+  it('backfills a matching commit when another toolchain pin is stale', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'stale-template-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: CURRENT_PACKAGER_COMMIT,
+          toolchainOverrides: { templateSha256: 'B'.repeat(64) },
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 1, toolchainBackfillCount: 1 });
+    expect(candidateInserts[0]).toMatchObject({ winget_id: 'Example.App' });
   });
 
   it('uses only the newest catalog profile when deciding whether an app is stale', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -15,7 +15,10 @@ import {
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
-import { buildQaPackageIdentity, QA_PSADT_TOOLCHAIN } from '@/lib/qa/package-profile';
+import {
+  buildQaPackageIdentity,
+  validateCurrentQaPackageProfile,
+} from '@/lib/qa/package-profile';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
@@ -33,7 +36,11 @@ const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
 interface QaCandidateProfileRow {
   id: string;
   winget_id: string;
+  version: string;
+  architecture: string;
+  installer_sha256: string;
   enqueued_at: string;
+  package_profile_sha256: string | null;
   test_config: unknown;
 }
 
@@ -41,20 +48,6 @@ function object(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
-}
-
-function catalogProfilePackagerCommit(testConfig: unknown): string {
-  const config = object(testConfig);
-  if (config.profileKind !== 'catalog-default') return '';
-  if (typeof config.packageProfileCanonicalJson !== 'string') return '';
-
-  try {
-    const profile = object(JSON.parse(config.packageProfileCanonicalJson));
-    const toolchain = object(profile.toolchain);
-    return typeof toolchain.packagerCommit === 'string' ? toolchain.packagerCommit : '';
-  } catch {
-    return '';
-  }
 }
 
 async function findToolchainBackfillIds(
@@ -68,7 +61,9 @@ async function findToolchainBackfillIds(
   while (true) {
     let candidateQuery = supabase
       .from('qa_candidates')
-      .select('id, winget_id, enqueued_at, test_config')
+      .select(
+        'id, winget_id, version, architecture, installer_sha256, enqueued_at, package_profile_sha256, test_config'
+      )
       .eq('test_level', 'psadt-package')
       .not('package_profile_sha256', 'is', null)
       .order('enqueued_at', { ascending: false })
@@ -87,10 +82,18 @@ async function findToolchainBackfillIds(
 
     const pageStaleIds: string[] = [];
     for (const row of rows) {
-      const commit = catalogProfilePackagerCommit(row.test_config);
-      if (!commit || decidedIds.has(row.winget_id)) continue;
+      const config = object(row.test_config);
+      if (config.profileKind !== 'catalog-default' || decidedIds.has(row.winget_id)) continue;
       decidedIds.add(row.winget_id);
-      if (commit !== QA_PSADT_TOOLCHAIN.packagerCommit) pageStaleIds.push(row.winget_id);
+      const validation = validateCurrentQaPackageProfile({
+        testConfig: row.test_config,
+        candidatePackageProfileSha256: row.package_profile_sha256,
+        candidateWingetId: row.winget_id,
+        candidateVersion: row.version,
+        candidateArchitecture: row.architecture,
+        candidateInstallerSha256: row.installer_sha256,
+      });
+      if (!validation.valid) pageStaleIds.push(row.winget_id);
     }
 
     if (pageStaleIds.length > 0) {

--- a/docs/qa/psadt-packaging-coverage.md
+++ b/docs/qa/psadt-packaging-coverage.md
@@ -1,0 +1,80 @@
+# PSADT packaging coverage and findings
+
+This document is the durable audit log for IntuneGet's PSAppDeployToolkit package generator and QA runner. A UI option is not considered fully supported until it is propagated into the package profile, rendered as valid PSADT syntax, exercised in the generated package, and covered by an automated test.
+
+## Normative version and references
+
+- Pinned toolkit: PSAppDeployToolkit 4.1.8
+- Release: <https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/releases/tag/4.1.8>
+- 4.1 reference: <https://psappdeploytoolkit.com/docs/4.1.x/reference>
+- `Start-ADTMsiProcess`: <https://psappdeploytoolkit.com/docs/4.1.x/reference/functions/Start-ADTMsiProcess>
+- Deployment structure: <https://psappdeploytoolkit.com/docs/4.1.x/deployment-concepts/deployment-structure>
+- Deployment CLI: <https://psappdeploytoolkit.com/docs/4.1.x/usage/how-to-deploy>
+
+The pinned template URL and SHA-256 are part of the package profile identity. A changed configuration, detection rule, installer, architecture, or installer switch automatically creates a different identity when the profile is built. A code change to default settings or profile/detection derivation must also increment `QA_PACKAGE_PROFILE_SCHEMA_VERSION` and the protected workflow verifier in the same rollout; changing the toolkit, template, or packaging code requires updating its corresponding toolchain pin. The dispatcher rejects the old identity until a new test is queued.
+
+Catalog-default profiles are rebuilt in bounded batches by the WinGet poller. Deployment-config profiles are rebuilt from the customer's effective deployment settings each time the auto-update policy is evaluated, before the exact-profile release gate is checked. The catalog poller intentionally does not replace customized deployment profiles with catalog defaults.
+
+The protected workflow treats `packageProfileCanonicalJson` as the executable source of truth after verifying its SHA-256, schema version, toolchain pins, release tuple, and embedded configuration/detection hashes. Duplicate convenience fields in the outer `test_config` object are not used to generate or execute the package.
+
+## Support definition
+
+| Level | Meaning |
+| --- | --- |
+| Implemented | A generator path exists, but complete generated-package verification is not yet present. |
+| Unit covered | Generator output is asserted without executing the complete package. |
+| VM verified | The exact generated PSADT package passed install, detection, uninstall, and post-uninstall detection as LocalSystem in the golden VM. |
+| UI verified | Interactive behavior and dialog evidence were also verified in a logged-on user session. |
+
+## Current coverage
+
+| Area | Shapes/options | Current evidence | Remaining work |
+| --- | --- | --- | --- |
+| Catalog default | Silent LocalSystem install, generated detection, uninstall, compact evidence | VM verified for nested ZIP portable with PIICrawler CLI | Add representative VM fixtures for each installer family. |
+| MSI/Wix | MSI file, product-code uninstall, nested MSI in ZIP, extra MSI properties | Implemented | Assert that only `Silent`, `SilentWithProgress`, and `Custom` become execution arguments; `InstallLocation` must be substituted deliberately, never treated as a silent switch. Add MSI/product-code VM fixtures. |
+| EXE families | Generic EXE, Inno, Nullsoft, Burn | Implemented | Add generated-command tests and one VM fixture per family, including non-zero success/reboot exit codes. |
+| Archives | ZIP with nested installer paths and zip-slip protection | Unit covered for nested portable | Cover multiple nested files, nested MSI/EXE, Unicode paths, spaces, very long paths, duplicate names, and malformed archives. |
+| Portable | Top-level and nested portable, machine/user scope, cleanup | Unit covered; nested machine-scope path VM verified | Add user-scope and command-alias fixtures plus upgrade-over-existing-version behavior. |
+| MSIX/AppX | MSIX/AppX/package-family detection and uninstall | Implemented | Add signed bundle, dependency, per-user/provisioned, and certificate failure fixtures. |
+| Custom commands | Install/uninstall overrides and ordered post-install/post-uninstall commands | Implemented | Add quoting, spaces, Unicode, exit-code propagation, and command-injection boundary tests. |
+| Detection | Registry, file/folder, MSI, script, marker path, version operators, 32-bit registry view | Implemented | Add an exact rule matrix and verify that detection changes alter the profile hash and runtime result. |
+| Process handling | Processes to close, close prompt/countdown, block execution, save prompt, forced close, persistent prompt | Implemented | Add generated-script assertions and interactive VM evidence. |
+| Deferral | Count, deadline, days | Implemented | Verify precedence/invalid combinations and persistence across repeated runs. |
+| UI | Deploy mode, progress, window location, custom prompts at four timings, restart prompt, balloon tips | Implemented | Add an interactive QA mode with screenshots and session-aware assertions; catalog-default silent runs intentionally do not prove UI behavior. |
+| Branding/assets | Company/title/message, accent, light/dark logos, banner | Implemented | Validate file existence/type/size, package inclusion, config rendering, dark mode, and screenshots. |
+| Lifecycle | Remove existing install, install verification, restart behavior, disk-space check | Implemented | Add upgrade, repair/reinstall, reboot-required, low-disk, and ARP-less application fixtures. |
+
+## Findings
+
+| Date | Finding | Classification | Status/evidence |
+| --- | --- | --- | --- |
+| 2026-08-08 | ZIP packages containing a nested portable executable were rejected by both packaging engines. | IntuneGet packager defect | Fixed in packager commit `70685a9a689b7cdeb4edba8ec5eadd1cc8bb2cc5`; PIICrawler CLI 26.0807.2256 passed install/detect/uninstall/detect-absent in [run 31257215383](https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/31257215383). |
+| 2026-08-08 | A stale TeamViewer deployment profile supplied `-Archive -Path` as MSI arguments although the authoritative Winget manifest only declared `InstallerSwitches.InstallLocation`. The MSI stalled and never created its expected log. | Stale/incorrect IntuneGet package profile; vendor not at fault | Old candidate failed in [run 31256080001](https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/31256080001). Must be regenerated with the current catalog builder and rerun before closing. |
+| 2026-08-08 | The dispatcher accepted queued PSADT profiles created by an obsolete packager or without a verifiable profile identity. | QA orchestration defect | Thirty stale queued candidates were superseded. The hardening patch verifies schema version, canonical hash, candidate binding, and every pinned toolchain field before claim. |
+| 2026-08-08 | Automated catalog candidates inherited a 60-minute timeout for each install, detection, and uninstall phase; smoke tests alone used ten minutes. | Capacity/recovery defect | Separate patch required. Use phase-specific limits and retain logs before golden rollback. |
+| 2026-08-08 | A full packager checkout consumed roughly 1.5-2.5 minutes in otherwise short runs. | Throughput opportunity | Evaluate sparse checkout or a small immutable, hash-verified toolchain artifact. |
+| 2026-08-08 | Current package-level tests focus on nested portable behavior; most website PSADT customizations have generator code but no generated-script or VM matrix. | Coverage gap | Open. Build fixture-driven generator assertions first, then interactive VM scenarios for UI behavior. |
+| 2026-08-08 | HanaAgent 0.444.1 is a user-scope Nullsoft profile (`/S /currentuser`) but QA executes as LocalSystem. Installation returned 0, while the generated HKCU marker detection returned 1 and uninstall returned 60001. | Scope/context packaging or QA-model defect; vendor not yet implicated | Failed in [run 31257980483](https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/31257980483). Reproduce which user hive receives the app and marker, then define separate LocalSystem/machine and logged-on-user/user-scope QA semantics. |
+
+## Failure classification
+
+Every failed run should be assigned one primary class before it is shown as a vendor failure:
+
+1. `profile-integrity`: stale/mismatched profile, toolchain, template, config, or hashes.
+2. `package-generation`: invalid PSADT syntax, wrong switches, missing payload, unsafe archive handling, or bad quoting.
+3. `install`: correctly generated package reached the vendor installer and the installer failed or timed out.
+4. `detection`: install succeeded but the exact Intune detection rules did not match.
+5. `uninstall`: installed state was detected but the generated/vendor uninstall failed.
+6. `cleanup`: uninstall completed but unexpected residual state remained.
+7. `infrastructure`: VM, runner, network, checkpoint, evidence collection, or publication failed.
+
+Only classes 3 and vendor-owned portions of 5 should normally be presented as vendor-specific. Classes 1, 2, 4, 6, and 7 are actionable IntuneGet engineering signals unless investigation proves otherwise.
+
+## Next coverage increments
+
+1. Add generated-script golden tests for every field in `PSADTConfig`, in both the GitHub PowerShell generator and the self-hosted TypeScript packager.
+2. Add representative fixtures for MSI/Wix, Inno, Nullsoft, Burn, generic EXE, MSIX/AppX, top-level portable, nested portable, and nested MSI/EXE archives.
+3. Add an interactive QA lane for non-silent profiles with PSADT dialog screenshots; keep it separate from high-throughput catalog-default silent QA.
+4. Record the failure class and remediation state in compact QA JSON so the web UI can distinguish "vendor install failed" from "IntuneGet packaging issue found/fixed/retest pending."
+5. Require a passing rerun of the new immutable profile before a remediation is marked verified or an automatic tenant update is released.
+6. Define and test user-scope behavior explicitly: install context, target user hive/profile, detection context, uninstall context, and how Intune assignment context maps to each one. Do not treat an HKCU failure under LocalSystem as a vendor failure.

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -142,7 +142,10 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     getQaResultMock.mockResolvedValue(failedPackageResult);
     getPackageResultMock.mockResolvedValue({ data: failedPackageResult, error: null });
 
-    const supabase = createSupabaseMock({});
+    const candidateInsertSpy = vi.fn();
+    const supabase = createSupabaseMock({
+      qa_candidates: { insertSpy: candidateInsertSpy },
+    });
     const trigger = makeTrigger(supabase);
     const policy = makePolicy({
       displayName: 'Test App',
@@ -163,6 +166,16 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     });
     expect(result.skipReason).toContain('exact PSADT package QA pass');
     expect(createHistorySpy).not.toHaveBeenCalled();
+    expect(candidateInsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        winget_id: UPDATE_INFO.wingetId,
+        status: 'queued',
+        test_config: expect.objectContaining({ profileKind: 'deployment-config' }),
+      })
+    );
+    expect(candidateInsertSpy.mock.calls[0][0].package_profile_sha256).not.toBe(
+      failedPackageResult.package_profile_sha256
+    );
   });
 
   describe('ensurePsadtConfig', () => {

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -23,3 +23,21 @@ describe.each(migrationPaths)('QA candidate migration contract: %s', (migrationP
     expect(sql).toContain("when normalized_outcome = 'retry' then 'error'");
   });
 });
+
+describe('QA dispatcher schema contract', () => {
+  const sql = readFileSync(
+    resolve(process.cwd(), 'supabase/migrations/20260807193111_qa_release_gate.sql'),
+    'utf8'
+  );
+
+  it('defines superseded as terminal and provides its completion timestamp', () => {
+    expect(sql).toContain("'error', 'superseded'");
+    expect(sql).toContain('finished_at timestamptz');
+  });
+
+  it('enforces a non-null integer priority and a single active candidate', () => {
+    expect(sql).toContain('priority integer not null default 0');
+    expect(sql).toContain('create unique index qa_candidates_single_active_idx');
+    expect(sql).toContain("where status in ('dispatched', 'running')");
+  });
+});

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
-import { buildQaPackageIdentity, canonicalQaJson } from './package-profile';
+import {
+  buildQaPackageIdentity,
+  canonicalQaJson,
+  QA_PACKAGE_PROFILE_SCHEMA_VERSION,
+  QA_PSADT_TOOLCHAIN,
+  qaSha256,
+  validateCurrentQaPackageProfile,
+} from './package-profile';
 
 const input = {
   profileKind: 'catalog-default' as const,
@@ -68,5 +75,243 @@ describe('PSADT QA package identity', () => {
       buildQaPackageIdentity({ ...input, profileKind: 'deployment-config' })
         .packageProfileSha256
     ).not.toBe(buildQaPackageIdentity(input).packageProfileSha256);
+  });
+});
+
+describe('current catalog QA package validation', () => {
+  function currentCandidate() {
+    const identity = buildQaPackageIdentity(input);
+    return {
+      testConfig: {
+        profileKind: 'catalog-default',
+        packageProfileCanonicalJson: identity.canonicalJson,
+        packageProfileSha256: identity.packageProfileSha256,
+      },
+      candidatePackageProfileSha256: identity.packageProfileSha256,
+      candidateWingetId: input.wingetId,
+      candidateVersion: input.version,
+      candidateArchitecture: input.architecture,
+      candidateInstallerSha256: input.installerSha256,
+    };
+  }
+
+  it('accepts a fully current profile identity', () => {
+    expect(validateCurrentQaPackageProfile(currentCandidate())).toMatchObject({
+      valid: true,
+    });
+  });
+
+  it('normalizes case and whitespace on both sides of candidate bindings', () => {
+    const identity = buildQaPackageIdentity(input);
+    const profile = identity.profile as {
+      app: Record<string, unknown>;
+      installer: Record<string, unknown>;
+    };
+    const normalizedProfile = {
+      ...profile,
+      app: {
+        ...profile.app,
+        wingetId: ` ${input.wingetId.toUpperCase()} `,
+        version: ` ${input.version} `,
+        architecture: 'X64',
+      },
+      installer: {
+        ...profile.installer,
+        sha256: input.installerSha256.toLowerCase(),
+      },
+    };
+    const canonicalJson = canonicalQaJson(normalizedProfile);
+    const hash = qaSha256(canonicalJson);
+
+    expect(
+      validateCurrentQaPackageProfile({
+        ...currentCandidate(),
+        testConfig: {
+          profileKind: 'catalog-default',
+          packageProfileCanonicalJson: canonicalJson,
+          packageProfileSha256: hash,
+        },
+        candidatePackageProfileSha256: hash.toLowerCase(),
+        candidateWingetId: ` ${input.wingetId.toLowerCase()} `,
+        candidateVersion: ` ${input.version} `,
+        candidateArchitecture: ' x64 ',
+        candidateInstallerSha256: ` ${input.installerSha256.toLowerCase()} `,
+      })
+    ).toMatchObject({ valid: true });
+  });
+
+  it('hashes the stored JSON bytes without re-serializing them', () => {
+    const identity = buildQaPackageIdentity(input);
+    const nonCanonicalJson = JSON.stringify(identity.profile);
+    const hash = qaSha256(nonCanonicalJson);
+    expect(
+      validateCurrentQaPackageProfile({
+        testConfig: {
+          profileKind: 'catalog-default',
+          packageProfileCanonicalJson: nonCanonicalJson,
+          packageProfileSha256: hash,
+        },
+        candidatePackageProfileSha256: hash,
+        candidateWingetId: input.wingetId,
+        candidateVersion: input.version,
+        candidateArchitecture: input.architecture,
+        candidateInstallerSha256: input.installerSha256,
+      })
+    ).toMatchObject({ valid: true, packageProfileSha256: hash });
+  });
+
+  it.each([
+    ['profileKind', 'wrong-profile-kind'],
+    ['packageProfileCanonicalJson', 'canonical-json-missing'],
+    ['packageProfileSha256', 'config-profile-sha-invalid'],
+  ])('rejects an invalid %s', (field, reason) => {
+    const candidate = currentCandidate();
+    delete candidate.testConfig[field as keyof typeof candidate.testConfig];
+    expect(validateCurrentQaPackageProfile(candidate)).toEqual({ valid: false, reason });
+  });
+
+  it('rejects malformed canonical JSON', () => {
+    const candidate = currentCandidate();
+    candidate.testConfig.packageProfileCanonicalJson = '{';
+    expect(validateCurrentQaPackageProfile(candidate)).toEqual({
+      valid: false,
+      reason: 'canonical-json-invalid',
+    });
+  });
+
+  it('rejects independent config and candidate hash mismatches', () => {
+    const configMismatch = currentCandidate();
+    configMismatch.testConfig.packageProfileSha256 = 'B'.repeat(64);
+    expect(validateCurrentQaPackageProfile(configMismatch)).toEqual({
+      valid: false,
+      reason: 'config-profile-sha-mismatch',
+    });
+
+    const candidateMismatch = currentCandidate();
+    candidateMismatch.candidatePackageProfileSha256 = 'B'.repeat(64);
+    expect(validateCurrentQaPackageProfile(candidateMismatch)).toEqual({
+      valid: false,
+      reason: 'candidate-profile-sha-mismatch',
+    });
+  });
+
+  it('accepts a current deployment-config profile', () => {
+    const identity = buildQaPackageIdentity({ ...input, profileKind: 'deployment-config' });
+    expect(
+      validateCurrentQaPackageProfile({
+        testConfig: {
+          profileKind: 'deployment-config',
+          packageProfileCanonicalJson: identity.canonicalJson,
+          packageProfileSha256: identity.packageProfileSha256,
+        },
+        candidatePackageProfileSha256: identity.packageProfileSha256,
+        candidateWingetId: input.wingetId,
+        candidateVersion: input.version,
+        candidateArchitecture: input.architecture,
+        candidateInstallerSha256: input.installerSha256,
+      })
+    ).toMatchObject({ valid: true });
+  });
+
+  it('rejects a missing test config and an invalid candidate hash', () => {
+    const candidate = currentCandidate();
+    expect(
+      validateCurrentQaPackageProfile({ ...candidate, testConfig: null })
+    ).toEqual({ valid: false, reason: 'test-config-invalid' });
+    expect(
+      validateCurrentQaPackageProfile({
+        ...candidate,
+        candidatePackageProfileSha256: 'not-a-hash',
+      })
+    ).toEqual({ valid: false, reason: 'candidate-profile-sha-invalid' });
+  });
+
+  it.each([
+    ['schemaVersion', QA_PACKAGE_PROFILE_SCHEMA_VERSION + 1, 'canonical-schema-version-mismatch'],
+    ['testLevel', 'other', 'canonical-test-level-mismatch'],
+    ['profileKind', 'deployment-config', 'canonical-profile-kind-mismatch'],
+    ['toolchain', null, 'toolchain-missing'],
+  ])('rejects canonical %s inconsistency', (field, value, reason) => {
+    const identity = buildQaPackageIdentity(input);
+    const profile = { ...identity.profile, [field]: value };
+    const canonicalJson = canonicalQaJson(profile);
+    const hash = qaSha256(canonicalJson);
+    expect(
+      validateCurrentQaPackageProfile({
+        testConfig: {
+          profileKind: 'catalog-default',
+          packageProfileCanonicalJson: canonicalJson,
+          packageProfileSha256: hash,
+        },
+        candidatePackageProfileSha256: hash,
+        candidateWingetId: input.wingetId,
+        candidateVersion: input.version,
+        candidateArchitecture: input.architecture,
+        candidateInstallerSha256: input.installerSha256,
+      })
+    ).toEqual({ valid: false, reason });
+  });
+
+  it.each([
+    ['candidateWingetId', 'Different.App', 'candidate-winget-id-mismatch'],
+    ['candidateVersion', '9.9.9', 'candidate-version-mismatch'],
+    ['candidateArchitecture', 'x86', 'candidate-architecture-mismatch'],
+    ['candidateInstallerSha256', 'B'.repeat(64), 'candidate-installer-sha-mismatch'],
+  ])('binds %s to the canonical profile', (field, value, reason) => {
+    const candidate = currentCandidate();
+    candidate[field as keyof typeof candidate] = value as never;
+    expect(validateCurrentQaPackageProfile(candidate)).toEqual({ valid: false, reason });
+  });
+
+  it.each(Object.keys(QA_PSADT_TOOLCHAIN))(
+    'rejects a mismatch in toolchain field %s',
+    (field) => {
+      const identity = buildQaPackageIdentity(input);
+      const profile = {
+        ...identity.profile,
+        toolchain: {
+          ...QA_PSADT_TOOLCHAIN,
+          [field]: 'stale-value',
+        },
+      };
+      const canonicalJson = canonicalQaJson(profile);
+      const hash = qaSha256(canonicalJson);
+      expect(
+        validateCurrentQaPackageProfile({
+          testConfig: {
+            profileKind: 'catalog-default',
+            packageProfileCanonicalJson: canonicalJson,
+            packageProfileSha256: hash,
+          },
+          candidatePackageProfileSha256: hash,
+          candidateWingetId: input.wingetId,
+          candidateVersion: input.version,
+          candidateArchitecture: input.architecture,
+          candidateInstallerSha256: input.installerSha256,
+        })
+      ).toEqual({ valid: false, reason: `toolchain-mismatch:${field}` });
+    }
+  );
+
+  it.each([
+    ['psadtConfigSha256', 'canonical-psadt-config-sha-mismatch'],
+    ['detectionRulesSha256', 'canonical-detection-rules-sha-mismatch'],
+  ])('rejects an inconsistent embedded %s', (field, reason) => {
+    const identity = buildQaPackageIdentity(input);
+    const profile = { ...identity.profile, [field]: 'B'.repeat(64) };
+    const canonicalJson = canonicalQaJson(profile);
+    const hash = qaSha256(canonicalJson);
+
+    expect(
+      validateCurrentQaPackageProfile({
+        ...currentCandidate(),
+        testConfig: {
+          profileKind: 'catalog-default',
+          packageProfileCanonicalJson: canonicalJson,
+          packageProfileSha256: hash,
+        },
+        candidatePackageProfileSha256: hash,
+      })
+    ).toEqual({ valid: false, reason });
   });
 });

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,6 +12,14 @@ export const QA_PSADT_TOOLCHAIN = {
   templateSha256: '50CB8D32973FC7648060A48CAD63912ECB5CACA5A70754F37E83AA06BD380283',
 } as const;
 
+/**
+ * Increment this whenever profile-building semantics change without a corresponding
+ * toolchain-pin change (for example, default PSADT settings or detection derivation),
+ * and update the protected workflow verifier in the same rollout. Existing candidates
+ * then fail closed and are rebuilt before they can be dispatched.
+ */
+export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 1;
+
 export interface QaPackageProfileInput {
   profileKind: 'catalog-default' | 'deployment-config';
   wingetId: string;
@@ -55,6 +63,36 @@ export interface QaWorkflowPackageInput {
   detectionRules?: string;
 }
 
+export type QaPackageProfileValidation =
+  | {
+      valid: true;
+      canonicalJson: string;
+      packageProfileSha256: string;
+    }
+  | {
+      valid: false;
+      reason: string;
+    };
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function sha256(value: unknown): string {
+  const normalized = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  return /^[A-F0-9]{64}$/.test(normalized) ? normalized : '';
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function lowerTextValue(value: unknown): string {
+  return textValue(value).toLowerCase();
+}
+
 function normalizeForJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalizeForJson);
   if (value && typeof value === 'object') {
@@ -74,6 +112,131 @@ export function canonicalQaJson(value: unknown): string {
 
 export function qaSha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex').toUpperCase();
+}
+
+/**
+ * Validates that a queued package candidate was produced by the complete current QA toolchain.
+ * The hash is calculated over the stored canonical string itself; parsing and re-serializing it
+ * would make the result dependent on object key order.
+ */
+export function validateCurrentQaPackageProfile(input: {
+  testConfig: unknown;
+  candidatePackageProfileSha256: unknown;
+  candidateWingetId: unknown;
+  candidateVersion: unknown;
+  candidateArchitecture: unknown;
+  candidateInstallerSha256: unknown;
+}): QaPackageProfileValidation {
+  const config = record(input.testConfig);
+  if (!config) return { valid: false, reason: 'test-config-invalid' };
+  if (config.profileKind !== 'catalog-default' && config.profileKind !== 'deployment-config') {
+    return { valid: false, reason: 'wrong-profile-kind' };
+  }
+
+  const canonicalJson =
+    typeof config.packageProfileCanonicalJson === 'string'
+      ? config.packageProfileCanonicalJson
+      : '';
+  if (!canonicalJson) return { valid: false, reason: 'canonical-json-missing' };
+
+  let profile: Record<string, unknown> | null = null;
+  try {
+    profile = record(JSON.parse(canonicalJson));
+  } catch {
+    return { valid: false, reason: 'canonical-json-invalid' };
+  }
+  if (!profile) return { valid: false, reason: 'canonical-json-invalid' };
+  if (profile.schemaVersion !== QA_PACKAGE_PROFILE_SCHEMA_VERSION) {
+    return { valid: false, reason: 'canonical-schema-version-mismatch' };
+  }
+  if (profile.testLevel !== 'psadt-package') {
+    return { valid: false, reason: 'canonical-test-level-mismatch' };
+  }
+  if (profile.profileKind !== config.profileKind) {
+    return { valid: false, reason: 'canonical-profile-kind-mismatch' };
+  }
+
+  const calculatedSha256 = qaSha256(canonicalJson);
+  const configSha256 = sha256(config.packageProfileSha256);
+  if (!configSha256) return { valid: false, reason: 'config-profile-sha-invalid' };
+  if (configSha256 !== calculatedSha256) {
+    return { valid: false, reason: 'config-profile-sha-mismatch' };
+  }
+  const candidateSha256 = sha256(input.candidatePackageProfileSha256);
+  if (!candidateSha256) return { valid: false, reason: 'candidate-profile-sha-invalid' };
+  if (candidateSha256 !== calculatedSha256) {
+    return { valid: false, reason: 'candidate-profile-sha-mismatch' };
+  }
+
+  const toolchain = record(profile.toolchain);
+  if (!toolchain) return { valid: false, reason: 'toolchain-missing' };
+  for (const [field, expected] of Object.entries(QA_PSADT_TOOLCHAIN)) {
+    if (toolchain[field] !== expected) {
+      return { valid: false, reason: `toolchain-mismatch:${field}` };
+    }
+  }
+
+  const embeddedPsadtConfigSha256 = sha256(profile.psadtConfigSha256);
+  if (!embeddedPsadtConfigSha256) {
+    return { valid: false, reason: 'canonical-psadt-config-sha-invalid' };
+  }
+  if (embeddedPsadtConfigSha256 !== qaSha256(canonicalQaJson(profile.psadtConfig))) {
+    return { valid: false, reason: 'canonical-psadt-config-sha-mismatch' };
+  }
+  const embeddedDetectionRulesSha256 = sha256(profile.detectionRulesSha256);
+  if (!embeddedDetectionRulesSha256) {
+    return { valid: false, reason: 'canonical-detection-rules-sha-invalid' };
+  }
+  if (embeddedDetectionRulesSha256 !== qaSha256(canonicalQaJson(profile.detectionRules))) {
+    return { valid: false, reason: 'canonical-detection-rules-sha-mismatch' };
+  }
+
+  const app = record(profile.app);
+  if (!app) return { valid: false, reason: 'canonical-app-missing' };
+  const canonicalWingetId = lowerTextValue(app.wingetId);
+  const candidateWingetId = lowerTextValue(input.candidateWingetId);
+  if (!canonicalWingetId) return { valid: false, reason: 'canonical-winget-id-invalid' };
+  if (!candidateWingetId) return { valid: false, reason: 'candidate-winget-id-invalid' };
+  if (canonicalWingetId !== candidateWingetId) {
+    return { valid: false, reason: 'candidate-winget-id-mismatch' };
+  }
+  const canonicalVersion = textValue(app.version);
+  const candidateVersion = textValue(input.candidateVersion);
+  if (!canonicalVersion) return { valid: false, reason: 'canonical-version-invalid' };
+  if (!candidateVersion) return { valid: false, reason: 'candidate-version-invalid' };
+  if (canonicalVersion !== candidateVersion) {
+    return { valid: false, reason: 'candidate-version-mismatch' };
+  }
+  const canonicalArchitecture = lowerTextValue(app.architecture);
+  const candidateArchitecture = lowerTextValue(input.candidateArchitecture);
+  if (!canonicalArchitecture) {
+    return { valid: false, reason: 'canonical-architecture-invalid' };
+  }
+  if (!candidateArchitecture) {
+    return { valid: false, reason: 'candidate-architecture-invalid' };
+  }
+  if (canonicalArchitecture !== candidateArchitecture) {
+    return { valid: false, reason: 'candidate-architecture-mismatch' };
+  }
+  const installer = record(profile.installer);
+  if (!installer) return { valid: false, reason: 'canonical-installer-missing' };
+  const canonicalInstallerSha256 = sha256(installer.sha256);
+  const candidateInstallerSha256 = sha256(input.candidateInstallerSha256);
+  if (!canonicalInstallerSha256) {
+    return { valid: false, reason: 'canonical-installer-sha-invalid' };
+  }
+  if (!candidateInstallerSha256) {
+    return { valid: false, reason: 'candidate-installer-sha-invalid' };
+  }
+  if (canonicalInstallerSha256 !== candidateInstallerSha256) {
+    return { valid: false, reason: 'candidate-installer-sha-mismatch' };
+  }
+
+  return {
+    valid: true,
+    canonicalJson,
+    packageProfileSha256: calculatedSha256,
+  };
 }
 
 export function normalizeQaPsadtConfig(
@@ -104,7 +267,7 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
   const psadtConfigSha256 = qaSha256(canonicalQaJson(input.psadtConfig));
   const detectionRulesSha256 = qaSha256(canonicalQaJson(input.detectionRules));
   const profile = {
-    schemaVersion: 1,
+    schemaVersion: QA_PACKAGE_PROFILE_SCHEMA_VERSION,
     testLevel: 'psadt-package',
     profileKind: input.profileKind,
     toolchain: QA_PSADT_TOOLCHAIN,


### PR DESCRIPTION
## Summary
- fail closed on stale or mismatched PSADT package profiles before dispatch
- bind canonical profiles to the exact candidate release and pinned QA toolchain
- preserve single-flight dispatch while scanning past invalid queued work
- backfill stale catalog profiles in bounded batches and preserve deployment-config recreation
- add a durable PSADT packaging coverage and findings ledger

## Safety and concurrency
- compare-and-set claim loss returns immediately instead of claiming a second app
- the existing partial unique index remains the database-level single-active guard
- malformed queue metadata is superseded without starving valid work
- keyset cursor values are validated and safely quoted
- workflow dispatch failures restore the candidate attempt state

## Verification
- Claude Code Opus 5 final review: APPROVE, no correctness or security blockers
- npm test: 54 files, 639 tests passed
- focused ESLint: passed
- npm run build:ci: passed
- git diff --check: passed

## QA findings captured
- nested portable packaging fix and passing PIICrawler rerun
- stale TeamViewer MSI argument profile
- HanaAgent user-scope versus LocalSystem/HKCU execution-context mismatch
- timeout, checkout overhead, and PSADT customization coverage gaps