### PR TITLE
Harden QA packaging and live telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
+# Explicitly opt in to publishing the live QA dashboard and VM screenshots.
+# Leave false for ordinary self-hosted/Docker installations.
+QA_LIVE_PUBLIC_ENABLED=false
+
 # ===========================================
 # Microsoft Entra ID Configuration (MSAL)
 # ===========================================

--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -268,8 +268,10 @@ function Get-PSADTAssetFileName {
 }
 
 # Extract config values with defaults
-# Escape special PowerShell characters for embedding in generated script
-$silentSwitchesEscaped = $SilentSwitches -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+# This value is embedded in a single-quoted string in the generated script.
+# Only a single quote needs escaping; changing backticks or dollar signs would
+# silently change valid vendor arguments.
+$silentSwitchesEscaped = $SilentSwitches -replace "'", "''"
 $uninstallCmd = $UninstallCommand -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
@@ -933,17 +935,13 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
     if ($installerTypeLower -eq 'inno') {
         $innoSwitches = $SilentSwitches.Trim()
         if ($innoSwitches -notmatch '(?i)(^|\s)/SP-(\s|$)') { $innoSwitches = "$innoSwitches /SP-".Trim() }
-        $innoSwitchesEscaped = $innoSwitches -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
-        $innoLogPathExpression = if ($IsUserScope) {
-            "(Join-Path `$env:LOCALAPPDATA 'IntuneGet\Logs\IntuneGet-Inno-Install.log')"
-        } else {
-            "(Join-Path `$env:WINDIR 'Logs\Software\IntuneGet-Inno-Install.log')"
-        }
-        $lines += @(
-            "    `$installerArguments = '$innoSwitchesEscaped /LOG=`"{0}`"' -f $innoLogPathExpression"
-            '    Write-ADTLogEntry -Message "Inno Setup verbose logging enabled" -Severity ''Info'' -Source ''Install-ADTDeployment'''
-        )
-        $installerArgumentList = '$installerArguments'
+        # Keep automatic observability out of the vendor command line. Some Inno
+        # packages fail during initialization when an injected /LOG target cannot
+        # be created or when vendor code rejects an otherwise valid extra switch.
+        # User-provided switches remain byte-for-byte authoritative apart from the
+        # idempotent /SP- safety switch and PowerShell single-quote encoding.
+        $innoSwitchesEscaped = $innoSwitches -replace "'", "''"
+        $installerArgumentList = "'$innoSwitchesEscaped'"
     }
     switch ($installerTypeLower) {
         { $_ -in 'msi', 'wix' } {

--- a/app/(marketing)/qa/page.tsx
+++ b/app/(marketing)/qa/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 import { T } from 'gt-next';
 import { Header } from '@/components/landing/Header';
 import { Footer } from '@/components/landing/sections/Footer';
 import { QaLiveClient } from './QaLiveClient';
+import { isQaLivePublicEnabled } from '@/lib/qa/public-access';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,7 +24,10 @@ const breadcrumbJsonLd = {
   ],
 };
 
-export default function QaPage() {
+export default async function QaPage() {
+  const host = (await headers()).get('host');
+  if (!isQaLivePublicEnabled(host)) notFound();
+
   return (
     <div className="flex min-h-screen flex-col bg-bg-deepest">
       <Header />

--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { rpcMock, createServerClientMock, applyRateLimitMock, applyStrictRateLimitMock } = vi.hoisted(() => {
   const rpc = vi.fn();
@@ -25,7 +25,33 @@ const candidateId = '11111111-1111-4111-8111-111111111111';
 
 describe('/api/qa/live/frame ingest boundary', () => {
   beforeEach(() => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'true');
     vi.clearAllMocks();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('is unavailable unless the operator explicitly enables public QA', async () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'false');
+    const response = await GET(new Request(
+      `https://www.intuneget.com/api/qa/live/frame?candidate=${candidateId}&sequence=1`
+    ));
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toContain('no-store');
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects ingest and cleanup while public QA is disabled', async () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'false');
+    const [postResponse, deleteResponse] = await Promise.all([
+      POST(new Request('https://www.intuneget.com/api/qa/live/frame', { method: 'POST' })),
+      DELETE(new Request('https://www.intuneget.com/api/qa/live/frame', { method: 'DELETE' })),
+    ]);
+    expect(postResponse.status).toBe(404);
+    expect(deleteResponse.status).toBe(404);
+    expect(postResponse.headers.get('cache-control')).toContain('no-store');
+    expect(deleteResponse.headers.get('cache-control')).toContain('no-store');
+    expect(createServerClientMock).not.toHaveBeenCalled();
   });
 
   it('rejects malformed frame metadata before reading or storing the body', async () => {
@@ -121,6 +147,7 @@ describe('/api/qa/live/frame ingest boundary', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('x-qa-frame-sequence')).toBe('42');
+    expect(response.headers.get('cache-control')).toBe('private, no-store, max-age=0');
   });
 
   it('returns a quiet 404 when cleanup removes the object after metadata is read', async () => {

--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -8,6 +8,7 @@ import {
   QA_LIVE_INGEST_RATE_LIMIT,
 } from '@/lib/rate-limit';
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
+import { isQaLivePublicEnabled } from '@/lib/qa/public-access';
 
 export const dynamic = 'force-dynamic';
 const BUCKET = 'qa-live-frames';
@@ -24,7 +25,7 @@ function noStoreHeaders(extra: Record<string, string> = {}): Record<string, stri
 
 function frameHeaders(extra: Record<string, string> = {}): Record<string, string> {
   return {
-    'Cache-Control': 'public, max-age=0, s-maxage=2, stale-while-revalidate=5',
+    'Cache-Control': 'private, no-store, max-age=0',
     'X-Content-Type-Options': 'nosniff',
     ...extra,
   };
@@ -72,6 +73,9 @@ async function authorizeCleanup(request: Request) {
 }
 
 export async function GET(request: Request) {
+  if (!isQaLivePublicEnabled(new URL(request.url).hostname)) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: noStoreHeaders() });
+  }
   const rateLimitResponse = await applyRateLimit(`qa-frame:${getIpKey(request)}`, QA_LIVE_FRAME_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;
 
@@ -137,6 +141,9 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  if (!isQaLivePublicEnabled(new URL(request.url).hostname)) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: noStoreHeaders() });
+  }
   const rateLimitResponse = await applyStrictRateLimit(`qa-frame-ingest:${getIpKey(request)}`, QA_LIVE_INGEST_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;
 
@@ -222,6 +229,9 @@ export async function POST(request: Request) {
 }
 
 export async function DELETE(request: Request) {
+  if (!isQaLivePublicEnabled(new URL(request.url).hostname)) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: noStoreHeaders() });
+  }
   const rateLimitResponse = await applyStrictRateLimit(`qa-frame-cleanup:${getIpKey(request)}`, QA_LIVE_INGEST_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;
 

--- a/app/api/qa/live/route.test.ts
+++ b/app/api/qa/live/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 const { getQaLiveSnapshotMock, applyRateLimitMock } = vi.hoisted(() => ({
@@ -17,8 +17,19 @@ import { GET } from './route';
 
 describe('GET /api/qa/live', () => {
   beforeEach(() => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'true');
     applyRateLimitMock.mockReset().mockResolvedValue(null);
     getQaLiveSnapshotMock.mockReset().mockResolvedValue({ active: false, current: null });
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('is unavailable unless the operator explicitly enables public QA', async () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'false');
+    const response = await GET(new NextRequest('http://localhost/api/qa/live'));
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toContain('no-store');
+    expect(getQaLiveSnapshotMock).not.toHaveBeenCalled();
   });
 
   it('is never cached', async () => {

--- a/app/api/qa/live/route.ts
+++ b/app/api/qa/live/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server';
 import { getQaLiveSnapshot } from '@/lib/qa/live';
 import { applyRateLimit, getIpKey, QA_LIVE_RATE_LIMIT } from '@/lib/rate-limit';
+import { isQaLivePublicEnabled } from '@/lib/qa/public-access';
 
 export const dynamic = 'force-dynamic';
 export async function GET(request: Request) {
+  if (!isQaLivePublicEnabled(new URL(request.url).hostname)) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: { 'Cache-Control': 'private, no-store' } });
+  }
   const rateLimitResponse = await applyRateLimit(`qa-live:${getIpKey(request)}`, QA_LIVE_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-}
       - NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-}
+      - QA_LIVE_PUBLIC_ENABLED=${QA_LIVE_PUBLIC_ENABLED:-false}
 
       # ===========================================
       # Microsoft Entra ID (Required)

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const packager = readFileSync(
+  resolve(process.cwd(), '.github/scripts/Create-PSADTPackage.ps1'),
+  'utf8'
+);
+
+describe('PSADT Inno packaging contract', () => {
+  it('does not inject diagnostic switches into the vendor command line', () => {
+    const innoBlock = packager.slice(
+      packager.indexOf("if ($installerTypeLower -eq 'inno')"),
+      packager.indexOf('switch ($installerTypeLower)')
+    );
+
+    expect(innoBlock).not.toContain('/LOG=');
+    expect(innoBlock).not.toContain('IntuneGet-Inno-Install.log');
+    expect(innoBlock).toContain("$installerArgumentList = \"'$innoSwitchesEscaped'\"");
+  });
+
+  it('keeps the startup-prompt suppression idempotent without format-string expansion', () => {
+    const innoBlock = packager.slice(
+      packager.indexOf("if ($installerTypeLower -eq 'inno')"),
+      packager.indexOf('switch ($installerTypeLower)')
+    );
+
+    expect(innoBlock).toContain("$innoSwitches -notmatch '(?i)(^|\\s)/SP-(\\s|$)'");
+    expect(innoBlock).not.toMatch(/\s-f\s/);
+    expect(innoBlock).not.toContain("-replace '`', '``'");
+    expect(innoBlock).not.toContain("-replace '\\$', '`$'");
+  });
+});
+
+describe('PSADT vendor argument contract', () => {
+  it('does not rewrite dollar signs or backticks in generic silent switches', () => {
+    expect(packager).toContain('$silentSwitchesEscaped = $SilentSwitches -replace "\'", "\'\'"');
+    const assignment = packager.match(/^\$silentSwitchesEscaped\s*=.*$/m)?.[0] ?? '';
+    expect(assignment).not.toContain("-replace '`'");
+    expect(assignment).not.toContain("-replace '\\$'");
+  });
+});

--- a/lib/qa/public-access.test.ts
+++ b/lib/qa/public-access.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isQaLivePublicEnabled } from './public-access';
+
+describe('public QA access policy', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('allows the canonical production host when no override exists', () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', undefined);
+    expect(isQaLivePublicEnabled('www.intuneget.com')).toBe(true);
+  });
+
+  it('keeps non-canonical self-hosts disabled by default', () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', undefined);
+    expect(isQaLivePublicEnabled('localhost:3000')).toBe(false);
+    expect(isQaLivePublicEnabled('intuneget.internal')).toBe(false);
+  });
+
+  it('honors explicit operator overrides before hostname defaults', () => {
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'false');
+    expect(isQaLivePublicEnabled('www.intuneget.com')).toBe(false);
+    vi.stubEnv('QA_LIVE_PUBLIC_ENABLED', 'true');
+    expect(isQaLivePublicEnabled('localhost:3000')).toBe(true);
+  });
+});

--- a/lib/qa/public-access.ts
+++ b/lib/qa/public-access.ts
@@ -1,0 +1,18 @@
+/**
+ * The live QA dashboard exposes short-lived screenshots from a real test VM.
+ * Keep it disabled for self-hosted installations unless the operator makes a
+ * deliberate decision to publish that telemetry.
+ */
+const CANONICAL_PUBLIC_HOSTS = new Set(['intuneget.com', 'www.intuneget.com']);
+
+export function isQaLivePublicEnabled(host?: string | null): boolean {
+  const configured = process.env.QA_LIVE_PUBLIC_ENABLED;
+  if (configured === 'true') return true;
+  if (configured === 'false') return false;
+
+  // Keep the first-party dashboard live without requiring a deployment-time
+  // flag. Docker explicitly supplies false, and non-canonical self-hosts stay
+  // disabled unless their operator opts in.
+  const hostname = host?.split(':', 1)[0]?.toLowerCase();
+  return Boolean(hostname && CANONICAL_PUBLIC_HOSTS.has(hostname));
+}


### PR DESCRIPTION
## What changed

- preserves literal vendor installer arguments and removes automatic Inno `/LOG` injection
- adds regression coverage for PSADT package generation
- makes public QA telemetry opt-in for self-hosted deployments while keeping the canonical IntuneGet dashboard available
- prevents browser and CDN caching of VM screenshots

## Why

OpenPnt exposed a packaging regression where diagnostic arguments changed the vendor command. The public QA feed also needed an explicit self-hosted security boundary.

## Validation

- 19 targeted Vitest tests
- ESLint
- complete Next.js production build
- Claude Code Fable focused review