### PR TITLE
feat(qa): show effective PSADT configuration

### DIFF
--- a/app/api/apps/[id]/qa/route.test.ts
+++ b/app/api/apps/[id]/qa/route.test.ts
@@ -38,6 +38,21 @@ const row = {
   changes: null,
   relevant_event_count: 0,
   environment: { executionContext: 'LocalSystem' },
+  effective_configuration: {
+    deployMode: 'Silent',
+    vendorSilentArguments: '/qn /norestart',
+    restartBehavior: 'Suppress',
+    promptConfiguration: {
+      closePrompt: false,
+      deferral: false,
+      progressDialog: false,
+      customPromptCount: 0,
+      restartPrompt: false,
+      balloonTipCount: 0,
+    },
+    processCloseCount: 0,
+    uiEvidenceExpected: false,
+  },
 };
 
 describe('GET /api/apps/[id]/qa', () => {
@@ -56,7 +71,9 @@ describe('GET /api/apps/[id]/qa', () => {
     expect(response.status).toBe(200);
     expect(body.commands.install).toContain('/qn');
     expect(body.environment).toEqual({ executionContext: 'LocalSystem' });
+    expect(body.effectiveConfiguration).toEqual(row.effective_configuration);
     expect(JSON.stringify(body)).not.toMatch(/runUrl|runId|runAttempt|testId|computerName|executedAs/);
+    expect(JSON.stringify(body)).not.toMatch(/processName|promptMessage|brandingPath/);
     expect(body.classification).toBeNull();
   });
 

--- a/app/api/apps/[id]/qa/route.ts
+++ b/app/api/apps/[id]/qa/route.ts
@@ -47,6 +47,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       changes: row.changes,
       relevantEventCount: row.relevant_event_count,
       environment: row.environment,
+      effectiveConfiguration: row.effective_configuration,
       package: {
         testLevel: row.test_level,
         profileSha256: row.package_profile_sha256,

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -11,7 +11,12 @@ import {
 import { StatusBadge } from '@/components/ui/status-badge';
 import { useQaDetails } from '@/hooks/use-qa';
 import { qaVersionMismatchMessage } from '@/lib/qa/version-mismatch';
-import { QA_CHANGE_CATEGORIES, type QaChangeSet, type QaPhaseResult } from '@/types/qa';
+import {
+  QA_CHANGE_CATEGORIES,
+  type QaChangeSet,
+  type QaPhaseResult,
+  type QaPromptConfiguration,
+} from '@/types/qa';
 
 interface QaDetailsDialogProps {
   wingetId: string;
@@ -52,6 +57,21 @@ function phaseStatus(
     ? result.exitCode === 0
     : [0, 3010, 1641].includes(result.exitCode);
   return { label: passed ? 'Passed' : 'Failed', passed };
+}
+
+function promptConfigurationSummary(configuration: QaPromptConfiguration): string {
+  const enabled: string[] = [];
+  if (configuration.closePrompt) enabled.push('Close prompt');
+  if (configuration.deferral) enabled.push('Deferral');
+  if (configuration.progressDialog) enabled.push('Progress dialog');
+  if (configuration.customPromptCount > 0) {
+    enabled.push(`${configuration.customPromptCount} custom prompt${configuration.customPromptCount === 1 ? '' : 's'}`);
+  }
+  if (configuration.restartPrompt) enabled.push('Restart prompt');
+  if (configuration.balloonTipCount > 0) {
+    enabled.push(`${configuration.balloonTipCount} balloon tip${configuration.balloonTipCount === 1 ? '' : 's'}`);
+  }
+  return enabled.length > 0 ? enabled.join(' · ') : 'No prompts configured';
 }
 
 function ChangeTable({ title, changes }: { title: string; changes: QaChangeSet }) {
@@ -136,6 +156,33 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                   <p>{qaVersionMismatchMessage(data.testedVersion, catalogVersion)}</p>
                 </div>
+              ) : null}
+
+              {data.effectiveConfiguration ? (
+                <section className="space-y-3">
+                  <div>
+                    <h4 className="text-sm font-semibold text-text-primary">Effective PSADT configuration</h4>
+                    <p className="mt-1 text-xs text-text-muted">Safe, compact settings from the exact package profile used for this test.</p>
+                  </div>
+                  <div className="grid gap-3 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 text-xs text-text-secondary sm:grid-cols-2 lg:grid-cols-4">
+                    <div><span className="block text-text-muted">Deploy mode</span><code>{data.effectiveConfiguration.deployMode}</code></div>
+                    <div><span className="block text-text-muted">Restart behavior</span><code>{data.effectiveConfiguration.restartBehavior}</code></div>
+                    <div><span className="block text-text-muted">Processes to close</span>{data.effectiveConfiguration.processCloseCount}</div>
+                    <div><span className="block text-text-muted">UI evidence expected</span>{data.effectiveConfiguration.uiEvidenceExpected ? 'Yes' : 'No'}</div>
+                    <div className="sm:col-span-2 lg:col-span-4">
+                      <span className="block text-text-muted">Prompt configuration</span>
+                      {promptConfigurationSummary(data.effectiveConfiguration.promptConfiguration)}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-xs text-text-muted">Vendor silent arguments</p>
+                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-overlay/10 bg-bg-base p-3 text-xs text-text-secondary">
+                      {data.effectiveConfiguration.vendorSilentArguments === null
+                        ? 'Custom deployment arguments withheld'
+                        : data.effectiveConfiguration.vendorSilentArguments || 'No arguments required'}
+                    </pre>
+                  </div>
+                </section>
               ) : null}
 
               <section className="space-y-3">

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -128,6 +128,7 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       changes: null,
       relevant_event_count: 0,
       environment: null,
+      effective_configuration: null,
       qa_schema_version: 1,
       synced_at: '2026-08-07T12:01:00Z',
       test_level: 'psadt-package',

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -135,6 +135,21 @@ const qaResults = [
     changes: null,
     relevant_event_count: 0,
     environment: { executionContext: 'LocalSystem' },
+    effective_configuration: {
+      deployMode: 'Silent',
+      vendorSilentArguments: '/qn',
+      restartBehavior: 'Suppress',
+      promptConfiguration: {
+        closePrompt: false,
+        deferral: false,
+        progressDialog: false,
+        customPromptCount: 0,
+        restartPrompt: false,
+        balloonTipCount: 0,
+      },
+      processCloseCount: 0,
+      uiEvidenceExpected: false,
+    },
     qa_schema_version: 1,
     synced_at: '2026-01-03T00:01:00Z',
     test_level: 'psadt-package',
@@ -255,6 +270,7 @@ describe('SnapshotCatalogSource', () => {
     const result = await source.getQaResult('Google.Chrome');
     expect(result?.detection.minimumVersion).toBe('120.0');
     expect(result?.phase_results.detectionAfterUninstall?.exitCode).toBe(1);
+    expect(result?.effective_configuration?.deployMode).toBe('Silent');
     expect(await source.getQaResult('Mozilla.Firefox')).toBeNull();
   });
 

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -23,6 +23,7 @@ import type {
   QaCandidateStatusRow,
   QaChanges,
   QaDetectionRule,
+  QaEffectiveConfiguration,
   QaEnvironment,
   QaPhaseResults,
   QaResultRow,
@@ -570,11 +571,12 @@ export class SnapshotCatalogSource implements CatalogSource {
             "SELECT * FROM qa_results WHERE winget_id = ? AND test_level = 'psadt-package' LIMIT 1"
           )
           .get(wingetId) as
-          | (Omit<QaResultRow, 'detection' | 'phase_results' | 'changes' | 'environment'> & {
+          | (Omit<QaResultRow, 'detection' | 'phase_results' | 'changes' | 'environment' | 'effective_configuration'> & {
               detection: string;
               phase_results: string;
               changes: string | null;
               environment: string | null;
+              effective_configuration: string | null;
             })
           | undefined;
 
@@ -589,6 +591,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           phase_results: phaseResults,
           changes: parseJson<QaChanges>(row.changes),
           environment: parseJson<QaEnvironment>(row.environment),
+          effective_configuration: parseJson<QaEffectiveConfiguration>(row.effective_configuration),
         };
       },
       () => null

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -387,7 +387,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     const { data, error } = await supabase
       .from('qa_results')
       .select(
-        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, installer_sha256, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, qa_schema_version, synced_at, test_level, package_profile_sha256, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256'
+        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, installer_sha256, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, synced_at, test_level, package_profile_sha256, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256'
       )
       .eq('winget_id', wingetId)
       .eq('test_level', 'psadt-package')

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -46,6 +46,7 @@ const failedRow = {
   changes: null,
   relevant_event_count: 0,
   environment: null,
+  effective_configuration: null,
   qa_schema_version: 1,
   synced_at: '2026-08-07T12:01:00Z',
   test_level: 'psadt-package',

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -104,3 +104,30 @@ describe('QA retry phase reset migration contract', () => {
     }
   });
 });
+
+describe('QA effective configuration migration contract', () => {
+  const sql = readFileSync(
+    resolve(process.cwd(), 'supabase/migrations/20260809060000_add_qa_effective_configuration.sql'),
+    'utf8'
+  );
+
+  it('allows only the compact public configuration shape', () => {
+    for (const field of [
+      'deployMode',
+      'vendorSilentArguments',
+      'restartBehavior',
+      'promptConfiguration',
+      'processCloseCount',
+      'uiEvidenceExpected',
+    ]) {
+      expect(sql).toContain(`'${field}'`);
+    }
+    expect(sql).toContain("effective_configuration - array[");
+    expect(sql).not.toMatch(/promptMessage|processName|brandingPath|registryPath|fileSystemPath/);
+  });
+
+  it('keeps the legacy helper private while syncing the new column', () => {
+    expect(sql).toContain('effective_configuration = excluded.effective_configuration');
+    expect(sql).toContain('from public, anon, authenticated, service_role');
+  });
+});

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -53,7 +53,7 @@ const QA_COLUMNS = [
   'winget_id', 'display_name', 'publisher', 'tested_version', 'architecture',
   'outcome', 'installer_sha256', 'tested_at_utc', 'overall_duration_seconds', 'installer_type',
   'install_command', 'uninstall_command', 'detection', 'phase_results', 'changes',
-  'relevant_event_count', 'environment', 'qa_schema_version', 'synced_at',
+  'relevant_event_count', 'environment', 'effective_configuration', 'qa_schema_version', 'synced_at',
   'test_level', 'package_profile_sha256', 'psadt_version', 'psadt_template_sha256',
   'psadt_config_sha256', 'detection_rules_sha256', 'packager_commit', 'package_content_sha256',
 ];
@@ -123,7 +123,8 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
         tested_at_utc TEXT NOT NULL, overall_duration_seconds REAL, installer_type TEXT,
         install_command TEXT NOT NULL, uninstall_command TEXT NOT NULL,
         detection TEXT NOT NULL, phase_results TEXT NOT NULL, changes TEXT,
-        relevant_event_count INTEGER, environment TEXT, qa_schema_version INTEGER NOT NULL,
+        relevant_event_count INTEGER, environment TEXT, effective_configuration TEXT,
+        qa_schema_version INTEGER NOT NULL,
         synced_at TEXT NOT NULL, test_level TEXT NOT NULL, package_profile_sha256 TEXT,
         psadt_version TEXT, psadt_template_sha256 TEXT, psadt_config_sha256 TEXT,
         detection_rules_sha256 TEXT, packager_commit TEXT, package_content_sha256 TEXT
@@ -154,13 +155,13 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       (winget_id, display_name, publisher, tested_version, architecture, outcome, installer_sha256,
        tested_at_utc, overall_duration_seconds, installer_type, install_command,
        uninstall_command, detection, phase_results, changes, relevant_event_count,
-       environment, qa_schema_version, synced_at, test_level, package_profile_sha256,
+       environment, effective_configuration, qa_schema_version, synced_at, test_level, package_profile_sha256,
        psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256,
        packager_commit, package_content_sha256)
       VALUES (@winget_id,@display_name,@publisher,@tested_version,@architecture,@outcome,@installer_sha256,
        @tested_at_utc,@overall_duration_seconds,@installer_type,@install_command,
        @uninstall_command,@detection,@phase_results,@changes,@relevant_event_count,
-       @environment,@qa_schema_version,@synced_at,@test_level,@package_profile_sha256,
+       @environment,@effective_configuration,@qa_schema_version,@synced_at,@test_level,@package_profile_sha256,
        @psadt_version,@psadt_template_sha256,@psadt_config_sha256,@detection_rules_sha256,
        @packager_commit,@package_content_sha256)`);
 
@@ -218,6 +219,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           changes: jsonOrNull(q.changes),
           relevant_event_count: q.relevant_event_count ?? null,
           environment: jsonOrNull(q.environment),
+          effective_configuration: jsonOrNull(q.effective_configuration),
           qa_schema_version: q.qa_schema_version ?? 1,
           synced_at: q.synced_at ?? new Date().toISOString(),
           test_level: q.test_level ?? 'installer-preflight',
@@ -344,6 +346,17 @@ async function selfTest() {
       },
       changes: null, relevant_event_count: 0,
       environment: { executionContext: 'LocalSystem' },
+      effective_configuration: {
+        deployMode: 'Silent',
+        vendorSilentArguments: '/qn',
+        restartBehavior: 'Suppress',
+        promptConfiguration: {
+          closePrompt: false, deferral: false, progressDialog: false,
+          customPromptCount: 0, restartPrompt: false, balloonTipCount: 0,
+        },
+        processCloseCount: 0,
+        uiEvidenceExpected: false,
+      },
       qa_schema_version: 1, synced_at: '2026-01-03T00:01:00Z',
     },
   ];
@@ -374,9 +387,10 @@ async function selfTest() {
   assert(vh.installer_url === 'https://x/chrome.msi', 'installer_url present');
   assert(JSON.parse(vh.installers)[0].Architecture === 'x64', 'installers JSON round-trip');
 
-  const qa = db.prepare(`SELECT outcome, detection FROM qa_results WHERE winget_id=?`).get('Google.Chrome');
+  const qa = db.prepare(`SELECT outcome, detection, effective_configuration FROM qa_results WHERE winget_id=?`).get('Google.Chrome');
   assert(qa.outcome === 'Passed', 'QA result present');
   assert(JSON.parse(qa.detection).minimumVersion === '120.0', 'QA detection JSON round-trip');
+  assert(JSON.parse(qa.effective_configuration).deployMode === 'Silent', 'QA effective configuration round-trip');
 
   // sccm mapping snake_case columns present
   const sccm = db.prepare(`SELECT winget_package_id FROM sccm_winget_mappings WHERE sccm_display_name_normalized=?`).get('google chrome');

--- a/supabase/migrations/20260809060000_add_qa_effective_configuration.sql
+++ b/supabase/migrations/20260809060000_add_qa_effective_configuration.sql
@@ -1,0 +1,218 @@
+-- Publish a compact, path-free description of the exact PSADT settings used
+-- by a QA run. Existing evidence remains valid and reports this field as null.
+
+alter table public.qa_results
+  add column if not exists effective_configuration jsonb;
+
+alter table public.qa_results
+  add constraint qa_results_effective_configuration_check check (
+    effective_configuration is null or (
+      jsonb_typeof(effective_configuration) = 'object'
+      and effective_configuration ?& array[
+        'deployMode',
+        'vendorSilentArguments',
+        'restartBehavior',
+        'promptConfiguration',
+        'processCloseCount',
+        'uiEvidenceExpected'
+      ]
+      and effective_configuration - array[
+        'deployMode',
+        'vendorSilentArguments',
+        'restartBehavior',
+        'promptConfiguration',
+        'processCloseCount',
+        'uiEvidenceExpected'
+      ] = '{}'::jsonb
+      and effective_configuration->>'deployMode' in ('Auto', 'Silent', 'NonInteractive')
+      and jsonb_typeof(effective_configuration->'vendorSilentArguments') in ('string', 'null')
+      and length(coalesce(effective_configuration->>'vendorSilentArguments', '')) <= 4096
+      and coalesce(effective_configuration->>'vendorSilentArguments', '') !~ E'[\r\n]'
+      and effective_configuration->>'restartBehavior' in ('Suppress', 'Force', 'Prompt')
+      and jsonb_typeof(effective_configuration->'promptConfiguration') = 'object'
+      and effective_configuration->'promptConfiguration' ?& array[
+        'closePrompt',
+        'deferral',
+        'progressDialog',
+        'customPromptCount',
+        'restartPrompt',
+        'balloonTipCount'
+      ]
+      and (effective_configuration->'promptConfiguration') - array[
+        'closePrompt',
+        'deferral',
+        'progressDialog',
+        'customPromptCount',
+        'restartPrompt',
+        'balloonTipCount'
+      ] = '{}'::jsonb
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'closePrompt') = 'boolean'
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'deferral') = 'boolean'
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'progressDialog') = 'boolean'
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'restartPrompt') = 'boolean'
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'customPromptCount') = 'number'
+      and (effective_configuration->'promptConfiguration'->>'customPromptCount') ~ '^\d+$'
+      and (effective_configuration->'promptConfiguration'->>'customPromptCount')::numeric between 0 and 100
+      and jsonb_typeof(effective_configuration->'promptConfiguration'->'balloonTipCount') = 'number'
+      and (effective_configuration->'promptConfiguration'->>'balloonTipCount') ~ '^\d+$'
+      and (effective_configuration->'promptConfiguration'->>'balloonTipCount')::numeric between 0 and 100
+      and jsonb_typeof(effective_configuration->'processCloseCount') = 'number'
+      and (effective_configuration->>'processCloseCount') ~ '^\d+$'
+      and (effective_configuration->>'processCloseCount')::numeric between 0 and 100
+      and jsonb_typeof(effective_configuration->'uiEvidenceExpected') = 'boolean'
+    )
+  );
+
+comment on column public.qa_results.effective_configuration is
+  'Safe aggregate PSADT settings from the exact tested package; excludes prompt text, process names, branding paths, and custom deployment arguments.';
+
+-- The replay-guarded v2 function calls this internal canonical mirror. Extend
+-- the internal function so the new field is updated atomically with the result.
+create or replace function public.sync_qa_results(
+  p_secret text,
+  p_rows jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  payload_count integer;
+  distinct_id_count integer;
+  existing_count integer;
+  remove_count integer;
+  maximum_automatic_deletes integer;
+  completed_at timestamptz := now();
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  if jsonb_typeof(p_rows) <> 'array' or jsonb_array_length(p_rows) = 0 then
+    raise exception 'At least one canonical QA result is required';
+  end if;
+
+  payload_count := jsonb_array_length(p_rows);
+  select count(distinct item->>'winget_id')
+  into distinct_id_count
+  from jsonb_array_elements(p_rows) item;
+  if distinct_id_count <> payload_count or exists (
+    select 1 from jsonb_array_elements(p_rows) item
+    where coalesce(item->>'winget_id', '') = ''
+  ) then
+    raise exception 'Canonical QA result IDs must be present and unique';
+  end if;
+
+  select count(*) into existing_count from public.qa_results;
+  select count(*)
+  into remove_count
+  from public.qa_results existing
+  where not exists (
+    select 1
+    from jsonb_array_elements(p_rows) item
+    where item->>'winget_id' = existing.winget_id
+  );
+  maximum_automatic_deletes := greatest(1, floor(existing_count * 0.25)::integer);
+  if not p_allow_large_delete and remove_count > maximum_automatic_deletes then
+    raise exception 'Refusing unexpectedly large QA result deletion';
+  end if;
+
+  insert into public.qa_results (
+    winget_id, display_name, publisher, tested_version, architecture, outcome,
+    tested_at_utc, overall_duration_seconds, installer_type, install_command,
+    uninstall_command, detection, phase_results, changes, relevant_event_count,
+    environment, effective_configuration, test_id, github_run_id,
+    github_run_attempt, qa_schema_version, synced_at
+  )
+  select
+    row_data.winget_id, row_data.display_name, row_data.publisher,
+    row_data.tested_version, row_data.architecture, row_data.outcome,
+    row_data.tested_at_utc, row_data.overall_duration_seconds,
+    row_data.installer_type, row_data.install_command, row_data.uninstall_command,
+    row_data.detection, row_data.phase_results, row_data.changes,
+    row_data.relevant_event_count,
+    case
+      when row_data.environment->>'executionContext' = 'User'
+        then '{"executionContext":"User"}'::jsonb
+      else '{"executionContext":"LocalSystem"}'::jsonb
+    end,
+    row_data.effective_configuration,
+    null, null, null, row_data.qa_schema_version, row_data.synced_at
+  from jsonb_to_recordset(p_rows) as row_data(
+    winget_id text, display_name text, publisher text, tested_version text,
+    architecture text, outcome text, tested_at_utc timestamptz,
+    overall_duration_seconds numeric, installer_type text, install_command text,
+    uninstall_command text, detection jsonb, phase_results jsonb, changes jsonb,
+    relevant_event_count integer, environment jsonb, effective_configuration jsonb,
+    qa_schema_version integer, synced_at timestamptz
+  )
+  on conflict (winget_id) do update set
+    display_name = excluded.display_name,
+    publisher = excluded.publisher,
+    tested_version = excluded.tested_version,
+    architecture = excluded.architecture,
+    outcome = excluded.outcome,
+    tested_at_utc = excluded.tested_at_utc,
+    overall_duration_seconds = excluded.overall_duration_seconds,
+    installer_type = excluded.installer_type,
+    install_command = excluded.install_command,
+    uninstall_command = excluded.uninstall_command,
+    detection = excluded.detection,
+    phase_results = excluded.phase_results,
+    changes = excluded.changes,
+    relevant_event_count = excluded.relevant_event_count,
+    environment = excluded.environment,
+    effective_configuration = excluded.effective_configuration,
+    test_id = null,
+    github_run_id = null,
+    github_run_attempt = null,
+    qa_schema_version = excluded.qa_schema_version,
+    synced_at = excluded.synced_at;
+
+  delete from public.qa_results existing
+  where not exists (
+    select 1
+    from jsonb_array_elements(p_rows) item
+    where item->>'winget_id' = existing.winget_id
+  );
+
+  insert into public.curated_sync_status (
+    id, last_run_started_at, last_run_completed_at, last_run_status,
+    items_processed, error_message, metadata, updated_at
+  )
+  values (
+    'sync-qa-results', completed_at, completed_at, 'success', payload_count, null,
+    jsonb_build_object(
+      'source', 'canonical-checkout',
+      'files', payload_count,
+      'mirrored', payload_count,
+      'removed', remove_count,
+      'invalid', jsonb_build_array()
+    ),
+    completed_at
+  )
+  on conflict (id) do update set
+    last_run_started_at = excluded.last_run_started_at,
+    last_run_completed_at = excluded.last_run_completed_at,
+    last_run_status = excluded.last_run_status,
+    items_processed = excluded.items_processed,
+    error_message = excluded.error_message,
+    metadata = excluded.metadata,
+    updated_at = excluded.updated_at;
+
+  return jsonb_build_object(
+    'files', payload_count,
+    'mirrored', payload_count,
+    'removed', remove_count,
+    'invalid', jsonb_build_array()
+  );
+end;
+$$;
+
+-- Keep the legacy internal helper outside the Data API. sync_qa_results_v2 is
+-- still the sole secret-authenticated synchronization endpoint.
+revoke all on function public.sync_qa_results(text, jsonb, boolean)
+  from public, anon, authenticated, service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -50,6 +50,7 @@ export interface Database {
           changes: Json | null;
           relevant_event_count: number | null;
           environment: Json | null;
+          effective_configuration: Json | null;
           test_id: string | null;
           github_run_id: string | null;
           github_run_attempt: number | null;
@@ -82,6 +83,7 @@ export interface Database {
           changes?: Json | null;
           relevant_event_count?: number | null;
           environment?: Json | null;
+          effective_configuration?: Json | null;
           test_id?: string | null;
           github_run_id?: string | null;
           github_run_attempt?: number | null;
@@ -114,6 +116,7 @@ export interface Database {
           changes?: Json | null;
           relevant_event_count?: number | null;
           environment?: Json | null;
+          effective_configuration?: Json | null;
           test_id?: string | null;
           github_run_id?: string | null;
           github_run_attempt?: number | null;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -51,6 +51,25 @@ export interface QaEnvironment {
   executionContext: 'LocalSystem' | 'User';
 }
 
+export interface QaPromptConfiguration {
+  closePrompt: boolean;
+  deferral: boolean;
+  progressDialog: boolean;
+  customPromptCount: number;
+  restartPrompt: boolean;
+  balloonTipCount: number;
+}
+
+export interface QaEffectiveConfiguration {
+  deployMode: 'Auto' | 'Silent' | 'NonInteractive';
+  /** Vendor-provided arguments only; custom deployment arguments are withheld. */
+  vendorSilentArguments: string | null;
+  restartBehavior: 'Suppress' | 'Force' | 'Prompt';
+  promptConfiguration: QaPromptConfiguration;
+  processCloseCount: number;
+  uiEvidenceExpected: boolean;
+}
+
 export type QaLivePhase =
   | 'queued'
   | 'preparing_package'
@@ -159,6 +178,7 @@ export interface QaResultRow extends QaStatusRow {
   changes: QaChanges | null;
   relevant_event_count: number | null;
   environment: QaEnvironment | null;
+  effective_configuration: QaEffectiveConfiguration | null;
   qa_schema_version: number;
   synced_at: string;
   psadt_version: string | null;
@@ -224,6 +244,7 @@ export interface QaDetailsResponse {
   changes: QaChanges | null;
   relevantEventCount: number | null;
   environment: QaEnvironment | null;
+  effectiveConfiguration: QaEffectiveConfiguration | null;
   classification: QaClassification | null;
   package?: {
     testLevel: QaTestLevel;


### PR DESCRIPTION
## What changed

- adds a constrained `effective_configuration` JSONB field to QA results
- returns it from the QA details API and public catalog snapshot
- displays deploy mode, vendor silent arguments, restart behavior, prompt flags/counts, process-close count, and UI-evidence expectation
- withholds custom deployment arguments and excludes paths, prompt text, and process names

## Why

This makes the one-to-one PSADT QA claim understandable in the app catalog without materially increasing payload size or exposing detailed system data.

## Validation

- `npm test` — 675 tests passed
- `npm run build:ci` — passed
- targeted ESLint — passed
- snapshot self-test — passed
- Supabase migration applied and verified