### PR TITLE
feat(qa): explain live PSADT visualization

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -84,6 +84,14 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
     [data.current]
   );
   const elapsed = useElapsedTime({ startTime: correctedStart });
+  const visualizationCaption = data.current?.expectedUi && data.current.deployMode !== 'Auto'
+    ? 'The VM image is genuine. Any panel labeled “configuration preview” is host-rendered from sanitized PSADT settings—not captured PSADT UI.'
+    : 'The VM image is genuine. Any PSADT dialog visible in the frame comes from the isolated test VM.';
+  const viewerModeLabel = data.current?.dialogExpected
+    ? 'Genuine PSADT UI may appear'
+    : data.current?.expectedUi && data.current.deployMode !== 'Auto'
+      ? `${data.current.deployMode} · configuration preview only`
+      : `${data.current?.deployMode || 'PSADT'} install`;
 
   if (!data.current) {
     return (
@@ -137,7 +145,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
             <Monitor className="h-4 w-4 text-accent-cyan" aria-hidden="true" />
             <h3 id="live-console-heading" className="text-sm font-medium text-text-primary">Live test VM</h3>
             <span className="hidden text-xs text-text-muted md:inline">
-              {data.current.dialogExpected ? 'PSADT UI may appear' : `${data.current.deployMode} install · no dialog expected`}
+              {viewerModeLabel}
             </span>
           </div>
           <div className="flex items-center gap-3 text-xs text-text-muted">
@@ -164,6 +172,9 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
             </div>
           )}
         </div>
+        <p className="border-t border-white/10 bg-bg-primary/80 px-4 py-2 text-xs leading-relaxed text-text-muted">
+          {visualizationCaption}
+        </p>
       </div>
     </section>
   );

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -22,7 +22,15 @@ describe('buildQaLiveResponse', () => {
         phase_started_at: '2026-08-08T16:45:00.000Z',
         phase_updated_at: '2026-08-08T16:59:00.000Z',
         test_config: {
-          packageProfileCanonicalJson: JSON.stringify({ installer: { installScope: 'user' } }),
+          packageProfileCanonicalJson: JSON.stringify({
+            installer: { installScope: 'user' },
+            psadtConfig: {
+              deployMode: 'NonInteractive', restartBehavior: 'Prompt', processesToClose: [{ name: 'private-process' }],
+              showClosePrompt: true, allowDefer: true, progressDialog: { enabled: true },
+              customPrompts: [{ enabled: true, message: 'private-message' }], restartPrompt: { enabled: false },
+              balloonTips: [{ enabled: true, text: 'private-notification' }],
+            },
+          }),
         },
         installer_url: 'https://secret.example/setup.exe',
         failure_summary: 'C:\\Users\\private',
@@ -61,8 +69,22 @@ describe('buildQaLiveResponse', () => {
       displayName: 'Example',
       phase: 'installing',
       executionContext: 'User',
-      deployMode: 'Silent',
-      dialogExpected: false,
+      deployMode: 'NonInteractive',
+      dialogExpected: true,
+      expectedUi: {
+        deployMode: 'NonInteractive',
+        restartBehavior: 'Prompt',
+        promptConfiguration: {
+          closePrompt: true,
+          deferral: true,
+          progressDialog: true,
+          customPromptCount: 1,
+          restartPrompt: false,
+          balloonTipCount: 1,
+        },
+        processCloseCount: 1,
+        uiEvidenceExpected: true,
+      },
       elapsedSeconds: 1200,
     });
     expect(response.viewer).toEqual({
@@ -74,7 +96,7 @@ describe('buildQaLiveResponse', () => {
       height: 720,
     });
     const serialized = JSON.stringify(response);
-    for (const forbidden of ['installer_url', 'failure_summary', 'github_run_url', 'private']) {
+    for (const forbidden of ['installer_url', 'failure_summary', 'github_run_url', 'private', 'vendorSilentArguments']) {
       expect(serialized).not.toContain(forbidden);
     }
   });
@@ -127,6 +149,7 @@ describe('buildQaLiveResponse', () => {
     });
     expect(response.current?.phase).toBe('preparing_package');
     expect(response.current?.phaseStartedAt).toBeNull();
+    expect(response.current?.expectedUi).toBeNull();
   });
 
   it('publishes only a sanitized GitHub rate-limit cause', () => {

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { createServerClient } from '@/lib/supabase';
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 import type { Json } from '@/types/database';
-import type { QaArchitecture, QaLivePhase, QaLiveResponse, QaOutcome } from '@/types/qa';
+import type { QaArchitecture, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome } from '@/types/qa';
 
 const RUNNER_STALE_MS = 10 * 60 * 1000;
 const POLL_STALE_MS = 5 * 60 * 1000;
@@ -117,6 +117,53 @@ function deployMode(config: Json): 'Auto' | 'Silent' | 'NonInteractive' {
   }
 }
 
+function expectedUiConfiguration(config: Json): QaLiveUiConfiguration | null {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return null;
+  const canonical = config.packageProfileCanonicalJson;
+  if (typeof canonical !== 'string') return null;
+  try {
+    const parsed = JSON.parse(canonical) as { psadtConfig?: Record<string, unknown> };
+    const psadt = parsed.psadtConfig;
+    if (!psadt || typeof psadt !== 'object' || Array.isArray(psadt)) return null;
+    const mode = psadt.deployMode === 'Auto' || psadt.deployMode === 'NonInteractive'
+      ? psadt.deployMode
+      : 'Silent';
+    const restartBehavior = psadt.restartBehavior === 'Force' || psadt.restartBehavior === 'Prompt'
+      ? psadt.restartBehavior
+      : 'Suppress';
+    const enabledCount = (value: unknown) => Array.isArray(value)
+      ? Math.min(100, value.filter((item) => item && typeof item === 'object' && !Array.isArray(item) && (item as Record<string, unknown>).enabled === true).length)
+      : 0;
+    const processCloseCount = Math.min(100, Array.isArray(psadt.processesToClose) ? psadt.processesToClose.length : 0);
+    const progressDialog = Boolean(
+      psadt.progressDialog && typeof psadt.progressDialog === 'object' && !Array.isArray(psadt.progressDialog) &&
+      (psadt.progressDialog as Record<string, unknown>).enabled === true
+    );
+    const restartPrompt = Boolean(
+      psadt.restartPrompt && typeof psadt.restartPrompt === 'object' && !Array.isArray(psadt.restartPrompt) &&
+      (psadt.restartPrompt as Record<string, unknown>).enabled === true
+    );
+    const promptConfiguration = {
+      closePrompt: psadt.showClosePrompt === true,
+      deferral: psadt.allowDefer === true,
+      progressDialog,
+      customPromptCount: enabledCount(psadt.customPrompts),
+      restartPrompt,
+      balloonTipCount: enabledCount(psadt.balloonTips),
+    };
+    const configuredUi = Object.entries(promptConfiguration).some(([, value]) => value === true || (typeof value === 'number' && value > 0));
+    return {
+      deployMode: mode,
+      restartBehavior,
+      promptConfiguration,
+      processCloseCount,
+      uiEvidenceExpected: mode !== 'Silent' && configuredUi,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function elapsedSeconds(start: string, now: Date): number {
   return Math.max(0, Math.floor((now.getTime() - new Date(start).getTime()) / 1000));
 }
@@ -173,6 +220,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
     input.frame?.candidate_id === input.current.id &&
     input.now.getTime() - new Date(input.frame.updated_at).getTime() <= QA_LIVE_FRAME_MAX_AGE_MS
   );
+  const currentExpectedUi = input.current ? expectedUiConfiguration(input.current.test_config) : null;
 
   return {
     serverTime: input.now.toISOString(),
@@ -198,7 +246,8 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
           architecture: architecture(input.current.architecture),
           executionContext: executionContext(input.current.test_config),
           deployMode: deployMode(input.current.test_config),
-          dialogExpected: deployMode(input.current.test_config) === 'Auto',
+          dialogExpected: currentExpectedUi?.uiEvidenceExpected ?? deployMode(input.current.test_config) === 'Auto',
+          expectedUi: currentExpectedUi,
           phase: phase(phaseIsCurrentAttempt ? input.current.phase : null),
           phaseStartedAt: phaseIsCurrentAttempt ? input.current.phase_started_at : null,
           startedAt: currentStartedAt,

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -70,6 +70,9 @@ export interface QaEffectiveConfiguration {
   uiEvidenceExpected: boolean;
 }
 
+/** Count/flag-only PSADT configuration safe for the public live QA view. */
+export type QaLiveUiConfiguration = Omit<QaEffectiveConfiguration, 'vendorSilentArguments'>;
+
 export type QaLivePhase =
   | 'queued'
   | 'preparing_package'
@@ -104,6 +107,7 @@ export interface QaLiveResponse {
     executionContext: 'LocalSystem' | 'User';
     deployMode: 'Auto' | 'Silent' | 'NonInteractive';
     dialogExpected: boolean;
+    expectedUi: QaLiveUiConfiguration | null;
     phase: QaLivePhase;
     phaseStartedAt: string | null;
     startedAt: string;


### PR DESCRIPTION
Adds a privacy-safe live PSADT configuration projection to the QA API and clearly distinguishes host-rendered configuration previews from genuine VM pixels. No vendor arguments, names, paths, URLs, or prompt text are exposed. Includes null-safe legacy handling and tests.

Validation: 675 tests passed; Next.js production build passed; ESLint passed.