### PR TITLE
Avoid live QA frame sequence races

### DIFF
--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -68,11 +68,59 @@ describe('/api/qa/live/frame ingest boundary', () => {
     expect(createServerClientMock).not.toHaveBeenCalled();
   });
 
-  it('requires the immutable frame sequence in the public URL', async () => {
+  it('requires a frame sequence cache-buster in the public URL', async () => {
     const response = await GET(new Request(`https://www.intuneget.com/api/qa/live/frame?candidate=${candidateId}`));
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'Invalid sequence' });
     expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('serves the newest frame when capture advances after the status request', async () => {
+    const chain = (result: unknown) => {
+      const query = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        in: vi.fn(),
+        order: vi.fn(),
+        limit: vi.fn(),
+        maybeSingle: vi.fn().mockResolvedValue(result),
+      };
+      query.select.mockReturnValue(query);
+      query.eq.mockReturnValue(query);
+      query.in.mockReturnValue(query);
+      query.order.mockReturnValue(query);
+      query.limit.mockReturnValue(query);
+      return query;
+    };
+    const activeQuery = chain({ data: { id: candidateId }, error: null });
+    const frameQuery = chain({
+      data: {
+        object_path: `${candidateId}/slot-0.jpg`,
+        captured_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        sequence: 42,
+      },
+      error: null,
+    });
+    const from = vi.fn()
+      .mockReturnValueOnce(activeQuery)
+      .mockReturnValueOnce(frameQuery);
+    const download = vi.fn().mockResolvedValue({
+      data: new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xd9])], { type: 'image/jpeg' }),
+      error: null,
+    });
+    createServerClientMock.mockReturnValueOnce({
+      rpc: rpcMock,
+      from,
+      storage: { from: vi.fn(() => ({ download })) },
+    } as never);
+
+    const response = await GET(new Request(
+      `https://www.intuneget.com/api/qa/live/frame?candidate=${candidateId}&sequence=41`
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-qa-frame-sequence')).toBe('42');
   });
 
   it('returns a quiet 404 when cleanup removes the object after metadata is read', async () => {

--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -104,11 +104,11 @@ export async function GET(request: Request) {
       .eq('candidate_id', active.id)
       .maybeSingle();
     if (frameError) throw new Error(`Could not load QA frame metadata: ${frameError.message}`);
-    if (
-      !frame ||
-      frame.sequence !== requestedSequence ||
-      Date.now() - new Date(frame.updated_at).getTime() > QA_LIVE_FRAME_MAX_AGE_MS
-    ) {
+    // The requested sequence is a cache-buster, not a lock. At a two-second
+    // capture cadence the producer can publish the next frame between the
+    // live-status request and this image request. Serve that newer frame for
+    // the same active candidate instead of flashing an avoidable 404.
+    if (!frame || Date.now() - new Date(frame.updated_at).getTime() > QA_LIVE_FRAME_MAX_AGE_MS) {
       return new NextResponse(null, { status: 404, headers: noStoreHeaders() });
     }
 


### PR DESCRIPTION
## Summary
- keep the frame sequence as a cache-buster
- serve a newer frame when capture advances between status and image requests
- retain active-candidate and maximum-age validation

## Validation
- 8 focused route tests
- targeted ESLint
- git diff --check