### PR TITLE
Refresh auto-update commands from current manifests

### DIFF
--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -3,16 +3,27 @@
  * per-package PSADT settings must survive app updates (issue follow-up to #96).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AutoUpdateTrigger } from '../trigger';
+import { AutoUpdateTrigger, getLatestInstallerInfo } from '../trigger';
 import type { AppUpdatePolicy, DeploymentConfig } from '@/types/update-policies';
 import type { QaResultRow } from '@/types/qa';
 
-const { getQaResultMock, getPackageResultMock } = vi.hoisted(() => ({
+const {
+  getQaResultMock,
+  getPackageResultMock,
+  getAppForInstallerMock,
+  getVersionInstallerInfoMock,
+} = vi.hoisted(() => ({
   getQaResultMock: vi.fn(),
   getPackageResultMock: vi.fn(),
+  getAppForInstallerMock: vi.fn(),
+  getVersionInstallerInfoMock: vi.fn(),
 }));
 vi.mock('@/lib/catalog', () => ({
-  getCatalogSource: () => ({ getQaResult: getQaResultMock }),
+  getCatalogSource: () => ({
+    getQaResult: getQaResultMock,
+    getAppForInstaller: getAppForInstallerMock,
+    getVersionInstallerInfo: getVersionInstallerInfoMock,
+  }),
 }));
 vi.mock('@/lib/supabase', () => ({
   createServerClient: () => ({
@@ -87,6 +98,9 @@ const UPDATE_INFO = {
   installerUrl: 'https://example.com/setup-2.0.0.zip',
   installerSha256: 'abc',
   installerType: 'zip',
+  installCommand: '"setup-2.0.0.exe" --current-version-silent',
+  silentSwitches: '--current-version-silent',
+  installScope: 'user' as const,
   nestedInstallerType: 'exe',
   nestedInstallerPath: 'setup-2.0.0.exe',
 };
@@ -102,6 +116,41 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     vi.clearAllMocks();
     getQaResultMock.mockResolvedValue(null);
     getPackageResultMock.mockResolvedValue({ data: null, error: null });
+    getAppForInstallerMock.mockReset();
+    getVersionInstallerInfoMock.mockReset();
+  });
+
+  it('builds the current version command from normalized WinGet switches', async () => {
+    getAppForInstallerMock.mockResolvedValue({
+      latest_version: '8.1.4087.62',
+      name: 'Vivaldi',
+    });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: 'https://example.com/Vivaldi.8.1.4087.62.x64.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      installer_scope: 'user',
+      silent_args: '--vivaldi-silent --do-not-launch-chrome',
+      installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/Vivaldi.8.1.4087.62.x64.exe',
+        InstallerSha256: 'A'.repeat(64),
+        InstallerType: 'exe',
+        Scope: 'user',
+        InstallerSwitches: {
+          Silent: '--vivaldi-silent',
+          Custom: '--do-not-launch-chrome',
+        },
+      }],
+    });
+
+    const result = await getLatestInstallerInfo({} as never, 'Vivaldi.Vivaldi', 'x64');
+
+    expect(result).toMatchObject({
+      installCommand: '"Vivaldi.8.1.4087.62.x64.exe" --vivaldi-silent --do-not-launch-chrome',
+      silentSwitches: '--vivaldi-silent --do-not-launch-chrome',
+      installScope: 'user',
+    });
   });
 
   it('records a current QA failure as a safety skip before creating history or a job', async () => {
@@ -268,8 +317,12 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       expect(result.id).toBe('job-2');
       expect(insertSpy).toHaveBeenCalledTimes(1);
       const jobData = insertSpy.mock.calls[0][0] as {
+        install_command: string;
+        install_scope: string;
         package_config: Record<string, unknown>;
       };
+      expect(jobData.install_command).toBe('"setup-2.0.0.exe" --current-version-silent');
+      expect(jobData.install_scope).toBe('user');
       expect(jobData.package_config.psadtConfig).toEqual(PSADT_CONFIG);
       expect(jobData.package_config.nestedInstallerType).toBe('exe');
       expect(jobData.package_config.nestedInstallerPath).toBe('setup-2.0.0.exe');

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -21,6 +21,9 @@ import {
 } from '@/lib/qa/candidate';
 import { ensureQaDemand, type QaDemandResult } from '@/lib/qa/demand';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
+import { generateInstallCommand } from '@/lib/detection-rules';
+import { normalizeInstaller } from '@/lib/manifest-api';
+import type { NormalizedInstaller, WingetInstaller, WingetScope } from '@/types/winget';
 
 interface TriggerResult {
   success: boolean;
@@ -41,6 +44,9 @@ interface UpdateInfo {
   installerUrl: string;
   installerSha256: string;
   installerType: string;
+  installCommand?: string;
+  silentSwitches?: string;
+  installScope?: WingetScope;
   nestedInstallerType?: string;
   nestedInstallerPath?: string;
   currentIntuneAppId?: string;
@@ -50,6 +56,18 @@ interface RateLimitCheck {
   allowed: boolean;
   reason?: string;
   retryAfterMinutes?: number;
+}
+
+function buildCurrentVersionInstallCommand(installer: NormalizedInstaller): string {
+  // The packager extracts arguments from this command and separately resolves
+  // the nested payload path. Keep a command-shaped value for archive packages
+  // so their nested installer's current silent switches are retained.
+  if (installer.type === 'zip') {
+    const nestedFileName = installer.nestedInstallerPath || 'installer.exe';
+    return `"${nestedFileName}" ${installer.silentArgs || ''}`.trim();
+  }
+
+  return generateInstallCommand(installer, installer.scope || 'machine');
 }
 
 function normalizeAssignments(config: DeploymentConfig): PackageAssignment[] {
@@ -180,6 +198,9 @@ export class AutoUpdateTrigger {
       const deploymentConfig = policy.deployment_config as DeploymentConfig;
       const sourceInstallerType =
         updateInfo.installerType || deploymentConfig.installerType || 'exe';
+      const customInstallCommand = deploymentConfig.psadtConfig?.installCommand?.trim();
+      const effectiveInstallCommand =
+        customInstallCommand || updateInfo.installCommand || deploymentConfig.installCommand || '';
       const qaDemand = await ensureQaDemand(this.supabase, {
         wingetId: updateInfo.wingetId,
         displayName: deploymentConfig.displayName || updateInfo.displayName,
@@ -191,12 +212,15 @@ export class AutoUpdateTrigger {
         installerType: sourceInstallerType,
         nestedInstallerType: updateInfo.nestedInstallerType,
         nestedInstallerPath: updateInfo.nestedInstallerPath,
-        silentSwitches: extractSilentSwitches(
-          deploymentConfig.installCommand || '',
-          sourceInstallerType
-        ),
+        // An explicit PSADT override remains authoritative. Otherwise QA must
+        // exercise the current version's manifest-derived command, not the
+        // generated command saved with the previous deployment.
+        silentSwitches: updateInfo.silentSwitches && !customInstallCommand
+          ? updateInfo.silentSwitches
+          : extractSilentSwitches(effectiveInstallCommand, sourceInstallerType),
         uninstallCommand: deploymentConfig.uninstallCommand || '',
-        installScope: deploymentConfig.installScope === 'user' ? 'user' : 'machine',
+        installScope: updateInfo.installScope ||
+          (deploymentConfig.installScope === 'user' ? 'user' : 'machine'),
         psadtConfig: deploymentConfig.psadtConfig
           ? JSON.stringify(deploymentConfig.psadtConfig)
           : undefined,
@@ -538,9 +562,12 @@ export class AutoUpdateTrigger {
       installer_type: updateInfo.installerType || config.installerType,
       installer_url: updateInfo.installerUrl,
       installer_sha256: updateInfo.installerSha256,
-      install_command: config.installCommand,
+      // Refresh vendor-controlled installer arguments for each version. A
+      // user-supplied psadtConfig.installCommand is kept in package_config and
+      // still takes precedence inside the packager.
+      install_command: updateInfo.installCommand || config.installCommand,
       uninstall_command: config.uninstallCommand,
-      install_scope: config.installScope,
+      install_scope: updateInfo.installScope || config.installScope,
       detection_rules: config.detectionRules,
       package_config: {
         assignments,
@@ -773,6 +800,7 @@ export async function getLatestInstallerInfo(
   let installerType = versionInfo.installer_type;
   let nestedInstallerType: string | undefined;
   let nestedInstallerPath: string | undefined;
+  let selectedManifestInstaller: WingetInstaller | null = null;
 
   // The installers JSONB uses PascalCase from WinGet manifests.
   if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
@@ -785,6 +813,7 @@ export async function getLatestInstallerInfo(
     nestedInstallerPath = Array.isArray(selectedInstaller.NestedInstallerFiles)
       ? selectedInstaller.NestedInstallerFiles[0]?.RelativeFilePath
       : undefined;
+    selectedManifestInstaller = selectedInstaller as WingetInstaller;
   } else if (architecture) {
     return null;
   }
@@ -794,6 +823,21 @@ export async function getLatestInstallerInfo(
     return null;
   }
 
+  const manifestInstaller = {
+    ...(selectedManifestInstaller || {}),
+    Architecture: (selectedManifestInstaller?.Architecture || architecture || 'x64'),
+    InstallerUrl: installerUrl,
+    InstallerSha256: normalizedSha256,
+    InstallerType: (installerType || 'exe'),
+    NestedInstallerType: selectedManifestInstaller?.NestedInstallerType || nestedInstallerType,
+    NestedInstallerFiles: selectedManifestInstaller?.NestedInstallerFiles ||
+      (nestedInstallerPath ? [{ RelativeFilePath: nestedInstallerPath }] : undefined),
+    Scope: selectedManifestInstaller?.Scope || versionInfo.installer_scope || undefined,
+    InstallerSwitches: selectedManifestInstaller?.InstallerSwitches ||
+      (versionInfo.silent_args ? { Silent: versionInfo.silent_args } : undefined),
+  } as WingetInstaller;
+  const normalizedInstaller = normalizeInstaller(manifestInstaller);
+
   return {
     wingetId,
     currentVersion: '', // Will be filled by caller
@@ -802,6 +846,9 @@ export async function getLatestInstallerInfo(
     installerUrl,
     installerSha256: normalizedSha256,
     installerType: installerType || 'exe',
+    installCommand: buildCurrentVersionInstallCommand(normalizedInstaller),
+    silentSwitches: normalizedInstaller.silentArgs,
+    installScope: normalizedInstaller.scope,
     nestedInstallerType,
     nestedInstallerPath,
   };

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -471,7 +471,7 @@ export class SnapshotCatalogSource implements CatalogSource {
       (db) => {
         const row = db
           .prepare(
-            `SELECT installer_url, installer_sha256, installer_type, installer_scope, installers
+            `SELECT installer_url, installer_sha256, installer_type, installer_scope, silent_args, installers
              FROM version_history
              WHERE winget_id = ? AND version = ?`
           )
@@ -481,6 +481,7 @@ export class SnapshotCatalogSource implements CatalogSource {
               installer_sha256: string | null;
               installer_type: string | null;
               installer_scope: string | null;
+              silent_args: string | null;
               installers: string | null;
             }
           | undefined;
@@ -491,6 +492,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           installer_sha256: row.installer_sha256,
           installer_type: row.installer_type,
           installer_scope: row.installer_scope,
+          silent_args: row.silent_args,
           installers: row.installers ? JSON.parse(row.installers) : null,
         };
       },
@@ -506,7 +508,7 @@ export class SnapshotCatalogSource implements CatalogSource {
       (db) => {
         const row = db
           .prepare(
-            `SELECT installer_url, installer_sha256, installer_type, installer_scope, installers
+            `SELECT installer_url, installer_sha256, installer_type, installer_scope, silent_args, installers
              FROM version_history
              WHERE winget_id = ? AND version = ?
              ORDER BY created_at DESC
@@ -518,6 +520,7 @@ export class SnapshotCatalogSource implements CatalogSource {
               installer_sha256: string | null;
               installer_type: string | null;
               installer_scope: string | null;
+              silent_args: string | null;
               installers: string | null;
             }
           | undefined;
@@ -528,6 +531,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           installer_sha256: row.installer_sha256,
           installer_type: row.installer_type,
           installer_scope: row.installer_scope,
+          silent_args: row.silent_args,
           installers: row.installers ? JSON.parse(row.installers) : null,
         };
       },

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -303,7 +303,7 @@ export class SupabaseCatalogSource implements CatalogSource {
 
     const { data, error } = await supabase
       .from('version_history')
-      .select('installer_url, installer_sha256, installer_type, installer_scope, installers')
+      .select('installer_url, installer_sha256, installer_type, installer_scope, silent_args, installers')
       .eq('winget_id', wingetId)
       .eq('version', version)
       .single();
@@ -323,7 +323,7 @@ export class SupabaseCatalogSource implements CatalogSource {
 
     const { data, error } = await supabase
       .from('version_history')
-      .select('installer_url, installer_sha256, installer_type, installer_scope, installers')
+      .select('installer_url, installer_sha256, installer_type, installer_scope, silent_args, installers')
       .eq('winget_id', wingetId)
       .eq('version', version)
       .order('created_at', { ascending: false })

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -114,6 +114,7 @@ export interface VersionInstallerInfo {
   installer_sha256: string | null;
   installer_type: string | null;
   installer_scope?: string | null;
+  silent_args?: string | null;
   installers: unknown;
 }
 


### PR DESCRIPTION
## What changed
- derive each auto-update install command, silent arguments, and scope from the current version's normalized WinGet installer
- use that same effective command for the pre-deployment QA identity and for the packaging job
- preserve an administrator's explicit `psadtConfig.installCommand` override as authoritative
- expose persisted `silent_args` consistently through Supabase and self-hosted catalog sources

## Why
Auto-update policies intentionally retain PSADT presentation and behavior settings, but the generated vendor command belongs to a specific installer version. Reusing the prior version's command could make QA and the eventual Intune package launch a new vendor installer interactively. Vivaldi exposed this with `--vivaldi-silent --do-not-launch-chrome` versus the stale generic `/S`.

## Validation
- 107 focused Vitest checks, including Vivaldi-shaped manifest and auto-update command regressions
- focused ESLint
- full Next.js production build (TypeScript and 141 routes)
- `git diff --check`