### PR TITLE
Refresh interactive QA frames every second

### DIFF
--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/rate-limit', () => ({
   applyStrictRateLimit: applyStrictRateLimitMock,
   getIpKey: () => 'ip:test',
   QA_LIVE_FRAME_RATE_LIMIT: { limit: 240, windowMs: 60_000 },
-  QA_LIVE_INGEST_RATE_LIMIT: { limit: 60, windowMs: 60_000 },
+  QA_LIVE_INGEST_RATE_LIMIT: { limit: 90, windowMs: 60_000 },
 }));
 
 import { DELETE, GET, POST } from './route';

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -53,8 +53,12 @@ export function useQaLive() {
       if (!response.ok) throw new Error('Failed to load live QA status');
       return response.json();
     },
-    staleTime: 1_000,
-    refetchInterval: (query) => (query.state.data?.active ? 2_000 : 10_000),
+    staleTime: 500,
+    refetchInterval: (query) => {
+      const phase = query.state.data?.current?.phase;
+      if (phase === 'installing' || phase === 'uninstalling') return 1_000;
+      return query.state.data?.active ? 2_000 : 10_000;
+    },
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: 'always',
   });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -102,9 +102,9 @@ export const QA_LIVE_FRAME_RATE_LIMIT: RateLimitConfig = {
   windowMs: 60 * 1000,
 };
 
-/** A single trusted host publishes roughly 30 frames per minute. */
+/** A trusted host can publish up to 60 frames/minute during interactive phases. */
 export const QA_LIVE_INGEST_RATE_LIMIT: RateLimitConfig = {
-  limit: 60,
+  limit: 90,
   windowMs: 60 * 1000,
 };
 


### PR DESCRIPTION
## Summary
- poll live QA metadata every one second during install and uninstall
- retain the two-second active cadence for other phases and ten seconds while idle
- raise trusted ingest capacity for the one-frame-per-second burst

## Validation
- targeted live API tests
- ESLint
- production Next.js build