### PR TITLE
perf(qa): colocate live endpoints in Frankfurt

### DIFF
--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -10,8 +10,6 @@ import {
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 
 export const dynamic = 'force-dynamic';
-export const preferredRegion = 'fra1';
-
 const BUCKET = 'qa-live-frames';
 const MAX_FRAME_BYTES = 204_800;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/app/api/qa/live/route.ts
+++ b/app/api/qa/live/route.ts
@@ -3,8 +3,6 @@ import { getQaLiveSnapshot } from '@/lib/qa/live';
 import { applyRateLimit, getIpKey, QA_LIVE_RATE_LIMIT } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
-export const preferredRegion = 'fra1';
-
 export async function GET(request: Request) {
   const rateLimitResponse = await applyRateLimit(`qa-live:${getIpKey(request)}`, QA_LIVE_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,13 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "app/api/qa/live/route.ts": {
+      "regions": ["fra1"]
+    },
+    "app/api/qa/live/frame/route.ts": {
+      "regions": ["fra1"]
+    }
+  },
   "crons": [
     {
       "path": "/api/cron/sync-packages",


### PR DESCRIPTION
## Summary
- run only the live QA metadata and frame functions in Vercel's Frankfurt region
- remove ineffective Node.js preferredRegion route hints
- keep all other functions on the existing project region

## Verification
- npx vitest run app/api/qa/live/route.test.ts app/api/qa/live/frame/route.test.ts
- npm run build:ci