### PR TITLE
Use customer-friendly installation test wording

### DIFF
--- a/app/(app)/dashboard/uploads/page.tsx
+++ b/app/(app)/dashboard/uploads/page.tsx
@@ -668,14 +668,14 @@ function UploadJobCard({
   const statusConfig = {
     awaiting_qa: {
       icon: ShieldCheck,
-      label: 'Awaiting QA',
+      label: 'Testing app',
       color: 'text-accent-violet',
       bg: 'bg-accent-violet/10',
       border: 'border-l-accent-violet',
     },
     qa_failed: {
       icon: XCircle,
-      label: 'QA failed',
+      label: 'Installation test failed',
       color: 'text-status-error',
       bg: 'bg-status-error/10',
       border: 'border-l-status-error',
@@ -930,7 +930,9 @@ function UploadJobCard({
             <ProgressStepper
               progress={job.progress_percent}
               status={job.status}
-              statusMessage={job.status_message}
+              statusMessage={job.status === 'awaiting_qa'
+                ? 'Running an isolated installation test to make sure this app works before deployment'
+                : job.status_message}
               startTime={job.status === 'awaiting_qa'
                 ? job.qa_requested_at || job.created_at
                 : job.packaging_started_at || job.qa_requested_at || job.created_at}

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -231,7 +231,7 @@ export async function GET(request: Request) {
             phase: null,
             phase_started_at: null,
             phase_updated_at: null,
-            failure_summary: 'QA workflow dispatch failed; retry scheduled.',
+            failure_summary: 'The installation test could not start; retry scheduled.',
             updated_at: new Date().toISOString(),
           })
           .eq('id', claimed.id)

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
         .from('packaging_jobs')
         .update({
           status: 'qa_failed',
-          status_message: candidate?.failure_summary || 'The required QA run could not complete.',
+          status_message: candidate?.failure_summary || 'The required installation test could not complete.',
           error_code: 'QA_FAILED_EXECUTION_PROFILE',
           error_stage: 'validation',
           error_category: 'installer',
@@ -84,7 +84,7 @@ export async function GET(request: Request) {
       .from('packaging_jobs')
       .update({
         status: nextStatus,
-        status_message: 'QA passed; packaging resumed automatically',
+        status_message: 'Installation test passed; packaging started automatically',
         qa_completed_at: now,
         packaging_started_at: features.localPackager ? null : now,
       })
@@ -153,7 +153,7 @@ export async function GET(request: Request) {
         .from('packaging_jobs')
         .update({
           status: 'failed',
-          status_message: 'QA passed, but automatic packaging resume failed',
+          status_message: 'Installation test passed, but packaging could not start automatically',
           error_code: 'QA_RESUME_DISPATCH_FAILED',
           error_stage: 'authenticate',
           error_category: 'network',

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -371,6 +371,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(body.jobs[0]).toMatchObject({ status: 'awaiting_qa' });
     expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'awaiting_qa',
+      status_message: 'Running an isolated installation test to make sure this app works before deployment',
       qa_candidate_id: 'candidate-1',
       execution_profile_sha256: 'A'.repeat(64),
       presentation_profile_sha256: 'B'.repeat(64),

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -445,7 +445,7 @@ export async function POST(request: NextRequest) {
               package_config: item as unknown as import('@/types/database').Json,
               status: initialStatus,
               status_message: qaDemand?.state === 'waiting'
-                ? 'Waiting for isolated QA of this PSADT execution profile'
+                ? 'Running an isolated installation test to make sure this app works before deployment'
                 : qaDemand?.state === 'failed'
                   ? qaDemand.failureSummary
                   : null,

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -403,7 +403,7 @@ export async function POST(request: NextRequest) {
                 .from('packaging_jobs')
                 .update({
                   status: 'cancelled',
-                  status_message: 'Skipped while awaiting exact QA pass',
+                  status_message: 'Waiting for the installation test to finish',
                   error_message: message,
                   cancelled_at: completedAt,
                   completed_at: completedAt,

--- a/components/ProgressStepper.tsx
+++ b/components/ProgressStepper.tsx
@@ -25,8 +25,8 @@ interface ProgressStepperProps {
 
 const QA_STAGE: ProgressStage = {
   id: 'qa',
-  label: 'QA',
-  description: 'Verifying the PSADT package in an isolated VM',
+  label: 'Test',
+  description: 'Running an isolated installation test before deployment',
   minProgress: 0,
   maxProgress: 0,
 };
@@ -102,7 +102,7 @@ export function ProgressStepper({
                     <Check className="w-[18px] h-[18px] text-status-success" />
                   ) : isCurrent ? (
                     isQaStage ? (
-                      <ShieldCheck className="w-[18px] h-[18px] text-accent-violet animate-pulse" aria-label="QA verification in progress" />
+                      <ShieldCheck className="w-[18px] h-[18px] text-accent-violet animate-pulse" aria-label="Installation test in progress" />
                     ) : (
                       <Loader2 className="w-[18px] h-[18px] text-accent-cyan animate-spin" aria-label="Processing" />
                     )
@@ -196,7 +196,7 @@ export function ProgressStepper({
               href={qaHref}
               className="inline-flex flex-shrink-0 items-center gap-1 text-xs font-medium text-accent-violet hover:underline"
             >
-              View QA activity
+              View installation test
               <ExternalLink className="h-3 w-3" aria-hidden="true" />
             </Link>
           )}

--- a/components/UploadCart.tsx
+++ b/components/UploadCart.tsx
@@ -431,7 +431,7 @@ export function UploadCart() {
                         {item.qaOverride && (
                           <span className="inline-flex items-center gap-1 rounded border border-status-warning/20 bg-status-warning/10 px-2 py-1 text-xs font-medium text-status-warning">
                             <ShieldAlert className="h-3 w-3" />
-                            QA override
+                            Test override
                           </span>
                         )}
                       </div>
@@ -440,9 +440,9 @@ export function UploadCart() {
                         <div className="mt-3 flex items-start gap-2 rounded-lg border border-status-error/20 bg-status-error/10 p-2.5">
                           <ShieldAlert className="mt-0.5 h-4 w-4 flex-shrink-0 text-status-error" />
                           <div className="flex-1 text-xs">
-                            <p className="font-medium text-status-error">QA failed for this exact version</p>
+                            <p className="font-medium text-status-error">Installation test failed for this version</p>
                             <p className="mt-0.5 text-text-secondary">
-                              Version {item.version} failed isolated install, detection, or uninstall testing. Review the result before deploying.
+                              Version {item.version} did not complete the install, detection, or uninstall checks. Review the result before deploying.
                             </p>
                             <div className="mt-2 flex flex-wrap gap-3">
                               <button
@@ -450,7 +450,7 @@ export function UploadCart() {
                                 onClick={() => setQaDetailsTarget({ wingetId: item.wingetId, version: item.version })}
                                 className="font-medium text-status-error underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-error"
                               >
-                                View QA details
+                                View test details
                               </button>
                               <button
                                 type="button"

--- a/components/msp/CrossTenantJobsTable.tsx
+++ b/components/msp/CrossTenantJobsTable.tsx
@@ -93,9 +93,9 @@ export function CrossTenantJobsTable({ jobs: initialJobs, isLoading: externalLoa
       case 'failed':
         return 'Failed';
       case 'qa_failed':
-        return 'QA failed';
+        return 'Installation test failed';
       case 'awaiting_qa':
-        return 'Awaiting QA';
+        return 'Testing app';
       case 'packaging':
         return 'Packaging';
       case 'uploading':

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -140,7 +140,7 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] max-w-3xl flex-col">
         <DialogHeader className="shrink-0">
-          <DialogTitle><T>PSADT package QA details</T></DialogTitle>
+          <DialogTitle><T>Installation test details</T></DialogTitle>
           <DialogDescription><T>Latest isolated test of the package IntuneGet deploys through Intune.</T></DialogDescription>
         </DialogHeader>
 
@@ -281,7 +281,7 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
               <section className="grid gap-3 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 text-xs text-text-secondary sm:grid-cols-2">
                 <div><span className="block text-text-muted"><T>Execution context</T></span><code>{data.environment?.executionContext || <T>Not recorded</T>}</code></div>
                 <div><span className="block text-text-muted"><T>Relevant Windows events</T></span>{data.relevantEventCount ?? <T>Not recorded</T>}</div>
-                <div><span className="block text-text-muted"><T>PSADT package profile</T></span><code>{data.package?.profileSha256?.slice(0, 12) || <T>Not recorded</T>}</code></div>
+                <div><span className="block text-text-muted"><T>Tested configuration</T></span><code>{data.package?.profileSha256?.slice(0, 12) || <T>Not recorded</T>}</code></div>
                 <div><span className="block text-text-muted"><T>Packager commit</T></span><code>{data.package?.packagerCommit?.slice(0, 12) || <T>Not recorded</T>}</code></div>
               </section>
             </>

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -168,7 +168,7 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       skipped: true,
       code: 'QA_FAILED_CURRENT_VERSION',
     });
-    expect(result.skipReason).toContain('failed isolated QA');
+    expect(result.skipReason).toBe('This app did not pass the isolated installation test.');
     expect(createHistorySpy).not.toHaveBeenCalled();
     expect(candidateInsertSpy).not.toHaveBeenCalled();
   });

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -575,10 +575,10 @@ export class AutoUpdateTrigger {
           ? 'awaiting_qa'
           : 'qa_failed',
       status_message: !qaDemand || qaDemand.state === 'passed'
-        ? 'Exact PSADT execution profile passed QA'
+        ? 'Installation test passed; preparing deployment'
         : qaDemand.state === 'waiting'
-          ? 'Waiting for isolated QA of this PSADT execution profile'
-          : qaDemand.failureSummary || 'The exact PSADT execution profile failed QA',
+          ? 'Running an isolated installation test to make sure this app works before deployment'
+          : qaDemand.failureSummary || 'This app did not pass the isolated installation test',
       progress_percent: 0,
       execution_profile_sha256: qaDemand?.identity.executionProfileSha256 || null,
       presentation_profile_sha256: qaDemand?.identity.presentationProfileSha256 || null,

--- a/lib/msp/batch-orchestrator.ts
+++ b/lib/msp/batch-orchestrator.ts
@@ -405,7 +405,7 @@ async function startBatchItems(batchId: string): Promise<number> {
       if (isQaSkip && jobId) {
         await db.jobs.update(jobId, {
           status: 'cancelled',
-          status_message: 'Skipped because current QA failed',
+          status_message: 'Skipped because the installation test failed',
           error_message: msg,
           cancelled_at: new Date().toISOString(),
           completed_at: new Date().toISOString(),

--- a/lib/qa/classify.ts
+++ b/lib/qa/classify.ts
@@ -11,11 +11,11 @@ const ENVIRONMENT_INSTALL_CODES = new Set([1601, 1618, 1622]);
 
 const REMEDIATION: Record<QaFailureBucket, string> = {
   package_definition:
-    "Review and correct the app's QA definition: silent switches, detection rule, or uninstall command.",
+    "Review the app's silent install arguments, detection rule, and uninstall command.",
   vendor_installer:
     'The vendor installer appears to fail even when driven correctly. Test a newer vendor release before deployment.',
   environment:
-    'The result may be specific to the QA machine. Re-run the test before changing the package definition.',
+    'The result may be specific to the test environment. Re-run the test before changing the package definition.',
   unknown:
     'The available aggregate evidence is inconclusive. Review the failing phase and its exit code.',
 };
@@ -138,7 +138,7 @@ export function classifyQaFailure(
       'phase_not_run',
       'environment',
       'low',
-      'A later QA phase did not run after an earlier phase completed.'
+      'A later test step did not run after an earlier step completed.'
     );
   }
 

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -44,7 +44,7 @@ export async function ensureQaDemand(
       identity,
       candidateId: null,
       state: 'failed',
-      failureSummary: 'The exact PSADT execution profile failed isolated QA.',
+      failureSummary: 'This app did not pass the isolated installation test.',
     };
   }
 
@@ -116,7 +116,7 @@ export async function ensureQaDemand(
       identity,
       candidateId: existing.id,
       state: 'failed',
-      failureSummary: existing.failure_summary || 'The exact execution profile failed QA.',
+      failureSummary: existing.failure_summary || 'This app did not pass the isolated installation test.',
     };
   }
 

--- a/lib/qa/gate.ts
+++ b/lib/qa/gate.ts
@@ -16,7 +16,7 @@ export class QaGateError extends Error {
     }
   ) {
     super(
-      `QA testing failed for ${details.wingetId} ${details.testedVersion} (${details.architecture})`
+      `Installation testing failed for ${details.wingetId} ${details.testedVersion} (${details.architecture})`
     );
     this.name = 'QaGateError';
   }
@@ -42,7 +42,7 @@ export class QaGateNotPassedError extends Error {
     }
   ) {
     super(
-      `Awaiting an exact PSADT package QA pass for ${details.wingetId} ${details.version} (${details.architecture}, ${details.installerSha256.slice(0, 8) || 'no hash'})`
+      `Installation testing has not passed yet for ${details.wingetId} ${details.version} (${details.architecture})`
     );
     this.name = 'QaGateNotPassedError';
   }
@@ -56,7 +56,7 @@ export function isQaGateError(error: unknown): error is AnyQaGateError {
 
 export function describeQaGateError(error: AnyQaGateError): string {
   if (error instanceof QaGateNotPassedError) {
-    return `${error.message}. Automatic deployment will resume after that exact PSADT package profile has passed isolated QA.`;
+    return `${error.message}. Automatic deployment will resume after the installation test passes.`;
   }
   const { classification, testedAtUtc } = error.details;
   return [

--- a/lib/qa/recovery.test.ts
+++ b/lib/qa/recovery.test.ts
@@ -39,7 +39,7 @@ describe('qaTimeoutRecoveryUpdate', () => {
       github_run_id: execution.github_run_id,
       github_run_url: execution.github_run_url,
       finished_at: '2026-08-07T20:50:00.000Z',
-      failure_summary: 'QA workflow did not report completion before the safety timeout.',
+      failure_summary: 'The installation test did not finish before the safety timeout.',
       updated_at: '2026-08-07T20:50:00.000Z',
     });
   });

--- a/lib/qa/recovery.ts
+++ b/lib/qa/recovery.ts
@@ -20,7 +20,7 @@ export function qaTimeoutRecoveryUpdate(
     github_run_url: exhausted ? candidate.github_run_url : null,
     finished_at: exhausted ? now : null,
     failure_summary: exhausted
-      ? 'QA workflow did not report completion before the safety timeout.'
+      ? 'The installation test did not finish before the safety timeout.'
       : null,
     ...(exhausted ? {} : {
       phase: null,


### PR DESCRIPTION
## Summary
- replace internal PSADT/execution-profile wording in deployment progress with plain installation-test language
- align customer, auto-update, MSP, retry, timeout, and resume messages
- keep QA/PSADT terminology only on the dedicated technical QA surfaces

## Verification
- full test suite: 700/700 passed (the translation fallback test passed on isolated rerun after a transient timeout)
- `npm run lint`
- `npm run build:ci`
- React quality checklist reviewed