### PR TITLE
Backfill demanded app QA and reveal system-change details

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -267,7 +267,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           <div className="h-full rounded-full bg-accent-cyan transition-[width] duration-500 motion-reduce:transition-none" style={{ width: `${phase.progressPercent}%` }} />
         </div>
 
-        <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,5fr)_minmax(320px,2fr)] xl:grid-cols-[minmax(0,7fr)_minmax(360px,3fr)]">
+        <div className="grid items-start gap-4 lg:grid-cols-[minmax(0,5fr)_minmax(320px,2fr)] xl:grid-cols-[minmax(0,7fr)_minmax(360px,3fr)]">
           <div className="-mx-5 w-[calc(100%+2.5rem)] overflow-hidden border-y border-overlay/10 bg-black sm:mx-0 sm:w-auto sm:rounded-xl sm:border" aria-labelledby="live-console-heading">
             <div className="flex items-center justify-between border-b border-white/10 bg-bg-surface/80 px-4 py-3">
               <div className="flex min-w-0 items-center gap-2">

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -65,14 +65,26 @@ function createSupabaseStub(options: {
   recipes?: Array<Record<string, unknown>>;
   candidates?: Array<Record<string, unknown>>;
   candidatePages?: Array<Array<Record<string, unknown>>>;
+  demandBackfillApps?: string[];
 }) {
   const pollRunInserts: Array<Record<string, unknown>> = [];
   const pollRunUpdates: Array<Record<string, unknown>> = [];
   const cursorUpdates: Array<Record<string, unknown>> = [];
   const candidateInserts: Array<Record<string, unknown>> = [];
+  const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
   let candidatePageIndex = 0;
 
   const client = {
+    rpc: vi.fn((name: string, args: Record<string, unknown>) => {
+      rpcCalls.push({ name, args });
+      if (name !== 'qa_missing_demand_backfill_ids') {
+        throw new Error(`Unexpected RPC: ${name}`);
+      }
+      return Promise.resolve({
+        data: (options.demandBackfillApps || []).map((winget_id) => ({ winget_id })),
+        error: null,
+      });
+    }),
     from: vi.fn((table: string) => {
       if (table === 'qa_poll_runs') {
         return {
@@ -142,7 +154,14 @@ function createSupabaseStub(options: {
       throw new Error(`Unexpected table: ${table}`);
     }),
   };
-  return { client, pollRunInserts, pollRunUpdates, cursorUpdates, candidateInserts };
+  return {
+    client,
+    pollRunInserts,
+    pollRunUpdates,
+    cursorUpdates,
+    candidateInserts,
+    rpcCalls,
+  };
 }
 
 const CURRENT_PACKAGER_COMMIT = '3fc86a5a4224986dcd34c4270f0a4d5c919651a2';
@@ -261,7 +280,8 @@ afterEach(() => {
 
 describe('GET /api/cron/qa-enqueue', () => {
   it('persists a successful full-catalog poll and advances its cursor', async () => {
-    const { client, pollRunInserts, pollRunUpdates, cursorUpdates } = createSupabaseStub({});
+    const { client, pollRunInserts, pollRunUpdates, cursorUpdates, rpcCalls } =
+      createSupabaseStub({});
     createServerClientMock.mockReturnValue(client);
 
     const response = await GET(cronRequest());
@@ -277,14 +297,61 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(pollRunInserts).toEqual([expect.objectContaining({ request_id: 'fra1::request-1' })]);
     expect(cursorUpdates).toEqual([expect.objectContaining({ head_sha: 'b'.repeat(40) })]);
+    expect(rpcCalls).toEqual([
+      { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 3 } },
+    ]);
     expect(pollRunUpdates).toEqual([
       expect.objectContaining({
         status: 'succeeded',
         recipe_count: 14_062,
         changed_package_count: 0,
         supported_changed_count: 0,
+        demand_backfill_requested_count: 0,
+        demand_backfill_count: 0,
       }),
     ]);
+  });
+
+  it('queues a demanded app missing latest-version catalog QA without a WinGet change', async () => {
+    const { client, candidateInserts, pollRunUpdates } = createSupabaseStub({
+      demandBackfillApps: ['Missing.App'],
+      supportedApps: [
+        {
+          winget_id: 'Missing.App',
+          name: 'Missing',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      changedPackageCount: 0,
+      demandBackfillRequestedCount: 1,
+      demandBackfillCount: 1,
+    });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({
+      winget_id: 'Missing.App',
+      version: '1.0.0',
+      status: 'queued',
+      priority: 1,
+      demand_source: 'managed',
+      catalog_version_at_enqueue: '1.0.0',
+      test_config: { profileKind: 'catalog-default' },
+    });
+    expect(pollRunUpdates[0]).toMatchObject({
+      demand_backfill_requested_count: 1,
+      demand_backfill_count: 1,
+    });
   });
 
   it('records a changed supported app failure without advancing the cursor', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -32,6 +32,7 @@ const MAX_RECORDED_ERRORS = 100;
 const MAX_ERROR_LENGTH = 1_000;
 const TOOLCHAIN_BACKFILL_BATCH_SIZE = 3;
 const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
+const DEMAND_BACKFILL_BATCH_SIZE = 3;
 
 interface QaCandidateProfileRow {
   id: string;
@@ -192,6 +193,22 @@ function recordPollError(summary: QaPollSummary, scope: string, error: unknown):
   }
 }
 
+async function findDemandBackfillIds(
+  supabase: ReturnType<typeof createServerClient>
+): Promise<string[]> {
+  const { data, error } = await supabase.rpc('qa_missing_demand_backfill_ids', {
+    p_limit: DEMAND_BACKFILL_BATCH_SIZE,
+  });
+  if (error) throw new Error(`Could not select demanded-app QA backfill: ${error.message}`);
+  return Array.from(
+    new Set(
+      ((data || []) as Array<{ winget_id?: unknown }>)
+        .map((row) => (typeof row.winget_id === 'string' ? row.winget_id.trim() : ''))
+        .filter(Boolean)
+    )
+  );
+}
+
 export async function GET(request: Request) {
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
@@ -215,6 +232,8 @@ export async function GET(request: Request) {
   let supportedChangedCount = 0;
   let toolchainBackfillCount = 0;
   let toolchainBackfillPagesScanned = 0;
+  let demandBackfillRequestedCount = 0;
+  let demandBackfillCount = 0;
   let baseSha: string | null = null;
   let headSha: string | null = null;
   let runId: string | null = null;
@@ -245,6 +264,8 @@ export async function GET(request: Request) {
         head_sha: headSha,
         changed_package_count: changedPackageCount,
         supported_changed_count: supportedChangedCount,
+        demand_backfill_requested_count: demandBackfillRequestedCount,
+        demand_backfill_count: demandBackfillCount,
       })
       .eq('id', runId);
     if (error) throw new Error(`Could not finalize QA poll run ${runId}: ${error.message}`);
@@ -294,11 +315,18 @@ export async function GET(request: Request) {
     baseSha = changes.baseSha;
     headSha = changes.headSha;
     changedPackageCount = changes.changedPackageIds.length;
-    const backfill = await findToolchainBackfillIds(supabase);
+    const [backfill, demandBackfillIds] = await Promise.all([
+      findToolchainBackfillIds(supabase),
+      findDemandBackfillIds(supabase),
+    ]);
     toolchainBackfillPagesScanned = backfill.pagesScanned;
+    demandBackfillRequestedCount = demandBackfillIds.length;
     const changedIds = new Set(changes.changedPackageIds);
     const backfillIds = new Set(backfill.ids);
-    const targetPackageIds = Array.from(new Set([...changedIds, ...backfillIds]));
+    const demandBackfillIdSet = new Set(demandBackfillIds);
+    const targetPackageIds = Array.from(
+      new Set([...changedIds, ...backfillIds, ...demandBackfillIdSet])
+    );
 
     structuredQaPollLog('info', 'qa_poll_started', {
       runId,
@@ -310,6 +338,7 @@ export async function GET(request: Request) {
       changedPackageCount,
       toolchainBackfillRequestedCount: backfill.ids.length,
       toolchainBackfillPagesScanned,
+      demandBackfillRequestedCount,
     });
 
     let supportedApps: Array<{
@@ -403,6 +432,9 @@ export async function GET(request: Request) {
     supportedApps = supportedApps.filter((app) => demandedIds.has(app.winget_id));
     supportedChangedCount = supportedApps.filter((app) => changedIds.has(app.winget_id)).length;
     toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
+    demandBackfillCount = supportedApps.filter((app) =>
+      demandBackfillIdSet.has(app.winget_id)
+    ).length;
     const recipeById = new Map(recipes.map((row) => [row.winget_id, row]));
     const resultById = new Map(results.map((row) => [row.winget_id, row]));
     const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
@@ -645,6 +677,8 @@ export async function GET(request: Request) {
       supportedChangedCount,
       toolchainBackfillCount,
       toolchainBackfillPagesScanned,
+      demandBackfillRequestedCount,
+      demandBackfillCount,
       ...summary,
     });
 
@@ -661,6 +695,8 @@ export async function GET(request: Request) {
         supportedChangedCount,
         toolchainBackfillCount,
         toolchainBackfillPagesScanned,
+        demandBackfillRequestedCount,
+        demandBackfillCount,
         ...summary,
       },
       { status: status === 'succeeded' ? 200 : 207 }
@@ -699,6 +735,8 @@ export async function GET(request: Request) {
         supportedChangedCount,
         toolchainBackfillCount,
         toolchainBackfillPagesScanned,
+        demandBackfillRequestedCount,
+        demandBackfillCount,
         ...summary,
       },
       { status: 500 }

--- a/components/qa/QaLiveActivityPanel.tsx
+++ b/components/qa/QaLiveActivityPanel.tsx
@@ -129,7 +129,7 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
   }
 
   return (
-    <section className="flex min-h-[22rem] flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-surface/45 lg:max-h-[32rem]" aria-labelledby="system-changes-heading">
+    <section className="flex min-h-[22rem] flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-surface/45" aria-labelledby="system-changes-heading">
       <div className="border-b border-overlay/10 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -235,7 +235,16 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
         </div>
       </div>
 
-      <div id="qa-activity-panel" role="tabpanel" aria-labelledby={`qa-activity-tab-${filter}`} className={cn('min-h-0 flex-1 overflow-y-auto', mobileView !== 'changes' && 'hidden sm:block')}>
+      <div
+        id="qa-activity-panel"
+        role="tabpanel"
+        aria-labelledby={`qa-activity-tab-${filter}`}
+        className={cn(
+          'min-h-0 flex-1 overflow-y-auto',
+          paginatedItems.length > 0 && 'min-h-72 sm:min-h-88',
+          mobileView !== 'changes' && 'hidden sm:block'
+        )}
+      >
         {paginatedItems.length ? (
           <>
             <div className="hidden sm:block">

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -131,3 +131,34 @@ describe('QA effective configuration migration contract', () => {
     expect(sql).toContain('from public, anon, authenticated, service_role');
   });
 });
+
+describe('demanded-app QA backfill migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260809204500_demanded_app_qa_backfill.sql'
+    ),
+    'utf8'
+  );
+
+  it('selects only supported, demanded apps missing current catalog QA', () => {
+    expect(sql).toContain('from public.upload_history as history');
+    expect(sql).toContain("policy.policy_type = 'auto_update'");
+    expect(sql).toContain('policy.is_enabled is true');
+    expect(sql).toContain('app.is_verified is true');
+    expect(sql).toContain('app.is_winget_verified is true');
+    expect(sql).toContain("app.app_source = 'win32'");
+    expect(sql).toContain('app.is_locale_variant is false');
+    expect(sql).toContain('candidate.version = app.latest_version');
+    expect(sql).toContain("candidate.status <> 'superseded'");
+    expect(sql).toContain("candidate.test_config @> '{\"profileKind\":\"catalog-default\"}'::jsonb");
+  });
+
+  it('keeps selection bounded, indexed, and service-only', () => {
+    expect(sql).toContain('limit greatest(1, least(coalesce(p_limit, 3), 100))');
+    expect(sql).toContain('qa_candidates_current_catalog_profile_idx');
+    expect(sql).toContain("set search_path = ''");
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+  });
+});

--- a/supabase/migrations/20260809204500_demanded_app_qa_backfill.sql
+++ b/supabase/migrations/20260809204500_demanded_app_qa_backfill.sql
@@ -1,0 +1,88 @@
+-- Gradually fill the latest-version QA gap for apps with real customer demand.
+-- The scheduler consumes only a few rows per poll so the single VM is not
+-- flooded, while customer-triggered deployment tests retain queue priority.
+
+alter table public.qa_poll_runs
+  add column if not exists demand_backfill_requested_count integer not null default 0
+    check (demand_backfill_requested_count >= 0),
+  add column if not exists demand_backfill_count integer not null default 0
+    check (demand_backfill_count >= 0);
+
+comment on column public.qa_poll_runs.demand_backfill_requested_count is
+  'Number of demanded apps missing latest-version catalog QA selected for this poll.';
+comment on column public.qa_poll_runs.demand_backfill_count is
+  'Number of selected demanded-app backfills that remained eligible after catalog filtering.';
+
+create index if not exists qa_candidates_current_catalog_profile_idx
+  on public.qa_candidates(winget_id, version)
+  where test_level = 'psadt-package'
+    and status <> 'superseded'
+    and test_config @> '{"profileKind":"catalog-default"}'::jsonb;
+
+create or replace function public.qa_missing_demand_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with demand_events as (
+    select
+      history.winget_id,
+      false as has_auto_update,
+      history.deployed_at as demanded_at
+    from public.upload_history as history
+    where nullif(btrim(history.winget_id), '') is not null
+
+    union all
+
+    select
+      policy.winget_id,
+      true as has_auto_update,
+      policy.updated_at as demanded_at
+    from public.app_update_policies as policy
+    where policy.policy_type = 'auto_update'
+      and policy.is_enabled is true
+      and nullif(btrim(policy.winget_id), '') is not null
+  ),
+  demand as (
+    select
+      event.winget_id,
+      bool_or(event.has_auto_update) as has_auto_update,
+      max(event.demanded_at) as last_demanded_at
+    from demand_events as event
+    group by event.winget_id
+  )
+  select app.winget_id
+  from demand
+  join public.curated_apps as app on app.winget_id = demand.winget_id
+  where app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and candidate.version = app.latest_version
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+  order by
+    demand.has_auto_update desc,
+    demand.last_demanded_at desc nulls last,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 100));
+$$;
+
+comment on function public.qa_missing_demand_backfill_ids(integer) is
+  'Returns a bounded service-only batch of demanded Win32 apps missing catalog QA for the current catalog version.';
+
+revoke all on function public.qa_missing_demand_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_missing_demand_backfill_ids(integer)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -270,6 +270,8 @@ export interface Database {
           head_sha: string | null;
           changed_package_count: number;
           supported_changed_count: number;
+          demand_backfill_requested_count: number;
+          demand_backfill_count: number;
           created_at: string;
         };
         Insert: {
@@ -292,6 +294,8 @@ export interface Database {
           head_sha?: string | null;
           changed_package_count?: number;
           supported_changed_count?: number;
+          demand_backfill_requested_count?: number;
+          demand_backfill_count?: number;
           created_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_poll_runs']['Insert']>;
@@ -2247,6 +2251,14 @@ export interface Database {
           p_byte_size: number;
         };
         Returns: boolean;
+      };
+      qa_missing_demand_backfill_ids: {
+        Args: {
+          p_limit?: number;
+        };
+        Returns: Array<{
+          winget_id: string;
+        }>;
       };
       increment_usage: {
         Args: {


### PR DESCRIPTION
## Summary
- select three previously deployed or auto-update-enabled apps missing current catalog QA on each 10-minute poll
- preserve the customer upload express lane and record backfill counts in poll observability
- keep paginated file and registry targets visibly sized instead of collapsing the table body

## Live database
- applied the service-only backfill selector migration to Supabase
- verified 1,104 demanded supported apps, 1,095 initially missing current-version catalog QA
- verified anon/authenticated cannot execute the selector; service_role can

## Verification
- 703 tests pass (702 in the full parallel run plus the known translation timeout passing in isolation)
- npm run lint
- npm run build:ci (141 routes)