### PR TITLE
fix(qa): require opaque version detection

### DIFF
--- a/.github/workflows-reference/package-intunewin.yml
+++ b/.github/workflows-reference/package-intunewin.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           repository: ugurkocde/IntuneGet
           # Update only after reviewing the referenced scripts in this commit.
-          ref: 686a469295bccb66daeff0cdc59961b4a9ff2022
+          ref: c533063a250c2c3f92adae9a55b4ddbc50d81a0c
           path: intuneget
           persist-credentials: false
 

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -139,7 +139,7 @@ function createSupabaseStub(options: {
   return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
 }
 
-const CURRENT_PACKAGER_COMMIT = '686a469295bccb66daeff0cdc59961b4a9ff2022';
+const CURRENT_PACKAGER_COMMIT = 'c533063a250c2c3f92adae9a55b4ddbc50d81a0c';
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '686a469295bccb66daeff0cdc59961b4a9ff2022',
+  packagerCommit: 'c533063a250c2c3f92adae9a55b4ddbc50d81a0c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Advances the canonical QA package profile and protected workflow reference to IntuneGet commit c533063a250c2c3f92adae9a55b4ddbc50d81a0c. Old profiles are rejected so opaque WinGet versions are rebuilt with exact-string registry detection. Validation: 91 focused tests passed.