### PR TITLE
Reduce idle QA dispatch latency

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -52,7 +52,9 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           </div>
           <div>
             <h2 id="current-test-heading" className="text-lg font-semibold text-text-primary">Runner is ready</h2>
-            <p className="text-sm text-text-secondary">No application is being tested right now.</p>
+            <p className="text-sm text-text-secondary">
+              {data.queue.count > 0 ? 'Waiting for the next dispatch check.' : 'No application is waiting to be tested.'}
+            </p>
           </div>
         </div>
       </section>
@@ -115,7 +117,13 @@ function DashboardContent() {
         <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
           <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">QA runner</span><Server className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>
           <StatusBadge tone={healthTone(data.runner.state)}>{data.runner.state === 'testing' ? 'Testing' : data.runner.state === 'stalled' ? 'Stalled' : 'Idle'}</StatusBadge>
-          <p className="mt-2 text-xs text-text-muted">{data.runner.heartbeatAt ? `Heartbeat ${relativeTime(data.runner.heartbeatAt)}` : 'Waiting for a runner heartbeat'}</p>
+          <p className="mt-2 text-xs text-text-muted">
+            {data.runner.heartbeatAt
+              ? `Heartbeat ${relativeTime(data.runner.heartbeatAt)}`
+              : data.queue.count > 0
+                ? 'Next dispatch check within one minute'
+                : 'No active test'}
+          </p>
         </div>
         <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
           <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">WinGet polling</span><Clock3 className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -54,6 +54,8 @@ export function useQaLive() {
       return response.json();
     },
     staleTime: 4_000,
-    refetchInterval: (query) => (query.state.data?.active ? 5_000 : 30_000),
+    refetchInterval: (query) => (query.state.data?.active ? 5_000 : 10_000),
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: 'always',
   });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/api/cron/qa-dispatch",
-      "schedule": "5-59/10 * * * *"
+      "schedule": "* * * * *"
     },
     {
       "path": "/api/cron/send-notifications",


### PR DESCRIPTION
## What changed
- check the protected QA dispatcher every minute while keeping WinGet discovery on its existing ten-minute cadence
- refresh the public live view every ten seconds while idle and every five seconds while testing, including background tabs
- replace the misleading idle heartbeat message with explicit next-dispatch status

## Why
A completed test could leave the single runner idle for nearly ten minutes before the next dispatch tick even with queued applications. The UI also described that normal idle interval as waiting for a heartbeat.

## Security and concurrency
The dispatcher remains protected by `CRON_SECRET`, uses an atomic candidate claim, and refuses dispatch whenever a candidate is already running or dispatched. This only reduces idle latency; it does not add parallel execution.

## Validation
- live QA route and snapshot tests (4 passing)
- scoped ESLint
- production Next.js build
- vercel.json schedule assertion
- git diff --check