### PR TITLE
Add demand-driven PSADT QA gating

### DIFF
--- a/app/(app)/dashboard/uploads/page.tsx
+++ b/app/(app)/dashboard/uploads/page.tsx
@@ -23,6 +23,7 @@ import {
   UserCircle,
   Trash2,
   AlertTriangle,
+  ShieldCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -56,7 +57,7 @@ interface PackagingJob {
   architecture: string;
   installer_type: string;
   app_source?: 'win32' | 'store';
-  status: 'queued' | 'packaging' | 'completed' | 'failed' | 'uploading' | 'deployed' | 'cancelled' | 'duplicate_skipped';
+  status: 'awaiting_qa' | 'qa_failed' | 'queued' | 'packaging' | 'completed' | 'failed' | 'uploading' | 'deployed' | 'cancelled' | 'duplicate_skipped';
   status_message?: string;
   progress_percent: number;
   error_message?: string;
@@ -190,7 +191,7 @@ export default function UploadsPage() {
   // background poll less often and a manual refresh remains available.
   useEffect(() => {
     const hasActiveJobs = jobs.some((job) =>
-      ['queued', 'packaging', 'uploading'].includes(job.status)
+      ['awaiting_qa', 'queued', 'packaging', 'uploading'].includes(job.status)
     );
 
     if (!hasActiveJobs || sessionExpired) return;
@@ -344,7 +345,7 @@ export default function UploadsPage() {
   const filteredJobs = jobs.filter((job) => {
     switch (filter) {
       case 'active':
-        return ['queued', 'packaging', 'uploading'].includes(job.status);
+        return ['awaiting_qa', 'queued', 'packaging', 'uploading'].includes(job.status);
       case 'completed':
         return ['completed', 'deployed', 'duplicate_skipped'].includes(job.status);
       case 'failed':
@@ -357,10 +358,10 @@ export default function UploadsPage() {
   const stats = {
     total: jobs.length,
     active: jobs.filter((j) =>
-      ['queued', 'packaging', 'uploading'].includes(j.status)
+      ['awaiting_qa', 'queued', 'packaging', 'uploading'].includes(j.status)
     ).length,
     completed: jobs.filter((j) => ['completed', 'deployed', 'duplicate_skipped'].includes(j.status)).length,
-    failed: jobs.filter((j) => j.status === 'failed').length,
+    failed: jobs.filter((j) => ['qa_failed', 'failed'].includes(j.status)).length,
   };
 
   const filterButtons = ['all', 'active', 'completed', 'failed'] as const;
@@ -662,6 +663,20 @@ function UploadJobCard({
   const prefersReducedMotion = useReducedMotion();
 
   const statusConfig = {
+    awaiting_qa: {
+      icon: ShieldCheck,
+      label: 'Awaiting QA',
+      color: 'text-accent-violet',
+      bg: 'bg-accent-violet/10',
+      border: 'border-l-accent-violet',
+    },
+    qa_failed: {
+      icon: XCircle,
+      label: 'QA failed',
+      color: 'text-status-error',
+      bg: 'bg-status-error/10',
+      border: 'border-l-status-error',
+    },
     queued: {
       icon: Clock,
       label: 'Queued',
@@ -722,11 +737,11 @@ function UploadJobCard({
 
   const config = statusConfig[job.status] || statusConfig.queued;
   const StatusIcon = config.icon;
-  const isActive = ['queued', 'packaging', 'uploading'].includes(job.status);
-  const isStale = isActive && (Date.now() - new Date(job.updated_at).getTime()) > 75 * 60 * 1000;
+  const isActive = ['awaiting_qa', 'queued', 'packaging', 'uploading'].includes(job.status);
+  const isStale = job.status !== 'awaiting_qa' && isActive && (Date.now() - new Date(job.updated_at).getTime()) > 75 * 60 * 1000;
   // Allow cancelling active jobs or dismissing completed/failed jobs
-  const isCancellable = ['queued', 'packaging', 'uploading'].includes(job.status);
-  const isDismissable = ['completed', 'failed', 'duplicate_skipped', 'deployed'].includes(job.status);
+  const isCancellable = ['awaiting_qa', 'queued', 'packaging', 'uploading'].includes(job.status);
+  const isDismissable = ['qa_failed', 'completed', 'failed', 'duplicate_skipped', 'deployed'].includes(job.status);
   const canRemove = isCancellable || isDismissable;
 
   const itemVariants = {
@@ -908,15 +923,21 @@ function UploadJobCard({
           </div>
 
           {/* Progress Stepper for active and failed jobs */}
-          {(isActive || job.status === 'failed') && (
+          {((isActive && job.status !== 'awaiting_qa') || job.status === 'failed' || job.status === 'qa_failed') && (
             <ProgressStepper
               progress={job.progress_percent}
               status={job.status}
               statusMessage={job.status_message}
               startTime={job.packaging_started_at || job.created_at}
-              endTime={job.status === 'failed' ? job.completed_at : null}
+              endTime={['failed', 'qa_failed'].includes(job.status) ? job.completed_at : null}
               errorStage={job.error_stage}
             />
+          )}
+
+          {job.status === 'awaiting_qa' && (
+            <div className="mt-4 rounded-lg border border-accent-violet/20 bg-accent-violet/5 p-3 text-sm text-text-secondary">
+              {job.status_message || 'This exact PSADT execution profile is queued for isolated QA. Packaging resumes automatically after it passes.'}
+            </div>
           )}
 
           <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
@@ -924,9 +945,9 @@ function UploadJobCard({
           </div>
 
           {/* Error message */}
-          {job.status === 'failed' && (job.error_message || job.error_code) && (
+          {['failed', 'qa_failed'].includes(job.status) && (job.error_message || job.error_code || job.status_message) && (
             <ErrorDisplay
-              errorMessage={job.error_message}
+              errorMessage={job.error_message || job.status_message}
               errorStage={job.error_stage}
               errorCategory={job.error_category}
               errorCode={job.error_code}
@@ -935,7 +956,7 @@ function UploadJobCard({
           )}
 
           {/* Retry button for failures */}
-          {job.status === 'failed' && (
+          {['failed', 'qa_failed'].includes(job.status) && (
             <div className="mt-3">
               <Button
                 size="sm"

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -113,6 +113,12 @@ function createSupabaseStub(options: {
       if (table === 'qa_recipes') {
         return query({ data: options.recipes || [], error: null });
       }
+      if (table === 'upload_history') {
+        return query({
+          data: (options.supportedApps || []).map((app) => ({ winget_id: app.winget_id })),
+          error: null,
+        });
+      }
       if (table === 'app_update_policies' || table === 'qa_results') {
         return query({ data: [], error: null });
       }
@@ -418,7 +424,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     );
     expect(canonical.psadtConfig).toMatchObject({
       deployMode: 'Auto',
-      progressDialog: { enabled: true, windowLocation: 'BottomRight' },
+      progressDialog: { enabled: true },
     });
   });
 

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -112,20 +112,44 @@ async function findToolchainBackfillIds(
     }
 
     if (pageStaleIds.length > 0) {
-      const { data: supported, error: supportedError } = await supabase
-        .from('curated_apps')
-        .select('winget_id')
-        .in('winget_id', pageStaleIds)
-        .eq('is_verified', true)
-        .eq('is_winget_verified', true)
-        .eq('app_source', 'win32')
-        .eq('is_locale_variant', false);
+      const [supportedResult, policyResult, deployedResult] = await Promise.all([
+        supabase
+          .from('curated_apps')
+          .select('winget_id')
+          .in('winget_id', pageStaleIds)
+          .eq('is_verified', true)
+          .eq('is_winget_verified', true)
+          .eq('app_source', 'win32')
+          .eq('is_locale_variant', false),
+        supabase
+          .from('app_update_policies')
+          .select('winget_id')
+          .in('winget_id', pageStaleIds)
+          .eq('policy_type', 'auto_update')
+          .eq('is_enabled', true),
+        supabase
+          .from('upload_history')
+          .select('winget_id')
+          .in('winget_id', pageStaleIds),
+      ]);
+      const { data: supported, error: supportedError } = supportedResult;
       if (supportedError) {
         throw new Error(`Could not filter QA toolchain backfill apps: ${supportedError.message}`);
       }
+      if (policyResult.error || deployedResult.error) {
+        throw new Error(
+          `Could not filter QA toolchain backfill demand: ${policyResult.error?.message || deployedResult.error?.message}`
+        );
+      }
       const supportedIds = new Set((supported || []).map((app) => app.winget_id));
+      const demandedIds = new Set([
+        ...(policyResult.data || []).map((row) => row.winget_id),
+        ...(deployedResult.data || []).map((row) => row.winget_id),
+      ]);
       for (const wingetId of pageStaleIds) {
-        if (supportedIds.has(wingetId)) supportedStaleIds.push(wingetId);
+        if (supportedIds.has(wingetId) && demandedIds.has(wingetId)) {
+          supportedStaleIds.push(wingetId);
+        }
       }
     }
 
@@ -306,9 +330,6 @@ export async function GET(request: Request) {
       if (error) throw new Error(`Could not filter changed WinGet packages: ${error.message}`);
       supportedApps = data || [];
     }
-    supportedChangedCount = supportedApps.filter((app) => changedIds.has(app.winget_id)).length;
-    toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
-
     const supportedIds = supportedApps.map((app) => app.winget_id);
     let recipes: Array<{
       winget_id: string;
@@ -317,6 +338,7 @@ export async function GET(request: Request) {
       installer_type: string;
     }> = [];
     let policies: Array<{ winget_id: string }> = [];
+    let deployedApps: Array<{ winget_id: string }> = [];
     let results: Array<{
       winget_id: string;
       tested_version: string;
@@ -328,7 +350,7 @@ export async function GET(request: Request) {
       package_profile_sha256: string | null;
     }> = [];
     if (supportedIds.length > 0) {
-      const [recipeResult, policyResult, resultResult] = await Promise.all([
+      const [recipeResult, policyResult, deployedResult, resultResult] = await Promise.all([
         supabase
           .from('qa_recipes')
           .select('winget_id, definition_path, architecture, installer_type')
@@ -340,6 +362,10 @@ export async function GET(request: Request) {
           .in('winget_id', supportedIds)
           .eq('policy_type', 'auto_update')
           .eq('is_enabled', true),
+        supabase
+          .from('upload_history')
+          .select('winget_id')
+          .in('winget_id', supportedIds),
         supabase
           .from('qa_results')
           .select(
@@ -353,11 +379,15 @@ export async function GET(request: Request) {
       if (policyResult.error) {
         throw new Error(`Could not prioritize QA candidates: ${policyResult.error.message}`);
       }
+      if (deployedResult.error) {
+        throw new Error(`Could not read deployed-app QA demand: ${deployedResult.error.message}`);
+      }
       if (resultResult.error) {
         throw new Error(`Could not read existing QA results: ${resultResult.error.message}`);
       }
       recipes = recipeResult.data || [];
       policies = policyResult.data || [];
+      deployedApps = deployedResult.data || [];
       results = resultResult.data || [];
     }
 
@@ -365,6 +395,14 @@ export async function GET(request: Request) {
     for (const policy of policies) {
       priorities.set(policy.winget_id, (priorities.get(policy.winget_id) || 0) + 1);
     }
+    const demandedIds = new Set<string>(policies.map((policy) => policy.winget_id));
+    for (const deployed of deployedApps) {
+      demandedIds.add(deployed.winget_id);
+      if (!priorities.has(deployed.winget_id)) priorities.set(deployed.winget_id, 1);
+    }
+    supportedApps = supportedApps.filter((app) => demandedIds.has(app.winget_id));
+    supportedChangedCount = supportedApps.filter((app) => changedIds.has(app.winget_id)).length;
+    toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
     const recipeById = new Map(recipes.map((row) => [row.winget_id, row]));
     const resultById = new Map(results.map((row) => [row.winget_id, row]));
     const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
@@ -477,6 +515,9 @@ export async function GET(request: Request) {
                 catalog_version_at_enqueue: app.latest_version,
                 status: initialStatus,
                 priority: priorities.get(app.winget_id) || 0,
+                demand_source: policies.some((policy) => policy.winget_id === app.winget_id)
+                  ? 'auto_update'
+                  : 'managed',
                 finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
                 updated_at: now,
               })

--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createServerClientMock, getFeatureFlagsMock } = vi.hoisted(() => ({
+  createServerClientMock: vi.fn(),
+  getFeatureFlagsMock: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
+vi.mock('@/lib/features', () => ({ getFeatureFlags: getFeatureFlagsMock }));
+vi.mock('@/lib/config', () => ({ getAppConfig: () => ({ app: { url: 'https://example.test' } }) }));
+vi.mock('@/lib/github-actions', () => ({ triggerPackagingWorkflow: vi.fn() }));
+
+import { GET } from './route';
+
+function chain(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'not', 'order', 'limit', 'update']) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.maybeSingle = vi.fn(async () => result);
+  builder.then = (resolve: (value: typeof result) => unknown) => Promise.resolve(result).then(resolve);
+  return builder;
+}
+
+describe('GET /api/cron/qa-resume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = 'secret';
+    getFeatureFlagsMock.mockReturnValue({ localPackager: true });
+  });
+
+  it('atomically releases a waiting local-packager job after an exact QA pass', async () => {
+    const job = {
+      id: 'job-1',
+      qa_candidate_id: 'candidate-1',
+      execution_profile_sha256: 'A'.repeat(64),
+      created_at: '2026-08-09T12:00:00Z',
+    };
+    const packagingUpdate = chain({ data: { id: 'job-1' }, error: null });
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          if (client.from.mock.calls.filter(([name]) => name === 'packaging_jobs').length === 1) {
+            return chain({ data: [job], error: null });
+          }
+          return packagingUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-1',
+              status: 'passed',
+              failure_summary: null,
+              package_profile_sha256: 'A'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        if (table === 'qa_package_results') {
+          return chain({ data: { outcome: 'Passed' }, error: null });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 1, failed: 0, waiting: 0 });
+    expect(packagingUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'queued',
+      qa_completed_at: expect.any(String),
+    }));
+  });
+});

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase';
+import { getFeatureFlags } from '@/lib/features';
+import { getAppConfig } from '@/lib/config';
+import { buildIntuneAppDescription } from '@/lib/intune-description';
+import { extractSilentSwitches } from '@/lib/msp/silent-switches';
+import { triggerPackagingWorkflow, type WorkflowInputs } from '@/lib/github-actions';
+import type { Win32CartItem } from '@/types/upload';
+
+const RESUME_BATCH_SIZE = 25;
+
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createServerClient();
+  const { data: jobs, error: jobsError } = await supabase
+    .from('packaging_jobs')
+    .select('*')
+    .eq('status', 'awaiting_qa')
+    .not('qa_candidate_id', 'is', null)
+    .order('created_at', { ascending: true })
+    .limit(RESUME_BATCH_SIZE);
+  if (jobsError) throw new Error(`Could not read QA-waiting jobs: ${jobsError.message}`);
+
+  const features = getFeatureFlags();
+  const config = getAppConfig();
+  const baseUrl = config.app.url || (process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'http://localhost:3000');
+  const callbackUrl = `${baseUrl}/api/package/callback`;
+  let resumed = 0;
+  let failed = 0;
+  let waiting = 0;
+
+  for (const job of jobs || []) {
+    const { data: candidate, error: candidateError } = await supabase
+      .from('qa_candidates')
+      .select('id, status, failure_summary, package_profile_sha256')
+      .eq('id', job.qa_candidate_id!)
+      .maybeSingle();
+    if (candidateError) throw candidateError;
+    if (!candidate || ['failed', 'error'].includes(candidate.status)) {
+      const now = new Date().toISOString();
+      const { data: updated } = await supabase
+        .from('packaging_jobs')
+        .update({
+          status: 'qa_failed',
+          status_message: candidate?.failure_summary || 'The required QA run could not complete.',
+          error_code: 'QA_FAILED_EXECUTION_PROFILE',
+          error_stage: 'validation',
+          error_category: 'installer',
+          qa_completed_at: now,
+          completed_at: now,
+        })
+        .eq('id', job.id)
+        .eq('status', 'awaiting_qa')
+        .select('id')
+        .maybeSingle();
+      if (updated) failed++;
+      continue;
+    }
+    if (candidate.status !== 'passed') {
+      waiting++;
+      continue;
+    }
+
+    const { data: result, error: resultError } = await supabase
+      .from('qa_package_results')
+      .select('outcome')
+      .eq('package_profile_sha256', job.execution_profile_sha256!)
+      .maybeSingle();
+    if (resultError) throw resultError;
+    if (result?.outcome !== 'Passed') {
+      waiting++;
+      continue;
+    }
+
+    const now = new Date().toISOString();
+    const nextStatus = features.localPackager ? 'queued' : 'packaging';
+    const { data: claimed, error: claimError } = await supabase
+      .from('packaging_jobs')
+      .update({
+        status: nextStatus,
+        status_message: 'QA passed; packaging resumed automatically',
+        qa_completed_at: now,
+        packaging_started_at: features.localPackager ? null : now,
+      })
+      .eq('id', job.id)
+      .eq('status', 'awaiting_qa')
+      .select('id')
+      .maybeSingle();
+    if (claimError) throw claimError;
+    if (!claimed) continue;
+
+    if (features.localPackager) {
+      resumed++;
+      continue;
+    }
+
+    try {
+      const item = job.package_config as unknown as Win32CartItem;
+      const installerSha256 = job.installer_sha256 || '';
+      const workflowInputs: WorkflowInputs = {
+        jobId: job.id,
+        tenantId: job.tenant_id || '',
+        wingetId: job.winget_id,
+        displayName: job.display_name,
+        description: buildIntuneAppDescription({
+          description: item.description,
+          fallback: `Deployed via IntuneGet from Winget: ${job.winget_id}`,
+        }),
+        publisher: job.publisher || item.publisher || 'Unknown Publisher',
+        version: job.version,
+        architecture: job.architecture || item.architecture,
+        installerUrl: job.installer_url || item.installerUrl,
+        installerSha256,
+        hashValidationMode: 'strict',
+        installerType: job.installer_type || item.installerType,
+        nestedInstallerType: item.nestedInstallerType,
+        nestedInstallerPath: item.nestedInstallerPath,
+        silentSwitches: extractSilentSwitches(
+          job.install_command || item.installCommand,
+          job.installer_type || item.installerType
+        ),
+        uninstallCommand: job.uninstall_command || item.uninstallCommand,
+        callbackUrl,
+        psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,
+        detectionRules: item.detectionRules ? JSON.stringify(item.detectionRules) : undefined,
+        requirementRules: item.requirementRules ? JSON.stringify(item.requirementRules) : undefined,
+        assignments: item.assignments ? JSON.stringify(item.assignments) : undefined,
+        categories: item.categories ? JSON.stringify(item.categories) : undefined,
+        espProfiles: item.espProfiles ? JSON.stringify(item.espProfiles) : undefined,
+        relationships: item.relationships?.length ? JSON.stringify(item.relationships) : undefined,
+        installScope: (job.install_scope || item.installScope) === 'user' ? 'user' : 'machine',
+        forceCreate: item.forceCreate,
+        sourceType: item.sourceType,
+      };
+      const trigger = await triggerPackagingWorkflow(workflowInputs);
+      await supabase
+        .from('packaging_jobs')
+        .update({
+          github_run_id: trigger.runId?.toString() || null,
+          github_run_url: trigger.runUrl || null,
+        })
+        .eq('id', job.id)
+        .eq('status', 'packaging');
+      resumed++;
+    } catch (error) {
+      await supabase
+        .from('packaging_jobs')
+        .update({
+          status: 'failed',
+          status_message: 'QA passed, but automatic packaging resume failed',
+          error_code: 'QA_RESUME_DISPATCH_FAILED',
+          error_stage: 'authenticate',
+          error_category: 'network',
+          error_message: error instanceof Error ? error.message : 'Unknown resume error',
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', job.id)
+        .eq('status', 'packaging');
+      failed++;
+    }
+  }
+
+  return NextResponse.json({ success: true, scanned: jobs?.length || 0, resumed, failed, waiting });
+}

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -16,7 +16,7 @@ const {
   getAppConfigMock,
   getFeatureFlagsMock,
   enforceInstallerPreflightMock,
-  enforceQaGateMock,
+  ensureQaDemandMock,
 } = vi.hoisted(() => ({
   getDatabaseMock: vi.fn(),
   getByUserIdMock: vi.fn(),
@@ -31,7 +31,7 @@ const {
   getAppConfigMock: vi.fn(),
   getFeatureFlagsMock: vi.fn(),
   enforceInstallerPreflightMock: vi.fn(),
-  enforceQaGateMock: vi.fn(),
+  ensureQaDemandMock: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -71,13 +71,7 @@ vi.mock('@/lib/installer-preflight', async (importOriginal) => {
   };
 });
 
-vi.mock('@/lib/qa/gate', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/lib/qa/gate')>();
-  return {
-    ...original,
-    enforceQaGate: enforceQaGateMock,
-  };
-});
+vi.mock('@/lib/qa/demand', () => ({ ensureQaDemand: ensureQaDemandMock }));
 
 vi.mock('@/lib/supabase', () => ({
   createServerClient: vi.fn(),
@@ -100,7 +94,6 @@ vi.mock('@/lib/store-app-deploy', () => ({
 
 import { GET, POST } from '@/app/api/package/route';
 import { InstallerPreflightError } from '@/lib/installer-preflight';
-import { QaGateError } from '@/lib/qa/gate';
 
 function makeJob(overrides: Partial<PackagingJob>): PackagingJob {
   const now = new Date().toISOString();
@@ -297,7 +290,15 @@ describe('POST /api/package (workflow dispatch)', () => {
       status: 'healthy',
       source: 'cache',
     });
-    enforceQaGateMock.mockResolvedValue(undefined);
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'passed',
+      candidateId: null,
+      identity: {
+        executionProfileSha256: 'A'.repeat(64),
+        packageProfileSha256: 'A'.repeat(64),
+        presentationProfileSha256: 'B'.repeat(64),
+      },
+    });
   });
 
   it('forwards item relationships into the workflow inputs', async () => {
@@ -341,6 +342,40 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
     expect(triggerPackagingWorkflowMock.mock.calls[0][0].relationships).toBeUndefined();
+  });
+
+  it('parks a customer deployment until its exact execution profile passes QA', async () => {
+    ensureQaDemandMock.mockResolvedValueOnce({
+      state: 'waiting',
+      candidateId: 'candidate-1',
+      identity: {
+        executionProfileSha256: 'A'.repeat(64),
+        packageProfileSha256: 'A'.repeat(64),
+        presentationProfileSha256: 'B'.repeat(64),
+      },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ items: [makeWin32Item()] }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.jobs[0]).toMatchObject({ status: 'awaiting_qa' });
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'awaiting_qa',
+      qa_candidate_id: 'candidate-1',
+      execution_profile_sha256: 'A'.repeat(64),
+      presentation_profile_sha256: 'B'.repeat(64),
+    }));
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
   it('calculates the hash in the workflow for a custom app without a supplied SHA256', async () => {
@@ -478,21 +513,17 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
-  it('returns a rich 409 before creating a job for a failed exact-version QA result', async () => {
-    enforceQaGateMock.mockRejectedValueOnce(new QaGateError({
-      wingetId: 'Test.App',
-      testedVersion: '1.0.0',
-      testedAtUtc: '2026-08-07T12:00:00Z',
-      architecture: 'x64',
-      classification: {
-        signal: 'uninstall_unknown_product',
-        bucket: 'package_definition',
-        confidence: 'high',
-        evidence: 'MSI exit code 1605',
-        remediation: 'Correct the uninstall command.',
-        source: 'heuristic',
+  it('creates an actionable blocked job for a failed execution profile', async () => {
+    ensureQaDemandMock.mockResolvedValueOnce({
+      state: 'failed',
+      candidateId: 'candidate-1',
+      failureSummary: 'Correct the uninstall command.',
+      identity: {
+        executionProfileSha256: 'A'.repeat(64),
+        packageProfileSha256: 'A'.repeat(64),
+        presentationProfileSha256: 'B'.repeat(64),
       },
-    }));
+    });
 
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',
@@ -506,14 +537,13 @@ describe('POST /api/package (workflow dispatch)', () => {
     const response = await POST(request);
     const body = await response.json();
 
-    expect(response.status).toBe(409);
-    expect(body).toMatchObject({
-      code: 'QA_FAILED_CURRENT_VERSION',
-      retryable: false,
-      package: { wingetId: 'Test.App', displayName: 'Test App', version: '1.0.0' },
-      qa: { testedVersion: '1.0.0', architecture: 'x64', classificationBucket: 'package_definition' },
-    });
-    expect(createMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(body.jobs[0]).toMatchObject({ status: 'qa_failed' });
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'qa_failed',
+      qa_candidate_id: 'candidate-1',
+      error_code: 'QA_FAILED_EXECUTION_PROFILE',
+    }));
     expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 });

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -36,7 +36,7 @@ import {
   enforceInstallerPreflight,
   InstallerPreflightError,
 } from '@/lib/installer-preflight';
-import { enforceQaGate, QaGateError } from '@/lib/qa/gate';
+import { ensureQaDemand } from '@/lib/qa/demand';
 
 export const maxDuration = 300;
 
@@ -246,45 +246,6 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Block only a known failed result for the exact version/architecture.
-    // Missing or stale QA data is intentionally non-blocking.
-    for (const item of win32Items) {
-      try {
-        await enforceQaGate({
-          wingetId: item.wingetId,
-          version: item.version,
-          architecture: item.architecture,
-          qaOverride: item.qaOverride,
-          sourceType: item.sourceType,
-        });
-      } catch (error) {
-        if (error instanceof QaGateError) {
-          return NextResponse.json(
-            {
-              error: 'QA testing blocked this deployment',
-              message: error.message,
-              code: error.code,
-              retryable: false,
-              package: {
-                wingetId: item.wingetId,
-                displayName: item.displayName || item.wingetId,
-                version: item.version,
-              },
-              qa: {
-                testedVersion: error.details.testedVersion,
-                testedAtUtc: error.details.testedAtUtc,
-                architecture: error.details.architecture,
-                classificationBucket: error.details.classification.bucket,
-                remediation: error.details.classification.remediation,
-              },
-            },
-            { status: 409 }
-          );
-        }
-        throw error;
-      }
-    }
-
     const jobs: PackagingJobRecord[] = [];
     const errors: { wingetId: string; error: string }[] = [];
 
@@ -436,6 +397,33 @@ export async function POST(request: NextRequest) {
           try {
             const jobId = crypto.randomUUID();
             const installerSha256 = item.installerSha256?.trim() || '';
+            const qaDemand = item.sourceType === 'custom'
+              ? null
+              : await ensureQaDemand(createServerClient(), {
+                  wingetId: item.wingetId,
+                  displayName: item.displayName,
+                  publisher: item.publisher || 'Unknown Publisher',
+                  version: item.version,
+                  architecture: item.architecture,
+                  installerUrl: item.installerUrl,
+                  installerSha256,
+                  installerType: item.installerType,
+                  nestedInstallerType: item.nestedInstallerType,
+                  nestedInstallerPath: item.nestedInstallerPath,
+                  silentSwitches: extractSilentSwitches(item.installCommand, item.installerType),
+                  uninstallCommand: item.uninstallCommand,
+                  installScope: item.installScope,
+                  psadtConfig: JSON.stringify(item.psadtConfig),
+                  detectionRules: JSON.stringify(item.detectionRules || []),
+                  priority: 2000,
+                  demandSource: 'customer',
+                });
+            const initialStatus = qaDemand?.state === 'waiting'
+              ? 'awaiting_qa'
+              : qaDemand?.state === 'failed'
+                ? 'qa_failed'
+                : 'queued';
+            const now = new Date().toISOString();
 
             const jobRecord = await db.jobs.create({
               id: jobId,
@@ -455,8 +443,21 @@ export async function POST(request: NextRequest) {
               install_scope: item.installScope,
               detection_rules: item.detectionRules as unknown as import('@/types/database').Json,
               package_config: item as unknown as import('@/types/database').Json,
-              status: 'queued',
+              status: initialStatus,
+              status_message: qaDemand?.state === 'waiting'
+                ? 'Waiting for isolated QA of this PSADT execution profile'
+                : qaDemand?.state === 'failed'
+                  ? qaDemand.failureSummary
+                  : null,
               progress_percent: 0,
+              execution_profile_sha256: qaDemand?.identity.executionProfileSha256 || null,
+              presentation_profile_sha256: qaDemand?.identity.presentationProfileSha256 || null,
+              qa_candidate_id: qaDemand?.candidateId || null,
+              qa_requested_at: qaDemand ? now : null,
+              qa_completed_at: qaDemand?.state === 'passed' ? now : null,
+              error_code: qaDemand?.state === 'failed' ? 'QA_FAILED_EXECUTION_PROFILE' : null,
+              error_stage: qaDemand?.state === 'failed' ? 'validation' : null,
+              error_category: qaDemand?.state === 'failed' ? 'installer' : null,
             });
 
             if (!jobRecord) {
@@ -464,7 +465,23 @@ export async function POST(request: NextRequest) {
               continue;
             }
 
-            // Local packager mode: leave job in queued state for pickup
+            if (qaDemand?.state === 'waiting' || qaDemand?.state === 'failed') {
+              jobs.push({
+                id: jobId,
+                user_id: userId,
+                tenant_id: tenantId,
+                winget_id: item.wingetId,
+                version: item.version,
+                display_name: item.displayName,
+                publisher: item.publisher,
+                status: initialStatus,
+                package_config: item,
+                created_at: jobRecord?.created_at || now,
+              });
+              continue;
+            }
+
+            // Local packager mode: leave passed/custom jobs queued for pickup.
             if (isLocalPackagerMode) {
               jobs.push({
                 id: jobId,

--- a/components/ProgressStepper.tsx
+++ b/components/ProgressStepper.tsx
@@ -35,7 +35,7 @@ export function ProgressStepper({
     endTime: endTime || null,
   });
 
-  const isJobFailed = status === 'failed';
+  const isJobFailed = status === 'failed' || status === 'qa_failed';
   const isJobCompleted = ['completed', 'deployed'].includes(status);
   const isActive = !isJobFailed && !isJobCompleted;
 

--- a/components/msp/CrossTenantJobsTable.tsx
+++ b/components/msp/CrossTenantJobsTable.tsx
@@ -74,10 +74,13 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
       case 'completed':
         return <CheckCircle2 className="w-4 h-4 text-green-500" />;
       case 'failed':
+      case 'qa_failed':
         return <XCircle className="w-4 h-4 text-red-500" />;
       case 'packaging':
       case 'uploading':
         return <Loader2 className="w-4 h-4 text-accent-cyan animate-spin" />;
+      case 'awaiting_qa':
+        return <Clock className="w-4 h-4 text-accent-violet" />;
       default:
         return <Clock className="w-4 h-4 text-text-muted" />;
     }
@@ -89,6 +92,10 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
         return 'Completed';
       case 'failed':
         return 'Failed';
+      case 'qa_failed':
+        return 'QA failed';
+      case 'awaiting_qa':
+        return 'Awaiting QA';
       case 'packaging':
         return 'Packaging';
       case 'uploading':
@@ -234,9 +241,10 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
                       <span className={cn(
                         'text-sm',
                         job.status === 'completed' && 'text-green-500',
-                        job.status === 'failed' && 'text-red-500',
+                        (job.status === 'failed' || job.status === 'qa_failed') && 'text-red-500',
                         (job.status === 'packaging' || job.status === 'uploading') && 'text-accent-cyan',
-                        job.status === 'queued' && 'text-text-muted'
+                        job.status === 'queued' && 'text-text-muted',
+                        job.status === 'awaiting_qa' && 'text-accent-violet'
                       )}>
                         {getStatusText(job.status)}
                       </span>

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -145,6 +145,9 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
 
     const candidateInsertSpy = vi.fn();
     const supabase = createSupabaseMock({
+      qa_package_results: {
+        maybeSingleResult: { data: { outcome: 'Failed' }, error: null },
+      },
       qa_candidates: { insertSpy: candidateInsertSpy },
     });
     const trigger = makeTrigger(supabase);
@@ -163,20 +166,11 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     expect(result).toMatchObject({
       success: false,
       skipped: true,
-      code: 'QA_NOT_PASSED_CURRENT_VERSION',
+      code: 'QA_FAILED_CURRENT_VERSION',
     });
-    expect(result.skipReason).toContain('exact PSADT package QA pass');
+    expect(result.skipReason).toContain('failed isolated QA');
     expect(createHistorySpy).not.toHaveBeenCalled();
-    expect(candidateInsertSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        winget_id: UPDATE_INFO.wingetId,
-        status: 'queued',
-        test_config: expect.objectContaining({ profileKind: 'deployment-config' }),
-      })
-    );
-    expect(candidateInsertSpy.mock.calls[0][0].package_profile_sha256).not.toBe(
-      failedPackageResult.package_profile_sha256
-    );
+    expect(candidateInsertSpy).not.toHaveBeenCalled();
   });
 
   describe('ensurePsadtConfig', () => {

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -15,17 +15,11 @@ import {
 } from '@/types/update-policies';
 import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
 import { getCatalogSource } from '@/lib/catalog';
-import { describeQaGateError, enforceQaGate, isQaGateError } from '@/lib/qa/gate';
 import {
   normalizeInstallerSha256,
-  normalizeQaInstallerType,
-  qaInstallerFileName,
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
-import {
-  buildQaPackageIdentityFromWorkflowInput,
-  normalizeQaPsadtConfig,
-} from '@/lib/qa/package-profile';
+import { ensureQaDemand, type QaDemandResult } from '@/lib/qa/demand';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 
 interface TriggerResult {
@@ -183,23 +177,23 @@ export class AutoUpdateTrigger {
       // created before psadtConfig was stored on deployment_config
       await this.ensurePsadtConfig(policy);
 
-      // A current, exact QA failure is an intentional safety skip, not a
-      // packaging failure. Keep it ahead of history/job creation so scheduled
-      // auto-updates do not leave misleading failed or queued jobs behind.
       const deploymentConfig = policy.deployment_config as DeploymentConfig;
-      const packageIdentity = buildQaPackageIdentityFromWorkflowInput({
+      const sourceInstallerType =
+        updateInfo.installerType || deploymentConfig.installerType || 'exe';
+      const qaDemand = await ensureQaDemand(this.supabase, {
         wingetId: updateInfo.wingetId,
         displayName: deploymentConfig.displayName || updateInfo.displayName,
         publisher: deploymentConfig.publisher || 'Unknown Publisher',
         version: updateInfo.latestVersion,
         architecture: deploymentConfig.architecture || 'x64',
+        installerUrl: updateInfo.installerUrl,
         installerSha256: updateInfo.installerSha256,
-        installerType: updateInfo.installerType || deploymentConfig.installerType || 'exe',
+        installerType: sourceInstallerType,
         nestedInstallerType: updateInfo.nestedInstallerType,
         nestedInstallerPath: updateInfo.nestedInstallerPath,
         silentSwitches: extractSilentSwitches(
           deploymentConfig.installCommand || '',
-          updateInfo.installerType || deploymentConfig.installerType || 'exe'
+          sourceInstallerType
         ),
         uninstallCommand: deploymentConfig.uninstallCommand || '',
         installScope: deploymentConfig.installScope === 'user' ? 'user' : 'machine',
@@ -207,110 +201,17 @@ export class AutoUpdateTrigger {
           ? JSON.stringify(deploymentConfig.psadtConfig)
           : undefined,
         detectionRules: JSON.stringify(deploymentConfig.detectionRules || []),
+        priority: 1500,
+        demandSource: 'auto_update',
       });
-      const normalizedPsadtConfig = normalizeQaPsadtConfig(
-        deploymentConfig.psadtConfig,
-        deploymentConfig.detectionRules || []
-      );
-      const sourceInstallerType =
-        updateInfo.installerType || deploymentConfig.installerType || 'exe';
-      const architecture = (deploymentConfig.architecture || 'x64').toLowerCase();
-      const now = new Date().toISOString();
-      const { error: candidateError } = await this.supabase.from('qa_candidates').insert({
-        winget_id: updateInfo.wingetId,
-        definition_path: null,
-        version: updateInfo.latestVersion,
-        architecture,
-        installer_url: updateInfo.installerUrl,
-        installer_sha256: updateInfo.installerSha256.toUpperCase(),
-        installer_type: normalizeQaInstallerType(sourceInstallerType),
-        installer_file_name: qaInstallerFileName(updateInfo.installerUrl, sourceInstallerType),
-        test_level: 'psadt-package',
-        package_profile_sha256: packageIdentity.packageProfileSha256,
-        test_config: {
-          mode: 'psadt-package',
-          displayName: deploymentConfig.displayName || updateInfo.displayName,
-          publisher: deploymentConfig.publisher || 'Unknown Publisher',
-          sourceInstallerType,
-          silentArgs: extractSilentSwitches(
-            deploymentConfig.installCommand || '',
-            sourceInstallerType
-          ),
-          productCode: '',
-          scope: deploymentConfig.installScope === 'user' ? 'user' : 'machine',
-          nestedInstallerType: updateInfo.nestedInstallerType || '',
-          nestedInstallerFiles: updateInfo.nestedInstallerPath
-            ? [updateInfo.nestedInstallerPath]
-            : [],
-          uninstallCommand: deploymentConfig.uninstallCommand || '',
-          psadtConfig: normalizedPsadtConfig,
-          detectionRules: deploymentConfig.detectionRules || [],
-          profileKind: 'deployment-config',
-          packageProfileCanonicalJson: packageIdentity.canonicalJson,
-          packageProfileSha256: packageIdentity.packageProfileSha256,
-          psadtConfigSha256: packageIdentity.psadtConfigSha256,
-          detectionRulesSha256: packageIdentity.detectionRulesSha256,
-        },
-        status: 'queued',
-        priority: 1000,
-        updated_at: now,
-      });
-      if (candidateError?.code === '23505') {
-        const { data: existingCandidate, error: existingCandidateError } = await this.supabase
-          .from('qa_candidates')
-          .select('id, status')
-          .eq('winget_id', updateInfo.wingetId)
-          .eq('version', updateInfo.latestVersion)
-          .eq('architecture', architecture)
-          .eq('installer_sha256', updateInfo.installerSha256.toUpperCase())
-          .eq('package_profile_sha256', packageIdentity.packageProfileSha256)
-          .maybeSingle();
-        if (existingCandidateError) {
-          throw new Error(`Could not read exact PSADT QA candidate: ${existingCandidateError.message}`);
-        }
-        if (existingCandidate && ['error', 'superseded'].includes(existingCandidate.status)) {
-          const { error: reactivateError } = await this.supabase
-            .from('qa_candidates')
-            .update({
-              status: 'queued',
-              priority: 1000,
-              attempts: 0,
-              dispatched_at: null,
-              started_at: null,
-              finished_at: null,
-              github_run_id: null,
-              github_run_url: null,
-              failure_summary: null,
-              updated_at: now,
-            })
-            .eq('id', existingCandidate.id)
-            .in('status', ['error', 'superseded']);
-          if (reactivateError) {
-            throw new Error(`Could not requeue exact PSADT package QA: ${reactivateError.message}`);
-          }
-        }
-      } else if (candidateError) {
-        throw new Error(`Could not queue exact PSADT package QA: ${candidateError.message}`);
-      }
-      try {
-        await enforceQaGate({
-          wingetId: updateInfo.wingetId,
-          version: updateInfo.latestVersion,
-          architecture: deploymentConfig.architecture,
-          installerSha256: updateInfo.installerSha256,
-          packageProfileSha256: packageIdentity.packageProfileSha256,
-          requirePassed: true,
-        });
-      } catch (error) {
-        if (isQaGateError(error)) {
-          return {
-            success: false,
-            skipped: true,
-            skipReason: describeQaGateError(error),
-            code: error.code,
-          };
-        }
-        throw error;
+      if (qaDemand.state === 'failed') {
+        return {
+          success: false,
+          skipped: true,
+          skipReason: qaDemand.failureSummary,
+          code: 'QA_FAILED_CURRENT_VERSION',
+          packageProfileSha256: qaDemand.identity.executionProfileSha256,
+        };
       }
 
       // Determine update type
@@ -323,13 +224,18 @@ export class AutoUpdateTrigger {
       const packagingJob = await this.createPackagingJob(
         policy,
         updateInfo,
-        historyRecord.id
+        historyRecord.id,
+        qaDemand
       );
 
       // Update history with job reference
       await this.updateHistoryRecord(historyRecord.id, {
         packaging_job_id: packagingJob.id,
-        status: 'packaging',
+        status: qaDemand.state === 'passed'
+          ? 'packaging'
+          : qaDemand.state === 'waiting'
+            ? 'pending'
+            : 'failed',
       });
 
       // Update policy tracking
@@ -339,7 +245,7 @@ export class AutoUpdateTrigger {
         success: true,
         packagingJobId: packagingJob.id,
         historyId: historyRecord.id,
-        packageProfileSha256: packageIdentity.packageProfileSha256,
+        packageProfileSha256: qaDemand.identity.executionProfileSha256,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -594,7 +500,8 @@ export class AutoUpdateTrigger {
   private async createPackagingJob(
     policy: AppUpdatePolicy,
     updateInfo: UpdateInfo,
-    historyId: string
+    historyId: string,
+    qaDemand?: QaDemandResult
   ): Promise<{ id: string }> {
     const config = policy.deployment_config as DeploymentConfig;
     const assignments = normalizeAssignments(config);
@@ -662,8 +569,22 @@ export class AutoUpdateTrigger {
         notes: config.notes,
         autoUpdateHistoryId: historyId,
       },
-      status: 'queued',
+      status: !qaDemand || qaDemand.state === 'passed'
+        ? 'queued'
+        : qaDemand.state === 'waiting'
+          ? 'awaiting_qa'
+          : 'qa_failed',
+      status_message: !qaDemand || qaDemand.state === 'passed'
+        ? 'Exact PSADT execution profile passed QA'
+        : qaDemand.state === 'waiting'
+          ? 'Waiting for isolated QA of this PSADT execution profile'
+          : qaDemand.failureSummary || 'The exact PSADT execution profile failed QA',
       progress_percent: 0,
+      execution_profile_sha256: qaDemand?.identity.executionProfileSha256 || null,
+      presentation_profile_sha256: qaDemand?.identity.presentationProfileSha256 || null,
+      qa_candidate_id: qaDemand?.candidateId || null,
+      qa_requested_at: qaDemand ? new Date().toISOString() : null,
+      qa_completed_at: !qaDemand || qaDemand.state === 'waiting' ? null : new Date().toISOString(),
       is_auto_update: true,
       auto_update_policy_id: policy.id,
     };

--- a/lib/db/sqlite.ts
+++ b/lib/db/sqlite.ts
@@ -80,6 +80,11 @@ function initializeSchema(db: Database.Database): void {
       error_code TEXT,
       error_details TEXT,
       warnings TEXT,
+      execution_profile_sha256 TEXT,
+      presentation_profile_sha256 TEXT,
+      qa_candidate_id TEXT,
+      qa_requested_at TEXT,
+      qa_completed_at TEXT,
       packager_id TEXT,
       packager_heartbeat_at TEXT,
       claimed_at TEXT,
@@ -106,6 +111,11 @@ function initializeSchema(db: Database.Database): void {
     error_details: 'TEXT',
     warnings: 'TEXT',
     archived_at: 'TEXT',
+    execution_profile_sha256: 'TEXT',
+    presentation_profile_sha256: 'TEXT',
+    qa_candidate_id: 'TEXT',
+    qa_requested_at: 'TEXT',
+    qa_completed_at: 'TEXT',
   };
   for (const [column, definition] of Object.entries(compatibleColumns)) {
     if (!existingColumns.has(column)) {
@@ -235,9 +245,13 @@ export const sqliteDb: DatabaseAdapter = {
           id, user_id, user_email, tenant_id, winget_id, version, display_name,
           publisher, architecture, installer_type, installer_url, installer_sha256,
           install_command, uninstall_command, install_scope, detection_rules,
-          package_config, app_source, status, progress_percent, created_at, updated_at
+          package_config, app_source, status, status_message, progress_percent,
+          error_stage, error_category, error_code, execution_profile_sha256,
+          presentation_profile_sha256, qa_candidate_id, qa_requested_at,
+          qa_completed_at, created_at, updated_at
         ) VALUES (
-          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
       `);
 
@@ -261,7 +275,16 @@ export const sqliteDb: DatabaseAdapter = {
         job.package_config ? JSON.stringify(job.package_config) : null,
         job.app_source || 'win32',
         job.status || 'queued',
+        job.status_message || null,
         job.progress_percent || 0,
+        job.error_stage || null,
+        job.error_category || null,
+        job.error_code || null,
+        job.execution_profile_sha256 || null,
+        job.presentation_profile_sha256 || null,
+        job.qa_candidate_id || null,
+        job.qa_requested_at || null,
+        job.qa_completed_at || null,
         now,
         now
       );

--- a/lib/db/supabase-adapter.ts
+++ b/lib/db/supabase-adapter.ts
@@ -222,7 +222,16 @@ export const supabaseDb: DatabaseAdapter = {
         package_config: job.package_config,
         app_source: job.app_source || 'win32',
         status: job.status || 'queued',
+        status_message: job.status_message,
         progress_percent: job.progress_percent || 0,
+        error_stage: job.error_stage,
+        error_category: job.error_category,
+        error_code: job.error_code,
+        execution_profile_sha256: job.execution_profile_sha256,
+        presentation_profile_sha256: job.presentation_profile_sha256,
+        qa_candidate_id: job.qa_candidate_id,
+        qa_requested_at: job.qa_requested_at,
+        qa_completed_at: job.qa_completed_at,
       };
 
       const { data, error } = await query

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -46,6 +46,11 @@ export interface PackagingJob {
   error_code: string | null;
   error_details: Json | null;
   warnings: Json | null;
+  execution_profile_sha256: string | null;
+  presentation_profile_sha256: string | null;
+  qa_candidate_id: string | null;
+  qa_requested_at: string | null;
+  qa_completed_at: string | null;
   packager_id: string | null;
   packager_heartbeat_at: string | null;
   claimed_at: string | null;

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -1,0 +1,151 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { normalizeQaInstallerType, qaInstallerFileName } from '@/lib/qa/candidate';
+import {
+  buildQaPackageIdentityFromWorkflowInput,
+  type QaPackageIdentity,
+  type QaWorkflowPackageInput,
+} from '@/lib/qa/package-profile';
+import type { Json } from '@/types/database';
+
+export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
+export type QaDemandState = 'passed' | 'failed' | 'waiting';
+
+export interface QaDemandInput extends QaWorkflowPackageInput {
+  installerUrl: string;
+  priority: number;
+  demandSource: QaDemandSource;
+}
+
+export interface QaDemandResult {
+  identity: QaPackageIdentity;
+  candidateId: string | null;
+  state: QaDemandState;
+  failureSummary?: string;
+}
+
+export async function ensureQaDemand(
+  supabase: SupabaseClient,
+  input: QaDemandInput
+): Promise<QaDemandResult> {
+  const identity = buildQaPackageIdentityFromWorkflowInput(input);
+  const profileSha256 = identity.executionProfileSha256;
+
+  const { data: passedResult, error: resultError } = await supabase
+    .from('qa_package_results')
+    .select('outcome')
+    .eq('package_profile_sha256', profileSha256)
+    .maybeSingle();
+  if (resultError) throw new Error(`Could not read exact package QA result: ${resultError.message}`);
+  if (passedResult?.outcome === 'Passed') {
+    return { identity, candidateId: null, state: 'passed' };
+  }
+  if (passedResult?.outcome === 'Failed') {
+    return {
+      identity,
+      candidateId: null,
+      state: 'failed',
+      failureSummary: 'The exact PSADT execution profile failed isolated QA.',
+    };
+  }
+
+  const architecture = (input.architecture || 'x64').toLowerCase();
+  const installerSha256 = input.installerSha256.toUpperCase();
+  const now = new Date().toISOString();
+  const profile = identity.profile as {
+    psadtConfig: unknown;
+    detectionRules: unknown;
+  };
+  const testConfig = {
+    mode: 'psadt-package',
+    profileKind: 'deployment-config',
+    packageProfileCanonicalJson: identity.canonicalJson,
+    packageProfileSha256: profileSha256,
+    executionProfileSha256: profileSha256,
+    presentationProfileSha256: identity.presentationProfileSha256,
+    psadtConfigSha256: identity.psadtConfigSha256,
+    detectionRulesSha256: identity.detectionRulesSha256,
+    psadtConfig: profile.psadtConfig as Json,
+    detectionRules: profile.detectionRules as Json,
+  };
+
+  const row = {
+    winget_id: input.wingetId,
+    definition_path: null,
+    version: input.version,
+    architecture,
+    installer_url: input.installerUrl,
+    installer_sha256: installerSha256,
+    installer_type: normalizeQaInstallerType(input.installerType),
+    installer_file_name: qaInstallerFileName(input.installerUrl, input.installerType),
+    test_level: 'psadt-package' as const,
+    package_profile_sha256: profileSha256,
+    test_config: testConfig as unknown as Json,
+    status: 'queued',
+    priority: input.priority,
+    demand_source: input.demandSource,
+    updated_at: now,
+  };
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('qa_candidates')
+    .insert(row)
+    .select('id, status, failure_summary')
+    .maybeSingle();
+  if (!insertError && inserted) {
+    return { identity, candidateId: inserted.id, state: 'waiting' };
+  }
+  if (insertError?.code !== '23505') {
+    throw new Error(`Could not queue exact package QA: ${insertError?.message || 'unknown error'}`);
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('qa_candidates')
+    .select('id, status, priority, failure_summary')
+    .eq('winget_id', input.wingetId)
+    .eq('version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('package_profile_sha256', profileSha256)
+    .maybeSingle();
+  if (existingError || !existing) {
+    throw new Error(`Could not resolve exact package QA candidate: ${existingError?.message || 'missing candidate'}`);
+  }
+
+  if (existing.status === 'failed') {
+    return {
+      identity,
+      candidateId: existing.id,
+      state: 'failed',
+      failureSummary: existing.failure_summary || 'The exact execution profile failed QA.',
+    };
+  }
+
+  if (['error', 'superseded'].includes(existing.status)) {
+    const { error: reactivateError } = await supabase
+      .from('qa_candidates')
+      .update({
+        status: 'queued',
+        priority: Math.max(existing.priority, input.priority),
+        demand_source: input.demandSource,
+        attempts: 0,
+        dispatched_at: null,
+        started_at: null,
+        finished_at: null,
+        github_run_id: null,
+        github_run_url: null,
+        failure_summary: null,
+        updated_at: now,
+      })
+      .eq('id', existing.id)
+      .in('status', ['error', 'superseded']);
+    if (reactivateError) throw new Error(`Could not reactivate exact QA: ${reactivateError.message}`);
+  } else if (existing.status === 'queued' && existing.priority < input.priority) {
+    await supabase
+      .from('qa_candidates')
+      .update({ priority: input.priority, demand_source: input.demandSource, updated_at: now })
+      .eq('id', existing.id)
+      .eq('status', 'queued');
+  }
+
+  return { identity, candidateId: existing.id, state: 'waiting' };
+}

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -51,6 +51,50 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('reuses execution QA when only presentation changes', () => {
+    const deploymentInput = { ...input, profileKind: 'deployment-config' as const };
+    const baseline = buildQaPackageIdentity(deploymentInput);
+    const branded = buildQaPackageIdentity({
+      ...deploymentInput,
+      displayName: 'Customer-facing Example',
+      publisher: 'Customer Publisher',
+      psadtConfig: {
+        ...DEFAULT_PSADT_CONFIG,
+        brandingCompanyName: 'Contoso',
+        brandingWelcomeTitle: 'Install Example',
+        brandingAccentColor: '#123456',
+        progressDialog: {
+          ...DEFAULT_PSADT_CONFIG.progressDialog,
+          statusMessage: 'A customer-specific message',
+          windowLocation: 'BottomRight',
+        },
+      },
+    });
+
+    expect(branded.executionProfileSha256).toBe(baseline.executionProfileSha256);
+    expect(branded.packageProfileSha256).toBe(baseline.packageProfileSha256);
+    expect(branded.presentationProfileSha256).not.toBe(
+      baseline.presentationProfileSha256
+    );
+  });
+
+  it('keeps interaction timing and custom command changes in the execution profile', () => {
+    const baseline = buildQaPackageIdentity(input);
+    const interactive = buildQaPackageIdentity({
+      ...input,
+      psadtConfig: {
+        ...DEFAULT_PSADT_CONFIG,
+        allowDefer: true,
+        deferTimes: 5,
+        postInstallCommands: ['echo verified'],
+      },
+    });
+
+    expect(interactive.executionProfileSha256).not.toBe(
+      baseline.executionProfileSha256
+    );
+  });
+
   it('changes when installer switches or detection rules change', () => {
     expect(
       buildQaPackageIdentity({ ...input, silentArgs: '/S' }).packageProfileSha256

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -18,7 +18,7 @@ export const QA_PSADT_TOOLCHAIN = {
  * and update the protected workflow verifier in the same rollout. Existing candidates
  * then fail closed and are rebuilt before they can be dispatched.
  */
-export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 1;
+export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 2;
 
 export interface QaPackageProfileInput {
   profileKind: 'catalog-default' | 'deployment-config';
@@ -33,7 +33,7 @@ export interface QaPackageProfileInput {
   uninstallCommand: string;
   installScope: string;
   nestedInstallerType: string;
-  nestedInstallerFiles: string[];
+  nestedInstallerFiles: readonly string[];
   psadtConfig: PSADTConfig;
   detectionRules: DetectionRule[];
 }
@@ -41,9 +41,91 @@ export interface QaPackageProfileInput {
 export interface QaPackageIdentity {
   profile: Record<string, unknown>;
   canonicalJson: string;
+  /** Backwards-compatible name for the behavior-affecting execution profile. */
   packageProfileSha256: string;
+  executionProfileSha256: string;
+  presentationProfileSha256: string;
   psadtConfigSha256: string;
   detectionRulesSha256: string;
+}
+
+const PRESENTATION_PLACEHOLDER = 'IntuneGet QA';
+
+/**
+ * Split PSADT configuration into the fields that can change execution and the
+ * fields that only change what a user sees. QA is deduplicated by execution;
+ * presentation remains auditable on the packaging job without multiplying VM runs.
+ */
+export function splitQaPsadtConfig(config: PSADTConfig): {
+  execution: PSADTConfig;
+  presentation: Record<string, unknown>;
+} {
+  const presentation = {
+    brandingCompanyName: config.brandingCompanyName,
+    brandingWelcomeTitle: config.brandingWelcomeTitle,
+    brandingWelcomeMessage: config.brandingWelcomeMessage,
+    brandingAccentColor: config.brandingAccentColor,
+    brandingLogoPath: config.brandingLogoPath,
+    brandingLogoDarkPath: config.brandingLogoDarkPath,
+    brandingBannerPath: config.brandingBannerPath,
+    windowLocation: config.windowLocation,
+    progressDialog: {
+      statusMessage: config.progressDialog.statusMessage,
+      windowLocation: config.progressDialog.windowLocation,
+    },
+    processesToClose: config.processesToClose.map(({ description }) => ({ description })),
+    customPrompts: config.customPrompts.map((prompt) => ({
+      title: prompt.title,
+      message: prompt.message,
+      icon: prompt.icon,
+      buttonLeftText: prompt.buttonLeftText,
+      buttonMiddleText: prompt.buttonMiddleText,
+      buttonRightText: prompt.buttonRightText,
+    })),
+    balloonTips: config.balloonTips.map((tip) => ({
+      title: tip.title,
+      text: tip.text,
+      icon: tip.icon,
+    })),
+  };
+
+  const execution: PSADTConfig = {
+    ...config,
+    brandingCompanyName: undefined,
+    brandingWelcomeTitle: undefined,
+    brandingWelcomeMessage: undefined,
+    brandingAccentColor: undefined,
+    brandingLogoPath: undefined,
+    brandingLogoDarkPath: undefined,
+    brandingBannerPath: undefined,
+    windowLocation: 'Default',
+    progressDialog: {
+      ...config.progressDialog,
+      statusMessage: config.progressDialog.enabled ? PRESENTATION_PLACEHOLDER : undefined,
+      windowLocation: undefined,
+    },
+    processesToClose: config.processesToClose.map(({ name }) => ({
+      name,
+      description: name,
+    })),
+    customPrompts: config.customPrompts.map((prompt) => ({
+      ...prompt,
+      title: PRESENTATION_PLACEHOLDER,
+      message: PRESENTATION_PLACEHOLDER,
+      icon: 'Information',
+      buttonLeftText: prompt.buttonLeftText ? 'Left' : undefined,
+      buttonMiddleText: prompt.buttonMiddleText ? 'Middle' : undefined,
+      buttonRightText: prompt.buttonRightText ? 'Right' : undefined,
+    })),
+    balloonTips: config.balloonTips.map((tip) => ({
+      ...tip,
+      title: PRESENTATION_PLACEHOLDER,
+      text: PRESENTATION_PLACEHOLDER,
+      icon: 'Info',
+    })),
+  };
+
+  return { execution, presentation };
 }
 
 export interface QaWorkflowPackageInput {
@@ -264,7 +346,14 @@ export function normalizeQaPsadtConfig(
 }
 
 export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageIdentity {
-  const psadtConfigSha256 = qaSha256(canonicalQaJson(input.psadtConfig));
+  const { execution: executionPsadtConfig, presentation } = splitQaPsadtConfig(
+    input.psadtConfig
+  );
+  const psadtConfigSha256 = qaSha256(canonicalQaJson(executionPsadtConfig));
+  const presentationProfileSha256 = qaSha256(canonicalQaJson({
+    app: { displayName: input.displayName, publisher: input.publisher },
+    psadt: presentation,
+  }));
   const detectionRulesSha256 = qaSha256(canonicalQaJson(input.detectionRules));
   const profile = {
     schemaVersion: QA_PACKAGE_PROFILE_SCHEMA_VERSION,
@@ -273,8 +362,8 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
     toolchain: QA_PSADT_TOOLCHAIN,
     app: {
       wingetId: input.wingetId,
-      displayName: input.displayName,
-      publisher: input.publisher,
+      displayName: input.profileKind === 'deployment-config' ? input.wingetId : input.displayName,
+      publisher: input.profileKind === 'deployment-config' ? 'IntuneGet QA' : input.publisher,
       version: input.version,
       architecture: input.architecture.toLowerCase(),
     },
@@ -287,16 +376,19 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
       nestedInstallerType: input.nestedInstallerType.toLowerCase(),
       nestedInstallerFiles: input.nestedInstallerFiles,
     },
-    psadtConfig: input.psadtConfig,
+    psadtConfig: executionPsadtConfig,
     detectionRules: input.detectionRules,
     psadtConfigSha256,
     detectionRulesSha256,
   };
   const canonicalJson = canonicalQaJson(profile);
+  const executionProfileSha256 = qaSha256(canonicalJson);
   return {
     profile,
     canonicalJson,
-    packageProfileSha256: qaSha256(canonicalJson),
+    packageProfileSha256: executionProfileSha256,
+    executionProfileSha256,
+    presentationProfileSha256,
     psadtConfigSha256,
     detectionRulesSha256,
   };

--- a/supabase/migrations/20260809182115_demand_driven_qa_waiting_jobs.sql
+++ b/supabase/migrations/20260809182115_demand_driven_qa_waiting_jobs.sql
@@ -1,0 +1,46 @@
+-- Demand-driven QA: customer packaging jobs wait on a tenant-independent,
+-- behavior-affecting PSADT execution profile. Presentation choices are kept
+-- separately so branding changes do not multiply isolated VM runs.
+
+alter table public.packaging_jobs
+  add column if not exists execution_profile_sha256 text,
+  add column if not exists presentation_profile_sha256 text,
+  add column if not exists qa_candidate_id uuid references public.qa_candidates(id) on delete set null,
+  add column if not exists qa_requested_at timestamptz,
+  add column if not exists qa_completed_at timestamptz;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'packaging_jobs_execution_profile_sha256_check') then
+    alter table public.packaging_jobs add constraint packaging_jobs_execution_profile_sha256_check
+      check (execution_profile_sha256 is null or execution_profile_sha256 ~ '^[A-F0-9]{64}$');
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'packaging_jobs_presentation_profile_sha256_check') then
+    alter table public.packaging_jobs add constraint packaging_jobs_presentation_profile_sha256_check
+      check (presentation_profile_sha256 is null or presentation_profile_sha256 ~ '^[A-F0-9]{64}$');
+  end if;
+end $$;
+
+create index if not exists idx_packaging_jobs_awaiting_qa
+  on public.packaging_jobs(qa_candidate_id, created_at)
+  where status = 'awaiting_qa';
+
+alter table public.qa_candidates
+  add column if not exists demand_source text not null default 'catalog';
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'qa_candidates_demand_source_check') then
+    alter table public.qa_candidates add constraint qa_candidates_demand_source_check
+      check (demand_source in ('customer', 'auto_update', 'managed', 'operator', 'catalog'));
+  end if;
+end $$;
+
+create index if not exists qa_candidates_demand_dispatch_idx
+  on public.qa_candidates(demand_source, priority desc, enqueued_at)
+  where status = 'queued';
+
+comment on column public.packaging_jobs.execution_profile_sha256 is
+  'Behavior-affecting PSADT QA identity. Equal profiles may reuse one isolated VM result.';
+comment on column public.packaging_jobs.presentation_profile_sha256 is
+  'Presentation-only PSADT identity retained for audit without forcing another VM run.';
+comment on column public.packaging_jobs.qa_candidate_id is
+  'Tenant-independent QA candidate currently gating this packaging job.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -184,6 +184,7 @@ export interface Database {
           activity_updated_at: string | null;
           live_log: Json | null;
           log_updated_at: string | null;
+          demand_source: 'customer' | 'auto_update' | 'managed' | 'operator' | 'catalog';
           updated_at: string;
         };
         Insert: {
@@ -217,6 +218,7 @@ export interface Database {
           activity_updated_at?: string | null;
           live_log?: Json | null;
           log_updated_at?: string | null;
+          demand_source?: 'customer' | 'auto_update' | 'managed' | 'operator' | 'catalog';
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_candidates']['Insert']>;
@@ -580,6 +582,9 @@ export interface Database {
           status: string;
           status_message: string | null;
           progress_percent: number;
+          error_stage: string | null;
+          error_category: string | null;
+          error_code: string | null;
           error_message: string | null;
           created_at: string;
           updated_at: string;
@@ -592,6 +597,11 @@ export interface Database {
           archived_at: string | null;
           is_auto_update: boolean;
           auto_update_policy_id: string | null;
+          execution_profile_sha256: string | null;
+          presentation_profile_sha256: string | null;
+          qa_candidate_id: string | null;
+          qa_requested_at: string | null;
+          qa_completed_at: string | null;
         };
         Insert: {
           id?: string;
@@ -624,6 +634,9 @@ export interface Database {
           status?: string;
           status_message?: string | null;
           progress_percent?: number;
+          error_stage?: string | null;
+          error_category?: string | null;
+          error_code?: string | null;
           error_message?: string | null;
           created_at?: string;
           updated_at?: string;
@@ -636,6 +649,11 @@ export interface Database {
           archived_at?: string | null;
           is_auto_update?: boolean;
           auto_update_policy_id?: string | null;
+          execution_profile_sha256?: string | null;
+          presentation_profile_sha256?: string | null;
+          qa_candidate_id?: string | null;
+          qa_requested_at?: string | null;
+          qa_completed_at?: string | null;
         };
         Update: {
           id?: string;
@@ -668,6 +686,9 @@ export interface Database {
           status?: string;
           status_message?: string | null;
           progress_percent?: number;
+          error_stage?: string | null;
+          error_category?: string | null;
+          error_code?: string | null;
           error_message?: string | null;
           created_at?: string;
           updated_at?: string;
@@ -680,6 +701,11 @@ export interface Database {
           archived_at?: string | null;
           is_auto_update?: boolean;
           auto_update_policy_id?: string | null;
+          execution_profile_sha256?: string | null;
+          presentation_profile_sha256?: string | null;
+          qa_candidate_id?: string | null;
+          qa_requested_at?: string | null;
+          qa_completed_at?: string | null;
         };
         Relationships: GenericRelationship[];
       };

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/qa-resume",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/qa-live-cleanup",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
## Summary
- gate customer Win32 packaging on the exact behavior-affecting PSADT execution profile
- automatically resume waiting jobs after QA passes and expose awaiting/failed states in the UI
- restrict WinGet QA polling to deployed apps and enabled auto-update demand
- add the database migration and schema-v2 execution profile contract

## Validation
- focused feature tests: 66 passed
- lint: passed
- production build: passed
- SQLite tests: 32 passed
- workflow contract tests: 13 passed
- full suite: 699/700 passed; one unrelated translation-provider timeout in scripts/maybe-translate.test.ts