### PR TITLE
Add live QA dashboard

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Clock3, Loader2, Server, ShieldCheck, XCircle } from 'lucide-react';
+import { AppIcon } from '@/components/AppIcon';
+import { QueryProvider } from '@/components/providers/QueryProvider';
+import { QaDetailsDialog } from '@/components/qa/QaDetailsDialog';
+import { QaPhaseTimeline } from '@/components/qa/QaPhaseTimeline';
+import { StatusBadge, type StatusTone } from '@/components/ui/status-badge';
+import { useElapsedTime } from '@/hooks/use-elapsed-time';
+import { useQaLive } from '@/hooks/use-qa';
+import type { QaLiveResponse } from '@/types/qa';
+
+function relativeTime(value: string | null): string {
+  if (!value) return 'No data yet';
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function duration(seconds: number | null): string {
+  if (seconds == null) return '—';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${Math.round(seconds % 60)}s`;
+}
+
+function healthTone(state: string): StatusTone {
+  if (state === 'healthy' || state === 'testing') return 'success';
+  if (state === 'degraded' || state === 'stalled') return 'error';
+  return 'neutral';
+}
+
+function CurrentTest({ data }: { data: QaLiveResponse }) {
+  const correctedStart = useMemo(
+    () => data.current
+      ? new Date(Date.now() - data.current.elapsedSeconds * 1000).toISOString()
+      : null,
+    [data.current]
+  );
+  const elapsed = useElapsedTime({ startTime: correctedStart });
+
+  if (!data.current) {
+    return (
+      <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6" aria-labelledby="current-test-heading">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-status-success/10 p-3 text-status-success">
+            <ShieldCheck className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <div>
+            <h2 id="current-test-heading" className="text-lg font-semibold text-text-primary">Runner is ready</h2>
+            <p className="text-sm text-text-secondary">No application is being tested right now.</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6 rounded-2xl border border-accent-cyan/20 bg-bg-elevated p-6 shadow-glow-cyan" aria-labelledby="current-test-heading">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-4">
+          <AppIcon packageId={data.current.wingetId} packageName={data.current.displayName} size="xl" />
+          <div className="min-w-0">
+            <div className="mb-1 flex flex-wrap items-center gap-2">
+              <StatusBadge tone={data.runner.state === 'stalled' ? 'error' : 'accent'} icon={data.runner.state === 'stalled' ? AlertTriangle : Loader2}>
+                {data.runner.state === 'stalled' ? 'Needs attention' : 'Testing now'}
+              </StatusBadge>
+              <span className="text-xs text-text-muted">{data.current.executionContext}</span>
+            </div>
+            <h2 id="current-test-heading" className="truncate text-xl font-semibold text-text-primary">{data.current.displayName}</h2>
+            <p className="truncate text-sm text-text-muted">{data.current.wingetId}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-5 sm:text-right">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Version</p>
+            <p className="font-mono text-sm text-text-primary">{data.current.version} · {data.current.architecture}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-text-muted">Elapsed</p>
+            <p className="font-mono text-lg font-semibold text-accent-cyan">{elapsed.formattedTime}</p>
+          </div>
+        </div>
+      </div>
+      <QaPhaseTimeline currentPhase={data.current.phase} />
+    </section>
+  );
+}
+
+function DashboardContent() {
+  const { data, isLoading, isError, refetch } = useQaLive();
+  const [selected, setSelected] = useState<{ wingetId: string; catalogVersion: string } | null>(null);
+
+  if (isLoading) {
+    return <div className="h-80 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated" aria-label="Loading live QA status" />;
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="rounded-2xl border border-status-error/20 bg-status-error/5 p-6 text-center">
+        <AlertTriangle className="mx-auto mb-3 h-6 w-6 text-status-error" aria-hidden="true" />
+        <p className="font-medium text-text-primary">Live QA status is temporarily unavailable.</p>
+        <button type="button" onClick={() => refetch()} className="mt-3 rounded-lg border border-overlay/10 px-4 py-2 text-sm text-text-secondary hover:text-text-primary">Try again</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
+          <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">QA runner</span><Server className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>
+          <StatusBadge tone={healthTone(data.runner.state)}>{data.runner.state === 'testing' ? 'Testing' : data.runner.state === 'stalled' ? 'Stalled' : 'Idle'}</StatusBadge>
+          <p className="mt-2 text-xs text-text-muted">{data.runner.heartbeatAt ? `Heartbeat ${relativeTime(data.runner.heartbeatAt)}` : 'Waiting for a runner heartbeat'}</p>
+        </div>
+        <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
+          <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">WinGet polling</span><Clock3 className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>
+          <StatusBadge tone={healthTone(data.scheduler.state)}>{data.scheduler.state.charAt(0).toUpperCase() + data.scheduler.state.slice(1)}</StatusBadge>
+          <p className="mt-2 text-xs text-text-muted">Last scan {relativeTime(data.scheduler.lastPollAt)}</p>
+        </div>
+        <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
+          <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">Queue</span><Loader2 className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>
+          <p className="text-2xl font-semibold tabular-nums text-text-primary">{data.queue.count}</p>
+          <p className="mt-1 text-xs text-text-muted">applications waiting</p>
+        </div>
+      </div>
+
+      <CurrentTest data={data} />
+
+      <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
+        <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6" aria-labelledby="queue-heading">
+          <div className="mb-4 flex items-baseline justify-between">
+            <h2 id="queue-heading" className="text-lg font-semibold text-text-primary">Next in queue</h2>
+            <span className="text-xs text-text-muted">Single-flight testing</span>
+          </div>
+          {data.queue.next.length ? (
+            <ol className="divide-y divide-overlay/10">
+              {data.queue.next.map((item, index) => (
+                <li key={`${item.wingetId}-${item.version}-${item.architecture}`} className="flex items-center gap-3 py-3">
+                  <span className="w-5 text-xs tabular-nums text-text-muted">{index + 1}</span>
+                  <AppIcon packageId={item.wingetId} packageName={item.displayName} size="sm" />
+                  <div className="min-w-0 flex-1"><p className="truncate text-sm font-medium text-text-primary">{item.displayName}</p><p className="truncate text-xs text-text-muted">{item.version} · {item.architecture}</p></div>
+                </li>
+              ))}
+            </ol>
+          ) : <p className="text-sm text-text-muted">The queue is clear.</p>}
+        </section>
+
+        <section className="overflow-hidden rounded-2xl border border-overlay/10 bg-bg-elevated" aria-labelledby="recent-heading">
+          <div className="flex items-baseline justify-between px-6 py-5">
+            <h2 id="recent-heading" className="text-lg font-semibold text-text-primary">Recent results</h2>
+            <span className="text-xs text-text-muted">Select a result for evidence</span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="border-y border-overlay/10 text-xs text-text-muted"><tr><th className="px-6 py-3 font-medium">Application</th><th className="px-3 py-3 font-medium">Result</th><th className="px-3 py-3 font-medium">Duration</th><th className="px-6 py-3 font-medium">Tested</th></tr></thead>
+              <tbody className="divide-y divide-overlay/10">
+                {data.recent.map((item) => (
+                  <tr key={item.wingetId}>
+                    <td className="px-6 py-3"><button type="button" onClick={() => setSelected({ wingetId: item.wingetId, catalogVersion: item.catalogVersion })} className="text-left hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"><span className="block font-medium text-text-primary">{item.displayName}</span><span className="text-xs text-text-muted">{item.testedVersion} · {item.architecture}</span></button></td>
+                    <td className="px-3 py-3"><StatusBadge tone={item.outcome === 'Passed' ? 'success' : 'error'} icon={item.outcome === 'Passed' ? CheckCircle2 : XCircle}>{item.outcome}</StatusBadge></td>
+                    <td className="px-3 py-3 font-mono text-xs text-text-secondary">{duration(item.durationSeconds)}</td>
+                    <td className="whitespace-nowrap px-6 py-3 text-xs text-text-muted">{relativeTime(item.testedAtUtc)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      {selected ? <QaDetailsDialog wingetId={selected.wingetId} catalogVersion={selected.catalogVersion} open={Boolean(selected)} onOpenChange={(open) => { if (!open) setSelected(null); }} /> : null}
+    </div>
+  );
+}
+
+export function QaLiveClient() {
+  return <QueryProvider><DashboardContent /></QueryProvider>;
+}

--- a/app/(marketing)/qa/page.tsx
+++ b/app/(marketing)/qa/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+import { T } from 'gt-next';
+import { Header } from '@/components/landing/Header';
+import { Footer } from '@/components/landing/sections/Footer';
+import { QaLiveClient } from './QaLiveClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Live Application QA - IntuneGet',
+  description: 'Follow IntuneGet application package quality assurance in real time, from isolated installation through detection and uninstall verification.',
+  alternates: { canonical: 'https://intuneget.com/qa' },
+};
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://intuneget.com' },
+    { '@type': 'ListItem', position: 2, name: 'Application QA', item: 'https://intuneget.com/qa' },
+  ],
+};
+
+export default function QaPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <main id="main-content" className="mx-auto w-full max-w-7xl flex-1 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
+        <div className="mb-10 max-w-3xl space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-accent-cyan"><T>Application quality assurance</T></p>
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>See package QA as it happens</T></h1>
+          <p className="text-lg text-text-secondary"><T>Every update is installed, detected, uninstalled, and verified inside a clean Windows VM before it can be released through IntuneGet.</T></p>
+        </div>
+        <QaLiveClient />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/api/qa/live/route.test.ts
+++ b/app/api/qa/live/route.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { getQaLiveSnapshotMock, applyRateLimitMock } = vi.hoisted(() => ({
+  getQaLiveSnapshotMock: vi.fn(),
+  applyRateLimitMock: vi.fn(),
+}));
+
+vi.mock('@/lib/qa/live', () => ({ getQaLiveSnapshot: getQaLiveSnapshotMock }));
+vi.mock('@/lib/rate-limit', () => ({
+  applyRateLimit: applyRateLimitMock,
+  getIpKey: () => 'ip:test',
+  QA_LIVE_RATE_LIMIT: { limit: 90, windowMs: 60_000 },
+}));
+
+import { GET } from './route';
+
+describe('GET /api/qa/live', () => {
+  beforeEach(() => {
+    applyRateLimitMock.mockReset().mockResolvedValue(null);
+    getQaLiveSnapshotMock.mockReset().mockResolvedValue({ active: false, current: null });
+  });
+
+  it('is never cached', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/qa/live'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('returns a sanitized unavailable response on server errors', async () => {
+    getQaLiveSnapshotMock.mockRejectedValue(new Error('private database detail'));
+    const response = await GET(new NextRequest('http://localhost/api/qa/live'));
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'Live QA status is temporarily unavailable' });
+  });
+});

--- a/app/api/qa/live/route.ts
+++ b/app/api/qa/live/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { getQaLiveSnapshot } from '@/lib/qa/live';
+import { applyRateLimit, getIpKey, QA_LIVE_RATE_LIMIT } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const rateLimitResponse = await applyRateLimit(getIpKey(request), QA_LIVE_RATE_LIMIT);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  try {
+    const response = await getQaLiveSnapshot();
+    return NextResponse.json(response, {
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  } catch (error) {
+    console.error('Failed to load live QA dashboard:', error);
+    return NextResponse.json(
+      { error: 'Live QA status is temporarily unavailable' },
+      { status: 503, headers: { 'Cache-Control': 'no-store' } }
+    );
+  }
+}

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -32,6 +32,7 @@ const AuthedAvatar = dynamic(
 
 const primaryNavLinks = [
   { href: "/apps", label: "Apps" },
+  { href: "/qa", label: "QA" },
   { href: "/#how-it-works", label: "How It Works" },
   { href: "/security", label: "Security" },
 ];

--- a/components/qa/QaPhaseTimeline.tsx
+++ b/components/qa/QaPhaseTimeline.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { CheckCircle2, Circle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { QaLivePhase } from '@/types/qa';
+
+const PHASES: Array<{ id: QaLivePhase; label: string }> = [
+  { id: 'preparing_package', label: 'Preparing package' },
+  { id: 'restoring_vm', label: 'Restoring golden VM' },
+  { id: 'installing', label: 'Installing' },
+  { id: 'detecting_install', label: 'Testing detection' },
+  { id: 'uninstalling', label: 'Uninstalling' },
+  { id: 'verifying_removal', label: 'Verifying removal' },
+  { id: 'publishing', label: 'Publishing result' },
+];
+
+export function QaPhaseTimeline({ currentPhase }: { currentPhase: QaLivePhase }) {
+  const currentIndex = Math.max(0, PHASES.findIndex((item) => item.id === currentPhase));
+
+  return (
+    <ol aria-label="QA test progress" className="grid gap-2 sm:grid-cols-2 lg:grid-cols-7">
+      {PHASES.map((item, index) => {
+        const complete = index < currentIndex;
+        const active = index === currentIndex;
+        const Icon = complete ? CheckCircle2 : active ? Loader2 : Circle;
+        return (
+          <li
+            key={item.id}
+            aria-current={active ? 'step' : undefined}
+            className={cn(
+              'flex min-h-16 items-center gap-2 rounded-xl border px-3 py-2 text-xs',
+              complete && 'border-status-success/20 bg-status-success/5 text-status-success',
+              active && 'border-accent-cyan/30 bg-accent-cyan/10 text-accent-cyan',
+              !complete && !active && 'border-overlay/10 bg-overlay/[0.02] text-text-muted'
+            )}
+          >
+            <Icon className={cn('h-4 w-4 shrink-0', active && 'animate-spin')} aria-hidden="true" />
+            <span className="font-medium leading-tight">{item.label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import type { QaDetailsResponse, QaStatus } from '@/types/qa';
+import type { QaDetailsResponse, QaLiveResponse, QaStatus } from '@/types/qa';
 
 interface QaStatusesResponse {
   statuses: Record<string, QaStatus | null>;
@@ -42,5 +42,18 @@ export function useQaDetails(wingetId: string, enabled: boolean) {
     },
     enabled: Boolean(wingetId) && enabled,
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useQaLive() {
+  return useQuery<QaLiveResponse>({
+    queryKey: ['qa', 'live'],
+    queryFn: async () => {
+      const response = await fetch('/api/qa/live', { cache: 'no-store' });
+      if (!response.ok) throw new Error('Failed to load live QA status');
+      return response.json();
+    },
+    staleTime: 4_000,
+    refetchInterval: (query) => (query.state.data?.active ? 5_000 : 30_000),
   });
 }

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -36,6 +36,7 @@ describe('dispatchQaCandidate', () => {
     const body = JSON.parse(String((request as RequestInit).body));
     expect(body.inputs).toMatchObject({
       app_definition: 'qa/apps/example.app.json',
+      candidate_label: 'Example.App 2.0.0 x64',
     });
     expect(JSON.parse(body.inputs.candidate_payload)).toMatchObject({
       version: '2.0.0',

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -31,6 +31,7 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
       ref: config.ref,
       inputs: {
         smoke_test: 'false',
+        candidate_label: `${candidate.winget_id} ${candidate.version} ${candidate.architecture}`,
         app_definition: candidate.definition_path || '',
         candidate_payload: JSON.stringify({
           id: candidate.id,

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { buildQaLiveResponse } from './live';
+
+describe('buildQaLiveResponse', () => {
+  it('returns a sanitized live projection and derives health', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-08T17:00:00.000Z'),
+      current: {
+        winget_id: 'Example.App',
+        version: '2.0.0',
+        architecture: 'x64',
+        status: 'running',
+        priority: 10,
+        enqueued_at: '2026-08-08T16:30:00.000Z',
+        dispatched_at: '2026-08-08T16:35:00.000Z',
+        started_at: '2026-08-08T16:40:00.000Z',
+        phase: 'installing',
+        phase_started_at: '2026-08-08T16:45:00.000Z',
+        phase_updated_at: '2026-08-08T16:59:00.000Z',
+        test_config: {
+          packageProfileCanonicalJson: JSON.stringify({ installer: { installScope: 'user' } }),
+        },
+        installer_url: 'https://secret.example/setup.exe',
+        failure_summary: 'C:\\Users\\private',
+        github_run_url: 'https://github.example/private',
+      } as never,
+      queuedCount: 1,
+      queued: [],
+      poll: {
+        status: 'succeeded',
+        started_at: '2026-08-08T16:50:00.000Z',
+        finished_at: '2026-08-08T16:50:10.000Z',
+      },
+      recent: [],
+      apps: [{
+        winget_id: 'Example.App',
+        name: 'Example',
+        publisher: 'Example Corp',
+        latest_version: '2.0.0',
+      }],
+    });
+
+    expect(response.runner.state).toBe('testing');
+    expect(response.scheduler.state).toBe('healthy');
+    expect(response.current).toMatchObject({
+      displayName: 'Example',
+      phase: 'installing',
+      executionContext: 'User',
+      elapsedSeconds: 1200,
+    });
+    const serialized = JSON.stringify(response);
+    for (const forbidden of ['installer_url', 'failure_summary', 'github_run_url', 'private']) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('marks stale runners and abandoned poll runs as degraded', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-08T17:00:00.000Z'),
+      current: {
+        winget_id: 'Example.App', version: '2', architecture: 'x64', status: 'running',
+        priority: 0, enqueued_at: '2026-08-08T15:00:00.000Z', dispatched_at: null,
+        started_at: '2026-08-08T15:30:00.000Z', phase: null, phase_started_at: null,
+        phase_updated_at: '2026-08-08T16:40:00.000Z', test_config: {},
+      },
+      queuedCount: 0,
+      queued: [],
+      poll: { status: 'running', started_at: '2026-08-08T16:00:00.000Z', finished_at: null },
+      recent: [],
+      apps: [],
+    });
+    expect(response.runner.state).toBe('stalled');
+    expect(response.scheduler.state).toBe('degraded');
+  });
+});

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -1,0 +1,249 @@
+import 'server-only';
+
+import { createServerClient } from '@/lib/supabase';
+import type { Json } from '@/types/database';
+import type { QaArchitecture, QaLivePhase, QaLiveResponse, QaOutcome } from '@/types/qa';
+
+const RUNNER_STALE_MS = 10 * 60 * 1000;
+const POLL_STALE_MS = 5 * 60 * 1000;
+
+interface CandidateRow {
+  winget_id: string;
+  version: string;
+  architecture: string;
+  status: string;
+  priority: number;
+  enqueued_at: string;
+  dispatched_at: string | null;
+  started_at: string | null;
+  phase: string | null;
+  phase_started_at: string | null;
+  phase_updated_at: string | null;
+  test_config: Json;
+}
+
+interface PollRow {
+  status: 'running' | 'succeeded' | 'partial' | 'failed';
+  started_at: string;
+  finished_at: string | null;
+}
+
+interface ResultRow {
+  winget_id: string;
+  display_name: string;
+  tested_version: string;
+  architecture: string;
+  outcome: string;
+  tested_at_utc: string;
+  overall_duration_seconds: number | null;
+}
+
+interface AppRow {
+  winget_id: string;
+  name: string;
+  publisher: string | null;
+  latest_version: string | null;
+}
+
+export interface QaLiveSnapshotInput {
+  now: Date;
+  current: CandidateRow | null;
+  queuedCount: number;
+  queued: CandidateRow[];
+  poll: PollRow | null;
+  recent: ResultRow[];
+  apps: AppRow[];
+}
+
+const VALID_PHASES = new Set<QaLivePhase>([
+  'queued',
+  'preparing_package',
+  'restoring_vm',
+  'installing',
+  'detecting_install',
+  'uninstalling',
+  'verifying_removal',
+  'publishing',
+]);
+
+function architecture(value: string): QaArchitecture {
+  return value === 'x86' || value === 'arm64' ? value : 'x64';
+}
+
+function phase(value: string | null): QaLivePhase {
+  return value && VALID_PHASES.has(value as QaLivePhase)
+    ? (value as QaLivePhase)
+    : 'preparing_package';
+}
+
+function executionContext(config: Json): 'LocalSystem' | 'User' {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return 'LocalSystem';
+  const canonical = config.packageProfileCanonicalJson;
+  if (typeof canonical !== 'string') return 'LocalSystem';
+  try {
+    const parsed = JSON.parse(canonical) as { installer?: { installScope?: unknown } };
+    return String(parsed.installer?.installScope || '').toLowerCase() === 'user'
+      ? 'User'
+      : 'LocalSystem';
+  } catch {
+    return 'LocalSystem';
+  }
+}
+
+function elapsedSeconds(start: string, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - new Date(start).getTime()) / 1000));
+}
+
+export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse {
+  const appById = new Map(input.apps.map((app) => [app.winget_id, app]));
+  const currentStartedAt = input.current
+    ? input.current.started_at || input.current.dispatched_at || input.current.enqueued_at
+    : null;
+  const heartbeatAt = input.current
+    ? input.current.phase_updated_at || currentStartedAt
+    : null;
+  const runnerStalled = Boolean(
+    heartbeatAt && input.now.getTime() - new Date(heartbeatAt).getTime() > RUNNER_STALE_MS
+  );
+
+  let schedulerState: QaLiveResponse['scheduler']['state'] = 'unknown';
+  if (input.poll) {
+    const staleRunning =
+      input.poll.status === 'running' &&
+      input.now.getTime() - new Date(input.poll.started_at).getTime() > POLL_STALE_MS;
+    schedulerState =
+      input.poll.status === 'succeeded'
+        ? 'healthy'
+        : input.poll.status === 'running' && !staleRunning
+          ? 'healthy'
+          : 'degraded';
+  }
+
+  const currentApp = input.current ? appById.get(input.current.winget_id) : null;
+
+  return {
+    serverTime: input.now.toISOString(),
+    active: Boolean(input.current),
+    runner: {
+      state: input.current ? (runnerStalled ? 'stalled' : 'testing') : 'idle',
+      heartbeatAt,
+    },
+    scheduler: {
+      state: schedulerState,
+      lastPollAt: input.poll?.finished_at || input.poll?.started_at || null,
+    },
+    current: input.current && currentStartedAt
+      ? {
+          wingetId: input.current.winget_id,
+          displayName: currentApp?.name || input.current.winget_id,
+          publisher: currentApp?.publisher || null,
+          version: input.current.version,
+          catalogVersion: currentApp?.latest_version || input.current.version,
+          architecture: architecture(input.current.architecture),
+          executionContext: executionContext(input.current.test_config),
+          phase: phase(input.current.phase),
+          phaseStartedAt: input.current.phase_started_at,
+          startedAt: currentStartedAt,
+          elapsedSeconds: elapsedSeconds(currentStartedAt, input.now),
+        }
+      : null,
+    queue: {
+      count: input.queuedCount,
+      next: input.queued.map((candidate) => ({
+        wingetId: candidate.winget_id,
+        displayName: appById.get(candidate.winget_id)?.name || candidate.winget_id,
+        version: candidate.version,
+        architecture: architecture(candidate.architecture),
+        enqueuedAt: candidate.enqueued_at,
+      })),
+    },
+    recent: input.recent.map((result) => ({
+      wingetId: result.winget_id,
+      displayName: result.display_name || appById.get(result.winget_id)?.name || result.winget_id,
+      testedVersion: result.tested_version,
+      catalogVersion: appById.get(result.winget_id)?.latest_version || result.tested_version,
+      architecture: architecture(result.architecture),
+      outcome: result.outcome === 'Passed' ? 'Passed' : ('Failed' as QaOutcome),
+      testedAtUtc: result.tested_at_utc,
+      durationSeconds: result.overall_duration_seconds,
+    })),
+  };
+}
+
+export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
+  const supabase = createServerClient();
+  const candidateColumns =
+    'winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, test_config';
+
+  const [activeResult, queueResult, countResult, pollResult, recentResult] = await Promise.all([
+    supabase
+      .from('qa_candidates')
+      .select(candidateColumns)
+      .eq('test_level', 'psadt-package')
+      .in('status', ['dispatched', 'running'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('qa_candidates')
+      .select(candidateColumns)
+      .eq('test_level', 'psadt-package')
+      .eq('status', 'queued')
+      .order('priority', { ascending: false })
+      .order('enqueued_at', { ascending: true })
+      .order('id', { ascending: true })
+      .limit(10),
+    supabase
+      .from('qa_candidates')
+      .select('id', { count: 'exact', head: true })
+      .eq('test_level', 'psadt-package')
+      .eq('status', 'queued'),
+    supabase
+      .from('qa_poll_runs')
+      .select('status, started_at, finished_at')
+      .order('started_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('qa_results')
+      .select(
+        'winget_id, display_name, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds'
+      )
+      .eq('test_level', 'psadt-package')
+      .order('tested_at_utc', { ascending: false })
+      .limit(10),
+  ]);
+
+  for (const result of [activeResult, queueResult, countResult, pollResult, recentResult]) {
+    if (result.error) throw new Error(`Could not load live QA data: ${result.error.message}`);
+  }
+
+  const current = (activeResult.data as CandidateRow | null) || null;
+  const queued = (queueResult.data || []) as CandidateRow[];
+  const recent = (recentResult.data || []) as ResultRow[];
+  const ids = [
+    ...(current ? [current.winget_id] : []),
+    ...queued.map((row) => row.winget_id),
+    ...recent.map((row) => row.winget_id),
+  ];
+  const uniqueIds = [...new Set(ids)];
+  let apps: AppRow[] = [];
+  if (uniqueIds.length) {
+    const appResult = await supabase
+      .from('curated_apps')
+      .select('winget_id, name, publisher, latest_version')
+      .in('winget_id', uniqueIds);
+    if (appResult.error) throw new Error(`Could not load QA app metadata: ${appResult.error.message}`);
+    apps = (appResult.data || []) as AppRow[];
+  }
+
+  return buildQaLiveResponse({
+    now: new Date(),
+    current,
+    queuedCount: countResult.count || 0,
+    queued,
+    poll: (pollResult.data as PollRow | null) || null,
+    recent,
+    apps,
+  });
+}

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -41,3 +41,22 @@ describe('QA dispatcher schema contract', () => {
     expect(sql).toContain("where status in ('dispatched', 'running')");
   });
 });
+
+describe('QA live dashboard migration contract', () => {
+  const sql = readFileSync(
+    resolve(process.cwd(), 'supabase/migrations/20260808165628_qa_live_dashboard.sql'),
+    'utf8'
+  );
+
+  it('keeps phase writes monotonic and limited to active candidates', () => {
+    expect(sql).toContain("status in ('dispatched', 'running')");
+    expect(sql).toContain('p_observed_at > phase_updated_at');
+    expect(sql).toContain('returns boolean');
+  });
+
+  it('preserves User context while stripping public execution provenance', () => {
+    expect(sql).toContain("row_data.environment->>'executionContext' = 'User'");
+    expect(sql).toContain('test_id = null');
+    expect(sql).toContain('github_run_id = null');
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -85,6 +85,12 @@ export const PUBLIC_RATE_LIMIT: RateLimitConfig = {
   windowMs: 60 * 1000,
 };
 
+/** Live QA dashboard: five-second polling with room for multiple tabs. */
+export const QA_LIVE_RATE_LIMIT: RateLimitConfig = {
+  limit: 90,
+  windowMs: 60 * 1000,
+};
+
 /** Strict limit for sensitive operations: 5 requests/minute */
 export const STRICT_RATE_LIMIT: RateLimitConfig = {
   limit: 5,

--- a/supabase/migrations/20260808165628_qa_live_dashboard.sql
+++ b/supabase/migrations/20260808165628_qa_live_dashboard.sql
@@ -1,0 +1,257 @@
+-- Live, sanitized progress for the private single-flight QA queue.
+alter table public.qa_candidates
+  add column if not exists phase text,
+  add column if not exists phase_started_at timestamptz,
+  add column if not exists phase_updated_at timestamptz;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'qa_candidates_phase_check'
+      and conrelid = 'public.qa_candidates'::regclass
+  ) then
+    alter table public.qa_candidates
+      add constraint qa_candidates_phase_check check (
+        phase is null or phase in (
+          'queued',
+          'preparing_package',
+          'restoring_vm',
+          'installing',
+          'detecting_install',
+          'uninstalling',
+          'verifying_removal',
+          'publishing'
+        )
+      );
+  end if;
+end $$;
+
+create index if not exists qa_results_recent_psadt_idx
+  on public.qa_results (tested_at_utc desc)
+  where test_level = 'psadt-package';
+
+-- The canonical repository already reports the true package execution context.
+-- Keep the public mirror sanitized while preserving LocalSystem versus User.
+alter table public.qa_results
+  drop constraint if exists qa_results_public_provenance_sanitized;
+
+alter table public.qa_results
+  add constraint qa_results_public_provenance_sanitized check (
+    test_id is null
+    and github_run_id is null
+    and github_run_attempt is null
+    and (
+      environment is null
+      or environment = '{"executionContext":"LocalSystem"}'::jsonb
+      or environment = '{"executionContext":"User"}'::jsonb
+    )
+  );
+
+create or replace function public.publish_qa_candidate_phase(
+  p_secret text,
+  p_candidate_id uuid,
+  p_phase text,
+  p_observed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  updated_count integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  if p_phase is null or p_phase not in (
+    'queued',
+    'preparing_package',
+    'restoring_vm',
+    'installing',
+    'detecting_install',
+    'uninstalling',
+    'verifying_removal',
+    'publishing'
+  ) then
+    raise exception 'Invalid QA candidate phase';
+  end if;
+
+  if p_observed_at is null or p_observed_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA phase observation time';
+  end if;
+
+  update public.qa_candidates
+  set
+    phase_started_at = case
+      when phase is distinct from p_phase then p_observed_at
+      else phase_started_at
+    end,
+    phase = p_phase,
+    phase_updated_at = p_observed_at,
+    updated_at = greatest(updated_at, p_observed_at)
+  where id = p_candidate_id
+    and status in ('dispatched', 'running')
+    and (phase_updated_at is null or p_observed_at > phase_updated_at);
+
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.publish_qa_candidate_phase(text, uuid, text, timestamptz)
+  from public, authenticated, service_role;
+grant execute on function public.publish_qa_candidate_phase(text, uuid, text, timestamptz)
+  to anon;
+
+-- Preserve the execution context supplied by the canonical QA JSON while
+-- continuing to strip machine identity and GitHub execution provenance.
+create or replace function public.sync_qa_results(
+  p_secret text,
+  p_rows jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  payload_count integer;
+  distinct_id_count integer;
+  existing_count integer;
+  remove_count integer;
+  maximum_automatic_deletes integer;
+  completed_at timestamptz := now();
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  if jsonb_typeof(p_rows) <> 'array' or jsonb_array_length(p_rows) = 0 then
+    raise exception 'At least one canonical QA result is required';
+  end if;
+
+  payload_count := jsonb_array_length(p_rows);
+  select count(distinct item->>'winget_id')
+  into distinct_id_count
+  from jsonb_array_elements(p_rows) item;
+  if distinct_id_count <> payload_count or exists (
+    select 1 from jsonb_array_elements(p_rows) item
+    where coalesce(item->>'winget_id', '') = ''
+  ) then
+    raise exception 'Canonical QA result IDs must be present and unique';
+  end if;
+
+  select count(*) into existing_count from public.qa_results;
+  select count(*)
+  into remove_count
+  from public.qa_results existing
+  where not exists (
+    select 1
+    from jsonb_array_elements(p_rows) item
+    where item->>'winget_id' = existing.winget_id
+  );
+  maximum_automatic_deletes := greatest(1, floor(existing_count * 0.25)::integer);
+  if not p_allow_large_delete and remove_count > maximum_automatic_deletes then
+    raise exception 'Refusing unexpectedly large QA result deletion';
+  end if;
+
+  insert into public.qa_results (
+    winget_id, display_name, publisher, tested_version, architecture, outcome,
+    tested_at_utc, overall_duration_seconds, installer_type, install_command,
+    uninstall_command, detection, phase_results, changes, relevant_event_count,
+    environment, test_id, github_run_id, github_run_attempt, qa_schema_version,
+    synced_at
+  )
+  select
+    row_data.winget_id, row_data.display_name, row_data.publisher,
+    row_data.tested_version, row_data.architecture, row_data.outcome,
+    row_data.tested_at_utc, row_data.overall_duration_seconds,
+    row_data.installer_type, row_data.install_command, row_data.uninstall_command,
+    row_data.detection, row_data.phase_results, row_data.changes,
+    row_data.relevant_event_count,
+    case
+      when row_data.environment->>'executionContext' = 'User'
+        then '{"executionContext":"User"}'::jsonb
+      else '{"executionContext":"LocalSystem"}'::jsonb
+    end,
+    null, null, null, row_data.qa_schema_version, row_data.synced_at
+  from jsonb_to_recordset(p_rows) as row_data(
+    winget_id text, display_name text, publisher text, tested_version text,
+    architecture text, outcome text, tested_at_utc timestamptz,
+    overall_duration_seconds numeric, installer_type text, install_command text,
+    uninstall_command text, detection jsonb, phase_results jsonb, changes jsonb,
+    relevant_event_count integer, environment jsonb, qa_schema_version integer,
+    synced_at timestamptz
+  )
+  on conflict (winget_id) do update set
+    display_name = excluded.display_name,
+    publisher = excluded.publisher,
+    tested_version = excluded.tested_version,
+    architecture = excluded.architecture,
+    outcome = excluded.outcome,
+    tested_at_utc = excluded.tested_at_utc,
+    overall_duration_seconds = excluded.overall_duration_seconds,
+    installer_type = excluded.installer_type,
+    install_command = excluded.install_command,
+    uninstall_command = excluded.uninstall_command,
+    detection = excluded.detection,
+    phase_results = excluded.phase_results,
+    changes = excluded.changes,
+    relevant_event_count = excluded.relevant_event_count,
+    environment = excluded.environment,
+    test_id = null,
+    github_run_id = null,
+    github_run_attempt = null,
+    qa_schema_version = excluded.qa_schema_version,
+    synced_at = excluded.synced_at;
+
+  delete from public.qa_results existing
+  where not exists (
+    select 1 from jsonb_array_elements(p_rows) item
+    where item->>'winget_id' = existing.winget_id
+  );
+
+  insert into public.curated_sync_status (
+    id, last_run_started_at, last_run_completed_at, last_run_status,
+    items_processed, error_message, metadata, updated_at
+  )
+  values (
+    'sync-qa-results', completed_at, completed_at, 'success', payload_count, null,
+    jsonb_build_object(
+      'source', 'canonical-checkout',
+      'files', payload_count,
+      'mirrored', payload_count,
+      'removed', remove_count,
+      'invalid', jsonb_build_array()
+    ),
+    completed_at
+  )
+  on conflict (id) do update set
+    last_run_started_at = excluded.last_run_started_at,
+    last_run_completed_at = excluded.last_run_completed_at,
+    last_run_status = excluded.last_run_status,
+    items_processed = excluded.items_processed,
+    error_message = excluded.error_message,
+    metadata = excluded.metadata,
+    updated_at = excluded.updated_at;
+
+  return jsonb_build_object(
+    'files', payload_count,
+    'mirrored', payload_count,
+    'removed', remove_count,
+    'invalid', jsonb_build_array()
+  );
+end;
+$$;
+
+revoke all on function public.sync_qa_results(text, jsonb, boolean)
+  from public, authenticated, service_role;
+grant execute on function public.sync_qa_results(text, jsonb, boolean)
+  to anon;

--- a/types/database.ts
+++ b/types/database.ts
@@ -173,6 +173,9 @@ export interface Database {
           github_run_id: string | null;
           github_run_url: string | null;
           failure_summary: string | null;
+          phase: string | null;
+          phase_started_at: string | null;
+          phase_updated_at: string | null;
           updated_at: string;
         };
         Insert: {
@@ -198,6 +201,9 @@ export interface Database {
           github_run_id?: string | null;
           github_run_url?: string | null;
           failure_summary?: string | null;
+          phase?: string | null;
+          phase_started_at?: string | null;
+          phase_updated_at?: string | null;
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_candidates']['Insert']>;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -48,7 +48,63 @@ export interface QaDetectionRule {
 }
 
 export interface QaEnvironment {
-  executionContext: 'LocalSystem';
+  executionContext: 'LocalSystem' | 'User';
+}
+
+export type QaLivePhase =
+  | 'queued'
+  | 'preparing_package'
+  | 'restoring_vm'
+  | 'installing'
+  | 'detecting_install'
+  | 'uninstalling'
+  | 'verifying_removal'
+  | 'publishing';
+
+export interface QaLiveResponse {
+  serverTime: string;
+  active: boolean;
+  runner: {
+    state: 'idle' | 'testing' | 'stalled';
+    heartbeatAt: string | null;
+  };
+  scheduler: {
+    state: 'healthy' | 'degraded' | 'unknown';
+    lastPollAt: string | null;
+  };
+  current: {
+    wingetId: string;
+    displayName: string;
+    publisher: string | null;
+    version: string;
+    catalogVersion: string;
+    architecture: QaArchitecture;
+    executionContext: 'LocalSystem' | 'User';
+    phase: QaLivePhase;
+    phaseStartedAt: string | null;
+    startedAt: string;
+    elapsedSeconds: number;
+  } | null;
+  queue: {
+    count: number;
+    next: Array<{
+      wingetId: string;
+      displayName: string;
+      version: string;
+      architecture: QaArchitecture;
+      enqueuedAt: string;
+    }>;
+  };
+  recent: Array<{
+    wingetId: string;
+    displayName: string;
+    testedVersion: string;
+    catalogVersion: string;
+    architecture: QaArchitecture;
+    outcome: QaOutcome;
+    testedAtUtc: string;
+    durationSeconds: number | null;
+  }>;
 }
 
 export type QaTestLevel = 'installer-preflight' | 'psadt-package';


### PR DESCRIPTION
## What changed
- add the public `/qa` dashboard using the existing marketing design
- show runner and scheduler health, the active app/version/context, elapsed time, current phase, queue preview, and recent results
- add a sanitized, rate-limited live QA API with adaptive client polling
- add Supabase candidate phase storage and secret-gated phase publishing
- preserve only compact public QA evidence; no package artifacts or private run provenance

## Why
Customers need a trustworthy real-time view of exactly which PSADT-wrapped package is being tested and where it is in the install/detect/uninstall lifecycle.

## Deployment order
Merge IntuneGet-Workflows PR #82 first so the dispatcher input and phase publisher exist before this change reaches production. The database migration has already been applied and verified.

## Validation
- npm test (645 passing)
- npm run build:ci
- scoped ESLint
- route and migration contract tests
- live Supabase schema, grants, RLS, and RPC verification
- Claude Opus architecture and code review