### PR TITLE
Make catalog QA universally interactive

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -877,7 +877,9 @@ $lines = @(
     $progressCall
 )
 
-# Add installer file existence check and progress display before install commands
+# Add installer file existence check before install commands. The progress dialog
+# is emitted above only when progressDialog.enabled is true so package behavior
+# continues to match the effective PSADT configuration.
 $lines += @(
     ''
     '    # Verify installer file exists before proceeding'
@@ -886,9 +888,6 @@ $lines += @(
     '        Write-ADTLogEntry -Message "Installer file not found: $installerPath" -Severity ''Error'' -Source ''Install-ADTDeployment'''
     '        throw "Installer file not found: $installerPath"'
     '    }'
-    ''
-    '    # Show installation progress'
-    "    Show-ADTInstallationProgress -StatusMessage `"Installing `$(`$adtSession.AppName)...`""
     ''
 )
 

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -148,11 +148,23 @@ function profileCandidate(options: {
   enqueuedAt?: string;
   profileKind?: string;
   toolchainOverrides?: Record<string, unknown>;
+  interactive?: boolean;
 }): Record<string, unknown> {
   const profileKind = options.profileKind || 'catalog-default';
   const version = '1.0.0';
   const architecture = 'x64';
   const installerSha256 = 'A'.repeat(64);
+  const psadtConfig = options.interactive === false
+    ? DEFAULT_PSADT_CONFIG
+    : {
+        ...DEFAULT_PSADT_CONFIG,
+        deployMode: 'Auto' as const,
+        progressDialog: {
+          ...DEFAULT_PSADT_CONFIG.progressDialog,
+          enabled: true,
+          windowLocation: 'BottomRight' as const,
+        },
+      };
   const identity = buildQaPackageIdentity({
     profileKind: profileKind as 'catalog-default' | 'deployment-config',
     wingetId: options.wingetId,
@@ -167,7 +179,7 @@ function profileCandidate(options: {
     installScope: 'machine',
     nestedInstallerType: '',
     nestedInstallerFiles: [],
-    psadtConfig: DEFAULT_PSADT_CONFIG,
+    psadtConfig,
     detectionRules: [],
   });
   const canonicalJson = canonicalQaJson({
@@ -379,6 +391,35 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(body).toMatchObject({ checked: 0, queued: 0, toolchainBackfillCount: 0 });
     expect(candidateInserts).toHaveLength(0);
     expect(resolveManifestMock).not.toHaveBeenCalled();
+  });
+
+  it('backfills a self-consistent Silent profile so every catalog QA run is interactive', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'silent-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: CURRENT_PACKAGER_COMMIT,
+          interactive: false,
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 1, toolchainBackfillCount: 1 });
+    const canonical = JSON.parse(
+      String((candidateInserts[0].test_config as Record<string, unknown>).packageProfileCanonicalJson)
+    );
+    expect(canonical.psadtConfig).toMatchObject({
+      deployMode: 'Auto',
+      progressDialog: { enabled: true, windowLocation: 'BottomRight' },
+    });
   });
 
   it('backfills a matching commit when another toolchain pin is stale', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -50,6 +50,19 @@ function object(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function hasInteractiveCatalogQaProfile(testConfig: unknown): boolean {
+  const canonicalJson = object(testConfig).packageProfileCanonicalJson;
+  if (typeof canonicalJson !== 'string') return false;
+  try {
+    const canonical = object(JSON.parse(canonicalJson));
+    const psadtConfig = object(canonical.psadtConfig);
+    const progressDialog = object(psadtConfig.progressDialog);
+    return psadtConfig.deployMode === 'Auto' && progressDialog.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
 async function findToolchainBackfillIds(
   supabase: ReturnType<typeof createServerClient>
 ): Promise<{ ids: string[]; pagesScanned: number }> {
@@ -93,7 +106,9 @@ async function findToolchainBackfillIds(
         candidateArchitecture: row.architecture,
         candidateInstallerSha256: row.installer_sha256,
       });
-      if (!validation.valid) pageStaleIds.push(row.winget_id);
+      if (!validation.valid || !hasInteractiveCatalogQaProfile(row.test_config)) {
+        pageStaleIds.push(row.winget_id);
+      }
     }
 
     if (pageStaleIds.length > 0) {
@@ -506,7 +521,6 @@ export async function GET(request: Request) {
                   .eq('test_level', 'psadt-package')
                   .contains('test_config', { profileKind: 'catalog-default' })
                   .eq('status', 'queued')
-                  .neq('version', resolution.version)
                   .neq('id', existing.id);
                 if (supersedeError) throw supersedeError;
                 summary.queued++;
@@ -541,7 +555,6 @@ export async function GET(request: Request) {
               .eq('test_level', 'psadt-package')
               .contains('test_config', { profileKind: 'catalog-default' })
               .eq('status', 'queued')
-              .neq('version', resolution.version)
               .neq('id', inserted.id);
             if (supersedeError) throw supersedeError;
           } catch (error) {

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -29,7 +29,14 @@ describe('buildQaCatalogTestConfig', () => {
       uninstallCommand: 'REGISTRY_UNINSTALL:Example',
       profileKind: 'catalog-default',
     });
-    expect(config.psadtConfig.deployMode).toBe('Silent');
+    expect(config.psadtConfig).toMatchObject({
+      deployMode: 'Auto',
+      progressDialog: {
+        enabled: true,
+        statusMessage: 'IntuneGet is validating this application package.',
+        windowLocation: 'BottomRight',
+      },
+    });
     expect(config.detectionRules[0]).toMatchObject({
       type: 'registry',
       keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Contoso_Example',

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -137,7 +137,19 @@ export function buildQaCatalogTestConfig({
     app.version,
     DEFAULT_PSADT_CONFIG.registryMarkerPath
   );
-  const psadtConfig: PSADTConfig = normalizeQaPsadtConfig(DEFAULT_PSADT_CONFIG, detectionRules);
+  const psadtConfig: PSADTConfig = normalizeQaPsadtConfig(
+    {
+      ...DEFAULT_PSADT_CONFIG,
+      deployMode: 'Auto',
+      progressDialog: {
+        ...DEFAULT_PSADT_CONFIG.progressDialog,
+        enabled: true,
+        statusMessage: 'IntuneGet is validating this application package.',
+        windowLocation: 'BottomRight',
+      },
+    },
+    detectionRules
+  );
 
   return {
     mode: 'psadt-package',

--- a/lib/winget-sync-resolution.mjs
+++ b/lib/winget-sync-resolution.mjs
@@ -42,6 +42,7 @@ export function createWingetManifestClient(options = {}) {
   }
 
   async function requestText(url, { accept = 'text/plain', allowNotFound = true } = {}) {
+    let useAuthenticatedApi = Boolean(token && url.startsWith('https://api.github.com/'));
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       let response;
       try {
@@ -49,7 +50,7 @@ export function createWingetManifestClient(options = {}) {
           Accept: accept,
           'User-Agent': 'IntuneGet-Manifest-Sync',
         };
-        if (token && url.startsWith('https://api.github.com/')) {
+        if (useAuthenticatedApi) {
           headers.Authorization = `Bearer ${token}`;
         }
         response = await fetchImpl(url, { headers, cache: 'no-store' });
@@ -62,6 +63,19 @@ export function createWingetManifestClient(options = {}) {
       }
 
       if (response.status === 404 && allowNotFound) return null;
+
+      const authenticatedRateLimit =
+        useAuthenticatedApi &&
+        (response.status === 429 ||
+          (response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0'));
+      if (authenticatedRateLimit) {
+        // The application PAT is shared by several read-only catalog features.
+        // Fall back once to GitHub's independent anonymous quota instead of
+        // stalling the durable WinGet cursor until the PAT window resets.
+        useAuthenticatedApi = false;
+        attempt--;
+        continue;
+      }
 
       const retryable = response.status === 403 || response.status === 429 || response.status >= 500;
       if (retryable && attempt < maxRetries) {

--- a/lib/winget-sync-resolution.test.ts
+++ b/lib/winget-sync-resolution.test.ts
@@ -93,6 +93,34 @@ describe('resolveWingetManifest', () => {
       .rejects.toMatchObject({ name: 'WingetSyncOperationalError', code: 'HTTP_429' });
   });
 
+  it('falls back to the anonymous GitHub quota when the application token is exhausted', async () => {
+    const yaml = [
+      'PackageIdentifier: Example.App',
+      'PackageVersion: 1.0.0',
+      'ManifestType: installer',
+      'Installers:',
+      '- Architecture: x64',
+      '  InstallerUrl: https://example.test/app.exe',
+    ].join('\n');
+    const apiPayload = JSON.stringify({
+      encoding: 'base64',
+      content: Buffer.from(yaml).toString('base64'),
+    });
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response('', {
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0' },
+      }))
+      .mockResolvedValueOnce(new Response(apiPayload, { status: 200 }));
+    const client = createWingetManifestClient({ token: 'secret-token', fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
+    expect(fetchImpl.mock.calls[1][1].headers.Authorization).toBe('Bearer secret-token');
+    expect(fetchImpl.mock.calls[2][1].headers.Authorization).toBeUndefined();
+  });
+
   it('treats invalid YAML as an operational error', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response('[unclosed', { status: 200 }));
     const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -152,6 +152,17 @@ describe('hosted PSADT portable generator', () => {
     expect(script).not.toContain("-Setting 'LogPath' -ValueLiteral \"'C:\\ProgramData\\IntuneGet\\Logs'\"");
   });
 
+  it('emits the PSADT progress dialog only when the package configuration enables it', () => {
+    const scriptPath = fileURLToPath(
+      new URL('../../.github/scripts/Create-PSADTPackage.ps1', import.meta.url),
+    );
+    const script = readFileSync(scriptPath, 'utf8');
+
+    expect(script).toContain('if ($progressConfig -and $progressConfig.enabled)');
+    expect(script).toContain('"    Show-ADTInstallationProgress$progressParamsStr"');
+    expect(script.match(/Show-ADTInstallationProgress/g)).toHaveLength(1);
+  });
+
   it('captures the vendor registry entry instead of invoking Winget as SYSTEM for uninstall', () => {
     const scriptPath = fileURLToPath(
       new URL('../../.github/scripts/Create-PSADTPackage.ps1', import.meta.url),


### PR DESCRIPTION
## Summary
- make every catalog QA package use PSADT Auto mode with an enabled bottom-right progress dialog
- backfill and supersede older silent catalog QA profiles
- keep customer package UI settings authoritative by removing the generator's unconditional progress call
- recover WinGet polling when the shared authenticated GitHub API quota is exhausted

## Validation
- `npx vitest run lib/winget-sync-resolution.test.ts lib/qa/test-config.test.ts app/api/cron/qa-enqueue/route.test.ts lib/qa/live.test.ts`
- full suite: 677 passed; one unrelated translation timeout then passed in isolation
- `npm run lint`
- `npm run build:ci`
- PowerShell parser validation for `.github/scripts/Create-PSADTPackage.ps1`