### PR TITLE
Preserve inherited WinGet installer switches

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -40,7 +40,7 @@ function healthTone(state: string): StatusTone {
 }
 
 function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): string | null {
-  if (issue === 'github_rate_limit') return 'GitHub API rate limit';
+  if (issue === 'github_rate_limit') return 'GitHub temporarily limited WinGet checks; scanning will retry automatically';
   if (issue === 'partial_failure') return 'Some package checks failed';
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
@@ -169,7 +169,9 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
           <AlertTriangle className="mr-1.5 inline h-3.5 w-3.5" aria-hidden="true" />
           <T>{schedulerIssue}</T>
           {data.scheduler.consecutiveFailures > 1
-            ? <> · <T><Var>{data.scheduler.consecutiveFailures}</Var> consecutive failures</T></>
+            ? data.scheduler.issue === 'github_rate_limit'
+              ? <> · <T><Var>{data.scheduler.consecutiveFailures}</Var> affected scans</T></>
+              : <> · <T><Var>{data.scheduler.consecutiveFailures}</Var> consecutive failures</T></>
             : null}
         </div>
       ) : null}

--- a/app/api/cron/sync-packages/route.ts
+++ b/app/api/cron/sync-packages/route.ts
@@ -5,6 +5,7 @@ import {
   createWingetManifestClient,
   resolveWingetManifest,
 } from '@/lib/winget-sync-resolution.mjs';
+import { normalizeInstaller, normalizeManifestInstallers } from '@/lib/manifest-api';
 import { selectAppsToSync } from './select-apps';
 
 const BATCH_SIZE = 10;
@@ -133,7 +134,7 @@ export async function GET(request: Request) {
             const localeManifest = await manifestClient.fetchLocaleManifest(winget_id, latestVersion);
 
             // Extract installer data
-            const installers = (installerManifest.Installers as Array<Record<string, unknown>>) || [];
+            const installers = normalizeManifestInstallers(installerManifest);
             const defaultInstaller = installers[0] || {};
 
             // Prepare version history record
@@ -146,10 +147,9 @@ export async function GET(request: Request) {
                 (defaultInstaller.InstallerType as string) ||
                 (installerManifest.InstallerType as string) ||
                 null,
-              silent_args:
-                (defaultInstaller.InstallerSwitches as Record<string, string>)?.Silent ||
-                (installerManifest.InstallerSwitches as Record<string, string>)?.Silent ||
-                null,
+              silent_args: defaultInstaller.Architecture
+                ? normalizeInstaller(defaultInstaller).silentArgs || null
+                : null,
               installers: JSON.stringify(installers),
               manifest_fetched_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   normalizeInstaller,
+  normalizeManifestInstallers,
   fetchLocaleManifest,
   getFullManifest,
   clearManifestCache,
@@ -525,6 +526,34 @@ describe('normalizeInstaller', () => {
 
       expect(normalizeInstaller(installer).architecture).toBe('neutral');
     });
+  });
+});
+
+describe('normalizeManifestInstallers', () => {
+  it('merges root and installer-specific switch fields like WinGet', () => {
+    const installers = normalizeManifestInstallers({
+      InstallerType: 'exe',
+      InstallerSwitches: {
+        Silent: '--vivaldi-silent',
+        SilentWithProgress: '--vivaldi-silent',
+      },
+      Installers: [{
+        Architecture: 'x64',
+        Scope: 'user',
+        InstallerUrl: 'https://downloads.vivaldi.com/stable/Vivaldi.exe',
+        InstallerSha256: 'abc123',
+        InstallerSwitches: { Custom: '--do-not-launch-chrome' },
+      }],
+    });
+
+    expect(installers[0].InstallerSwitches).toEqual({
+      Silent: '--vivaldi-silent',
+      SilentWithProgress: '--vivaldi-silent',
+      Custom: '--do-not-launch-chrome',
+    });
+    expect(normalizeInstaller(installers[0]).silentArgs).toBe(
+      '--vivaldi-silent --do-not-launch-chrome'
+    );
   });
 });
 

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -9,6 +9,7 @@ import { createClient } from '@supabase/supabase-js';
 import type {
   WingetManifest,
   WingetInstaller,
+  WingetInstallerSwitches,
   NormalizedInstaller,
   WingetInstallerType,
 } from '@/types/winget';
@@ -314,7 +315,11 @@ async function getManifestFromSupabase(
     // Parse installers from JSONB, recover malformed stringified JSON, or fetch fresh installer manifest
     let installers: WingetInstaller[] = [];
 
-    const parsedInstallers = coerceInstallersArray(versionData.installers, versionData.installer_type);
+    const parsedInstallers = coerceInstallersArray(
+      versionData.installers,
+      versionData.installer_type,
+      versionData.silent_args
+    );
 
     if (parsedInstallers.length > 0) {
       installers = parsedInstallers;
@@ -322,7 +327,7 @@ async function getManifestFromSupabase(
       // If DB row is incomplete or legacy, fetch authoritative installer manifest for this version.
       const installerManifest = await fetchInstallerManifest(wingetId, versionData.version);
       if (installerManifest) {
-        installers = normalizeInstallers(installerManifest);
+        installers = normalizeManifestInstallers(installerManifest);
       }
     }
 
@@ -361,7 +366,11 @@ async function getManifestFromSupabase(
   }
 }
 
-function coerceInstallersArray(rawInstallers: unknown, defaultType?: string): WingetInstaller[] {
+function coerceInstallersArray(
+  rawInstallers: unknown,
+  defaultType?: string,
+  defaultSilentArgs?: string
+): WingetInstaller[] {
   let installerArray: Array<Record<string, unknown>> = [];
 
   if (Array.isArray(rawInstallers)) {
@@ -389,7 +398,10 @@ function coerceInstallersArray(rawInstallers: unknown, defaultType?: string): Wi
     NestedInstallerType: inst.NestedInstallerType as WingetInstaller['NestedInstallerType'],
     NestedInstallerFiles: inst.NestedInstallerFiles as WingetInstaller['NestedInstallerFiles'],
     Scope: inst.Scope as WingetInstaller['Scope'],
-    InstallerSwitches: inst.InstallerSwitches as WingetInstaller['InstallerSwitches'],
+    InstallerSwitches: mergeInstallerSwitches(
+      defaultSilentArgs ? { Silent: defaultSilentArgs } : undefined,
+      inst.InstallerSwitches
+    ),
     ProductCode: inst.ProductCode as string,
     PackageFamilyName: inst.PackageFamilyName as string,
     UpgradeBehavior: inst.UpgradeBehavior as WingetInstaller['UpgradeBehavior'],
@@ -465,7 +477,7 @@ export async function getFullManifest(
     );
 
     // Normalize installers
-    const installers = normalizeInstallers(installerManifest);
+    const installers = normalizeManifestInstallers(installerManifest);
 
     // Build combined manifest. Description prefers ShortDescription to match
     // what the catalog syncs store in curated_apps, so the same app gets the
@@ -504,7 +516,21 @@ export async function getFullManifest(
 /**
  * Normalize installers from raw YAML
  */
-function normalizeInstallers(manifest: Record<string, unknown>): WingetInstaller[] {
+function mergeInstallerSwitches(
+  inherited: unknown,
+  installerSpecific: unknown
+): WingetInstallerSwitches | undefined {
+  const inheritedRecord = inherited && typeof inherited === 'object' && !Array.isArray(inherited)
+    ? inherited as Record<string, unknown>
+    : {};
+  const installerRecord = installerSpecific && typeof installerSpecific === 'object' && !Array.isArray(installerSpecific)
+    ? installerSpecific as Record<string, unknown>
+    : {};
+  const merged = { ...inheritedRecord, ...installerRecord } as WingetInstallerSwitches;
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export function normalizeManifestInstallers(manifest: Record<string, unknown>): WingetInstaller[] {
   const rawInstallers = (manifest.Installers as Array<Record<string, unknown>>) || [];
 
   // Get top-level defaults
@@ -512,7 +538,7 @@ function normalizeInstallers(manifest: Record<string, unknown>): WingetInstaller
   const defaultNestedType = manifest.NestedInstallerType as string;
   const defaultNestedFiles = manifest.NestedInstallerFiles as WingetInstaller['NestedInstallerFiles'];
   const defaultScope = manifest.Scope as string;
-  const defaultSwitches = manifest.InstallerSwitches as Record<string, string>;
+  const defaultSwitches = manifest.InstallerSwitches;
   const defaultPlatform = manifest.Platform as string[];
   const defaultMinOS = manifest.MinimumOSVersion as string;
   const defaultUpgrade = manifest.UpgradeBehavior as string;
@@ -532,8 +558,9 @@ function normalizeInstallers(manifest: Record<string, unknown>): WingetInstaller
                           defaultNestedFiles,
     Scope: (installer.Scope as WingetInstaller['Scope']) ||
            (defaultScope as WingetInstaller['Scope']),
-    InstallerSwitches: (installer.InstallerSwitches as WingetInstaller['InstallerSwitches']) ||
-                       defaultSwitches,
+    // WinGet inherits installer switches per field. An installer-level Custom
+    // value must not discard a root-level Silent value (Vivaldi is one example).
+    InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
     ProductCode: installer.ProductCode as string,
     PackageFamilyName: installer.PackageFamilyName as string,
     UpgradeBehavior: (installer.UpgradeBehavior as WingetInstaller['UpgradeBehavior']) ||
@@ -692,7 +719,7 @@ export async function getLiveInstallers(
   if (!installerManifest) {
     return [];
   }
-  return normalizeInstallers(installerManifest).map(normalizeInstaller);
+  return normalizeManifestInstallers(installerManifest).map(normalizeInstaller);
 }
 
 /**

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -227,4 +227,29 @@ describe('buildQaLiveResponse', () => {
     });
     expect(JSON.stringify(response)).not.toContain('secret-detail');
   });
+
+  it('identifies a persisted GitHub cooldown as a rate limit', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-10T07:11:00.000Z'),
+      current: null,
+      queuedCount: 0,
+      queued: [],
+      poll: {
+        status: 'partial',
+        started_at: '2026-08-10T07:10:47.000Z',
+        finished_at: '2026-08-10T07:10:49.000Z',
+        errors: ['system: WinGet GitHub change feed paused until 2026-08-10T07:33:39.000Z'],
+      },
+      consecutivePollFailures: 1,
+      recent: [],
+      apps: [],
+      frame: null,
+    });
+
+    expect(response.scheduler).toMatchObject({
+      state: 'degraded',
+      lastOutcome: 'partial',
+      issue: 'github_rate_limit',
+    });
+  });
 });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -229,7 +229,10 @@ function schedulerIssue(
   if (staleRunning) return 'stalled';
   const errors = Array.isArray(poll.errors) ? poll.errors : [];
   const combined = errors.filter((error): error is string => typeof error === 'string').join(' ');
-  if (/github|winget change feed/i.test(combined) && /rate limit/i.test(combined)) {
+  if (
+    /github|winget change feed/i.test(combined) &&
+    /rate limit|paused until/i.test(combined)
+  ) {
     return 'github_rate_limit';
   }
   if (poll.status === 'partial') return 'partial_failure';

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -104,7 +104,7 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
-  it('uses installer switch objects without merging root switch keys', () => {
+  it('inherits root switch fields that are not overridden by the installer', () => {
     const config = buildQaCatalogTestConfig({
       app: {
         wingetId: 'Contoso.Example',
@@ -120,7 +120,30 @@ describe('buildQaCatalogTestConfig', () => {
       },
     });
 
-    expect(config.silentArgs).toBe('/S /CURRENTUSER');
+    expect(config.silentArgs).toBe('/ROOT /CURRENTUSER');
+  });
+
+  it('preserves Vivaldi-style root silent and installer custom switches', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Vivaldi.Vivaldi',
+        name: 'Vivaldi',
+        publisher: 'Vivaldi',
+        version: '8.1.4087.62',
+      },
+      manifest: {
+        InstallerType: 'exe',
+        InstallerSwitches: { Silent: '--vivaldi-silent' },
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'exe',
+        Scope: 'user',
+        InstallerSwitches: { Custom: '--do-not-launch-chrome' },
+      },
+    });
+
+    expect(config.silentArgs).toBe('--vivaldi-silent --do-not-launch-chrome');
   });
 
   it('keeps portable packages argument-free', () => {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -72,9 +72,13 @@ export function buildQaCatalogTestConfig({
   manifest: ManifestRecord;
   installer: WingetInstallerCandidate & ManifestRecord;
 }): QaCatalogTestConfig {
-  const effectiveSwitches = isRecord(installer.InstallerSwitches)
-    ? installer.InstallerSwitches
-    : manifest.InstallerSwitches;
+  // WinGet installer defaults are inherited per switch field, not as one
+  // replaceable object. Preserve root Silent when a selected installer only
+  // overrides Custom, Log, or another field.
+  const effectiveSwitches = {
+    ...record(manifest.InstallerSwitches),
+    ...record(installer.InstallerSwitches),
+  };
   const effectiveNestedFiles = Array.isArray(installer.NestedInstallerFiles)
     ? installer.NestedInstallerFiles
     : Array.isArray(manifest.NestedInstallerFiles)


### PR DESCRIPTION
## What changed
- merge manifest-level and installer-level `InstallerSwitches` per field
- use the same normalized switches in direct manifests, cached Supabase version rows, catalog synchronization, catalog QA, and customer PSADT package profiles
- preserve silent plus custom arguments in the package identity, forcing fresh QA when effective behavior changes
- classify persisted GitHub cooldowns correctly on `/QA` and explain that scanning retries automatically

## Root cause
WinGet manifests inherit installer settings per field. IntuneGet treated an installer-level switch object as replacing the root object. Vivaldi defines `Silent: --vivaldi-silent` at the root and `Custom: --do-not-launch-chrome` per installer, so the package fell back to `/S` and displayed an interactive installer.

## Validation
- 81 focused Vitest checks across manifest normalization, QA configuration, and live health
- focused ESLint
- full Next.js production build
- `git diff --check`

## Operational follow-up
After deployment, requeue Vivaldi so the corrected package identity is built and tested in the clean VM.