### PR TITLE
Widen QA preview and authenticate manifest reads

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -267,7 +267,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           <div className="h-full rounded-full bg-accent-cyan transition-[width] duration-500 motion-reduce:transition-none" style={{ width: `${phase.progressPercent}%` }} />
         </div>
 
-        <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(340px,2fr)]">
+        <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,5fr)_minmax(320px,2fr)] xl:grid-cols-[minmax(0,7fr)_minmax(360px,3fr)]">
           <div className="-mx-5 w-[calc(100%+2.5rem)] overflow-hidden border-y border-overlay/10 bg-black sm:mx-0 sm:w-auto sm:rounded-xl sm:border" aria-labelledby="live-console-heading">
             <div className="flex items-center justify-between border-b border-white/10 bg-bg-surface/80 px-4 py-3">
               <div className="flex min-w-0 items-center gap-2">

--- a/app/(marketing)/qa/page.tsx
+++ b/app/(marketing)/qa/page.tsx
@@ -32,7 +32,7 @@ export default async function QaPage() {
     <div className="flex min-h-screen flex-col bg-bg-deepest">
       <Header />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-      <main id="main-content" className="mx-auto w-full max-w-7xl flex-1 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
+      <main id="main-content" className="mx-auto w-full max-w-[1600px] flex-1 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
         <div className="mb-8 max-w-3xl space-y-3">
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-accent-cyan"><T>Application quality assurance</T></p>
           <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>See package QA as it happens</T></h1>

--- a/lib/winget-sync-resolution.mjs
+++ b/lib/winget-sync-resolution.mjs
@@ -126,9 +126,16 @@ export function createWingetManifestClient(options = {}) {
   }
 
   async function fetchYamlFile(relativePath) {
-    let text = await requestText(`${rawBase}/${relativePath}`);
+    // Prefer the authenticated Contents API when a token is available. Raw
+    // content requests cannot use that token and share a much smaller IP quota
+    // across all Vercel functions in the region.
+    let text = token
+      ? await fetchContentsFile(relativePath)
+      : await requestText(`${rawBase}/${relativePath}`);
     if (text === null) {
-      text = await fetchContentsFile(relativePath);
+      text = token
+        ? await requestText(`${rawBase}/${relativePath}`)
+        : await fetchContentsFile(relativePath);
     }
     if (text === null) return null;
 

--- a/lib/winget-sync-resolution.test.ts
+++ b/lib/winget-sync-resolution.test.ts
@@ -85,6 +85,29 @@ describe('resolveWingetManifest', () => {
       .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
   });
 
+  it('uses the authenticated Contents API before the anonymous raw endpoint', async () => {
+    const yaml = [
+      'PackageIdentifier: Example.App',
+      'PackageVersion: 1.0.0',
+      'ManifestType: installer',
+      'Installers:',
+      '- Architecture: x64',
+      '  InstallerUrl: https://example.test/app.exe',
+    ].join('\n');
+    const apiPayload = JSON.stringify({
+      encoding: 'base64',
+      content: Buffer.from(yaml).toString('base64'),
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(apiPayload, { status: 200 }));
+    const client = createWingetManifestClient({ token: 'secret-token', fetchImpl, maxRetries: 0 });
+
+    await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
+      .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toContain('https://api.github.com/');
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('Bearer secret-token');
+  });
+
   it('treats exhausted rate limits as operational errors', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
     const client = createWingetManifestClient({ fetchImpl, maxRetries: 0 });
@@ -107,7 +130,6 @@ describe('resolveWingetManifest', () => {
       content: Buffer.from(yaml).toString('base64'),
     });
     const fetchImpl = vi.fn()
-      .mockResolvedValueOnce(new Response('', { status: 404 }))
       .mockResolvedValueOnce(new Response('', {
         status: 403,
         headers: { 'x-ratelimit-remaining': '0' },
@@ -117,8 +139,8 @@ describe('resolveWingetManifest', () => {
 
     await expect(resolveWingetManifest({ client, wingetId: 'Example.App', storedVersion: '1.0.0' }))
       .resolves.toMatchObject({ status: 'resolved', version: '1.0.0' });
-    expect(fetchImpl.mock.calls[1][1].headers.Authorization).toBe('Bearer secret-token');
-    expect(fetchImpl.mock.calls[2][1].headers.Authorization).toBeUndefined();
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('Bearer secret-token');
+    expect(fetchImpl.mock.calls[1][1].headers.Authorization).toBeUndefined();
   });
 
   it('treats invalid YAML as an operational error', async () => {


### PR DESCRIPTION
## Summary
- widen the desktop QA page to 1600px and give the VM preview roughly 70% of the live split
- prefer authenticated GitHub Contents API reads for WinGet YAML manifests when the configured PAT is available
- retain anonymous fallback behavior and add coverage for authenticated-first reads

## Root cause
The QA scheduler's degraded state came from repeated HTTP 429 responses from raw.githubusercontent.com. The poller used the anonymous raw endpoint first even with GITHUB_PAT configured.

## Verification
- 22 focused Vitest tests passed
- ESLint passed for all changed files
- Next.js production build passed
- React review: layout-only class changes; no hook, accessibility, serialization, or bundle regressions