### PR TITLE
Finalize auto-updates after QA failures

### DIFF
--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createServerClientMock, getFeatureFlagsMock } = vi.hoisted(() => ({
+const { createServerClientMock, getFeatureFlagsMock, handleAutoUpdateJobCompletionMock } = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
   getFeatureFlagsMock: vi.fn(),
+  handleAutoUpdateJobCompletionMock: vi.fn(),
 }));
 
 vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
 vi.mock('@/lib/features', () => ({ getFeatureFlags: getFeatureFlagsMock }));
 vi.mock('@/lib/config', () => ({ getAppConfig: () => ({ app: { url: 'https://example.test' } }) }));
 vi.mock('@/lib/github-actions', () => ({ triggerPackagingWorkflow: vi.fn() }));
+vi.mock('@/lib/auto-update/cleanup', () => ({
+  handleAutoUpdateJobCompletion: handleAutoUpdateJobCompletionMock,
+}));
 
 import { GET } from './route';
 
@@ -75,5 +79,56 @@ describe('GET /api/cron/qa-resume', () => {
       status: 'queued',
       qa_completed_at: expect.any(String),
     }));
+    expect(handleAutoUpdateJobCompletionMock).not.toHaveBeenCalled();
+  });
+
+  it('finalizes auto-update tracking when the required QA candidate fails', async () => {
+    const job = {
+      id: 'job-failed-qa',
+      qa_candidate_id: 'candidate-failed',
+      execution_profile_sha256: 'A'.repeat(64),
+      created_at: '2026-08-09T12:00:00Z',
+    };
+    const packagingUpdate = chain({ data: { id: job.id }, error: null });
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          if (client.from.mock.calls.filter(([name]) => name === 'packaging_jobs').length === 1) {
+            return chain({ data: [job], error: null });
+          }
+          return packagingUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-failed',
+              status: 'failed',
+              failure_summary: 'Installer remained interactive.',
+              package_profile_sha256: 'A'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 0, failed: 1, waiting: 0 });
+    expect(packagingUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'qa_failed',
+      status_message: 'Installer remained interactive.',
+    }));
+    expect(handleAutoUpdateJobCompletionMock).toHaveBeenCalledWith(
+      job.id,
+      'failed',
+      'Installer remained interactive.'
+    );
   });
 });

--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createServerClientMock, getFeatureFlagsMock, handleAutoUpdateJobCompletionMock } = vi.hoisted(() => ({
+const {
+  createServerClientMock,
+  getFeatureFlagsMock,
+  handleAutoUpdateJobCompletionMock,
+  triggerPackagingWorkflowMock,
+} = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
   getFeatureFlagsMock: vi.fn(),
   handleAutoUpdateJobCompletionMock: vi.fn(),
+  triggerPackagingWorkflowMock: vi.fn(),
 }));
 
 vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
 vi.mock('@/lib/features', () => ({ getFeatureFlags: getFeatureFlagsMock }));
 vi.mock('@/lib/config', () => ({ getAppConfig: () => ({ app: { url: 'https://example.test' } }) }));
-vi.mock('@/lib/github-actions', () => ({ triggerPackagingWorkflow: vi.fn() }));
+vi.mock('@/lib/github-actions', () => ({ triggerPackagingWorkflow: triggerPackagingWorkflowMock }));
 vi.mock('@/lib/auto-update/cleanup', () => ({
   handleAutoUpdateJobCompletion: handleAutoUpdateJobCompletionMock,
 }));
@@ -129,6 +135,71 @@ describe('GET /api/cron/qa-resume', () => {
       job.id,
       'failed',
       'Installer remained interactive.'
+    );
+  });
+
+  it('finalizes auto-update tracking when packaging dispatch fails after QA passes', async () => {
+    getFeatureFlagsMock.mockReturnValue({ localPackager: false });
+    triggerPackagingWorkflowMock.mockRejectedValue(new Error('GitHub dispatch unavailable'));
+    const job = {
+      id: 'job-dispatch-failed',
+      qa_candidate_id: 'candidate-passed',
+      execution_profile_sha256: 'B'.repeat(64),
+      created_at: '2026-08-09T12:00:00Z',
+      winget_id: 'Example.App',
+      display_name: 'Example App',
+      version: '1.0.0',
+      installer_url: 'https://example.test/installer.exe',
+      installer_type: 'exe',
+      install_command: 'installer.exe /silent',
+      package_config: {},
+    };
+    const claimUpdate = chain({ data: { id: job.id }, error: null });
+    const failedUpdate = chain({ data: { id: job.id }, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          packagingCall++;
+          if (packagingCall === 1) return chain({ data: [job], error: null });
+          if (packagingCall === 2) return claimUpdate;
+          return failedUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-passed',
+              status: 'passed',
+              failure_summary: null,
+              package_profile_sha256: 'B'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        if (table === 'qa_package_results') {
+          return chain({ data: { outcome: 'Passed' }, error: null });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 0, failed: 1, waiting: 0 });
+    expect(failedUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_code: 'QA_RESUME_DISPATCH_FAILED',
+      error_message: 'GitHub dispatch unavailable',
+    }));
+    expect(handleAutoUpdateJobCompletionMock).toHaveBeenCalledWith(
+      job.id,
+      'failed',
+      'GitHub dispatch unavailable'
     );
   });
 });

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -147,7 +147,7 @@ export async function GET(request: Request) {
         sourceType: item.sourceType,
       };
       const trigger = await triggerPackagingWorkflow(workflowInputs);
-      const { data: failedJob } = await supabase
+      await supabase
         .from('packaging_jobs')
         .update({
           github_run_id: trigger.runId?.toString() || null,
@@ -157,7 +157,7 @@ export async function GET(request: Request) {
         .eq('status', 'packaging');
       resumed++;
     } catch (error) {
-      await supabase
+      const { data: failedJob } = await supabase
         .from('packaging_jobs')
         .update({
           status: 'failed',

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -5,6 +5,7 @@ import { getAppConfig } from '@/lib/config';
 import { buildIntuneAppDescription } from '@/lib/intune-description';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { triggerPackagingWorkflow, type WorkflowInputs } from '@/lib/github-actions';
+import { handleAutoUpdateJobCompletion } from '@/lib/auto-update/cleanup';
 import type { Win32CartItem } from '@/types/upload';
 
 const RESUME_BATCH_SIZE = 25;
@@ -59,7 +60,14 @@ export async function GET(request: Request) {
         .eq('status', 'awaiting_qa')
         .select('id')
         .maybeSingle();
-      if (updated) failed++;
+      if (updated) {
+        failed++;
+        await handleAutoUpdateJobCompletion(
+          job.id,
+          'failed',
+          candidate?.failure_summary || 'The required installation test could not complete.'
+        );
+      }
       continue;
     }
     if (candidate.status !== 'passed') {
@@ -139,7 +147,7 @@ export async function GET(request: Request) {
         sourceType: item.sourceType,
       };
       const trigger = await triggerPackagingWorkflow(workflowInputs);
-      await supabase
+      const { data: failedJob } = await supabase
         .from('packaging_jobs')
         .update({
           github_run_id: trigger.runId?.toString() || null,
@@ -161,7 +169,16 @@ export async function GET(request: Request) {
           completed_at: new Date().toISOString(),
         })
         .eq('id', job.id)
-        .eq('status', 'packaging');
+        .eq('status', 'packaging')
+        .select('id')
+        .maybeSingle();
+      if (failedJob) {
+        await handleAutoUpdateJobCompletion(
+          job.id,
+          'failed',
+          error instanceof Error ? error.message : 'Unknown resume error'
+        );
+      }
       failed++;
     }
   }


### PR DESCRIPTION
## What changed
- run the existing idempotent auto-update cleanup whenever a QA-gated packaging job fails
- also clean up if packaging cannot be dispatched after QA passes
- add a route regression proving a failed candidate finalizes the linked auto-update

## Why
A QA failure moved the packaging job to `qa_failed`, but left `auto_update_history` pending and `last_auto_update_version` set. That prevented the corrected version from naturally retrying and left stale dashboard state.

## Result
The shared cleanup now marks history failed, clears the attempted version so it can be retried, applies the consecutive-failure circuit breaker, and dismisses the failed auto-update job.

## Validation
- focused route regression suite
- focused ESLint
- `git diff --check`