### PR TITLE
fix(packager): use writable PSADT user logs

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -359,13 +359,15 @@ if (Use-PSADTBrandAsset -Source $brandingBannerPath -TargetName $bannerTarget -P
     Update-PowerShellDataSetting -Path $configPath -Section 'Assets' -Setting 'Banner' -ValueLiteral (ConvertTo-PSADTConfigValue $bannerTarget)
 }
 
-# User-scope apps run as the logged-in user who cannot write to C:\Windows\Logs\Software
-# Override the PSADT log directory to ProgramData which is writable by all authenticated users
+# PSADT 4.1 selects LogPathNoAdminRights when RequireAdmin is false. Its default
+# ProgramData location is not writable by a standard user when the parent folder
+# does not already exist, so session initialization can fail with exit code 60008.
 if ($IsUserScope) {
-    # Use literal path since .psd1 files load in restricted language mode
-    # where PSADT runtime variables like $envProgramData are not available
-    Update-PowerShellDataSetting -Path $configPath -Section 'Toolkit' -Setting 'LogPath' -ValueLiteral "'C:\ProgramData\IntuneGet\Logs'"
-    Write-Host "User-scope: Log directory overridden to C:\ProgramData\IntuneGet\Logs"
+    # Keep the PSADT variable as a literal for expansion when the toolkit opens
+    # the user session; the resulting path is owned and writable by that user.
+    $userLogPathLiteral = "'`$envLocalAppData\IntuneGet\Logs'"
+    Update-PowerShellDataSetting -Path $configPath -Section 'Toolkit' -Setting 'LogPathNoAdminRights' -ValueLiteral $userLogPathLiteral
+    Write-Host 'User-scope: non-admin log directory set below the current user LocalAppData path'
 }
 
 # Auto-detect installer type from file extension (override incorrect manifest data)

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -137,4 +137,15 @@ describe('hosted PSADT portable generator', () => {
     expect(script).toContain('Archive entry escapes the portable staging directory');
     expect(script).not.toContain('Portable nested installers are not supported yet');
   });
+
+  it('uses the non-admin PSADT log setting for user-scope packages', () => {
+    const scriptPath = fileURLToPath(
+      new URL('../../.github/scripts/Create-PSADTPackage.ps1', import.meta.url),
+    );
+    const script = readFileSync(scriptPath, 'utf8');
+
+    expect(script).toContain("-Setting 'LogPathNoAdminRights'");
+    expect(script).toContain("`$envLocalAppData\\IntuneGet\\Logs");
+    expect(script).not.toContain("-Setting 'LogPath' -ValueLiteral \"'C:\\ProgramData\\IntuneGet\\Logs'\"");
+  });
 });


### PR DESCRIPTION
User-scope PSADT 4.1.8 packages set RequireAdmin=false, which selects Toolkit.LogPathNoAdminRights. The template default points to a ProgramData parent a standard user cannot create, causing exit 60008 during Open-ADTSession before logs are available. This sets the non-admin path to the current user's LocalAppData and leaves MSI.LogPathNoAdminRights null so it inherits the toolkit path.\n\nVerified against the hash-pinned official 4.1.8 template. Targeted Vitest (12 cases) and PowerShell parsing pass. Claude Code Opus review was attempted but its tool call parser failed twice without returning a verdict.