### PR TITLE
Promote passed QA candidates to catalog

### DIFF
--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -277,11 +277,12 @@ export async function GET(request: Request) {
       winget_id: string;
       name: string;
       publisher: string;
+      latest_version: string | null;
     }> = [];
     if (targetPackageIds.length > 0) {
       const { data, error } = await supabase
         .from('curated_apps')
-        .select('winget_id, name, publisher')
+        .select('winget_id, name, publisher, latest_version')
         .in('winget_id', targetPackageIds)
         .eq('is_verified', true)
         .eq('is_winget_verified', true)
@@ -458,6 +459,7 @@ export async function GET(request: Request) {
                 test_level: 'psadt-package',
                 package_profile_sha256: packageIdentity.packageProfileSha256,
                 test_config: testConfig as never,
+                catalog_version_at_enqueue: app.latest_version,
                 status: initialStatus,
                 priority: priorities.get(app.winget_id) || 0,
                 finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
@@ -490,6 +492,7 @@ export async function GET(request: Request) {
                     finished_at: null,
                     failure_summary: null,
                     test_config: testConfig as never,
+                    catalog_version_at_enqueue: app.latest_version,
                     updated_at: now,
                   })
                   .eq('id', existing.id)

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { useQaDetails } from '@/hooks/use-qa';
+import { qaVersionMismatchMessage } from '@/lib/qa/version-mismatch';
 import { QA_CHANGE_CATEGORIES, type QaChangeSet, type QaPhaseResult } from '@/types/qa';
 
 interface QaDetailsDialogProps {
@@ -133,7 +134,7 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
               {data.testedVersion !== catalogVersion ? (
                 <div className="flex gap-2 rounded-xl border border-status-warning/20 bg-status-warning/10 p-3 text-sm text-status-warning">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                  <p>This result is for version {data.testedVersion}; the catalog now offers {catalogVersion}. The outcome may not apply to the newer version.</p>
+                  <p>{qaVersionMismatchMessage(data.testedVersion, catalogVersion)}</p>
                 </div>
               ) : null}
 

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from 'vitest';
 const migrationPaths = [
   'supabase/migrations/20260807193111_qa_release_gate.sql',
   'supabase/migrations/20260807205000_qa_candidate_terminal_evidence.sql',
+  'supabase/migrations/20260808193500_qa_candidate_catalog_promotion.sql',
+  'supabase/migrations/20260808194800_harden_qa_catalog_promotion_order.sql',
 ];
 
 describe.each(migrationPaths)('QA candidate migration contract: %s', (migrationPath) => {
@@ -21,6 +23,33 @@ describe.each(migrationPaths)('QA candidate migration contract: %s', (migrationP
   it('keeps terminal retry exhaustion distinct from a re-queued retry', () => {
     expect(sql).toContain("when normalized_outcome = 'retry' and attempts < 2 then 'queued'");
     expect(sql).toContain("when normalized_outcome = 'retry' then 'error'");
+  });
+});
+
+describe('QA candidate catalog promotion migration contract', () => {
+  const sql = readFileSync(
+    resolve(process.cwd(), 'supabase/migrations/20260808194800_harden_qa_catalog_promotion_order.sql'),
+    'utf8'
+  );
+
+  it('requires exact passed package evidence before promotion', () => {
+    expect(sql).toContain("result.outcome = 'Passed'");
+    expect(sql).toContain('result.tested_version = candidate.version');
+    expect(sql).toContain('result.installer_sha256 = candidate.installer_sha256');
+    expect(sql).toContain('result.package_profile_sha256 = candidate.package_profile_sha256');
+  });
+
+  it('uses an optimistic catalog-version guard to prevent rollback', () => {
+    expect(sql).toContain('app.latest_version is not distinct from candidate.catalog_version_at_enqueue');
+    expect(sql).toContain('later.enqueued_at > candidate.enqueued_at');
+    expect(sql).not.toContain('catalog_version_at_enqueue = candidate.version');
+  });
+
+  it('supersedes stale retries and records skipped promotions', () => {
+    expect(sql).toContain("set status = 'superseded'");
+    expect(sql).toContain('Retry superseded because the catalog version changed after enqueue.');
+    expect(sql).toContain('Catalog promotion skipped because a newer release candidate exists.');
+    expect(sql).toContain('Catalog promotion skipped because the catalog version changed after enqueue.');
   });
 });
 

--- a/lib/qa/version-mismatch.test.ts
+++ b/lib/qa/version-mismatch.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { qaVersionMismatchMessage } from './version-mismatch';
+
+describe('qaVersionMismatchMessage', () => {
+  it('identifies a catalog version older than the tested version', () => {
+    expect(qaVersionMismatchMessage('2.4.0', '2.3.2')).toContain(
+      'catalog still offers the older version 2.3.2'
+    );
+  });
+
+  it('identifies a catalog version newer than the tested version', () => {
+    expect(qaVersionMismatchMessage('2.3.2', '2.4.0')).toContain(
+      'catalog now offers the newer version 2.4.0'
+    );
+  });
+
+  it('does not invent a direction for equivalent but non-identical identifiers', () => {
+    expect(qaVersionMismatchMessage('1.2', '1.2.0')).toContain('identifiers differ');
+  });
+});

--- a/lib/qa/version-mismatch.ts
+++ b/lib/qa/version-mismatch.ts
@@ -1,0 +1,13 @@
+import { compareVersions } from '@/lib/version-compare';
+
+export function qaVersionMismatchMessage(testedVersion: string, catalogVersion: string): string {
+  const catalogComparedWithTested = compareVersions(catalogVersion, testedVersion);
+
+  if (catalogComparedWithTested < 0) {
+    return `This QA result is for version ${testedVersion}; the catalog still offers the older version ${catalogVersion}. The newer tested version has not been promoted to the catalog.`;
+  }
+  if (catalogComparedWithTested > 0) {
+    return `This QA result is for version ${testedVersion}; the catalog now offers the newer version ${catalogVersion}. The outcome may not apply to that version.`;
+  }
+  return `This QA result is for version ${testedVersion}; the catalog version is ${catalogVersion}. The identifiers differ, so QA applies only to the exact tested version.`;
+}

--- a/supabase/migrations/20260808193500_qa_candidate_catalog_promotion.sql
+++ b/supabase/migrations/20260808193500_qa_candidate_catalog_promotion.sql
@@ -1,0 +1,218 @@
+-- Promote an exact WinGet release into the deployable catalog immediately
+-- after its PSADT package QA result passes. The daily full sync remains a
+-- reconciliation job; it is no longer the release path for tested updates.
+alter table public.qa_candidates
+  add column if not exists catalog_version_at_enqueue text;
+
+comment on column public.qa_candidates.catalog_version_at_enqueue is
+  'Optimistic-lock value used to prevent a completed QA run from rolling back a catalog version changed after enqueue.';
+
+-- Existing candidates can safely inherit the catalog value only when the
+-- catalog row has not changed since they entered the queue.
+update public.qa_candidates as candidate
+set catalog_version_at_enqueue = app.latest_version
+from public.curated_apps as app
+where app.winget_id = candidate.winget_id
+  and candidate.catalog_version_at_enqueue is null
+  and candidate.enqueued_at >= app.updated_at;
+
+create or replace function public.report_qa_candidate_result(
+  p_secret text,
+  p_candidate_id uuid,
+  p_outcome text,
+  p_summary text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  normalized_outcome text := lower(coalesce(p_outcome, ''));
+  candidate public.qa_candidates%rowtype;
+  changed integer;
+  promoted integer := 0;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if normalized_outcome not in ('passed', 'failed', 'error', 'retry') then
+    raise exception 'Invalid QA candidate outcome';
+  end if;
+
+  update public.qa_candidates
+  set status = case
+        when normalized_outcome = 'retry' and attempts < 2 then 'queued'
+        when normalized_outcome = 'retry' then 'error'
+        else normalized_outcome
+      end,
+      dispatched_at = case when normalized_outcome = 'retry' and attempts < 2 then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_url end,
+      phase = case when normalized_outcome = 'retry' and attempts < 2 then null else phase end,
+      phase_started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_started_at end,
+      phase_updated_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_updated_at end,
+      finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
+      failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
+      updated_at = now()
+  where id = p_candidate_id and status in ('dispatched', 'running')
+  returning * into candidate;
+  get diagnostics changed = row_count;
+  if changed <> 1 then
+    return false;
+  end if;
+
+  if normalized_outcome = 'passed'
+     and candidate.test_level = 'psadt-package'
+     and candidate.test_config->>'profileKind' = 'catalog-default' then
+    if not exists (
+      select 1
+      from public.qa_results as result
+      where result.winget_id = candidate.winget_id
+        and result.outcome = 'Passed'
+        and result.test_level = 'psadt-package'
+        and result.tested_version = candidate.version
+        and result.architecture = candidate.architecture
+        and result.installer_sha256 = candidate.installer_sha256
+        and result.package_profile_sha256 = candidate.package_profile_sha256
+    ) then
+      raise exception 'Exact passed QA package evidence is missing for catalog promotion';
+    end if;
+
+    update public.curated_apps as app
+    set latest_version = candidate.version,
+        updated_at = now()
+    where app.winget_id = candidate.winget_id
+      and (
+        app.latest_version is not distinct from candidate.catalog_version_at_enqueue
+        or app.latest_version = candidate.version
+      );
+    get diagnostics promoted = row_count;
+
+    if promoted = 1 then
+      insert into public.version_history (
+        winget_id, version, installer_url, installer_sha256, installer_type,
+        installer_scope, silent_args, installers, manifest_fetched_at, updated_at
+      )
+      values (
+        candidate.winget_id,
+        candidate.version,
+        candidate.installer_url,
+        candidate.installer_sha256,
+        coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+        nullif(candidate.test_config->>'scope', ''),
+        nullif(candidate.test_config->>'silentArgs', ''),
+        jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+          'Architecture', candidate.architecture,
+          'InstallerUrl', candidate.installer_url,
+          'InstallerSha256', candidate.installer_sha256,
+          'InstallerType', coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+          'Scope', nullif(candidate.test_config->>'scope', ''),
+          'InstallerSwitches', case
+            when nullif(candidate.test_config->>'silentArgs', '') is null then null
+            else jsonb_build_object('Silent', candidate.test_config->>'silentArgs')
+          end
+        ))),
+        now(),
+        now()
+      )
+      on conflict (winget_id, version) do nothing;
+
+      -- A newer release may already be waiting behind this candidate. Move
+      -- its optimistic-lock value forward now that this promotion succeeded.
+      update public.qa_candidates as pending
+      set catalog_version_at_enqueue = candidate.version,
+          updated_at = now()
+      where pending.winget_id = candidate.winget_id
+        and pending.status = 'queued'
+        and pending.catalog_version_at_enqueue is not distinct from candidate.catalog_version_at_enqueue;
+    end if;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.report_qa_candidate_result(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.report_qa_candidate_result(text, uuid, text, text) to anon;
+
+-- Reconcile the newest already-passed exact result per application. The
+-- optimistic value above is populated only when the catalog did not change
+-- after enqueue, so this cannot overwrite a concurrently refreshed catalog.
+with eligible as (
+  select distinct on (candidate.winget_id)
+    candidate.winget_id,
+    candidate.version,
+    candidate.catalog_version_at_enqueue
+  from public.qa_candidates as candidate
+  join public.qa_results as result
+    on result.winget_id = candidate.winget_id
+   and result.outcome = 'Passed'
+   and result.test_level = 'psadt-package'
+   and result.tested_version = candidate.version
+   and result.architecture = candidate.architecture
+   and result.installer_sha256 = candidate.installer_sha256
+   and result.package_profile_sha256 = candidate.package_profile_sha256
+  where candidate.status = 'passed'
+    and candidate.test_level = 'psadt-package'
+    and candidate.test_config->>'profileKind' = 'catalog-default'
+    and candidate.catalog_version_at_enqueue is not null
+  order by candidate.winget_id, candidate.finished_at desc nulls last
+)
+update public.curated_apps as app
+set latest_version = eligible.version,
+    updated_at = now()
+from eligible
+where app.winget_id = eligible.winget_id
+  and app.latest_version is not distinct from eligible.catalog_version_at_enqueue;
+
+insert into public.version_history (
+  winget_id, version, installer_url, installer_sha256, installer_type,
+  installer_scope, silent_args, installers, manifest_fetched_at, updated_at
+)
+select distinct on (candidate.winget_id, candidate.version)
+  candidate.winget_id,
+  candidate.version,
+  candidate.installer_url,
+  candidate.installer_sha256,
+  coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+  nullif(candidate.test_config->>'scope', ''),
+  nullif(candidate.test_config->>'silentArgs', ''),
+  jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+    'Architecture', candidate.architecture,
+    'InstallerUrl', candidate.installer_url,
+    'InstallerSha256', candidate.installer_sha256,
+    'InstallerType', coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+    'Scope', nullif(candidate.test_config->>'scope', '')
+  ))),
+  now(),
+  now()
+from public.qa_candidates as candidate
+join public.qa_results as result
+  on result.winget_id = candidate.winget_id
+ and result.outcome = 'Passed'
+ and result.test_level = 'psadt-package'
+ and result.tested_version = candidate.version
+ and result.architecture = candidate.architecture
+ and result.installer_sha256 = candidate.installer_sha256
+ and result.package_profile_sha256 = candidate.package_profile_sha256
+join public.curated_apps as app
+  on app.winget_id = candidate.winget_id
+ and app.latest_version = candidate.version
+where candidate.status = 'passed'
+  and candidate.test_level = 'psadt-package'
+  and candidate.test_config->>'profileKind' = 'catalog-default'
+order by candidate.winget_id, candidate.version, candidate.finished_at desc nulls last
+on conflict (winget_id, version) do nothing;
+
+-- Queued work has not started and can safely use the newly reconciled catalog
+-- value as its optimistic-lock baseline.
+update public.qa_candidates as candidate
+set catalog_version_at_enqueue = app.latest_version,
+    updated_at = now()
+from public.curated_apps as app
+where app.winget_id = candidate.winget_id
+  and candidate.status = 'queued';

--- a/supabase/migrations/20260808194800_harden_qa_catalog_promotion_order.sql
+++ b/supabase/migrations/20260808194800_harden_qa_catalog_promotion_order.sql
@@ -1,0 +1,160 @@
+-- Harden catalog promotion when multiple releases for one application are
+-- observed before the queue drains. Observation order, rather than parsing
+-- vendor-specific version strings, determines which candidate is current.
+create or replace function public.report_qa_candidate_result(
+  p_secret text,
+  p_candidate_id uuid,
+  p_outcome text,
+  p_summary text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  normalized_outcome text := lower(coalesce(p_outcome, ''));
+  candidate public.qa_candidates%rowtype;
+  changed integer;
+  promoted integer := 0;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if normalized_outcome not in ('passed', 'failed', 'error', 'retry') then
+    raise exception 'Invalid QA candidate outcome';
+  end if;
+
+  update public.qa_candidates
+  set status = case
+        when normalized_outcome = 'retry' and attempts < 2 then 'queued'
+        when normalized_outcome = 'retry' then 'error'
+        else normalized_outcome
+      end,
+      dispatched_at = case when normalized_outcome = 'retry' and attempts < 2 then null else dispatched_at end,
+      started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else started_at end,
+      github_run_id = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_id end,
+      github_run_url = case when normalized_outcome = 'retry' and attempts < 2 then null else github_run_url end,
+      phase = case when normalized_outcome = 'retry' and attempts < 2 then null else phase end,
+      phase_started_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_started_at end,
+      phase_updated_at = case when normalized_outcome = 'retry' and attempts < 2 then null else phase_updated_at end,
+      finished_at = case when normalized_outcome = 'retry' and attempts < 2 then null else now() end,
+      failure_summary = case when normalized_outcome = 'passed' then null else left(p_summary, 1000) end,
+      updated_at = now()
+  where id = p_candidate_id and status in ('dispatched', 'running')
+  returning * into candidate;
+  get diagnostics changed = row_count;
+  if changed <> 1 then
+    return false;
+  end if;
+
+  -- A retry for a release whose catalog baseline has moved is obsolete. Do
+  -- not spend another VM run on it and never refresh its optimistic lock.
+  if normalized_outcome = 'retry'
+     and candidate.status = 'queued'
+     and exists (
+       select 1
+       from public.curated_apps as app
+       where app.winget_id = candidate.winget_id
+         and app.latest_version is distinct from candidate.catalog_version_at_enqueue
+         and app.latest_version is distinct from candidate.version
+     ) then
+    update public.qa_candidates
+    set status = 'superseded',
+        finished_at = now(),
+        failure_summary = 'Retry superseded because the catalog version changed after enqueue.',
+        updated_at = now()
+    where id = candidate.id;
+    return true;
+  end if;
+
+  if normalized_outcome = 'passed'
+     and candidate.test_level = 'psadt-package'
+     and candidate.test_config->>'profileKind' = 'catalog-default' then
+    if not exists (
+      select 1
+      from public.qa_results as result
+      where result.winget_id = candidate.winget_id
+        and result.outcome = 'Passed'
+        and result.test_level = 'psadt-package'
+        and result.tested_version = candidate.version
+        and result.architecture = candidate.architecture
+        and result.installer_sha256 = candidate.installer_sha256
+        and result.package_profile_sha256 = candidate.package_profile_sha256
+    ) then
+      raise exception 'Exact passed QA package evidence is missing for catalog promotion';
+    end if;
+
+    -- If a later manifest change has already produced another candidate, the
+    -- older passing result is valid evidence but is no longer the release to
+    -- expose. The newest candidate retains the original catalog baseline.
+    if exists (
+      select 1
+      from public.qa_candidates as later
+      where later.winget_id = candidate.winget_id
+        and later.test_level = 'psadt-package'
+        and later.test_config->>'profileKind' = 'catalog-default'
+        and later.enqueued_at > candidate.enqueued_at
+    ) then
+      update public.qa_candidates
+      set failure_summary = 'Catalog promotion skipped because a newer release candidate exists.',
+          updated_at = now()
+      where id = candidate.id;
+      return true;
+    end if;
+
+    update public.curated_apps as app
+    set latest_version = candidate.version,
+        updated_at = now()
+    where app.winget_id = candidate.winget_id
+      and (
+        app.latest_version is not distinct from candidate.catalog_version_at_enqueue
+        or app.latest_version = candidate.version
+      );
+    get diagnostics promoted = row_count;
+
+    if promoted = 0 then
+      update public.qa_candidates
+      set failure_summary = 'Catalog promotion skipped because the catalog version changed after enqueue.',
+          updated_at = now()
+      where id = candidate.id;
+      return true;
+    end if;
+
+    insert into public.version_history (
+      winget_id, version, installer_url, installer_sha256, installer_type,
+      installer_scope, silent_args, installers, manifest_fetched_at, updated_at
+    )
+    values (
+      candidate.winget_id,
+      candidate.version,
+      candidate.installer_url,
+      candidate.installer_sha256,
+      coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+      nullif(candidate.test_config->>'scope', ''),
+      nullif(candidate.test_config->>'silentArgs', ''),
+      jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+        'Architecture', candidate.architecture,
+        'InstallerUrl', candidate.installer_url,
+        'InstallerSha256', candidate.installer_sha256,
+        'InstallerType', coalesce(nullif(candidate.test_config->>'sourceInstallerType', ''), candidate.installer_type),
+        'Scope', nullif(candidate.test_config->>'scope', ''),
+        'InstallerSwitches', case
+          when nullif(candidate.test_config->>'silentArgs', '') is null then null
+          else jsonb_build_object('Silent', candidate.test_config->>'silentArgs')
+        end
+      ))),
+      now(),
+      now()
+    )
+    on conflict (winget_id, version) do nothing;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.report_qa_candidate_result(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.report_qa_candidate_result(text, uuid, text, text) to anon;

--- a/types/database.ts
+++ b/types/database.ts
@@ -163,6 +163,7 @@ export interface Database {
           test_config: Json;
           test_level: 'installer-preflight' | 'psadt-package';
           package_profile_sha256: string | null;
+          catalog_version_at_enqueue: string | null;
           status: string;
           priority: number;
           attempts: number;
@@ -191,6 +192,7 @@ export interface Database {
           test_config?: Json;
           test_level?: 'installer-preflight' | 'psadt-package';
           package_profile_sha256?: string | null;
+          catalog_version_at_enqueue?: string | null;
           status?: string;
           priority?: number;
           attempts?: number;


### PR DESCRIPTION
## What changed

- record the catalog version observed when each WinGet QA candidate is enqueued
- atomically promote an exact candidate after its PSADT package QA result passes
- require matching version, architecture, installer SHA-256, and package-profile SHA-256 evidence
- use an optimistic catalog-version guard so an older run cannot overwrite a catalog row changed after enqueue
- add a minimal version-history row for the exact tested installer; the daily full sync can enrich it later
- distinguish older, newer, and equivalent-but-different version mismatches in the QA dialog

## Root cause

The 10-minute pipeline created and tested release candidates, but successful results were only written to QA tables. `curated_apps.latest_version` was still advanced by the separate catalog sync, leaving Moonfin QA-passed at 2.4.0 while the catalog remained at 2.3.2.

## Production migration

The backward-compatible migration has been applied. Its guarded reconciliation promoted Moonfin to 2.4.0 with an exact matching installer hash.

## Validation

- 38 focused tests passed across polling, enqueue, migration contracts, live status, and mismatch wording
- targeted ESLint passed
- `npm run build:ci` passed, including TypeScript and 140 generated routes
- Supabase security and performance advisors were checked; no new table/RLS issue was introduced
- production WinGet polling recovered: latest run succeeded, queued 11 changed supported apps, and `/api/qa/live` reports healthy with zero consecutive failures