### PR TITLE
Show system changes during installation

### DIFF
--- a/components/qa/QaLiveActivityPanel.tsx
+++ b/components/qa/QaLiveActivityPanel.tsx
@@ -104,7 +104,13 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
           <div>
             <h3 id="system-changes-heading" className="text-sm font-medium text-text-primary">Detected system changes</h3>
             <p className="mt-1 text-xs text-text-muted">
-              {activity?.stage === 'after_uninstall' ? 'Removal comparison' : activity ? 'Installation comparison' : 'Awaiting comparison'}
+              {activity?.stage === 'during_install'
+                ? 'Live installation activity'
+                : activity?.stage === 'after_uninstall'
+                  ? 'Removal comparison'
+                  : activity
+                    ? 'Installation comparison'
+                    : 'Awaiting comparison'}
             </p>
           </div>
           <span className="flex items-center gap-1.5 text-xs text-text-muted">

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -24,7 +24,7 @@ describe('buildQaLiveResponse', () => {
         activity_updated_at: '2026-08-08T16:58:30.000Z',
         log_updated_at: '2026-08-08T16:59:30.000Z',
         live_activity: {
-          stage: 'after_install',
+          stage: 'during_install',
           counts: {
             registryAdded: 2, registryChanged: 1, registryRemoved: 0,
             filesAdded: 12, filesChanged: 3, filesRemoved: 0,
@@ -115,7 +115,7 @@ describe('buildQaLiveResponse', () => {
       height: 720,
     });
     expect(response.activity).toEqual({
-      stage: 'after_install',
+      stage: 'during_install',
       observedAt: '2026-08-08T16:58:30.000Z',
       counts: {
         registryAdded: 2, registryChanged: 1, registryRemoved: 0,

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -99,7 +99,7 @@ function liveActivity(value: Json | undefined, observedAt: string | null | undef
   if (!value || typeof value !== 'object' || Array.isArray(value) || !observedAt || !attemptStartedAt) return null;
   if (new Date(observedAt).getTime() < new Date(attemptStartedAt).getTime()) return null;
   const stage = value.stage;
-  if (stage !== 'after_install' && stage !== 'after_uninstall') return null;
+  if (stage !== 'during_install' && stage !== 'after_install' && stage !== 'after_uninstall') return null;
   const rawCounts = value.counts;
   if (!rawCounts || typeof rawCounts !== 'object' || Array.isArray(rawCounts)) return null;
   const countNames = [

--- a/supabase/migrations/20260809114000_qa_during_install_activity.sql
+++ b/supabase/migrations/20260809114000_qa_during_install_activity.sql
@@ -1,0 +1,73 @@
+-- Permit bounded, sanitized activity samples while the installer is still running.
+create or replace function public.publish_qa_candidate_activity(
+  p_secret text,
+  p_candidate_id uuid,
+  p_activity jsonb,
+  p_observed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  updated_count integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+  if p_observed_at is null or p_observed_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA activity observation time';
+  end if;
+  if p_activity is null or jsonb_typeof(p_activity) <> 'object'
+    or p_activity->>'stage' not in ('during_install', 'after_install', 'after_uninstall')
+    or jsonb_typeof(p_activity->'counts') <> 'object'
+    or jsonb_typeof(p_activity->'items') <> 'array'
+    or jsonb_array_length(p_activity->'items') > 40
+    or jsonb_typeof(p_activity->'truncated') <> 'boolean'
+    or octet_length(p_activity::text) > 16384 then
+    raise exception 'Invalid QA activity payload';
+  end if;
+  if exists (
+    select 1
+    from unnest(array[
+      'registryAdded', 'registryChanged', 'registryRemoved',
+      'filesAdded', 'filesChanged', 'filesRemoved'
+    ]) count_name
+    where jsonb_typeof(p_activity->'counts'->count_name) <> 'number'
+      or (p_activity->'counts'->>count_name)::numeric < 0
+      or (p_activity->'counts'->>count_name)::numeric > 50000000
+      or trunc((p_activity->'counts'->>count_name)::numeric) <> (p_activity->'counts'->>count_name)::numeric
+  ) then
+    raise exception 'Invalid QA activity counts';
+  end if;
+  if exists (
+    select 1
+    from jsonb_array_elements(p_activity->'items') item
+    where jsonb_typeof(item) <> 'object'
+      or item->>'kind' not in ('file', 'registry')
+      or item->>'change' not in ('added', 'changed', 'removed')
+      or length(coalesce(item->>'target', '')) not between 1 and 240
+      or item->>'target' ~ '[[:cntrl:]]'
+      or item->>'target' !~* '^(%(PROGRAMFILES|PROGRAMFILES\(X86\)|PROGRAMDATA|WINDIR|PUBLIC|USERPROFILE)%\\|HK(LM|CU)\\)'
+  ) then
+    raise exception 'Invalid QA activity item';
+  end if;
+
+  update public.qa_candidates
+  set live_activity = p_activity,
+      activity_updated_at = p_observed_at,
+      updated_at = greatest(updated_at, p_observed_at)
+  where id = p_candidate_id
+    and status in ('dispatched', 'running')
+    and (activity_updated_at is null or p_observed_at > activity_updated_at);
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.publish_qa_candidate_activity(text, uuid, jsonb, timestamptz)
+  from public, authenticated, service_role;
+grant execute on function public.publish_qa_candidate_activity(text, uuid, jsonb, timestamptz)
+  to anon;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -92,7 +92,7 @@ export interface QaLiveActivityCounts {
 }
 
 export interface QaLiveActivity {
-  stage: 'after_install' | 'after_uninstall';
+  stage: 'during_install' | 'after_install' | 'after_uninstall';
   observedAt: string;
   counts: QaLiveActivityCounts;
   items: QaLiveActivityItem[];


### PR DESCRIPTION
## Summary
- accept and render bounded during-install activity
- label live installer activity separately from completed install/removal comparisons
- keep the two-second frame race fix already merged in #269
- add the database contract for the sanitized during_install stage

## Validation
- 12 focused live/frame tests
- targeted ESLint
- migration applied successfully
- git diff --check