### PR TITLE
Pin QA to unattended uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'e7c263d5703884ca3e0507c7b0165b882ce9e61d',
+  packagerCommit: '90b9a62446621395f7da57504273221c71210341',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## Summary
- pin new QA profiles to protected packager commit 90b9a62446621395f7da57504273221c71210341
- ensure stale queued profiles are superseded before dispatch

## Verification
- npx vitest run app/api/cron/qa-enqueue/route.test.ts lib/qa/package-profile.test.ts
- npx eslint lib/qa/package-profile.ts