### PR TITLE
Pin QA to fixed packager

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -139,7 +139,7 @@ function createSupabaseStub(options: {
   return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
 }
 
-const CURRENT_PACKAGER_COMMIT = '0a6128c63baece425dee66acc643196bbcecf343';
+const CURRENT_PACKAGER_COMMIT = '991986b3071b11438596a9af1fa7875a2e46e810';
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0a6128c63baece425dee66acc643196bbcecf343',
+  packagerCommit: '991986b3071b11438596a9af1fa7875a2e46e810',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## What changed
- pin catalog QA package identities to the packager commit containing machine-scope selection, bounded install timeouts, and collected Inno logs
- update enqueue regression expectations

## Why
The protected QA workflow deliberately rejects candidates built by an unpinned toolchain. This pin makes the Storage Explorer fix effective and causes stale catalog profiles to be rebuilt.

## Validation
- 41 focused tests passed
- targeted ESLint passed