### PR TITLE
Activate Burn uninstall fix for QA

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -164,7 +164,7 @@ function createSupabaseStub(options: {
   };
 }
 
-const CURRENT_PACKAGER_COMMIT = '3fc86a5a4224986dcd34c4270f0a4d5c919651a2';
+const CURRENT_PACKAGER_COMMIT = QA_PSADT_TOOLCHAIN.packagerCommit;
 
 function profileCandidate(options: {
   id: string;

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3fc86a5a4224986dcd34c4270f0a4d5c919651a2',
+  packagerCommit: '1e24bd1a9aa2a6d768e38180450eb4d52a927d88',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## Summary
- update the public QA package identity to the merged Burn-uninstall packager revision
- keep toolchain-backfill tests coupled to the exported toolchain constant

## Verification
- package profile, QA enqueue, and QA dispatch tests: 53 passed