### PR TITLE
Make WinGet polling rate-limit aware

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -66,6 +66,7 @@ function createSupabaseStub(options: {
   candidates?: Array<Record<string, unknown>>;
   candidatePages?: Array<Array<Record<string, unknown>>>;
   demandBackfillApps?: string[];
+  pollState?: Record<string, unknown>;
 }) {
   const pollRunInserts: Array<Record<string, unknown>> = [];
   const pollRunUpdates: Array<Record<string, unknown>> = [];
@@ -115,7 +116,15 @@ function createSupabaseStub(options: {
       }
       if (table === 'qa_winget_poll_state') {
         return {
-          select: vi.fn(() => query({ data: { head_sha: 'a'.repeat(40), last_checked_at: null }, error: null })),
+          select: vi.fn(() => query({
+            data: options.pollState || {
+              head_sha: 'a'.repeat(40),
+              last_checked_at: null,
+              github_etag: null,
+              github_rate_limited_until: null,
+            },
+            error: null,
+          })),
           update: vi.fn((row: Record<string, unknown>) => {
             cursorUpdates.push(row);
             return query({ data: null, error: null });
@@ -270,6 +279,8 @@ beforeEach(() => {
     changedFiles: 0,
     changedPackageIds: [],
     initialized: false,
+    etag: '"next"',
+    rateLimitedUntil: null,
   });
 });
 
@@ -296,7 +307,13 @@ describe('GET /api/cron/qa-enqueue', () => {
       errorCount: 0,
     });
     expect(pollRunInserts).toEqual([expect.objectContaining({ request_id: 'fra1::request-1' })]);
-    expect(cursorUpdates).toEqual([expect.objectContaining({ head_sha: 'b'.repeat(40) })]);
+    expect(cursorUpdates).toEqual([
+      expect.objectContaining({
+        head_sha: 'b'.repeat(40),
+        github_etag: '"next"',
+        github_rate_limited_until: null,
+      }),
+    ]);
     expect(rpcCalls).toEqual([
       { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 3 } },
     ]);
@@ -310,6 +327,43 @@ describe('GET /api/cron/qa-enqueue', () => {
         demand_backfill_count: 0,
       }),
     ]);
+  });
+
+  it('persists GitHub rate-limit deferral and does not advance the change cursor', async () => {
+    const resetAt = '2026-08-10T09:00:00.000Z';
+    detectWingetChangesMock.mockResolvedValue({
+      baseSha: 'a'.repeat(40),
+      headSha: 'a'.repeat(40),
+      changedFiles: 0,
+      changedPackageIds: [],
+      initialized: false,
+      etag: '"current"',
+      rateLimitedUntil: resetAt,
+    });
+    const { client, cursorUpdates, pollRunUpdates } = createSupabaseStub({
+      pollState: {
+        head_sha: 'a'.repeat(40),
+        last_checked_at: null,
+        github_etag: '"current"',
+        github_rate_limited_until: null,
+      },
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(207);
+    expect(body).toMatchObject({
+      success: false,
+      checked: 0,
+      errorCount: 1,
+      errors: [`system: WinGet GitHub change feed paused until ${resetAt}`],
+    });
+    expect(cursorUpdates).toEqual([
+      expect.objectContaining({ github_rate_limited_until: resetAt }),
+    ]);
+    expect(pollRunUpdates[0]).toMatchObject({ status: 'partial', error_count: 1 });
   });
 
   it('queues a demanded app missing latest-version catalog QA without a WinGet change', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -291,7 +291,7 @@ export async function GET(request: Request) {
         .eq('is_locale_variant', false),
       supabase
         .from('qa_winget_poll_state')
-        .select('head_sha, last_checked_at')
+        .select('head_sha, last_checked_at, github_etag, github_rate_limited_until')
         .eq('id', POLL_STATE_ID)
         .maybeSingle(),
     ]);
@@ -311,10 +311,29 @@ export async function GET(request: Request) {
       token: process.env.GITHUB_PAT,
       baseSha,
       since: stateResult.data?.last_checked_at || lookbackStart,
+      etag: stateResult.data?.github_etag || null,
+      rateLimitedUntil: stateResult.data?.github_rate_limited_until || null,
     });
     baseSha = changes.baseSha;
     headSha = changes.headSha;
     changedPackageCount = changes.changedPackageIds.length;
+    if (changes.rateLimitedUntil) {
+      const { error: rateLimitStateError } = await supabase
+        .from('qa_winget_poll_state')
+        .update({
+          github_rate_limited_until: changes.rateLimitedUntil,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', POLL_STATE_ID);
+      if (rateLimitStateError) {
+        throw new Error(`Could not persist the GitHub rate-limit reset: ${rateLimitStateError.message}`);
+      }
+      recordPollError(
+        summary,
+        'system',
+        `WinGet GitHub change feed paused until ${changes.rateLimitedUntil}`
+      );
+    }
     const [backfill, demandBackfillIds] = await Promise.all([
       findToolchainBackfillIds(supabase),
       findDemandBackfillIds(supabase),
@@ -642,6 +661,8 @@ export async function GET(request: Request) {
         .from('qa_winget_poll_state')
         .update({
           head_sha: headSha,
+          github_etag: changes.etag,
+          github_rate_limited_until: null,
           last_checked_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         })

--- a/lib/qa/winget-changes.test.ts
+++ b/lib/qa/winget-changes.test.ts
@@ -93,7 +93,7 @@ describe('detectWingetChanges', () => {
     );
   });
 
-  it('falls back to the public feed when an authenticated request is rate limited', async () => {
+  it('persists the authenticated reset time without falling back to a shared public IP quota', async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
@@ -101,33 +101,46 @@ describe('detectWingetChanges', () => {
           status: 403,
           headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1786220000' },
         })
-      )
-      .mockResolvedValueOnce(new Response(JSON.stringify([{ sha: BASE }]), { status: 200 }));
+      );
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     await expect(
       detectWingetChanges({ token: 'configured-token', baseSha: BASE, fetchImpl })
-    ).resolves.toMatchObject({ headSha: BASE, changedPackageIds: [] });
+    ).resolves.toMatchObject({
+      headSha: BASE,
+      changedPackageIds: [],
+      rateLimitedUntil: new Date(1786220000 * 1000).toISOString(),
+    });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(new Headers(fetchImpl.mock.calls[0][1]?.headers).get('Authorization')).toBe(
       'Bearer configured-token'
     );
-    expect(new Headers(fetchImpl.mock.calls[1][1]?.headers).has('Authorization')).toBe(false);
   });
 
-  it('reports the reset time when both authenticated and public feeds are rate limited', async () => {
-    const limited = () =>
-      new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
-        status: 403,
-        headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1786220000' },
-      });
-    const fetchImpl = vi.fn().mockImplementation(limited);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  it('uses a persistent ETag and returns immediately on 304', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, { status: 304, headers: { etag: '"current"' } })
+    );
 
     await expect(
-      detectWingetChanges({ token: 'configured-token', baseSha: BASE, fetchImpl })
-    ).rejects.toThrow(/resets 2026-/);
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+      detectWingetChanges({ token: 'configured-token', baseSha: BASE, etag: '"current"', fetchImpl })
+    ).resolves.toMatchObject({
+      headSha: BASE,
+      changedPackageIds: [],
+      etag: '"current"',
+      rateLimitedUntil: null,
+    });
+    expect(new Headers(fetchImpl.mock.calls[0][1]?.headers).get('If-None-Match')).toBe('"current"');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call GitHub before a stored rate-limit reset', async () => {
+    const fetchImpl = vi.fn();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    await expect(
+      detectWingetChanges({ baseSha: BASE, rateLimitedUntil: future, fetchImpl })
+    ).resolves.toMatchObject({ headSha: BASE, rateLimitedUntil: future });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/lib/qa/winget-changes.ts
+++ b/lib/qa/winget-changes.ts
@@ -24,13 +24,24 @@ export interface WingetChangeSet {
   changedFiles: number;
   changedPackageIds: string[];
   initialized: boolean;
+  etag: string | null;
+  rateLimitedUntil: string | null;
 }
 
 export interface DetectWingetChangesOptions {
   token?: string;
   baseSha?: string | null;
   since?: string;
+  etag?: string | null;
+  rateLimitedUntil?: string | null;
   fetchImpl?: typeof fetch;
+}
+
+class GitHubRateLimitError extends Error {
+  constructor(public readonly resetAt: string | null) {
+    super(`WinGet GitHub change feed is rate limited${resetAt ? ` until ${resetAt}` : ''}`);
+    this.name = 'GitHubRateLimitError';
+  }
 }
 
 function githubHeaders(token?: string): HeadersInit {
@@ -45,38 +56,33 @@ function githubHeaders(token?: string): HeadersInit {
 async function githubJson<T>(
   fetchImpl: typeof fetch,
   path: string,
-  token?: string
-): Promise<T> {
-  const request = (requestToken?: string) =>
-    fetchImpl(`${GITHUB_API_BASE}${path}`, {
-      headers: githubHeaders(requestToken),
-      cache: 'no-store',
-    });
-  let response = await request(token);
+  token?: string,
+  ifNoneMatch?: string | null
+): Promise<{ data: T | null; etag: string | null; notModified: boolean }> {
+  const headers = new Headers(githubHeaders(token));
+  if (ifNoneMatch) headers.set('If-None-Match', ifNoneMatch);
+  const response = await fetchImpl(`${GITHUB_API_BASE}${path}`, {
+    headers,
+    cache: 'no-store',
+  });
+  if (response.status === 304) {
+    return { data: null, etag: response.headers.get('etag') || ifNoneMatch || null, notModified: true };
+  }
   if (!response.ok) {
-    let detail = (await response.text()).slice(0, 500);
+    const detail = (await response.text()).slice(0, 500);
     const rateLimited =
       response.status === 429 ||
       (response.status === 403 &&
         (response.headers.get('x-ratelimit-remaining') === '0' ||
           /rate limit exceeded/i.test(detail)));
 
-    if (token && rateLimited) {
+    if (rateLimited) {
       const resetEpoch = Number(response.headers.get('x-ratelimit-reset'));
-      console.warn(
-        JSON.stringify({
-          level: 'warning',
-          message: 'qa_winget_github_authenticated_rate_limit',
-          route: '/api/cron/qa-enqueue',
-          resetAt:
-            Number.isFinite(resetEpoch) && resetEpoch > 0
-              ? new Date(resetEpoch * 1000).toISOString()
-              : null,
-        })
-      );
-      response = await request(undefined);
-      if (response.ok) return (await response.json()) as T;
-      detail = (await response.text()).slice(0, 500);
+      const resetAt =
+        Number.isFinite(resetEpoch) && resetEpoch > 0
+          ? new Date(resetEpoch * 1000).toISOString()
+          : null;
+      throw new GitHubRateLimitError(resetAt);
     }
 
     const resetEpoch = Number(response.headers.get('x-ratelimit-reset'));
@@ -86,7 +92,11 @@ async function githubJson<T>(
         : '';
     throw new Error(`WinGet change feed failed (${response.status}${reset}): ${detail || path}`);
   }
-  return (await response.json()) as T;
+  return {
+    data: (await response.json()) as T,
+    etag: response.headers.get('etag'),
+    notModified: false,
+  };
 }
 
 export function wingetIdFromManifestPath(path: string): string | null {
@@ -119,11 +129,12 @@ async function compare(
   token?: string
 ): Promise<{ changedFiles: number; changedPackageIds: string[] }> {
   if (baseSha === headSha) return { changedFiles: 0, changedPackageIds: [] };
-  const result = await githubJson<GitHubComparison>(
+  const response = await githubJson<GitHubComparison>(
     fetchImpl,
     `/compare/${baseSha}...${headSha}`,
     token
   );
+  const result = response.data!;
   if (result.status === 'diverged' || result.status === 'behind') {
     throw new Error(`WinGet change cursor is not an ancestor of ${headSha}`);
   }
@@ -138,9 +149,64 @@ export async function detectWingetChanges({
   token,
   baseSha,
   since = new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  etag,
+  rateLimitedUntil,
   fetchImpl = fetch,
 }: DetectWingetChangesOptions = {}): Promise<WingetChangeSet> {
-  const latest = await githubJson<GitHubCommitSummary[]>(fetchImpl, '/commits?per_page=1', token);
+  const deferredUntilMs = rateLimitedUntil ? Date.parse(rateLimitedUntil) : Number.NaN;
+  if (baseSha && Number.isFinite(deferredUntilMs) && deferredUntilMs > Date.now()) {
+    return {
+      baseSha,
+      headSha: baseSha,
+      changedFiles: 0,
+      changedPackageIds: [],
+      initialized: false,
+      etag: etag || null,
+      rateLimitedUntil: new Date(deferredUntilMs).toISOString(),
+    };
+  }
+
+  let latestResponse: Awaited<ReturnType<typeof githubJson<GitHubCommitSummary[]>>>;
+  try {
+    latestResponse = await githubJson<GitHubCommitSummary[]>(
+      fetchImpl,
+      '/commits?per_page=1',
+      token,
+      baseSha ? etag : null
+    );
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError && baseSha) {
+      console.warn(JSON.stringify({
+        level: 'warning',
+        message: 'qa_winget_github_authenticated_rate_limit',
+        route: '/api/cron/qa-enqueue',
+        resetAt: error.resetAt,
+      }));
+      return {
+        baseSha,
+        headSha: baseSha,
+        changedFiles: 0,
+        changedPackageIds: [],
+        initialized: false,
+        etag: etag || null,
+        rateLimitedUntil: error.resetAt || new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      };
+    }
+    throw error;
+  }
+  if (latestResponse.notModified) {
+    if (!baseSha) throw new Error('WinGet change feed returned 304 without a stored cursor');
+    return {
+      baseSha,
+      headSha: baseSha,
+      changedFiles: 0,
+      changedPackageIds: [],
+      initialized: false,
+      etag: latestResponse.etag || etag || null,
+      rateLimitedUntil: null,
+    };
+  }
+  const latest = latestResponse.data!;
   const headSha = latest[0]?.sha?.toLowerCase() || '';
   if (!SHA_PATTERN.test(headSha)) throw new Error('WinGet change feed returned an invalid head SHA');
 
@@ -148,14 +214,22 @@ export async function detectWingetChanges({
     const normalizedBase = baseSha.toLowerCase();
     if (!SHA_PATTERN.test(normalizedBase)) throw new Error('Stored WinGet cursor SHA is invalid');
     const changes = await compare(fetchImpl, normalizedBase, headSha, token);
-    return { baseSha: normalizedBase, headSha, ...changes, initialized: false };
+    return {
+      baseSha: normalizedBase,
+      headSha,
+      ...changes,
+      initialized: false,
+      etag: latestResponse.etag || null,
+      rateLimitedUntil: null,
+    };
   }
 
-  const recent = await githubJson<GitHubCommitSummary[]>(
+  const recentResponse = await githubJson<GitHubCommitSummary[]>(
     fetchImpl,
     `/commits?per_page=100&since=${encodeURIComponent(since)}`,
     token
   );
+  const recent = recentResponse.data!;
   if (recent.length === 0) {
     return {
       baseSha: null,
@@ -163,6 +237,8 @@ export async function detectWingetChanges({
       changedFiles: 0,
       changedPackageIds: [],
       initialized: true,
+      etag: latestResponse.etag || null,
+      rateLimitedUntil: null,
     };
   }
   if (recent.length >= 100) {
@@ -173,5 +249,12 @@ export async function detectWingetChanges({
     throw new Error('Initial WinGet change feed did not include a valid parent SHA');
   }
   const changes = await compare(fetchImpl, oldestParent, headSha, token);
-  return { baseSha: oldestParent, headSha, ...changes, initialized: true };
+  return {
+    baseSha: oldestParent,
+    headSha,
+    ...changes,
+    initialized: true,
+    etag: latestResponse.etag || null,
+    rateLimitedUntil: null,
+  };
 }

--- a/supabase/migrations/20260810062448_add_qa_winget_github_cache_state.sql
+++ b/supabase/migrations/20260810062448_add_qa_winget_github_cache_state.sql
@@ -1,0 +1,8 @@
+alter table public.qa_winget_poll_state
+  add column if not exists github_etag text,
+  add column if not exists github_rate_limited_until timestamptz;
+
+comment on column public.qa_winget_poll_state.github_etag is
+  'GitHub commits endpoint ETag used for conditional WinGet change-feed requests.';
+comment on column public.qa_winget_poll_state.github_rate_limited_until is
+  'GitHub primary-rate-limit reset time; requests are deferred until this instant.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -329,12 +329,16 @@ export interface Database {
         Row: {
           id: string;
           head_sha: string | null;
+          github_etag: string | null;
+          github_rate_limited_until: string | null;
           last_checked_at: string | null;
           updated_at: string;
         };
         Insert: {
           id: string;
           head_sha?: string | null;
+          github_etag?: string | null;
+          github_rate_limited_until?: string | null;
           last_checked_at?: string | null;
           updated_at?: string;
         };


### PR DESCRIPTION
## Summary
- persist and reuse GitHub ETags for conditional WinGet commit polling
- stop falling back to the shared unauthenticated Vercel IP quota
- persist GitHub reset timestamps and defer requests until reset
- continue demand backfill while the upstream change feed is deferred

## Verification
- 20 focused Vitest tests pass
- targeted ESLint passes
- Supabase columns applied and queried successfully
- Supabase advisors show no new issue attributable to this migration

The local Next production build exceeded the command wrapper's 120-second observation window; protected PR/Vercel checks remain authoritative.