### PR TITLE
Align QA package profile pin

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -139,7 +139,7 @@ function createSupabaseStub(options: {
   return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
 }
 
-const CURRENT_PACKAGER_COMMIT = '991986b3071b11438596a9af1fa7875a2e46e810';
+const CURRENT_PACKAGER_COMMIT = '3fc86a5a4224986dcd34c4270f0a4d5c919651a2';
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '991986b3071b11438596a9af1fa7875a2e46e810',
+  packagerCommit: '3fc86a5a4224986dcd34c4270f0a4d5c919651a2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## What changed

Updates the website-side QA package identity to the fixed IntuneGet packager commit `3fc86a5a4224986dcd34c4270f0a4d5c919651a2` and updates regression fixtures.

## Why

Without this companion pin, the poller continued to generate stale candidate profiles even after the workflow switched to the fixed packager.

## Validation

- 43 focused package-profile, enqueue, and dispatch tests
- ESLint
- repository pre-push lint