### PR TITLE
feat(qa): add live VM viewer

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { AlertTriangle, CheckCircle2, Clock3, Loader2, Server, ShieldCheck, XCircle } from 'lucide-react';
+import Image from 'next/image';
+import { AlertTriangle, CheckCircle2, Clock3, Eye, Loader2, Monitor, Server, ShieldCheck, XCircle } from 'lucide-react';
 import { AppIcon } from '@/components/AppIcon';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import { QaDetailsDialog } from '@/components/qa/QaDetailsDialog';
@@ -40,6 +41,39 @@ function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): strin
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
   return null;
+}
+
+function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
+  const [visibleSrc, setVisibleSrc] = useState<string | null>(null);
+
+  return (
+    <>
+      {visibleSrc ? (
+        <Image
+          src={visibleSrc}
+          alt={alt}
+          fill
+          unoptimized
+          loading="eager"
+          sizes="(min-width: 1024px) 960px, 100vw"
+          className="object-contain"
+        />
+      ) : null}
+      {src !== visibleSrc ? (
+        <Image
+          src={src}
+          alt=""
+          aria-hidden="true"
+          fill
+          unoptimized
+          loading="eager"
+          sizes="(min-width: 1024px) 960px, 100vw"
+          className="object-contain opacity-0"
+          onLoad={() => setVisibleSrc(src)}
+        />
+      ) : null}
+    </>
+  );
 }
 
 function CurrentTest({ data }: { data: QaLiveResponse }) {
@@ -97,6 +131,40 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
         </div>
       </div>
       <QaPhaseTimeline currentPhase={data.current.phase} />
+      <div className="overflow-hidden rounded-xl border border-overlay/10 bg-black" aria-labelledby="live-console-heading">
+        <div className="flex items-center justify-between border-b border-white/10 bg-bg-primary/80 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Monitor className="h-4 w-4 text-accent-cyan" aria-hidden="true" />
+            <h3 id="live-console-heading" className="text-sm font-medium text-text-primary">Live test VM</h3>
+            <span className="hidden text-xs text-text-muted md:inline">
+              {data.current.dialogExpected ? 'PSADT UI may appear' : `${data.current.deployMode} install · no dialog expected`}
+            </span>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-text-muted">
+            <span className="hidden items-center gap-1.5 sm:flex"><Eye className="h-3.5 w-3.5" aria-hidden="true" />Read-only</span>
+            {data.viewer.available ? (
+              <span className="flex items-center gap-1.5 text-status-success">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-status-success" aria-hidden="true" />
+                Live · {relativeTime(data.viewer.capturedAt)}
+              </span>
+            ) : <span>Waiting for a console frame</span>}
+          </div>
+        </div>
+        <div className="relative aspect-video w-full bg-black">
+          {data.viewer.available && data.viewer.sequence != null && data.viewer.candidateId ? (
+            <LiveFrameImage
+              key={data.viewer.candidateId}
+              src={`/api/qa/live/frame?candidate=${encodeURIComponent(data.viewer.candidateId)}&sequence=${data.viewer.sequence}`}
+              alt={`Read-only live view of the isolated QA VM while testing ${data.current.displayName}`}
+            />
+          ) : (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
+              <Monitor className="h-8 w-8 text-white/25" aria-hidden="true" />
+              <p className="max-w-md text-sm text-white/50">The private host is preparing a safe, read-only VM console view. No keyboard, mouse, clipboard, or audio channel is exposed.</p>
+            </div>
+          )}
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/api/cron/qa-live-cleanup/route.ts
+++ b/app/api/cron/qa-live-cleanup/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const BUCKET = 'qa-live-frames';
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const supabase = createServerClient();
+    const cutoff = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const { data: staleFrames, error: staleError } = await supabase
+      .from('qa_live_frames')
+      .select('candidate_id')
+      .lt('updated_at', cutoff)
+      .limit(25);
+    if (staleError) throw new Error(`Could not load stale QA frames: ${staleError.message}`);
+
+    let removedObjects = 0;
+    const cleanedCandidateIds: string[] = [];
+    for (const frame of staleFrames || []) {
+      try {
+        const { data: objects, error: listError } = await supabase.storage.from(BUCKET).list(frame.candidate_id, { limit: 10 });
+        if (listError) throw new Error(listError.message);
+        const paths = (objects || []).map((object) => `${frame.candidate_id}/${object.name}`);
+        if (paths.length) {
+          const { error: removeError } = await supabase.storage.from(BUCKET).remove(paths);
+          if (removeError) throw new Error(removeError.message);
+          removedObjects += paths.length;
+        }
+        cleanedCandidateIds.push(frame.candidate_id);
+      } catch (error) {
+        console.error(`Could not clean stale QA frames for candidate ${frame.candidate_id}:`, error);
+      }
+    }
+
+    if (cleanedCandidateIds.length) {
+      const { error: deleteError } = await supabase.from('qa_live_frames').delete().in('candidate_id', cleanedCandidateIds);
+      if (deleteError) throw new Error(`Could not remove stale QA frame metadata: ${deleteError.message}`);
+    }
+
+    return NextResponse.json({
+      cleanedCandidates: cleanedCandidateIds.length,
+      skippedCandidates: (staleFrames || []).length - cleanedCandidateIds.length,
+      removedObjects,
+    });
+  } catch (error) {
+    console.error('QA live-frame cleanup failed:', error);
+    return NextResponse.json({ error: 'QA live-frame cleanup failed' }, { status: 500 });
+  }
+}

--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { rpcMock, createServerClientMock, applyRateLimitMock, applyStrictRateLimitMock } = vi.hoisted(() => {
+  const rpc = vi.fn();
+  return {
+    rpcMock: rpc,
+    createServerClientMock: vi.fn(() => ({ rpc })),
+    applyRateLimitMock: vi.fn().mockResolvedValue(null),
+    applyStrictRateLimitMock: vi.fn().mockResolvedValue(null),
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
+vi.mock('@/lib/rate-limit', () => ({
+  applyRateLimit: applyRateLimitMock,
+  applyStrictRateLimit: applyStrictRateLimitMock,
+  getIpKey: () => 'ip:test',
+  QA_LIVE_FRAME_RATE_LIMIT: { limit: 240, windowMs: 60_000 },
+  QA_LIVE_INGEST_RATE_LIMIT: { limit: 60, windowMs: 60_000 },
+}));
+
+import { DELETE, GET, POST } from './route';
+
+const candidateId = '11111111-1111-4111-8111-111111111111';
+
+describe('/api/qa/live/frame ingest boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects malformed frame metadata before reading or storing the body', async () => {
+    const response = await POST(new Request('https://intuneget.com/api/qa/live/frame', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer this-is-a-long-enough-test-secret',
+        'x-qa-candidate-id': candidateId,
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid frame metadata' });
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('does not coerce a missing frame slot header to slot zero', async () => {
+    const response = await POST(new Request('https://www.intuneget.com/api/qa/live/frame', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer this-is-a-long-enough-test-secret',
+        'x-qa-candidate-id': candidateId,
+        'x-qa-captured-at': new Date().toISOString(),
+        'x-qa-frame-sequence': '1',
+        'x-qa-frame-width': '1280',
+        'x-qa-frame-height': '720',
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a candidate-bound public frame request', async () => {
+    const response = await GET(new Request('https://intuneget.com/api/qa/live/frame'));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid candidate' });
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('requires the immutable frame sequence in the public URL', async () => {
+    const response = await GET(new Request(`https://www.intuneget.com/api/qa/live/frame?candidate=${candidateId}`));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid sequence' });
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('requires the QA-only secret and an active exact-package candidate', async () => {
+    rpcMock.mockResolvedValueOnce({ data: false, error: null });
+    const response = await POST(new Request('https://intuneget.com/api/qa/live/frame', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer this-is-a-long-enough-test-secret',
+        'x-qa-candidate-id': candidateId,
+        'x-qa-captured-at': new Date().toISOString(),
+        'x-qa-frame-sequence': '1',
+        'x-qa-frame-width': '1280',
+        'x-qa-frame-height': '720',
+        'x-qa-frame-slot': '1',
+      },
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+    }));
+
+    expect(response.status).toBe(401);
+    expect(rpcMock).toHaveBeenCalledOnce();
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('does not allow unauthenticated cleanup', async () => {
+    const response = await DELETE(new Request('https://intuneget.com/api/qa/live/frame', {
+      method: 'DELETE',
+      headers: { 'x-qa-candidate-id': candidateId },
+    }));
+
+    expect(response.status).toBe(401);
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -1,0 +1,249 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import {
+  applyRateLimit,
+  applyStrictRateLimit,
+  getIpKey,
+  QA_LIVE_FRAME_RATE_LIMIT,
+  QA_LIVE_INGEST_RATE_LIMIT,
+} from '@/lib/rate-limit';
+import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
+
+export const dynamic = 'force-dynamic';
+
+const BUCKET = 'qa-live-frames';
+const MAX_FRAME_BYTES = 204_800;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function noStoreHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    'Cache-Control': 'private, no-store, max-age=0',
+    'X-Content-Type-Options': 'nosniff',
+    ...extra,
+  };
+}
+
+function frameHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    'Cache-Control': 'public, max-age=0, s-maxage=2, stale-while-revalidate=5',
+    'X-Content-Type-Options': 'nosniff',
+    ...extra,
+  };
+}
+
+function bearerSecret(request: Request): string | null {
+  const value = request.headers.get('authorization');
+  if (!value?.startsWith('Bearer ')) return null;
+  const secret = value.slice('Bearer '.length);
+  return secret.length >= 24 && secret.length <= 256 ? secret : null;
+}
+
+function candidateId(request: Request): string | null {
+  const value = request.headers.get('x-qa-candidate-id');
+  return value && UUID_PATTERN.test(value) ? value : null;
+}
+
+async function authorizeIngest(request: Request, capturedAt: string) {
+  const secret = bearerSecret(request);
+  const id = candidateId(request);
+  if (!secret || !id) return { authorized: false as const, id: null };
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase.rpc('authorize_qa_live_frame_ingest', {
+    p_secret: secret,
+    p_candidate_id: id,
+    p_captured_at: capturedAt,
+  });
+  if (error) throw new Error(`Could not authorize QA live-frame ingest: ${error.message}`);
+  return { authorized: data === true, id };
+}
+
+async function authorizeCleanup(request: Request) {
+  const secret = bearerSecret(request);
+  const id = candidateId(request);
+  if (!secret || !id) return { authorized: false as const, id: null };
+
+  const supabase = createServerClient();
+  const { data, error } = await supabase.rpc('authorize_qa_live_frame_cleanup', {
+    p_secret: secret,
+    p_candidate_id: id,
+  });
+  if (error) throw new Error(`Could not authorize QA live-frame cleanup: ${error.message}`);
+  return { authorized: data === true, id };
+}
+
+export async function GET(request: Request) {
+  const rateLimitResponse = await applyRateLimit(`qa-frame:${getIpKey(request)}`, QA_LIVE_FRAME_RATE_LIMIT);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  try {
+    const requestedCandidate = new URL(request.url).searchParams.get('candidate');
+    if (!requestedCandidate || !UUID_PATTERN.test(requestedCandidate)) {
+      return NextResponse.json({ error: 'Invalid candidate' }, { status: 400, headers: noStoreHeaders() });
+    }
+    const requestedSequenceValue = new URL(request.url).searchParams.get('sequence');
+    const requestedSequence = requestedSequenceValue === null ? NaN : Number(requestedSequenceValue);
+    if (!Number.isSafeInteger(requestedSequence) || requestedSequence < 0) {
+      return NextResponse.json({ error: 'Invalid sequence' }, { status: 400, headers: noStoreHeaders() });
+    }
+    const supabase = createServerClient();
+    const { data: active, error: activeError } = await supabase
+      .from('qa_candidates')
+      .select('id')
+      .eq('id', requestedCandidate)
+      .eq('test_level', 'psadt-package')
+      .in('status', ['dispatched', 'running'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (activeError) throw new Error(`Could not load active QA candidate: ${activeError.message}`);
+    if (!active) return new NextResponse(null, { status: 404, headers: noStoreHeaders() });
+
+    const { data: frame, error: frameError } = await supabase
+      .from('qa_live_frames')
+      .select('object_path, captured_at, updated_at, sequence')
+      .eq('candidate_id', active.id)
+      .maybeSingle();
+    if (frameError) throw new Error(`Could not load QA frame metadata: ${frameError.message}`);
+    if (
+      !frame ||
+      frame.sequence !== requestedSequence ||
+      Date.now() - new Date(frame.updated_at).getTime() > QA_LIVE_FRAME_MAX_AGE_MS
+    ) {
+      return new NextResponse(null, { status: 404, headers: noStoreHeaders() });
+    }
+
+    const { data: image, error: downloadError } = await supabase.storage.from(BUCKET).download(frame.object_path);
+    if (downloadError || !image) throw new Error(`Could not download QA live frame: ${downloadError?.message || 'missing object'}`);
+
+    return new NextResponse(await image.arrayBuffer(), {
+      headers: frameHeaders({
+        'Content-Type': 'image/jpeg',
+        'Content-Length': String(image.size),
+        'X-QA-Frame-Sequence': String(frame.sequence),
+      }),
+    });
+  } catch (error) {
+    console.error('Failed to serve QA live frame:', error);
+    return NextResponse.json(
+      { error: 'Live QA frame is temporarily unavailable' },
+      { status: 503, headers: noStoreHeaders() }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const rateLimitResponse = await applyStrictRateLimit(`qa-frame-ingest:${getIpKey(request)}`, QA_LIVE_INGEST_RATE_LIMIT);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  try {
+    const capturedAtHeader = request.headers.get('x-qa-captured-at');
+    const capturedAtDate = capturedAtHeader ? new Date(capturedAtHeader) : null;
+    const capturedAt = capturedAtDate && Number.isFinite(capturedAtDate.getTime())
+      ? capturedAtDate.toISOString()
+      : null;
+    const sequenceHeader = request.headers.get('x-qa-frame-sequence');
+    const widthHeader = request.headers.get('x-qa-frame-width');
+    const heightHeader = request.headers.get('x-qa-frame-height');
+    const slotHeader = request.headers.get('x-qa-frame-slot');
+    const sequence = sequenceHeader === null ? NaN : Number(sequenceHeader);
+    const width = widthHeader === null ? NaN : Number(widthHeader);
+    const height = heightHeader === null ? NaN : Number(heightHeader);
+    const slot = slotHeader === null ? NaN : Number(slotHeader);
+    if (
+      !sequenceHeader?.trim() || !widthHeader?.trim() || !heightHeader?.trim() || !slotHeader?.trim() ||
+      !capturedAt ||
+      !Number.isSafeInteger(sequence) || sequence < 0 ||
+      !Number.isInteger(width) || width < 64 || width > 1920 ||
+      !Number.isInteger(height) || height < 64 || height > 1200 ||
+      !Number.isInteger(slot) || slot < 0 || slot > 2
+    ) {
+      return NextResponse.json({ error: 'Invalid frame metadata' }, { status: 400, headers: noStoreHeaders() });
+    }
+
+    const authorization = await authorizeIngest(request, capturedAt);
+    if (!authorization.authorized || !authorization.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: noStoreHeaders() });
+    }
+
+    const bytes = new Uint8Array(await request.arrayBuffer());
+    if (
+      bytes.length < 4 || bytes.length > MAX_FRAME_BYTES ||
+      bytes[0] !== 0xff || bytes[1] !== 0xd8 ||
+      bytes[bytes.length - 2] !== 0xff || bytes[bytes.length - 1] !== 0xd9
+    ) {
+      return NextResponse.json({ error: 'Invalid JPEG frame' }, { status: 400, headers: noStoreHeaders() });
+    }
+
+    const supabase = createServerClient();
+    const objectPath = `${authorization.id}/slot-${slot}.jpg`;
+    const { error: uploadError } = await supabase.storage.from(BUCKET).upload(objectPath, bytes, {
+      contentType: 'image/jpeg',
+      upsert: true,
+      cacheControl: '0',
+    });
+    if (uploadError) throw new Error(`Could not store QA live frame: ${uploadError.message}`);
+
+    const { data: published, error: metadataError } = await supabase.rpc('publish_qa_live_frame_metadata', {
+      p_secret: bearerSecret(request) || '',
+      p_candidate_id: authorization.id,
+      p_object_path: objectPath,
+      p_sequence: sequence,
+      p_captured_at: capturedAt,
+      p_width: width,
+      p_height: height,
+      p_byte_size: bytes.length,
+    });
+    if (metadataError || published !== true) {
+      const { data: currentFrame } = await supabase
+        .from('qa_live_frames')
+        .select('object_path')
+        .eq('candidate_id', authorization.id)
+        .maybeSingle();
+      if (currentFrame?.object_path !== objectPath) {
+        await supabase.storage.from(BUCKET).remove([objectPath]);
+      }
+      if (metadataError) throw new Error(`Could not publish QA live frame metadata: ${metadataError.message}`);
+      return NextResponse.json({ error: 'Stale frame sequence' }, { status: 409, headers: noStoreHeaders() });
+    }
+
+    return NextResponse.json({ accepted: true, sequence }, { headers: noStoreHeaders() });
+  } catch (error) {
+    console.error('Failed to ingest QA live frame:', error);
+    return NextResponse.json(
+      { error: 'Live QA frame ingest failed' },
+      { status: 503, headers: noStoreHeaders() }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const rateLimitResponse = await applyStrictRateLimit(`qa-frame-cleanup:${getIpKey(request)}`, QA_LIVE_INGEST_RATE_LIMIT);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  try {
+    const authorization = await authorizeCleanup(request);
+    if (!authorization.authorized || !authorization.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: noStoreHeaders() });
+    }
+
+    const supabase = createServerClient();
+    const { data: objects, error: listError } = await supabase.storage.from(BUCKET).list(authorization.id, { limit: 10 });
+    if (listError) throw new Error(`Could not list QA live frames: ${listError.message}`);
+    const paths = (objects || []).map((object) => `${authorization.id}/${object.name}`);
+    if (paths.length) {
+      const { error: removeError } = await supabase.storage.from(BUCKET).remove(paths);
+      if (removeError) throw new Error(`Could not remove QA live frames: ${removeError.message}`);
+    }
+    const { error: metadataError } = await supabase.from('qa_live_frames').delete().eq('candidate_id', authorization.id);
+    if (metadataError) throw new Error(`Could not clear QA live frame metadata: ${metadataError.message}`);
+
+    return NextResponse.json({ cleared: true }, { headers: noStoreHeaders() });
+  } catch (error) {
+    console.error('Failed to clear QA live frames:', error);
+    return NextResponse.json(
+      { error: 'Live QA frame cleanup failed' },
+      { status: 503, headers: noStoreHeaders() }
+    );
+  }
+}

--- a/app/api/qa/live/route.ts
+++ b/app/api/qa/live/route.ts
@@ -5,7 +5,7 @@ import { applyRateLimit, getIpKey, QA_LIVE_RATE_LIMIT } from '@/lib/rate-limit';
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
-  const rateLimitResponse = await applyRateLimit(getIpKey(request), QA_LIVE_RATE_LIMIT);
+  const rateLimitResponse = await applyRateLimit(`qa-live:${getIpKey(request)}`, QA_LIVE_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;
 
   try {

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -53,9 +53,9 @@ export function useQaLive() {
       if (!response.ok) throw new Error('Failed to load live QA status');
       return response.json();
     },
-    staleTime: 4_000,
-    refetchInterval: (query) => (query.state.data?.active ? 5_000 : 10_000),
-    refetchIntervalInBackground: true,
+    staleTime: 1_000,
+    refetchInterval: (query) => (query.state.data?.active ? 2_000 : 10_000),
+    refetchIntervalInBackground: false,
     refetchOnWindowFocus: 'always',
   });
 }

--- a/lib/qa/constants.ts
+++ b/lib/qa/constants.ts
@@ -1,0 +1,1 @@
+export const QA_LIVE_FRAME_MAX_AGE_MS = 15_000;

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -9,6 +9,7 @@ describe('buildQaLiveResponse', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-08T17:00:00.000Z'),
       current: {
+        id: '11111111-1111-1111-1111-111111111111',
         winget_id: 'Example.App',
         version: '2.0.0',
         architecture: 'x64',
@@ -43,6 +44,14 @@ describe('buildQaLiveResponse', () => {
         publisher: 'Example Corp',
         latest_version: '2.0.0',
       }],
+      frame: {
+        candidate_id: '11111111-1111-1111-1111-111111111111',
+        sequence: 42,
+        captured_at: '2026-08-08T16:59:58.000Z',
+        updated_at: '2026-08-08T16:59:59.000Z',
+        width: 1280,
+        height: 720,
+      },
     });
 
     expect(response.runner.state).toBe('testing');
@@ -52,7 +61,17 @@ describe('buildQaLiveResponse', () => {
       displayName: 'Example',
       phase: 'installing',
       executionContext: 'User',
+      deployMode: 'Silent',
+      dialogExpected: false,
       elapsedSeconds: 1200,
+    });
+    expect(response.viewer).toEqual({
+      candidateId: '11111111-1111-1111-1111-111111111111',
+      available: true,
+      capturedAt: '2026-08-08T16:59:59.000Z',
+      sequence: 42,
+      width: 1280,
+      height: 720,
     });
     const serialized = JSON.stringify(response);
     for (const forbidden of ['installer_url', 'failure_summary', 'github_run_url', 'private']) {
@@ -64,6 +83,7 @@ describe('buildQaLiveResponse', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-08T17:00:00.000Z'),
       current: {
+        id: '22222222-2222-2222-2222-222222222222',
         winget_id: 'Example.App', version: '2', architecture: 'x64', status: 'running',
         priority: 0, enqueued_at: '2026-08-08T15:00:00.000Z', dispatched_at: null,
         started_at: '2026-08-08T15:30:00.000Z', phase: null, phase_started_at: null,
@@ -75,6 +95,7 @@ describe('buildQaLiveResponse', () => {
       consecutivePollFailures: 2,
       recent: [],
       apps: [],
+      frame: null,
     });
     expect(response.runner.state).toBe('stalled');
     expect(response.scheduler.state).toBe('degraded');
@@ -85,6 +106,7 @@ describe('buildQaLiveResponse', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-08T18:26:00.000Z'),
       current: {
+        id: '33333333-3333-3333-3333-333333333333',
         winget_id: 'Example.App', version: '2', architecture: 'x64', status: 'dispatched',
         priority: 0, enqueued_at: '2026-08-08T15:00:00.000Z',
         dispatched_at: '2026-08-08T18:25:40.000Z', started_at: null,
@@ -97,6 +119,7 @@ describe('buildQaLiveResponse', () => {
       consecutivePollFailures: 0,
       recent: [],
       apps: [],
+      frame: null,
     });
     expect(response.runner).toEqual({
       state: 'testing',
@@ -121,6 +144,7 @@ describe('buildQaLiveResponse', () => {
       consecutivePollFailures: 2,
       recent: [],
       apps: [],
+      frame: null,
     });
 
     expect(response.scheduler).toMatchObject({

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { createServerClient } from '@/lib/supabase';
+import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 import type { Json } from '@/types/database';
 import type { QaArchitecture, QaLivePhase, QaLiveResponse, QaOutcome } from '@/types/qa';
 
@@ -8,6 +9,7 @@ const RUNNER_STALE_MS = 10 * 60 * 1000;
 const POLL_STALE_MS = 5 * 60 * 1000;
 
 interface CandidateRow {
+  id: string;
   winget_id: string;
   version: string;
   architecture: string;
@@ -20,6 +22,15 @@ interface CandidateRow {
   phase_started_at: string | null;
   phase_updated_at: string | null;
   test_config: Json;
+}
+
+interface FrameRow {
+  candidate_id: string;
+  sequence: number;
+  captured_at: string;
+  updated_at: string;
+  width: number;
+  height: number;
 }
 
 interface PollRow {
@@ -55,6 +66,7 @@ export interface QaLiveSnapshotInput {
   consecutivePollFailures: number;
   recent: ResultRow[];
   apps: AppRow[];
+  frame: FrameRow | null;
 }
 
 const VALID_PHASES = new Set<QaLivePhase>([
@@ -89,6 +101,19 @@ function executionContext(config: Json): 'LocalSystem' | 'User' {
       : 'LocalSystem';
   } catch {
     return 'LocalSystem';
+  }
+}
+
+function deployMode(config: Json): 'Auto' | 'Silent' | 'NonInteractive' {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return 'Silent';
+  const canonical = config.packageProfileCanonicalJson;
+  if (typeof canonical !== 'string') return 'Silent';
+  try {
+    const parsed = JSON.parse(canonical) as { psadtConfig?: { deployMode?: unknown } };
+    const value = parsed.psadtConfig?.deployMode;
+    return value === 'Auto' || value === 'NonInteractive' ? value : 'Silent';
+  } catch {
+    return 'Silent';
   }
 }
 
@@ -143,6 +168,11 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
   }
 
   const currentApp = input.current ? appById.get(input.current.winget_id) : null;
+  const frameIsCurrent = Boolean(
+    input.current &&
+    input.frame?.candidate_id === input.current.id &&
+    input.now.getTime() - new Date(input.frame.updated_at).getTime() <= QA_LIVE_FRAME_MAX_AGE_MS
+  );
 
   return {
     serverTime: input.now.toISOString(),
@@ -167,12 +197,22 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
           catalogVersion: currentApp?.latest_version || input.current.version,
           architecture: architecture(input.current.architecture),
           executionContext: executionContext(input.current.test_config),
+          deployMode: deployMode(input.current.test_config),
+          dialogExpected: deployMode(input.current.test_config) === 'Auto',
           phase: phase(phaseIsCurrentAttempt ? input.current.phase : null),
           phaseStartedAt: phaseIsCurrentAttempt ? input.current.phase_started_at : null,
           startedAt: currentStartedAt,
           elapsedSeconds: elapsedSeconds(currentStartedAt, input.now),
         }
       : null,
+    viewer: {
+      candidateId: frameIsCurrent ? input.current?.id || null : null,
+      available: frameIsCurrent,
+      capturedAt: frameIsCurrent ? input.frame?.updated_at || null : null,
+      sequence: frameIsCurrent ? input.frame?.sequence ?? null : null,
+      width: frameIsCurrent ? input.frame?.width ?? null : null,
+      height: frameIsCurrent ? input.frame?.height ?? null : null,
+    },
     queue: {
       count: input.queuedCount,
       next: input.queued.map((candidate) => ({
@@ -199,7 +239,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
 export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const supabase = createServerClient();
   const candidateColumns =
-    'winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, test_config';
+    'id, winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, test_config';
 
   const [activeResult, queueResult, countResult, pollResult, recentResult] = await Promise.all([
     supabase
@@ -259,6 +299,16 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   ];
   const uniqueIds = [...new Set(ids)];
   let apps: AppRow[] = [];
+  let frame: FrameRow | null = null;
+  if (current) {
+    const frameResult = await supabase
+      .from('qa_live_frames')
+      .select('candidate_id, sequence, captured_at, updated_at, width, height')
+      .eq('candidate_id', current.id)
+      .maybeSingle();
+    if (frameResult.error) throw new Error(`Could not load QA live frame metadata: ${frameResult.error.message}`);
+    frame = (frameResult.data as FrameRow | null) || null;
+  }
   if (uniqueIds.length) {
     const appResult = await supabase
       .from('curated_apps')
@@ -277,5 +327,6 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
     consecutivePollFailures,
     recent,
     apps,
+    frame,
   });
 }

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { getIpKey } from './rate-limit';
+
+describe('getIpKey', () => {
+  it('prefers the trusted edge peer address', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'x-real-ip': '203.0.113.10',
+        'x-forwarded-for': '198.51.100.1, 192.0.2.20',
+      },
+    });
+    expect(getIpKey(request)).toBe('ip:203.0.113.10');
+  });
+
+  it('uses the last forwarded hop instead of a client-controlled first hop', () => {
+    const request = new Request('https://example.com', {
+      headers: { 'x-forwarded-for': '198.51.100.1, 192.0.2.20' },
+    });
+    expect(getIpKey(request)).toBe('ip:192.0.2.20');
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -54,8 +54,13 @@ export function getUserKey(userId: string): string {
 }
 
 export function getIpKey(request: Request): string {
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  if (realIp) return `ip:${realIp}`;
   const forwarded = request.headers.get('x-forwarded-for');
-  const ip = forwarded ? forwarded.split(',')[0].trim() : 'unknown';
+  const hops = forwarded
+    ? forwarded.split(',').map((hop) => hop.trim()).filter(Boolean)
+    : [];
+  const ip = hops.at(-1) || 'unknown';
   return `ip:${ip}`;
 }
 
@@ -85,9 +90,21 @@ export const PUBLIC_RATE_LIMIT: RateLimitConfig = {
   windowMs: 60 * 1000,
 };
 
-/** Live QA dashboard: five-second polling with room for multiple tabs. */
+/** Live QA status: two-second foreground polling with room for shared egress. */
 export const QA_LIVE_RATE_LIMIT: RateLimitConfig = {
-  limit: 90,
+  limit: 180,
+  windowMs: 60 * 1000,
+};
+
+/** Cacheable live-frame reads can be shared by several viewers behind one IP. */
+export const QA_LIVE_FRAME_RATE_LIMIT: RateLimitConfig = {
+  limit: 240,
+  windowMs: 60 * 1000,
+};
+
+/** A single trusted host publishes roughly 30 frames per minute. */
+export const QA_LIVE_INGEST_RATE_LIMIT: RateLimitConfig = {
+  limit: 60,
   windowMs: 60 * 1000,
 };
 
@@ -213,6 +230,33 @@ export async function applyRateLimit(
   }
 
   return null;
+}
+
+/**
+ * Apply the distributed limiter without the per-instance memory fallback.
+ * Sensitive machine-to-machine endpoints fail closed if the DB limiter is
+ * unavailable instead of multiplying their allowance across Vercel instances.
+ */
+export async function applyStrictRateLimit(
+  key: string,
+  config: RateLimitConfig
+): Promise<NextResponse | null> {
+  const result = await checkRateLimitDB(key, config);
+  if (!result.limited) return null;
+
+  const retryAfter = Math.max(1, Math.ceil((result.resetAt - Date.now()) / 1000));
+  return NextResponse.json(
+    { error: 'Too many requests', retryAfter },
+    {
+      status: 429,
+      headers: {
+        'X-RateLimit-Limit': result.limit.toString(),
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': Math.ceil(result.resetAt / 1000).toString(),
+        'Retry-After': retryAfter.toString(),
+      },
+    }
+  );
 }
 
 /**

--- a/supabase/migrations/20260808201500_qa_live_frames.sql
+++ b/supabase/migrations/20260808201500_qa_live_frames.sql
@@ -1,0 +1,71 @@
+-- Private, short-lived VM console frames for the public read-only QA viewer.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('qa-live-frames', 'qa-live-frames', false, 204800, array['image/jpeg'])
+on conflict (id) do update set
+  public = false,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+create table if not exists public.qa_live_frames (
+  candidate_id uuid primary key references public.qa_candidates(id) on delete cascade,
+  object_path text not null unique,
+  sequence bigint not null check (sequence >= 0),
+  captured_at timestamptz not null,
+  width integer not null check (width between 64 and 1920),
+  height integer not null check (height between 64 and 1200),
+  byte_size integer not null check (byte_size between 4 and 204800),
+  updated_at timestamptz not null default now(),
+  constraint qa_live_frames_object_path_check check (
+    object_path ~ ('^' || candidate_id::text || '/slot-[0-2]\.jpg$')
+  )
+);
+
+comment on table public.qa_live_frames is
+  'Service-only pointer to the latest private Hyper-V console frame for an active QA candidate.';
+
+alter table public.qa_live_frames enable row level security;
+revoke all on table public.qa_live_frames from public, anon, authenticated;
+grant select, insert, update, delete on table public.qa_live_frames to service_role;
+
+create index if not exists qa_live_frames_stale_idx
+  on public.qa_live_frames (updated_at);
+
+create or replace function public.authorize_qa_live_frame_ingest(
+  p_secret text,
+  p_candidate_id uuid,
+  p_captured_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    return false;
+  end if;
+
+  if p_captured_at is null
+    or p_captured_at < now() - interval '2 minutes'
+    or p_captured_at > now() + interval '2 minutes'
+  then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.qa_candidates
+    where id = p_candidate_id
+      and test_level = 'psadt-package'
+      and status in ('dispatched', 'running')
+  );
+end;
+$$;
+
+revoke all on function public.authorize_qa_live_frame_ingest(text, uuid, timestamptz)
+  from public, anon, authenticated;
+grant execute on function public.authorize_qa_live_frame_ingest(text, uuid, timestamptz)
+  to service_role;
+

--- a/supabase/migrations/20260808202500_harden_qa_live_frames.sql
+++ b/supabase/migrations/20260808202500_harden_qa_live_frames.sql
@@ -1,0 +1,81 @@
+-- Preserve stale metadata long enough for the hourly storage sweeper even if a
+-- candidate row is removed, and serialize latest-frame publication in SQL.
+alter table public.qa_live_frames
+  drop constraint if exists qa_live_frames_candidate_id_fkey;
+
+create or replace function public.publish_qa_live_frame_metadata(
+  p_secret text,
+  p_candidate_id uuid,
+  p_object_path text,
+  p_sequence bigint,
+  p_captured_at timestamptz,
+  p_width integer,
+  p_height integer,
+  p_byte_size integer
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  updated_count integer;
+begin
+  if not public.authorize_qa_live_frame_ingest(p_secret, p_candidate_id, p_captured_at) then
+    return false;
+  end if;
+
+  insert into public.qa_live_frames (
+    candidate_id, object_path, sequence, captured_at, width, height, byte_size, updated_at
+  ) values (
+    p_candidate_id, p_object_path, p_sequence, p_captured_at, p_width, p_height, p_byte_size, now()
+  )
+  on conflict (candidate_id) do update set
+    object_path = excluded.object_path,
+    sequence = excluded.sequence,
+    captured_at = excluded.captured_at,
+    width = excluded.width,
+    height = excluded.height,
+    byte_size = excluded.byte_size,
+    updated_at = now()
+  where excluded.sequence > public.qa_live_frames.sequence;
+
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+create or replace function public.authorize_qa_live_frame_cleanup(
+  p_secret text,
+  p_candidate_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    return false;
+  end if;
+
+  return exists (
+    select 1 from public.qa_live_frames where candidate_id = p_candidate_id
+  ) or exists (
+    select 1 from public.qa_candidates where id = p_candidate_id
+  );
+end;
+$$;
+
+revoke all on function public.publish_qa_live_frame_metadata(text, uuid, text, bigint, timestamptz, integer, integer, integer)
+  from public, anon, authenticated;
+grant execute on function public.publish_qa_live_frame_metadata(text, uuid, text, bigint, timestamptz, integer, integer, integer)
+  to service_role;
+
+revoke all on function public.authorize_qa_live_frame_cleanup(text, uuid)
+  from public, anon, authenticated;
+grant execute on function public.authorize_qa_live_frame_cleanup(text, uuid)
+  to service_role;
+

--- a/supabase/migrations/20260808205500_bound_qa_live_frame_ingest.sql
+++ b/supabase/migrations/20260808205500_bound_qa_live_frame_ingest.sql
@@ -1,0 +1,41 @@
+-- A detached capture process must not keep an abandoned VM publicly live for
+-- the full candidate-recovery window.
+create or replace function public.authorize_qa_live_frame_ingest(
+  p_secret text,
+  p_candidate_id uuid,
+  p_captured_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    return false;
+  end if;
+
+  if p_captured_at is null
+    or p_captured_at < now() - interval '2 minutes'
+    or p_captured_at > now() + interval '2 minutes'
+  then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.qa_candidates
+    where id = p_candidate_id
+      and test_level = 'psadt-package'
+      and status in ('dispatched', 'running')
+      and coalesce(started_at, dispatched_at, enqueued_at) > now() - interval '4 hours'
+  );
+end;
+$$;
+
+revoke all on function public.authorize_qa_live_frame_ingest(text, uuid, timestamptz)
+  from public, anon, authenticated;
+grant execute on function public.authorize_qa_live_frame_ingest(text, uuid, timestamptz)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -284,6 +284,30 @@ export interface Database {
         Update: Partial<Database['public']['Tables']['qa_poll_runs']['Insert']>;
         Relationships: GenericRelationship[];
       };
+      qa_live_frames: {
+        Row: {
+          candidate_id: string;
+          object_path: string;
+          sequence: number;
+          captured_at: string;
+          width: number;
+          height: number;
+          byte_size: number;
+          updated_at: string;
+        };
+        Insert: {
+          candidate_id: string;
+          object_path: string;
+          sequence: number;
+          captured_at: string;
+          width: number;
+          height: number;
+          byte_size: number;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['qa_live_frames']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
       qa_winget_poll_state: {
         Row: {
           id: string;
@@ -2159,6 +2183,34 @@ export interface Database {
       };
     };
     Functions: {
+      authorize_qa_live_frame_ingest: {
+        Args: {
+          p_secret: string;
+          p_candidate_id: string;
+          p_captured_at: string;
+        };
+        Returns: boolean;
+      };
+      authorize_qa_live_frame_cleanup: {
+        Args: {
+          p_secret: string;
+          p_candidate_id: string;
+        };
+        Returns: boolean;
+      };
+      publish_qa_live_frame_metadata: {
+        Args: {
+          p_secret: string;
+          p_candidate_id: string;
+          p_object_path: string;
+          p_sequence: number;
+          p_captured_at: string;
+          p_width: number;
+          p_height: number;
+          p_byte_size: number;
+        };
+        Returns: boolean;
+      };
       increment_usage: {
         Args: {
           p_org_id: string;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -83,11 +83,21 @@ export interface QaLiveResponse {
     catalogVersion: string;
     architecture: QaArchitecture;
     executionContext: 'LocalSystem' | 'User';
+    deployMode: 'Auto' | 'Silent' | 'NonInteractive';
+    dialogExpected: boolean;
     phase: QaLivePhase;
     phaseStartedAt: string | null;
     startedAt: string;
     elapsedSeconds: number;
   } | null;
+  viewer: {
+    candidateId: string | null;
+    available: boolean;
+    capturedAt: string | null;
+    sequence: number | null;
+    width: number | null;
+    height: number | null;
+  };
   queue: {
     count: number;
     next: Array<{

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/qa-live-cleanup",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/send-notifications",
       "schedule": "0 4 * * *"
     },


### PR DESCRIPTION
## Summary
- add a two-second read-only VM console to /qa
- keep frames in private Supabase storage behind a candidate-bound CDN proxy
- add bounded cleanup, replay guards, and distributed rate limits

## Verification
- 12 focused Vitest tests passed
- changed-file ESLint passed
- Next.js production build passed
- Claude Code Opus final review: APPROVE