### PR TITLE
Reset QA phase state between retries

### DIFF
--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -176,6 +176,9 @@ export async function GET(request: Request) {
           status: 'dispatched',
           attempts: candidate.attempts + 1,
           dispatched_at: dispatchedAt,
+          phase: null,
+          phase_started_at: null,
+          phase_updated_at: null,
           failure_summary: null,
           updated_at: dispatchedAt,
         })
@@ -225,6 +228,9 @@ export async function GET(request: Request) {
             status: 'queued',
             attempts: candidate.attempts,
             dispatched_at: null,
+            phase: null,
+            phase_started_at: null,
+            phase_updated_at: null,
             failure_summary: 'QA workflow dispatch failed; retry scheduled.',
             updated_at: new Date().toISOString(),
           })
@@ -270,6 +276,9 @@ export async function POST(request: Request) {
       finished_at: null,
       github_run_id: null,
       github_run_url: null,
+      phase: null,
+      phase_started_at: null,
+      phase_updated_at: null,
       failure_summary: null,
       updated_at: now,
     })

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -75,4 +75,28 @@ describe('buildQaLiveResponse', () => {
     expect(response.runner.state).toBe('stalled');
     expect(response.scheduler.state).toBe('degraded');
   });
+
+  it('ignores phase evidence left behind by an earlier retry attempt', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-08T18:26:00.000Z'),
+      current: {
+        winget_id: 'Example.App', version: '2', architecture: 'x64', status: 'dispatched',
+        priority: 0, enqueued_at: '2026-08-08T15:00:00.000Z',
+        dispatched_at: '2026-08-08T18:25:40.000Z', started_at: null,
+        phase: 'restoring_vm', phase_started_at: '2026-08-08T18:00:00.000Z',
+        phase_updated_at: '2026-08-08T18:00:00.000Z', test_config: {},
+      },
+      queuedCount: 1,
+      queued: [],
+      poll: null,
+      recent: [],
+      apps: [],
+    });
+    expect(response.runner).toEqual({
+      state: 'testing',
+      heartbeatAt: '2026-08-08T18:25:40.000Z',
+    });
+    expect(response.current?.phase).toBe('preparing_package');
+    expect(response.current?.phaseStartedAt).toBeNull();
+  });
 });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -99,8 +99,13 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
   const currentStartedAt = input.current
     ? input.current.started_at || input.current.dispatched_at || input.current.enqueued_at
     : null;
+  const phaseIsCurrentAttempt = Boolean(
+    input.current?.phase_updated_at &&
+    currentStartedAt &&
+    new Date(input.current.phase_updated_at).getTime() >= new Date(currentStartedAt).getTime()
+  );
   const heartbeatAt = input.current
-    ? input.current.phase_updated_at || currentStartedAt
+    ? (phaseIsCurrentAttempt ? input.current.phase_updated_at : null) || currentStartedAt
     : null;
   const runnerStalled = Boolean(
     heartbeatAt && input.now.getTime() - new Date(heartbeatAt).getTime() > RUNNER_STALE_MS
@@ -141,8 +146,8 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
           catalogVersion: currentApp?.latest_version || input.current.version,
           architecture: architecture(input.current.architecture),
           executionContext: executionContext(input.current.test_config),
-          phase: phase(input.current.phase),
-          phaseStartedAt: input.current.phase_started_at,
+          phase: phase(phaseIsCurrentAttempt ? input.current.phase : null),
+          phaseStartedAt: phaseIsCurrentAttempt ? input.current.phase_started_at : null,
           startedAt: currentStartedAt,
           elapsedSeconds: elapsedSeconds(currentStartedAt, input.now),
         }

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -60,3 +60,18 @@ describe('QA live dashboard migration contract', () => {
     expect(sql).toContain('github_run_id = null');
   });
 });
+
+describe('QA retry phase reset migration contract', () => {
+  const sql = readFileSync(
+    resolve(process.cwd(), 'supabase/migrations/20260808182702_clear_qa_retry_phase.sql'),
+    'utf8'
+  );
+
+  it('clears previous-attempt phase evidence only when a retry is re-queued', () => {
+    for (const column of ['phase', 'phase_started_at', 'phase_updated_at']) {
+      expect(sql).toContain(
+        `${column} = case when normalized_outcome = 'retry' and attempts < 2 then null else ${column} end`
+      );
+    }
+  });
+});

--- a/lib/qa/recovery.test.ts
+++ b/lib/qa/recovery.test.ts
@@ -19,6 +19,9 @@ describe('qaTimeoutRecoveryUpdate', () => {
       github_run_url: null,
       finished_at: null,
       failure_summary: null,
+      phase: null,
+      phase_started_at: null,
+      phase_updated_at: null,
     });
   });
 

--- a/lib/qa/recovery.ts
+++ b/lib/qa/recovery.ts
@@ -22,6 +22,11 @@ export function qaTimeoutRecoveryUpdate(
     failure_summary: exhausted
       ? 'QA workflow did not report completion before the safety timeout.'
       : null,
+    ...(exhausted ? {} : {
+      phase: null,
+      phase_started_at: null,
+      phase_updated_at: null,
+    }),
     updated_at: now,
   };
 }

--- a/supabase/migrations/20260808182702_clear_qa_retry_phase.sql
+++ b/supabase/migrations/20260808182702_clear_qa_retry_phase.sql
@@ -1,0 +1,58 @@
+-- A retried candidate is a new execution attempt. Do not let a previous
+-- attempt's phase make a newly dispatched workflow appear stalled.
+create or replace function public.report_qa_candidate_result(
+  p_secret text,
+  p_candidate_id uuid,
+  p_outcome text,
+  p_summary text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  normalized_outcome text := lower(coalesce(p_outcome, ''));
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if normalized_outcome not in ('passed', 'failed', 'error', 'retry') then
+    raise exception 'Invalid QA candidate outcome';
+  end if;
+
+  update public.qa_candidates
+  set status = case
+        when normalized_outcome = 'retry' and attempts < 2 then 'queued'
+        when normalized_outcome = 'retry' then 'error'
+        else normalized_outcome
+      end,
+      dispatched_at = case when normalized_outcome = 'retry' and attempts < 2 then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_url end,
+      phase = case when normalized_outcome = 'retry' and attempts < 2 then null else phase end,
+      phase_started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_started_at end,
+      phase_updated_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_updated_at end,
+      finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
+      failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
+      updated_at = now()
+  where id = p_candidate_id and status in ('dispatched', 'running');
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.report_qa_candidate_result(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.report_qa_candidate_result(text, uuid, text, text) to anon;
+
+update public.qa_candidates
+set phase = null,
+    phase_started_at = null,
+    phase_updated_at = null
+where status in ('dispatched', 'running')
+  and phase_updated_at is not null
+  and phase_updated_at < coalesce(started_at, dispatched_at);


### PR DESCRIPTION
## What changed
- clear phase timestamps whenever an infrastructure retry is re-queued or newly dispatched
- ignore phase evidence older than the current execution attempt in the public live projection
- clean stale phase evidence already attached to an active retry
- add migration, recovery, and projection regression coverage

## Root cause
Phase fields were introduced after the retry RPC. The retry transition cleared run IDs and execution timestamps but retained phase evidence from the previous attempt, causing a fresh dispatch to appear stalled during checkout.

## Security
The migration preserves the existing hash-gated RPC, explicit grants, active-state restriction, RLS posture, and sanitized public projection. It does not expose candidate rows or runner provenance.

## Validation
- focused QA tests (23 passing)
- scoped ESLint
- production Next.js build
- live migration applied and function contract verified
- git diff --check