### PR TITLE
Align QA profiles with protected packager

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -139,7 +139,7 @@ function createSupabaseStub(options: {
   return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
 }
 
-const CURRENT_PACKAGER_COMMIT = 'c533063a250c2c3f92adae9a55b4ddbc50d81a0c';
+const CURRENT_PACKAGER_COMMIT = '0a6128c63baece425dee66acc643196bbcecf343';
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c533063a250c2c3f92adae9a55b4ddbc50d81a0c',
+  packagerCommit: '0a6128c63baece425dee66acc643196bbcecf343',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## Summary
- stamp QA package profiles with the merged live-monitoring packager commit
- update the enqueue contract test to protect the new pin

## Validation
- 41 targeted Vitest tests
- targeted ESLint
- git diff --check