### PR TITLE
Remove QA preview authenticity caption

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -87,7 +87,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
   const elapsed = useElapsedTime({ startTime: correctedStart });
   const visualizationCaption = data.current?.expectedUi && data.current.deployMode !== 'Auto'
     ? 'The VM image is genuine. Any panel labeled “configuration preview” is host-rendered from sanitized PSADT settings—not captured PSADT UI.'
-    : 'The VM image is genuine. Any PSADT dialog visible in the frame comes from the isolated test VM.';
+    : null;
   const viewerModeLabel = data.current?.dialogExpected
     ? 'Genuine PSADT UI may appear'
     : data.current?.expectedUi && data.current.deployMode !== 'Auto'
@@ -174,9 +174,11 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
             </div>
           )}
         </div>
-        <p className="border-t border-white/10 bg-bg-primary/80 px-4 py-2 text-xs leading-relaxed text-text-muted">
-          {visualizationCaption}
-        </p>
+        {visualizationCaption ? (
+          <p className="border-t border-white/10 bg-bg-primary/80 px-4 py-2 text-xs leading-relaxed text-text-muted">
+            {visualizationCaption}
+          </p>
+        ) : null}
       </div>
       <QaLiveActivityPanel activity={data.activity} log={data.log} phase={data.current.phase} serverTime={data.serverTime} />
       </div>


### PR DESCRIPTION
Removes the requested VM authenticity sentence from the live QA preview and avoids rendering an empty caption footer when no configuration-preview disclaimer is needed.