### PR TITLE
Add live QA system activity and PSADT logs

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -929,6 +929,17 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
         "    Start-ADTProcess -FilePath `"`$env:SystemRoot\System32\cmd.exe`" -ArgumentList '/c $customInstallCommandEscaped' -WorkingDirectory `$adtSession.DirFiles -WindowStyle Hidden"
     )
 } else {
+    $installerArgumentList = "'$silentSwitchesEscaped'"
+    if ($installerTypeLower -eq 'inno') {
+        $innoSwitches = $SilentSwitches.Trim()
+        if ($innoSwitches -notmatch '(?i)(^|\s)/SP-(\s|$)') { $innoSwitches = "$innoSwitches /SP-".Trim() }
+        $innoSwitchesEscaped = $innoSwitches -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+        $lines += @(
+            "    `$installerArguments = '$innoSwitchesEscaped /LOG=`"{0}`"' -f (Join-Path `$env:TEMP 'IntuneGet-Inno-Install.log')"
+            '    Write-ADTLogEntry -Message "Inno Setup verbose logging enabled" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+        )
+        $installerArgumentList = '$installerArguments'
+    }
     switch ($installerTypeLower) {
         { $_ -in 'msi', 'wix' } {
             $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
@@ -1136,7 +1147,7 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                     '    try {'
                     '        Write-ADTLogEntry -Message "Running per-user installer from user temp directory" -Severity ''Info'' -Source ''Install-ADTDeployment'''
                     '        # Use -UseShellExecute for shell context which inherits environment variables'
-                    "        Start-ADTProcess -FilePath `$installerDest -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                    "        Start-ADTProcess -FilePath `$installerDest -ArgumentList $installerArgumentList -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
                     '    }'
                     '    finally {'
                     '        # Cleanup temp directory'
@@ -1147,7 +1158,7 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                 )
             } else {
                 $lines += @(
-                    "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                    "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
                 )
             }
         }

--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -7,6 +7,7 @@ import { AppIcon } from '@/components/AppIcon';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import { QaDetailsDialog } from '@/components/qa/QaDetailsDialog';
 import { QaPhaseTimeline } from '@/components/qa/QaPhaseTimeline';
+import { QaLiveActivityPanel } from '@/components/qa/QaLiveActivityPanel';
 import { StatusBadge, type StatusTone } from '@/components/ui/status-badge';
 import { useElapsedTime } from '@/hooks/use-elapsed-time';
 import { useQaLive } from '@/hooks/use-qa';
@@ -139,6 +140,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
         </div>
       </div>
       <QaPhaseTimeline currentPhase={data.current.phase} />
+      <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(340px,2fr)]">
       <div className="overflow-hidden rounded-xl border border-overlay/10 bg-black" aria-labelledby="live-console-heading">
         <div className="flex items-center justify-between border-b border-white/10 bg-bg-primary/80 px-4 py-3">
           <div className="flex items-center gap-2">
@@ -175,6 +177,8 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
         <p className="border-t border-white/10 bg-bg-primary/80 px-4 py-2 text-xs leading-relaxed text-text-muted">
           {visualizationCaption}
         </p>
+      </div>
+      <QaLiveActivityPanel activity={data.activity} log={data.log} phase={data.current.phase} serverTime={data.serverTime} />
       </div>
     </section>
   );

--- a/components/qa/QaLiveActivityPanel.tsx
+++ b/components/qa/QaLiveActivityPanel.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { memo, useMemo, useState, type KeyboardEvent } from 'react';
+import { FileCode2, ListTree, Minus, Pencil, Plus, ScrollText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { QaLiveActivity, QaLiveActivityChange, QaLiveActivityKind, QaLiveLog, QaLivePhase } from '@/types/qa';
+
+type Filter = 'all' | QaLiveActivityKind;
+
+const FILTERS: Array<{ id: Filter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'file', label: 'Files' },
+  { id: 'registry', label: 'Registry' },
+];
+
+const CHANGE_PRESENTATION: Record<QaLiveActivityChange, { label: string; className: string; Icon: typeof Plus }> = {
+  added: { label: 'Added', className: 'bg-status-success/10 text-status-success', Icon: Plus },
+  changed: { label: 'Updated', className: 'bg-status-warning/10 text-status-warning', Icon: Pencil },
+  removed: { label: 'Removed', className: 'bg-status-error/10 text-status-error', Icon: Minus },
+};
+
+function compactTarget(target: string): string {
+  if (target.length <= 56) return target;
+  const separator = target.lastIndexOf('\\');
+  const leaf = separator >= 0 ? target.slice(separator + 1) : target.slice(-24);
+  const prefixLength = Math.max(18, 52 - leaf.length);
+  return `${target.slice(0, prefixLength)}…\\${leaf}`;
+}
+
+function ChangeBadge({ change }: { change: QaLiveActivityChange }) {
+  const presentation = CHANGE_PRESENTATION[change];
+  return (
+    <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium', presentation.className)}>
+      <presentation.Icon className="h-3 w-3" aria-hidden="true" />
+      {presentation.label}
+    </span>
+  );
+}
+
+function KindLabel({ kind }: { kind: QaLiveActivityKind }) {
+  const Icon = kind === 'file' ? FileCode2 : ListTree;
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-text-secondary">
+      <Icon className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
+      {kind === 'file' ? 'File' : 'Registry'}
+    </span>
+  );
+}
+
+function emptyMessage(phase: QaLivePhase): string {
+  if (phase === 'installing') return 'Changes appear after installation completes and the clean and installed snapshots are compared.';
+  if (phase === 'uninstalling') return 'The install comparison is complete. Uninstall changes appear after removal finishes.';
+  if (phase === 'detecting_install' || phase === 'verifying_removal') return 'The VM is comparing trusted before-and-after snapshots.';
+  return 'System-change evidence will appear when an installation snapshot is available.';
+}
+
+export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
+  activity,
+  log,
+  phase,
+  serverTime,
+}: {
+  activity: QaLiveActivity | null;
+  log: QaLiveLog | null;
+  phase: QaLivePhase;
+  serverTime: string;
+}) {
+  const [filter, setFilter] = useState<Filter>('all');
+  const fileCount = activity
+    ? activity.counts.filesAdded + activity.counts.filesChanged + activity.counts.filesRemoved
+    : 0;
+  const registryCount = activity
+    ? activity.counts.registryAdded + activity.counts.registryChanged + activity.counts.registryRemoved
+    : 0;
+  const filteredItems = useMemo(
+    () => activity?.items.filter((item) => filter === 'all' || item.kind === filter) ?? [],
+    [activity, filter]
+  );
+  const filterCounts: Record<Filter, number> = {
+    all: fileCount + registryCount,
+    file: fileCount,
+    registry: registryCount,
+  };
+  const logAgeSeconds = log ? Math.max(0, Math.floor((new Date(serverTime).getTime() - new Date(log.lastWriteAt).getTime()) / 1000)) : null;
+  const logStatus = logAgeSeconds != null && logAgeSeconds >= 60
+    ? `No new entry for ${Math.floor(logAgeSeconds / 60)}m`
+    : log
+      ? `Last entry ${new Date(log.lastWriteAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`
+      : 'Waiting for output';
+
+  function moveFilter(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    const offset = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (index + offset + FILTERS.length) % FILTERS.length;
+    setFilter(FILTERS[nextIndex].id);
+    document.getElementById(`qa-activity-tab-${FILTERS[nextIndex].id}`)?.focus();
+  }
+
+  return (
+    <section className="flex min-h-[24rem] flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-primary/45 lg:max-h-[32rem]" aria-labelledby="system-changes-heading">
+      <div className="border-b border-overlay/10 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 id="system-changes-heading" className="text-sm font-medium text-text-primary">Detected system changes</h3>
+            <p className="mt-1 text-xs text-text-muted">
+              {activity?.stage === 'after_uninstall' ? 'Removal comparison' : activity ? 'Installation comparison' : 'Awaiting comparison'}
+            </p>
+          </div>
+          <span className="flex items-center gap-1.5 text-xs text-text-muted">
+            <span className={cn('h-1.5 w-1.5 rounded-full', activity ? 'bg-status-success' : 'animate-pulse bg-accent-cyan')} aria-hidden="true" />
+            {activity ? 'Observed' : 'Collecting'}
+          </span>
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2" aria-live="polite" aria-atomic="true">
+          <div className="rounded-lg border border-overlay/10 bg-overlay/[0.03] px-3 py-2">
+            <p className="text-[11px] uppercase tracking-wide text-text-muted">Files</p>
+            <p className="mt-0.5 font-mono text-lg font-semibold text-text-primary">{fileCount}</p>
+          </div>
+          <div className="rounded-lg border border-overlay/10 bg-overlay/[0.03] px-3 py-2">
+            <p className="text-[11px] uppercase tracking-wide text-text-muted">Registry</p>
+            <p className="mt-0.5 font-mono text-lg font-semibold text-text-primary">{registryCount}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-b border-overlay/10 bg-black/15 px-4 py-3">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <span className="flex items-center gap-2 text-xs font-medium text-text-secondary">
+            <ScrollText className="h-3.5 w-3.5 text-accent-cyan" aria-hidden="true" />
+            Live PSADT log
+          </span>
+          <span className="text-[10px] text-text-muted">
+            {logStatus}
+          </span>
+        </div>
+        {log?.lines.length ? (
+          <ol className="max-h-28 space-y-1 overflow-y-auto font-mono text-[10px] leading-relaxed text-text-muted" aria-label="Latest sanitized PSADT log entries">
+            {log.lines.map((line, index) => <li key={`${index}-${line}`}>{line}</li>)}
+          </ol>
+        ) : (
+          <p className="text-xs text-text-muted">Sanitized toolkit messages will appear while the installer is running.</p>
+        )}
+      </div>
+
+      <div className="border-b border-overlay/10 px-3 py-2">
+        <div className="flex gap-1" role="tablist" aria-label="System change type">
+          {FILTERS.map((item, index) => (
+            <button
+              id={`qa-activity-tab-${item.id}`}
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={filter === item.id}
+              aria-controls="qa-activity-panel"
+              tabIndex={filter === item.id ? 0 : -1}
+              onClick={() => setFilter(item.id)}
+              onKeyDown={(event) => moveFilter(event, index)}
+              className={cn(
+                'rounded-md px-2.5 py-1.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan',
+                filter === item.id ? 'bg-overlay/10 text-text-primary' : 'text-text-muted hover:text-text-secondary'
+              )}
+            >
+              {item.label} <span className="font-mono text-[10px]">{filterCounts[item.id]}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div id="qa-activity-panel" role="tabpanel" aria-labelledby={`qa-activity-tab-${filter}`} className="min-h-0 flex-1 overflow-y-auto">
+        {filteredItems.length ? (
+          <>
+            <div className="hidden sm:block">
+              <table className="w-full table-fixed text-left">
+                <caption className="sr-only">Sanitized file and registry changes detected by snapshot comparison</caption>
+                <thead className="sticky top-0 z-10 border-b border-overlay/10 bg-bg-elevated text-[11px] text-text-muted">
+                  <tr>
+                    <th scope="col" className="w-24 px-4 py-2 font-medium">Kind</th>
+                    <th scope="col" className="w-24 px-2 py-2 font-medium">Change</th>
+                    <th scope="col" className="px-2 py-2 pr-4 font-medium">Target</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-overlay/10">
+                  {filteredItems.map((item) => (
+                    <tr key={`${item.kind}|${item.change}|${item.target}`}>
+                      <td className="px-4 py-2.5"><KindLabel kind={item.kind} /></td>
+                      <td className="px-2 py-2.5"><ChangeBadge change={item.change} /></td>
+                      <td className="px-2 py-2.5 pr-4"><code className="block truncate text-[11px] text-text-secondary" title={item.target}>{compactTarget(item.target)}</code></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <ul className="divide-y divide-overlay/10 sm:hidden" aria-label="Detected system changes">
+              {filteredItems.map((item) => (
+                <li key={`${item.kind}|${item.change}|${item.target}`} className="space-y-2 px-4 py-3">
+                  <div className="flex items-center justify-between gap-3"><KindLabel kind={item.kind} /><ChangeBadge change={item.change} /></div>
+                  <code className="block break-all text-[11px] leading-relaxed text-text-secondary">{item.target}</code>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <div className="flex h-full min-h-44 items-center justify-center px-6 py-8 text-center">
+            <div>
+              <ListTree className="mx-auto h-6 w-6 text-text-muted" aria-hidden="true" />
+              <p className="mt-3 text-sm text-text-secondary">{activity ? 'No changes in this category were detected.' : emptyMessage(phase)}</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <p className="border-t border-overlay/10 px-4 py-2.5 text-[11px] leading-relaxed text-text-muted">
+        {activity ? `Compared at ${new Date(activity.observedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}. ` : ''}
+        Snapshot comparison, not a complete real-time trace. Paths are sanitized and {activity?.truncated ? 'the first 40 entries are shown.' : 'up to 40 entries are shown.'}
+      </p>
+    </section>
+  );
+});

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -123,7 +123,7 @@ describe('normalizeInstaller', () => {
 
       const result = normalizeInstaller(installer);
 
-      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS');
+      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS');
     });
 
     it('should append Custom after Silent when both are provided', () => {
@@ -236,7 +236,7 @@ describe('normalizeInstaller', () => {
 
       const result = normalizeInstaller(installer);
 
-      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART');
+      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
     });
 
     it('should use default args for Nullsoft (NSIS)', () => {
@@ -340,7 +340,7 @@ describe('normalizeInstaller', () => {
 
       const result = normalizeInstaller(installer);
 
-      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART');
+      expect(result.silentArgs).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
     });
 
     it('should prefer declared Silent switches over nested-type defaults', () => {

--- a/lib/custom-app.ts
+++ b/lib/custom-app.ts
@@ -35,7 +35,7 @@ export type CustomInstallerType = Extract<
 export const CUSTOM_SILENT_SWITCH_DEFAULTS: Record<CustomInstallerType, string> = {
   exe: '/S',
   msi: '/qn /norestart',
-  inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+  inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
   nullsoft: '/S',
   burn: '/quiet /norestart',
 };

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -399,7 +399,7 @@ function getDefaultSilentArgs(type: WingetInstallerType): string {
     msix: '',
     appx: '',
     exe: '/S',
-    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',
     burn: '/quiet /norestart',

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -578,7 +578,7 @@ function getDefaultSilentSwitch(installerType: WingetInstallerType): string {
     msix: '',
     appx: '',
     exe: '/S',
-    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',
     burn: '/quiet /norestart',

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -11,7 +11,7 @@ export function extractSilentSwitches(installCommand: string, installerType: str
   const defaultSwitches: Record<string, string> = {
     msi: '/qn /norestart',
     exe: '/S',
-    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+    inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',
     burn: '/q /norestart',

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -21,6 +21,25 @@ describe('buildQaLiveResponse', () => {
         phase: 'installing',
         phase_started_at: '2026-08-08T16:45:00.000Z',
         phase_updated_at: '2026-08-08T16:59:00.000Z',
+        activity_updated_at: '2026-08-08T16:58:30.000Z',
+        log_updated_at: '2026-08-08T16:59:30.000Z',
+        live_activity: {
+          stage: 'after_install',
+          counts: {
+            registryAdded: 2, registryChanged: 1, registryRemoved: 0,
+            filesAdded: 12, filesChanged: 3, filesRemoved: 0,
+          },
+          items: [
+            { kind: 'file', change: 'added', target: '%PROGRAMFILES%\\Example\\Example.exe' },
+            { kind: 'registry', change: 'changed', target: 'HKLM\\SOFTWARE\\Example\\Version' },
+          ],
+          truncated: false,
+        },
+        live_log: {
+          source: 'PSADT',
+          lastWriteAt: '2026-08-08T16:59:28.000Z',
+          lines: ['Installing Example…', 'Vendor installer is running.'],
+        },
         test_config: {
           packageProfileCanonicalJson: JSON.stringify({
             installer: { installScope: 'user' },
@@ -95,6 +114,25 @@ describe('buildQaLiveResponse', () => {
       width: 1280,
       height: 720,
     });
+    expect(response.activity).toEqual({
+      stage: 'after_install',
+      observedAt: '2026-08-08T16:58:30.000Z',
+      counts: {
+        registryAdded: 2, registryChanged: 1, registryRemoved: 0,
+        filesAdded: 12, filesChanged: 3, filesRemoved: 0,
+      },
+      items: [
+        { kind: 'file', change: 'added', target: '%PROGRAMFILES%\\Example\\Example.exe' },
+        { kind: 'registry', change: 'changed', target: 'HKLM\\SOFTWARE\\Example\\Version' },
+      ],
+      truncated: false,
+    });
+    expect(response.log).toEqual({
+      source: 'PSADT',
+      observedAt: '2026-08-08T16:59:30.000Z',
+      lastWriteAt: '2026-08-08T16:59:28.000Z',
+      lines: ['Installing Example…', 'Vendor installer is running.'],
+    });
     const serialized = JSON.stringify(response);
     for (const forbidden of ['installer_url', 'failure_summary', 'github_run_url', 'private', 'vendorSilentArguments']) {
       expect(serialized).not.toContain(forbidden);
@@ -134,6 +172,15 @@ describe('buildQaLiveResponse', () => {
         dispatched_at: '2026-08-08T18:25:40.000Z', started_at: null,
         phase: 'restoring_vm', phase_started_at: '2026-08-08T18:00:00.000Z',
         phase_updated_at: '2026-08-08T18:00:00.000Z', test_config: {},
+        activity_updated_at: '2026-08-08T18:00:00.000Z',
+        log_updated_at: '2026-08-08T18:00:00.000Z',
+        live_activity: {
+          stage: 'after_install',
+          counts: { registryAdded: 1, registryChanged: 0, registryRemoved: 0, filesAdded: 1, filesChanged: 0, filesRemoved: 0 },
+          items: [{ kind: 'file', change: 'added', target: '%PROGRAMFILES%\\Old\\old.exe' }],
+          truncated: false,
+        },
+        live_log: { source: 'PSADT', lastWriteAt: '2026-08-08T18:00:00.000Z', lines: ['old'] },
       },
       queuedCount: 1,
       queued: [],
@@ -150,6 +197,8 @@ describe('buildQaLiveResponse', () => {
     expect(response.current?.phase).toBe('preparing_package');
     expect(response.current?.phaseStartedAt).toBeNull();
     expect(response.current?.expectedUi).toBeNull();
+    expect(response.activity).toBeNull();
+    expect(response.log).toBeNull();
   });
 
   it('publishes only a sanitized GitHub rate-limit cause', () => {

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { createServerClient } from '@/lib/supabase';
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 import type { Json } from '@/types/database';
-import type { QaArchitecture, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome } from '@/types/qa';
+import type { QaArchitecture, QaLiveActivity, QaLiveLog, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome } from '@/types/qa';
 
 const RUNNER_STALE_MS = 10 * 60 * 1000;
 const POLL_STALE_MS = 5 * 60 * 1000;
@@ -21,6 +21,10 @@ interface CandidateRow {
   phase: string | null;
   phase_started_at: string | null;
   phase_updated_at: string | null;
+  live_activity?: Json | null;
+  activity_updated_at?: string | null;
+  live_log?: Json | null;
+  log_updated_at?: string | null;
   test_config: Json;
 }
 
@@ -79,6 +83,7 @@ const VALID_PHASES = new Set<QaLivePhase>([
   'verifying_removal',
   'publishing',
 ]);
+const LIVE_ACTIVITY_TARGET = /^(?:%(?:PROGRAMFILES|PROGRAMFILES\(X86\)|PROGRAMDATA|WINDIR|PUBLIC|USERPROFILE|LOCALAPPDATA|APPDATA)%\\|HK(?:LM|CU)\\)/i;
 
 function architecture(value: string): QaArchitecture {
   return value === 'x86' || value === 'arm64' ? value : 'x64';
@@ -88,6 +93,54 @@ function phase(value: string | null): QaLivePhase {
   return value && VALID_PHASES.has(value as QaLivePhase)
     ? (value as QaLivePhase)
     : 'preparing_package';
+}
+
+function liveActivity(value: Json | undefined, observedAt: string | null | undefined, attemptStartedAt: string | null): QaLiveActivity | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || !observedAt || !attemptStartedAt) return null;
+  if (new Date(observedAt).getTime() < new Date(attemptStartedAt).getTime()) return null;
+  const stage = value.stage;
+  if (stage !== 'after_install' && stage !== 'after_uninstall') return null;
+  const rawCounts = value.counts;
+  if (!rawCounts || typeof rawCounts !== 'object' || Array.isArray(rawCounts)) return null;
+  const countNames = [
+    'registryAdded', 'registryChanged', 'registryRemoved',
+    'filesAdded', 'filesChanged', 'filesRemoved',
+  ] as const;
+  const counts = {} as QaLiveActivity['counts'];
+  for (const name of countNames) {
+    const candidate = rawCounts[name];
+    if (!Number.isInteger(candidate) || Number(candidate) < 0 || Number(candidate) > 50_000_000) return null;
+    counts[name] = Number(candidate);
+  }
+  if (!Array.isArray(value.items) || value.items.length > 40 || typeof value.truncated !== 'boolean') return null;
+  const items: QaLiveActivity['items'] = [];
+  for (const item of value.items) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
+    const kind = item.kind;
+    const change = item.change;
+    const target = item.target;
+    if (
+      (kind !== 'file' && kind !== 'registry') ||
+      (change !== 'added' && change !== 'changed' && change !== 'removed') ||
+      typeof target !== 'string' || target.length < 1 || target.length > 240 ||
+      /[\u0000-\u001f\u007f]/.test(target) || !LIVE_ACTIVITY_TARGET.test(target)
+    ) return null;
+    items.push({ kind, change, target });
+  }
+  return { stage, observedAt, counts, items, truncated: value.truncated };
+}
+
+function liveLog(value: Json | undefined, observedAt: string | null | undefined, attemptStartedAt: string | null): QaLiveLog | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || !observedAt || !attemptStartedAt) return null;
+  if (new Date(observedAt).getTime() < new Date(attemptStartedAt).getTime()) return null;
+  if (value.source !== 'PSADT' || typeof value.lastWriteAt !== 'string' || !Array.isArray(value.lines) || value.lines.length > 8) return null;
+  if (!Number.isFinite(new Date(value.lastWriteAt).getTime())) return null;
+  const lines: string[] = [];
+  for (const line of value.lines) {
+    if (typeof line !== 'string' || line.length < 1 || line.length > 180 || /[\u0000-\u001f\u007f]/.test(line) || /[A-Z]:\\|INTUNE-QA\\/i.test(line)) return null;
+    lines.push(line);
+  }
+  return { source: 'PSADT', observedAt, lastWriteAt: value.lastWriteAt, lines };
 }
 
 function executionContext(config: Json): 'LocalSystem' | 'User' {
@@ -221,6 +274,12 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
     input.now.getTime() - new Date(input.frame.updated_at).getTime() <= QA_LIVE_FRAME_MAX_AGE_MS
   );
   const currentExpectedUi = input.current ? expectedUiConfiguration(input.current.test_config) : null;
+  const currentActivity = input.current
+    ? liveActivity(input.current.live_activity, input.current.activity_updated_at, currentStartedAt)
+    : null;
+  const currentLog = input.current
+    ? liveLog(input.current.live_log, input.current.log_updated_at, currentStartedAt)
+    : null;
 
   return {
     serverTime: input.now.toISOString(),
@@ -262,6 +321,8 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       width: frameIsCurrent ? input.frame?.width ?? null : null,
       height: frameIsCurrent ? input.frame?.height ?? null : null,
     },
+    activity: currentActivity,
+    log: currentLog,
     queue: {
       count: input.queuedCount,
       next: input.queued.map((candidate) => ({
@@ -288,7 +349,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
 export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const supabase = createServerClient();
   const candidateColumns =
-    'id, winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, test_config';
+    'id, winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, live_activity, activity_updated_at, live_log, log_updated_at, test_config';
 
   const [activeResult, queueResult, countResult, pollResult, recentResult] = await Promise.all([
     supabase

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -46,7 +46,7 @@ describe('buildQaCatalogTestConfig', () => {
   });
 
   it.each([
-    ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'],
+    ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
     ['nullsoft', '/S'],
   ])('applies the WinGet default silent switches for %s installers', (installerType, expected) => {
     const config = buildQaCatalogTestConfig({
@@ -83,7 +83,7 @@ describe('buildQaCatalogTestConfig', () => {
       sourceInstallerType: 'zip',
       nestedInstallerType: 'inno',
       nestedInstallerFiles: ['setup\\install.exe'],
-      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     });
   });
 
@@ -100,7 +100,7 @@ describe('buildQaCatalogTestConfig', () => {
     });
 
     expect(config.silentArgs).toBe(
-      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS'
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS'
     );
   });
 

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -766,6 +766,17 @@ ${steps}
     Write-ADTLogEntry -Message "Portable app installed to: $installPath" -Severity 'Success' -Source 'Install-ADTDeployment'`;
     }
 
+    if (installerType === 'inno') {
+      const innoSwitches = /(^|\s)\/SP-(\s|$)/i.test(silentSwitches)
+        ? silentSwitches
+        : `${silentSwitches} /SP-`.trim();
+      const escapedSwitches = innoSwitches.replace(/'/g, "''");
+      return `$innoLogPath = Join-Path $env:TEMP 'IntuneGet-Inno-Install.log'
+    $innoArguments = '${escapedSwitches} /LOG="{0}"' -f $innoLogPath
+    Write-ADTLogEntry -Message "Inno Setup verbose logging enabled" -Severity 'Info' -Source 'Install-ADTDeployment'
+    Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\${fileName}" -ArgumentList $innoArguments -WindowStyle Hidden -WaitForMsiExec`;
+    }
+
     return `Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\${fileName}" -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec`;
   }
 
@@ -1028,7 +1039,7 @@ ${steps}
     const defaultSwitches: Record<string, string> = {
       msi: '/qn /norestart',
       exe: '/S',
-      inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART',
+      inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
       nullsoft: '/S',
       wix: '/qn /norestart',
       burn: '/q /norestart',

--- a/supabase/migrations/20260809093000_qa_live_activity.sql
+++ b/supabase/migrations/20260809093000_qa_live_activity.sql
@@ -1,0 +1,116 @@
+-- Bounded, sanitized before/after evidence for the public live QA dashboard.
+alter table public.qa_candidates
+  add column if not exists live_activity jsonb,
+  add column if not exists activity_updated_at timestamptz;
+
+create or replace function public.publish_qa_candidate_activity(
+  p_secret text,
+  p_candidate_id uuid,
+  p_activity jsonb,
+  p_observed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  updated_count integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if p_observed_at is null or p_observed_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA activity observation time';
+  end if;
+  if p_activity is null or jsonb_typeof(p_activity) <> 'object'
+    or p_activity->>'stage' not in ('after_install', 'after_uninstall')
+    or jsonb_typeof(p_activity->'counts') <> 'object'
+    or jsonb_typeof(p_activity->'items') <> 'array'
+    or jsonb_array_length(p_activity->'items') > 40
+    or jsonb_typeof(p_activity->'truncated') <> 'boolean'
+    or octet_length(p_activity::text) > 16384 then
+    raise exception 'Invalid QA activity payload';
+  end if;
+  if exists (
+    select 1
+    from unnest(array[
+      'registryAdded', 'registryChanged', 'registryRemoved',
+      'filesAdded', 'filesChanged', 'filesRemoved'
+    ]) count_name
+    where jsonb_typeof(p_activity->'counts'->count_name) <> 'number'
+      or (p_activity->'counts'->>count_name)::numeric < 0
+      or (p_activity->'counts'->>count_name)::numeric > 50000000
+      or trunc((p_activity->'counts'->>count_name)::numeric) <> (p_activity->'counts'->>count_name)::numeric
+  ) then
+    raise exception 'Invalid QA activity counts';
+  end if;
+  if exists (
+    select 1
+    from jsonb_array_elements(p_activity->'items') item
+    where jsonb_typeof(item) <> 'object'
+      or item->>'kind' not in ('file', 'registry')
+      or item->>'change' not in ('added', 'changed', 'removed')
+      or length(coalesce(item->>'target', '')) not between 1 and 240
+      or item->>'target' ~ '[[:cntrl:]]'
+      or item->>'target' !~* '^(%(PROGRAMFILES|PROGRAMFILES\(X86\)|PROGRAMDATA|WINDIR|PUBLIC|USERPROFILE)%\\|HK(LM|CU)\\)'
+  ) then
+    raise exception 'Invalid QA activity item';
+  end if;
+
+  update public.qa_candidates
+  set live_activity = p_activity,
+      activity_updated_at = p_observed_at,
+      updated_at = greatest(updated_at, p_observed_at)
+  where id = p_candidate_id
+    and status in ('dispatched', 'running')
+    and (activity_updated_at is null or p_observed_at > activity_updated_at);
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.publish_qa_candidate_activity(text, uuid, jsonb, timestamptz)
+  from public, authenticated, service_role;
+grant execute on function public.publish_qa_candidate_activity(text, uuid, jsonb, timestamptz)
+  to anon;
+
+create or replace function public.mark_qa_candidate_running(
+  p_secret text,
+  p_candidate_id uuid,
+  p_run_id text,
+  p_run_url text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  update public.qa_candidates
+  set status = 'running',
+      started_at = now(),
+      github_run_id = p_run_id,
+      github_run_url = p_run_url,
+      failure_summary = null,
+      live_activity = null,
+      activity_updated_at = null,
+      updated_at = now()
+  where id = p_candidate_id and status = 'dispatched';
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.mark_qa_candidate_running(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.mark_qa_candidate_running(text, uuid, text, text)
+  to anon;

--- a/supabase/migrations/20260809103000_qa_live_log.sql
+++ b/supabase/migrations/20260809103000_qa_live_log.sql
@@ -1,0 +1,109 @@
+-- Sanitized PSADT log tail for the public live QA dashboard.
+alter table public.qa_candidates
+  add column if not exists live_log jsonb,
+  add column if not exists log_updated_at timestamptz;
+
+create or replace function public.publish_qa_candidate_log(
+  p_secret text,
+  p_candidate_id uuid,
+  p_log jsonb,
+  p_observed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  updated_count integer;
+  last_write_at timestamptz;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if p_observed_at is null or p_observed_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA log observation time';
+  end if;
+  if p_log is null or jsonb_typeof(p_log) <> 'object'
+    or p_log->>'source' <> 'PSADT'
+    or jsonb_typeof(p_log->'lines') <> 'array'
+    or jsonb_array_length(p_log->'lines') > 8
+    or octet_length(p_log::text) > 4096 then
+    raise exception 'Invalid QA log payload';
+  end if;
+  begin
+    last_write_at := (p_log->>'lastWriteAt')::timestamptz;
+  exception when others then
+    raise exception 'Invalid QA log timestamp';
+  end;
+  if last_write_at < now() - interval '1 day' or last_write_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA log timestamp';
+  end if;
+  if exists (
+    select 1 from jsonb_array_elements(p_log->'lines') line
+    where jsonb_typeof(line) <> 'string'
+      or length(line #>> '{}') not between 1 and 180
+      or (line #>> '{}') ~ '[[:cntrl:]]'
+      or (line #>> '{}') ~* '([A-Z]:\\|INTUNE-QA\\)'
+  ) then
+    raise exception 'Invalid QA log line';
+  end if;
+
+  update public.qa_candidates
+  set live_log = p_log,
+      log_updated_at = p_observed_at,
+      updated_at = greatest(updated_at, p_observed_at)
+  where id = p_candidate_id
+    and status in ('dispatched', 'running')
+    and (log_updated_at is null or p_observed_at > log_updated_at);
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.publish_qa_candidate_log(text, uuid, jsonb, timestamptz)
+  from public, authenticated, service_role;
+grant execute on function public.publish_qa_candidate_log(text, uuid, jsonb, timestamptz)
+  to anon;
+
+create or replace function public.mark_qa_candidate_running(
+  p_secret text,
+  p_candidate_id uuid,
+  p_run_id text,
+  p_run_url text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  update public.qa_candidates
+  set status = 'running',
+      started_at = now(),
+      github_run_id = p_run_id,
+      github_run_url = p_run_url,
+      failure_summary = null,
+      live_activity = null,
+      activity_updated_at = null,
+      live_log = null,
+      log_updated_at = null,
+      updated_at = now()
+  where id = p_candidate_id and status = 'dispatched';
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.mark_qa_candidate_running(text, uuid, text, text)
+  from public, authenticated, service_role;
+grant execute on function public.mark_qa_candidate_running(text, uuid, text, text)
+  to anon;

--- a/types/database.ts
+++ b/types/database.ts
@@ -180,6 +180,10 @@ export interface Database {
           phase: string | null;
           phase_started_at: string | null;
           phase_updated_at: string | null;
+          live_activity: Json | null;
+          activity_updated_at: string | null;
+          live_log: Json | null;
+          log_updated_at: string | null;
           updated_at: string;
         };
         Insert: {
@@ -209,6 +213,10 @@ export interface Database {
           phase?: string | null;
           phase_started_at?: string | null;
           phase_updated_at?: string | null;
+          live_activity?: Json | null;
+          activity_updated_at?: string | null;
+          live_log?: Json | null;
+          log_updated_at?: string | null;
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_candidates']['Insert']>;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -73,6 +73,39 @@ export interface QaEffectiveConfiguration {
 /** Count/flag-only PSADT configuration safe for the public live QA view. */
 export type QaLiveUiConfiguration = Omit<QaEffectiveConfiguration, 'vendorSilentArguments'>;
 
+export type QaLiveActivityKind = 'file' | 'registry';
+export type QaLiveActivityChange = 'added' | 'changed' | 'removed';
+
+export interface QaLiveActivityItem {
+  kind: QaLiveActivityKind;
+  change: QaLiveActivityChange;
+  target: string;
+}
+
+export interface QaLiveActivityCounts {
+  registryAdded: number;
+  registryChanged: number;
+  registryRemoved: number;
+  filesAdded: number;
+  filesChanged: number;
+  filesRemoved: number;
+}
+
+export interface QaLiveActivity {
+  stage: 'after_install' | 'after_uninstall';
+  observedAt: string;
+  counts: QaLiveActivityCounts;
+  items: QaLiveActivityItem[];
+  truncated: boolean;
+}
+
+export interface QaLiveLog {
+  source: 'PSADT';
+  observedAt: string;
+  lastWriteAt: string;
+  lines: string[];
+}
+
 export type QaLivePhase =
   | 'queued'
   | 'preparing_package'
@@ -121,6 +154,8 @@ export interface QaLiveResponse {
     width: number | null;
     height: number | null;
   };
+  activity: QaLiveActivity | null;
+  log: QaLiveLog | null;
   queue: {
     count: number;
     next: Array<{


### PR DESCRIPTION
## What changed

- adds a responsive 3:2 desktop layout with the live VM on the left and system evidence on the right
- shows sanitized PSADT log messages while installation is running
- shows bounded file and registry change tables after snapshot comparison, with mobile card fallbacks
- adds secret-protected Supabase publishers and defensive server-side projections
- adds Inno Setup `/SP-` defaults and a per-run verbose `/LOG` file for diagnosis

## Why

The QA page previously showed only the VM frame and counts. A stalled Inno installer also exposed that PSADT output was available locally but neither streamed to the dashboard nor used to explain inactivity.

## Safety

Public telemetry is limited to eight redacted log lines and forty placeholder-root file/registry targets. Raw logs, credentials, full paths, package contents, and detailed artifacts remain off the public API.

## Validation

- Next.js production build
- 131 targeted Vitest tests
- targeted ESLint
- packager TypeScript build
- Supabase migration applied and function privileges verified