### PR TITLE
Harden WinGet polling monitoring

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -34,6 +34,14 @@ function healthTone(state: string): StatusTone {
   return 'neutral';
 }
 
+function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): string | null {
+  if (issue === 'github_rate_limit') return 'GitHub API rate limit';
+  if (issue === 'partial_failure') return 'Some package checks failed';
+  if (issue === 'stalled') return 'Poll did not finish';
+  if (issue === 'upstream_error') return 'Upstream polling error';
+  return null;
+}
+
 function CurrentTest({ data }: { data: QaLiveResponse }) {
   const correctedStart = useMemo(
     () => data.current
@@ -129,6 +137,14 @@ function DashboardContent() {
           <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">WinGet polling</span><Clock3 className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>
           <StatusBadge tone={healthTone(data.scheduler.state)}>{data.scheduler.state.charAt(0).toUpperCase() + data.scheduler.state.slice(1)}</StatusBadge>
           <p className="mt-2 text-xs text-text-muted">Last scan {relativeTime(data.scheduler.lastPollAt)}</p>
+          {data.scheduler.issue && (
+            <p className="mt-1 text-xs text-status-error">
+              {schedulerIssueLabel(data.scheduler.issue)}
+              {data.scheduler.consecutiveFailures > 1
+                ? ` · ${data.scheduler.consecutiveFailures} consecutive failures`
+                : ''}
+            </p>
+          )}
         </div>
         <div className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5">
           <div className="mb-3 flex items-center justify-between"><span className="text-sm text-text-muted">Queue</span><Loader2 className="h-4 w-4 text-text-muted" aria-hidden="true" /></div>

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -33,7 +33,9 @@ describe('buildQaLiveResponse', () => {
         status: 'succeeded',
         started_at: '2026-08-08T16:50:00.000Z',
         finished_at: '2026-08-08T16:50:10.000Z',
+        errors: [],
       },
+      consecutivePollFailures: 0,
       recent: [],
       apps: [{
         winget_id: 'Example.App',
@@ -45,6 +47,7 @@ describe('buildQaLiveResponse', () => {
 
     expect(response.runner.state).toBe('testing');
     expect(response.scheduler.state).toBe('healthy');
+    expect(response.scheduler).toMatchObject({ lastOutcome: 'succeeded', issue: null, consecutiveFailures: 0 });
     expect(response.current).toMatchObject({
       displayName: 'Example',
       phase: 'installing',
@@ -68,12 +71,14 @@ describe('buildQaLiveResponse', () => {
       },
       queuedCount: 0,
       queued: [],
-      poll: { status: 'running', started_at: '2026-08-08T16:00:00.000Z', finished_at: null },
+      poll: { status: 'running', started_at: '2026-08-08T16:00:00.000Z', finished_at: null, errors: [] },
+      consecutivePollFailures: 2,
       recent: [],
       apps: [],
     });
     expect(response.runner.state).toBe('stalled');
     expect(response.scheduler.state).toBe('degraded');
+    expect(response.scheduler.issue).toBe('stalled');
   });
 
   it('ignores phase evidence left behind by an earlier retry attempt', () => {
@@ -89,6 +94,7 @@ describe('buildQaLiveResponse', () => {
       queuedCount: 1,
       queued: [],
       poll: null,
+      consecutivePollFailures: 0,
       recent: [],
       apps: [],
     });
@@ -98,5 +104,31 @@ describe('buildQaLiveResponse', () => {
     });
     expect(response.current?.phase).toBe('preparing_package');
     expect(response.current?.phaseStartedAt).toBeNull();
+  });
+
+  it('publishes only a sanitized GitHub rate-limit cause', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-08T19:11:00.000Z'),
+      current: null,
+      queuedCount: 0,
+      queued: [],
+      poll: {
+        status: 'failed',
+        started_at: '2026-08-08T19:10:00.000Z',
+        finished_at: '2026-08-08T19:10:01.000Z',
+        errors: ['system: WinGet change feed failed (403): API rate limit exceeded secret-detail'],
+      },
+      consecutivePollFailures: 2,
+      recent: [],
+      apps: [],
+    });
+
+    expect(response.scheduler).toMatchObject({
+      state: 'degraded',
+      lastOutcome: 'failed',
+      issue: 'github_rate_limit',
+      consecutiveFailures: 2,
+    });
+    expect(JSON.stringify(response)).not.toContain('secret-detail');
   });
 });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -26,6 +26,7 @@ interface PollRow {
   status: 'running' | 'succeeded' | 'partial' | 'failed';
   started_at: string;
   finished_at: string | null;
+  errors: Json;
 }
 
 interface ResultRow {
@@ -51,6 +52,7 @@ export interface QaLiveSnapshotInput {
   queuedCount: number;
   queued: CandidateRow[];
   poll: PollRow | null;
+  consecutivePollFailures: number;
   recent: ResultRow[];
   apps: AppRow[];
 }
@@ -94,6 +96,21 @@ function elapsedSeconds(start: string, now: Date): number {
   return Math.max(0, Math.floor((now.getTime() - new Date(start).getTime()) / 1000));
 }
 
+function schedulerIssue(
+  poll: PollRow | null,
+  staleRunning: boolean
+): QaLiveResponse['scheduler']['issue'] {
+  if (!poll || poll.status === 'succeeded') return null;
+  if (staleRunning) return 'stalled';
+  const errors = Array.isArray(poll.errors) ? poll.errors : [];
+  const combined = errors.filter((error): error is string => typeof error === 'string').join(' ');
+  if (/github|winget change feed/i.test(combined) && /rate limit/i.test(combined)) {
+    return 'github_rate_limit';
+  }
+  if (poll.status === 'partial') return 'partial_failure';
+  return 'upstream_error';
+}
+
 export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse {
   const appById = new Map(input.apps.map((app) => [app.winget_id, app]));
   const currentStartedAt = input.current
@@ -112,14 +129,15 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
   );
 
   let schedulerState: QaLiveResponse['scheduler']['state'] = 'unknown';
+  let stalePoll = false;
   if (input.poll) {
-    const staleRunning =
+    stalePoll =
       input.poll.status === 'running' &&
       input.now.getTime() - new Date(input.poll.started_at).getTime() > POLL_STALE_MS;
     schedulerState =
       input.poll.status === 'succeeded'
         ? 'healthy'
-        : input.poll.status === 'running' && !staleRunning
+        : input.poll.status === 'running' && !stalePoll
           ? 'healthy'
           : 'degraded';
   }
@@ -136,6 +154,9 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
     scheduler: {
       state: schedulerState,
       lastPollAt: input.poll?.finished_at || input.poll?.started_at || null,
+      lastOutcome: input.poll?.status || null,
+      issue: schedulerIssue(input.poll, stalePoll),
+      consecutiveFailures: input.consecutivePollFailures,
     },
     current: input.current && currentStartedAt
       ? {
@@ -205,10 +226,9 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
       .eq('status', 'queued'),
     supabase
       .from('qa_poll_runs')
-      .select('status, started_at, finished_at')
+      .select('status, started_at, finished_at, errors')
       .order('started_at', { ascending: false })
-      .limit(1)
-      .maybeSingle(),
+      .limit(10),
     supabase
       .from('qa_results')
       .select(
@@ -226,6 +246,12 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const current = (activeResult.data as CandidateRow | null) || null;
   const queued = (queueResult.data || []) as CandidateRow[];
   const recent = (recentResult.data || []) as ResultRow[];
+  const polls = (pollResult.data || []) as PollRow[];
+  let consecutivePollFailures = 0;
+  for (const poll of polls) {
+    if (poll.status !== 'failed' && poll.status !== 'partial') break;
+    consecutivePollFailures += 1;
+  }
   const ids = [
     ...(current ? [current.winget_id] : []),
     ...queued.map((row) => row.winget_id),
@@ -247,7 +273,8 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
     current,
     queuedCount: countResult.count || 0,
     queued,
-    poll: (pollResult.data as PollRow | null) || null,
+    poll: polls[0] || null,
+    consecutivePollFailures,
     recent,
     apps,
   });

--- a/lib/qa/winget-changes.test.ts
+++ b/lib/qa/winget-changes.test.ts
@@ -92,4 +92,42 @@ describe('detectWingetChanges', () => {
       'compare limits'
     );
   });
+
+  it('falls back to the public feed when an authenticated request is rate limited', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+          status: 403,
+          headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1786220000' },
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ sha: BASE }]), { status: 200 }));
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      detectWingetChanges({ token: 'configured-token', baseSha: BASE, fetchImpl })
+    ).resolves.toMatchObject({ headSha: BASE, changedPackageIds: [] });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(new Headers(fetchImpl.mock.calls[0][1]?.headers).get('Authorization')).toBe(
+      'Bearer configured-token'
+    );
+    expect(new Headers(fetchImpl.mock.calls[1][1]?.headers).has('Authorization')).toBe(false);
+  });
+
+  it('reports the reset time when both authenticated and public feeds are rate limited', async () => {
+    const limited = () =>
+      new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1786220000' },
+      });
+    const fetchImpl = vi.fn().mockImplementation(limited);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      detectWingetChanges({ token: 'configured-token', baseSha: BASE, fetchImpl })
+    ).rejects.toThrow(/resets 2026-/);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
 });

--- a/lib/qa/winget-changes.ts
+++ b/lib/qa/winget-changes.ts
@@ -47,13 +47,44 @@ async function githubJson<T>(
   path: string,
   token?: string
 ): Promise<T> {
-  const response = await fetchImpl(`${GITHUB_API_BASE}${path}`, {
-    headers: githubHeaders(token),
-    cache: 'no-store',
-  });
+  const request = (requestToken?: string) =>
+    fetchImpl(`${GITHUB_API_BASE}${path}`, {
+      headers: githubHeaders(requestToken),
+      cache: 'no-store',
+    });
+  let response = await request(token);
   if (!response.ok) {
-    const detail = (await response.text()).slice(0, 500);
-    throw new Error(`WinGet change feed failed (${response.status}): ${detail || path}`);
+    let detail = (await response.text()).slice(0, 500);
+    const rateLimited =
+      response.status === 429 ||
+      (response.status === 403 &&
+        (response.headers.get('x-ratelimit-remaining') === '0' ||
+          /rate limit exceeded/i.test(detail)));
+
+    if (token && rateLimited) {
+      const resetEpoch = Number(response.headers.get('x-ratelimit-reset'));
+      console.warn(
+        JSON.stringify({
+          level: 'warning',
+          message: 'qa_winget_github_authenticated_rate_limit',
+          route: '/api/cron/qa-enqueue',
+          resetAt:
+            Number.isFinite(resetEpoch) && resetEpoch > 0
+              ? new Date(resetEpoch * 1000).toISOString()
+              : null,
+        })
+      );
+      response = await request(undefined);
+      if (response.ok) return (await response.json()) as T;
+      detail = (await response.text()).slice(0, 500);
+    }
+
+    const resetEpoch = Number(response.headers.get('x-ratelimit-reset'));
+    const reset =
+      Number.isFinite(resetEpoch) && resetEpoch > 0
+        ? `; resets ${new Date(resetEpoch * 1000).toISOString()}`
+        : '';
+    throw new Error(`WinGet change feed failed (${response.status}${reset}): ${detail || path}`);
   }
   return (await response.json()) as T;
 }

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -71,6 +71,9 @@ export interface QaLiveResponse {
   scheduler: {
     state: 'healthy' | 'degraded' | 'unknown';
     lastPollAt: string | null;
+    lastOutcome: 'running' | 'succeeded' | 'partial' | 'failed' | null;
+    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | null;
+    consecutiveFailures: number;
   };
   current: {
     wingetId: string;


### PR DESCRIPTION
## What changed

- retry the public WinGet GitHub feed without authentication when the configured credential is explicitly rate-limited
- expose a sanitized scheduler cause and consecutive-failure count on `/QA`
- keep raw upstream errors and credentials out of the public response

## Why

The 10-minute cron was running, but its GitHub credential exhausted its API quota. This made `/QA` report only `degraded`, without explaining whether polling had stopped or an upstream request had failed.

The cursor is not advanced on failed polls, so the next successful run safely catches up.

## Validation

- `npx vitest run lib/qa/winget-changes.test.ts lib/qa/live.test.ts app/api/qa/live/route.test.ts` (13 tests passed)
- targeted ESLint passed
- `npm run build:ci` passed, including TypeScript and static generation
- `git diff --check` passed