### PR TITLE
Colocate QA live APIs in Europe

### DIFF
--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -10,6 +10,7 @@ import {
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 
 export const dynamic = 'force-dynamic';
+export const preferredRegion = 'fra1';
 
 const BUCKET = 'qa-live-frames';
 const MAX_FRAME_BYTES = 204_800;

--- a/app/api/qa/live/route.ts
+++ b/app/api/qa/live/route.ts
@@ -3,6 +3,7 @@ import { getQaLiveSnapshot } from '@/lib/qa/live';
 import { applyRateLimit, getIpKey, QA_LIVE_RATE_LIMIT } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
+export const preferredRegion = 'fra1';
 
 export async function GET(request: Request) {
   const rateLimitResponse = await applyRateLimit(`qa-live:${getIpKey(request)}`, QA_LIVE_RATE_LIMIT);


### PR DESCRIPTION
## Summary
- run only the QA live metadata and frame Route Handlers in Vercel fra1
- colocate them with the Berlin runner and Supabase eu-central-1 project
- leave all other application routes unchanged

## Validation
- live route tests
- ESLint
- production Next.js build

## References
- Next.js Route Segment Config supports a statically analyzable preferredRegion on Route Handlers