### PR TITLE
Merge cached WinGet installer switch fields

### DIFF
--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -138,7 +138,6 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
         InstallerType: 'exe',
         Scope: 'user',
         InstallerSwitches: {
-          Silent: '--vivaldi-silent',
           Custom: '--do-not-launch-chrome',
         },
       }],

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -833,8 +833,13 @@ export async function getLatestInstallerInfo(
     NestedInstallerFiles: selectedManifestInstaller?.NestedInstallerFiles ||
       (nestedInstallerPath ? [{ RelativeFilePath: nestedInstallerPath }] : undefined),
     Scope: selectedManifestInstaller?.Scope || versionInfo.installer_scope || undefined,
-    InstallerSwitches: selectedManifestInstaller?.InstallerSwitches ||
-      (versionInfo.silent_args ? { Silent: versionInfo.silent_args } : undefined),
+    // Current snapshots keep the manifest-level Silent value in silent_args
+    // and installer-level overrides (for example Custom) in each installer.
+    // Merge them per field just like a freshly fetched WinGet manifest.
+    InstallerSwitches: {
+      ...(versionInfo.silent_args ? { Silent: versionInfo.silent_args } : {}),
+      ...(selectedManifestInstaller?.InstallerSwitches || {}),
+    },
   } as WingetInstaller;
   const normalizedInstaller = normalizeInstaller(manifestInstaller);
 


### PR DESCRIPTION
## What changed
- merge the cached manifest-level `silent_args` value with per-installer `InstallerSwitches`
- update the Vivaldi regression to exactly match the current production `version_history` shape

## Why
Existing catalog rows intentionally store the manifest-level silent value separately from installer-level custom switches. The auto-update resolver must combine both fields just as it combines a freshly fetched manifest.

## Validation
- focused auto-update regression suite
- focused ESLint
- `git diff --check`
- verified against the current Vivaldi production row (`--vivaldi-silent` plus `--do-not-launch-chrome`)