### PR TITLE
Fix QA installer selection and timeouts

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -934,8 +934,13 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
         $innoSwitches = $SilentSwitches.Trim()
         if ($innoSwitches -notmatch '(?i)(^|\s)/SP-(\s|$)') { $innoSwitches = "$innoSwitches /SP-".Trim() }
         $innoSwitchesEscaped = $innoSwitches -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+        $innoLogPathExpression = if ($IsUserScope) {
+            "(Join-Path `$env:LOCALAPPDATA 'IntuneGet\Logs\IntuneGet-Inno-Install.log')"
+        } else {
+            "(Join-Path `$env:WINDIR 'Logs\Software\IntuneGet-Inno-Install.log')"
+        }
         $lines += @(
-            "    `$installerArguments = '$innoSwitchesEscaped /LOG=`"{0}`"' -f (Join-Path `$env:TEMP 'IntuneGet-Inno-Install.log')"
+            "    `$installerArguments = '$innoSwitchesEscaped /LOG=`"{0}`"' -f $innoLogPathExpression"
             '    Write-ADTLogEntry -Message "Inno Setup verbose logging enabled" -Severity ''Info'' -Source ''Install-ADTDeployment'''
         )
         $installerArgumentList = '$installerArguments'
@@ -1054,9 +1059,9 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                         }
                         default {
                             if ($IsUserScope) {
-                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
                             } else {
-                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                                $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
                             }
                         }
                     }
@@ -1147,7 +1152,7 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                     '    try {'
                     '        Write-ADTLogEntry -Message "Running per-user installer from user temp directory" -Severity ''Info'' -Source ''Install-ADTDeployment'''
                     '        # Use -UseShellExecute for shell context which inherits environment variables'
-                    "        Start-ADTProcess -FilePath `$installerDest -ArgumentList $installerArgumentList -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                    "        Start-ADTProcess -FilePath `$installerDest -ArgumentList $installerArgumentList -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
                     '    }'
                     '    finally {'
                     '        # Cleanup temp directory'
@@ -1158,7 +1163,7 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                 )
             } else {
                 $lines += @(
-                    "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 30) -TimeoutAction Stop"
+                    "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
                 )
             }
         }

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -29,6 +29,34 @@ describe('QA candidate normalization', () => {
     expect(selectQaVmInstaller([{ Architecture: 'arm64' }])).toBeNull();
   });
 
+  it('prefers a machine-scope installer within the selected architecture', () => {
+    const scopedInstallers = [
+      {
+        Architecture: 'x64',
+        Scope: 'user',
+        InstallerUrl: 'https://example.test/current-user.exe',
+      },
+      {
+        Architecture: 'x64',
+        Scope: 'machine',
+        InstallerUrl: 'https://example.test/all-users.exe',
+      },
+    ];
+
+    expect(selectQaVmInstaller(scopedInstallers)?.installer.InstallerUrl).toContain('all-users');
+    expect(selectWingetInstaller(scopedInstallers, 'x64')?.InstallerUrl).toContain('all-users');
+  });
+
+  it('falls back to user scope when no machine or unspecified-scope installer exists', () => {
+    const userInstaller = {
+      Architecture: 'x64',
+      Scope: 'user',
+      InstallerUrl: 'https://example.test/current-user.exe',
+    };
+
+    expect(selectQaVmInstaller([userInstaller])?.installer).toBe(userInstaller);
+  });
+
   it('accepts and uppercases only complete SHA-256 values', () => {
     expect(normalizeInstallerSha256('a'.repeat(64))).toBe('A'.repeat(64));
     expect(normalizeInstallerSha256('abc')).toBe('');

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -19,6 +19,18 @@ export interface QaInstallerSelection {
 
 const SUPPORTED_ARCHITECTURES = new Set(['x64', 'x86', 'arm64']);
 
+function preferredScopeInstaller(
+  installers: WingetInstallerCandidate[]
+): WingetInstallerCandidate | null {
+  return (
+    installers.find((installer) => installer.Scope?.trim().toLowerCase() === 'machine') ||
+    installers.find((installer) => !installer.Scope?.trim()) ||
+    installers.find((installer) => installer.Scope?.trim().toLowerCase() === 'user') ||
+    installers[0] ||
+    null
+  );
+}
+
 export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 'arm64' {
   const normalized = value?.trim().toLowerCase();
   return SUPPORTED_ARCHITECTURES.has(normalized || '')
@@ -33,25 +45,35 @@ export function selectWingetInstaller(
 ): WingetInstallerCandidate | null {
   if (!installers?.length) return null;
   const target = normalizeQaArchitecture(architecture);
-  return (
-    installers.find((installer) => installer.Architecture?.toLowerCase() === target) ||
-    installers.find((installer) => installer.Architecture?.toLowerCase() === 'neutral') ||
-    null
+  const exactArchitecture = installers.filter(
+    (installer) => installer.Architecture?.toLowerCase() === target
   );
+  if (exactArchitecture.length) return preferredScopeInstaller(exactArchitecture);
+  const neutral = installers.filter(
+    (installer) => installer.Architecture?.toLowerCase() === 'neutral'
+  );
+  return preferredScopeInstaller(neutral);
 }
 
-/** Select an installer executable by the x64 QA VM (x64/neutral first, then x86). */
+/**
+ * Select an installer for the x64 QA VM. Within each architecture, prefer
+ * machine scope so elevated PSADT execution does not launch a per-user setup.
+ */
 export function selectQaVmInstaller(
   installers: WingetInstallerCandidate[] | null | undefined
 ): QaInstallerSelection | null {
   if (!installers?.length) return null;
-  const x64 = installers.find((installer) => installer.Architecture?.toLowerCase() === 'x64');
+  const x64 = preferredScopeInstaller(
+    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'x64')
+  );
   if (x64) return { installer: x64, architecture: 'x64' };
-  const neutral = installers.find(
-    (installer) => installer.Architecture?.toLowerCase() === 'neutral'
+  const neutral = preferredScopeInstaller(
+    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'neutral')
   );
   if (neutral) return { installer: neutral, architecture: 'x64' };
-  const x86 = installers.find((installer) => installer.Architecture?.toLowerCase() === 'x86');
+  const x86 = preferredScopeInstaller(
+    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'x86')
+  );
   return x86 ? { installer: x86, architecture: 'x86' } : null;
 }
 

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -37,6 +37,7 @@ describe('dispatchQaCandidate', () => {
     expect(body.inputs).toMatchObject({
       app_definition: 'qa/apps/example.app.json',
       candidate_label: 'Example.App 2.0.0 x64',
+      timeout_minutes: '20',
     });
     expect(JSON.parse(body.inputs.candidate_payload)).toMatchObject({
       version: '2.0.0',

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -46,7 +46,7 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
           packageProfileSha256: candidate.package_profile_sha256,
           testConfig: candidate.test_config,
         }),
-        timeout_minutes: '60',
+        timeout_minutes: '20',
       },
     }),
   });


### PR DESCRIPTION
## What changed
- prefer machine-scope WinGet installers within the selected architecture
- cap PSADT vendor install processes at 15 minutes and the complete QA command stage at 20 minutes
- write Inno Setup verbose logs into the PSADT diagnostic log directories
- add installer-selection and dispatch-timeout regression coverage

## Root cause
Microsoft Azure Storage Explorer publishes both per-user and machine-scope x64 Inno installers. QA selected the first x64 entry, which was the per-user `/CURRENTUSER` installer, then waited 30 minutes for an elevated PSADT process that never returned. The Inno log was also written outside the paths collected by failure diagnostics.

## Impact
Fresh catalog QA candidates now prefer the `/ALLUSERS` machine installer when available. Hung vendor installers terminate earlier, and the watchdog receives the Inno log needed for diagnosis.

## Validation
- `npm test` — 59 files, 681 tests passed
- targeted ESLint passed
- PowerShell parser and packager timeout/log-path safeguards passed