### PR TITLE
Treat cleaned-up QA frames as expected misses

### DIFF
--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -75,6 +75,53 @@ describe('/api/qa/live/frame ingest boundary', () => {
     expect(createServerClientMock).not.toHaveBeenCalled();
   });
 
+  it('returns a quiet 404 when cleanup removes the object after metadata is read', async () => {
+    const chain = (result: unknown) => {
+      const query = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        in: vi.fn(),
+        order: vi.fn(),
+        limit: vi.fn(),
+        maybeSingle: vi.fn().mockResolvedValue(result),
+      };
+      query.select.mockReturnValue(query);
+      query.eq.mockReturnValue(query);
+      query.in.mockReturnValue(query);
+      query.order.mockReturnValue(query);
+      query.limit.mockReturnValue(query);
+      return query;
+    };
+    const activeQuery = chain({ data: { id: candidateId }, error: null });
+    const frameQuery = chain({
+      data: {
+        object_path: `${candidateId}/slot-1.jpg`,
+        captured_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        sequence: 42,
+      },
+      error: null,
+    });
+    const from = vi.fn()
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(frameQuery);
+    const download = vi.fn().mockResolvedValue({ data: null, error: { message: 'Object not found' } });
+    createServerClientMock.mockReturnValueOnce({
+      rpc: rpcMock,
+      from,
+      storage: { from: vi.fn(() => ({ download })) },
+    } as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const response = await GET(new Request(
+      `https://www.intuneget.com/api/qa/live/frame?candidate=${candidateId}&sequence=42`
+    ));
+
+    expect(response.status).toBe(404);
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it('requires the QA-only secret and an active exact-package candidate', async () => {
     rpcMock.mockResolvedValueOnce({ data: false, error: null });
     const response = await POST(new Request('https://intuneget.com/api/qa/live/frame', {

--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -114,6 +114,11 @@ export async function GET(request: Request) {
     }
 
     const { data: image, error: downloadError } = await supabase.storage.from(BUCKET).download(frame.object_path);
+    if (downloadError?.message === 'Object not found' || (!downloadError && !image)) {
+      // Cleanup and ring-slot replacement can win the race after metadata was
+      // read. This is an expected stale-frame miss, not a platform failure.
+      return new NextResponse(null, { status: 404, headers: noStoreHeaders() });
+    }
     if (downloadError || !image) throw new Error(`Could not download QA live frame: ${downloadError?.message || 'missing object'}`);
 
     return new NextResponse(await image.arrayBuffer(), {


### PR DESCRIPTION
Returns a no-store 404 when a live-frame object is deleted between metadata lookup and download. This is the expected cleanup/ring race handled by the viewer's last-good-frame preload logic; genuine storage errors still return 503 and remain logged.

Focused Vitest: 7/7. ESLint passes. Claude Code Opus: APPROVE.