### PR TITLE
Redesign live QA progress layout

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -17,7 +17,8 @@ import {
 import { AppIcon } from '@/components/AppIcon';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import { QaDetailsDialog } from '@/components/qa/QaDetailsDialog';
-import { QaLiveActivityPanel } from '@/components/qa/QaLiveActivityPanel';
+import { QaLiveActivityDialog } from '@/components/qa/QaLiveActivityDialog';
+import { QaLiveStepTimeline } from '@/components/qa/QaLiveStepTimeline';
 import { StatusBadge, type StatusTone } from '@/components/ui/status-badge';
 import { useElapsedTime } from '@/hooks/use-elapsed-time';
 import { useQaLive } from '@/hooks/use-qa';
@@ -285,7 +286,19 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
               )}
             </div>
           </div>
-          <QaLiveActivityPanel activity={data.activity} log={data.log} phase={data.current.phase} serverTime={data.serverTime} />
+          <QaLiveStepTimeline
+            phase={data.current.phase}
+            log={data.log}
+            className="lg:col-start-2 lg:row-span-2 lg:row-start-1"
+          />
+          <div className="lg:col-start-1 lg:row-start-2">
+            <QaLiveActivityDialog
+              activity={data.activity}
+              log={data.log}
+              phase={data.current.phase}
+              serverTime={data.serverTime}
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/components/qa/QaLiveActivityDialog.tsx
+++ b/components/qa/QaLiveActivityDialog.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { ChevronRight, FileCode2, ListTree, ScrollText } from 'lucide-react';
+import { T, Var } from 'gt-next';
+import { QaLiveActivityPanel } from '@/components/qa/QaLiveActivityPanel';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import type { QaLiveActivity, QaLiveLog, QaLivePhase } from '@/types/qa';
+
+export function QaLiveActivityDialog({
+  activity,
+  log,
+  phase,
+  serverTime,
+}: {
+  activity: QaLiveActivity | null;
+  log: QaLiveLog | null;
+  phase: QaLivePhase;
+  serverTime: string;
+}) {
+  const fileCount = activity
+    ? activity.counts.filesAdded + activity.counts.filesChanged + activity.counts.filesRemoved
+    : 0;
+  const registryCount = activity
+    ? activity.counts.registryAdded + activity.counts.registryChanged + activity.counts.registryRemoved
+    : 0;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="group flex min-h-16 w-full flex-col gap-3 rounded-xl border border-overlay/10 bg-bg-surface/45 px-4 py-3 text-left transition-all hover:border-accent-cyan/25 hover:bg-overlay/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan sm:flex-row sm:items-center sm:justify-between"
+        >
+          <span className="flex min-w-0 items-center gap-3">
+            <span className="rounded-lg bg-accent-cyan/10 p-2 text-accent-cyan" aria-hidden="true">
+              <ListTree className="h-4 w-4" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-text-primary"><T>Detected system changes</T></span>
+              <span className="mt-0.5 block text-xs text-text-muted">
+                <T>Open live files, registry activity, and the sanitized PSADT log</T>
+              </span>
+            </span>
+          </span>
+          <span className="flex items-center gap-2 sm:shrink-0">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-overlay/[0.06] px-2.5 py-1 text-xs text-text-secondary">
+              <FileCode2 className="h-3.5 w-3.5" aria-hidden="true" />
+              <T><Var>{fileCount}</Var> files</T>
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-overlay/[0.06] px-2.5 py-1 text-xs text-text-secondary">
+              <ListTree className="h-3.5 w-3.5" aria-hidden="true" />
+              <T><Var>{registryCount}</Var> registry</T>
+            </span>
+            {log?.lines.length ? (
+              <span className="hidden rounded-full bg-status-success/10 p-1.5 text-status-success sm:inline-flex" title="Live PSADT log available">
+                <ScrollText className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+            ) : null}
+            <ChevronRight className="h-4 w-4 text-text-muted transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+          </span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[92vh] w-[calc(100%_-_1.5rem)] max-w-6xl flex-col">
+        <DialogHeader className="shrink-0 pr-10">
+          <DialogTitle><T>Live installation evidence</T></DialogTitle>
+          <DialogDescription>
+            <T>Sanitized snapshot changes and PSADT activity from the isolated test VM.</T>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-5">
+          <QaLiveActivityPanel
+            activity={activity}
+            log={log}
+            phase={phase}
+            serverTime={serverTime}
+            mode="dialog"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/qa/QaLiveActivityPanel.tsx
+++ b/components/qa/QaLiveActivityPanel.tsx
@@ -74,11 +74,13 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
   log,
   phase,
   serverTime,
+  mode = 'panel',
 }: {
   activity: QaLiveActivity | null;
   log: QaLiveLog | null;
   phase: QaLivePhase;
   serverTime: string;
+  mode?: 'panel' | 'dialog';
 }) {
   const [filter, setFilter] = useState<Filter>('all');
   const [page, setPage] = useState(1);
@@ -132,7 +134,13 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
   }
 
   return (
-    <section className="flex min-h-[22rem] flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-surface/45" aria-labelledby="system-changes-heading">
+    <section
+      className={cn(
+        'flex flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-surface/45',
+        mode === 'dialog' ? 'min-h-[34rem]' : 'min-h-[22rem]'
+      )}
+      aria-labelledby="system-changes-heading"
+    >
       <div className="border-b border-overlay/10 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -265,7 +273,14 @@ export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
                     <tr key={`${item.kind}|${item.change}|${item.target}`}>
                       <td className="px-4 py-2.5"><KindLabel kind={item.kind} /></td>
                       <td className="px-2 py-2.5"><ChangeBadge change={item.change} /></td>
-                      <td className="px-2 py-2.5 pr-4"><code className="block truncate text-[11px] text-text-secondary" title={item.target}>{compactTarget(item.target)}</code></td>
+                      <td className="px-2 py-2.5 pr-4">
+                        <code
+                          className={cn('block text-[11px] text-text-secondary', mode === 'dialog' ? 'break-all' : 'truncate')}
+                          title={item.target}
+                        >
+                          {mode === 'dialog' ? item.target : compactTarget(item.target)}
+                        </code>
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/components/qa/QaLiveStepTimeline.tsx
+++ b/components/qa/QaLiveStepTimeline.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import {
+  Check,
+  ClipboardCheck,
+  FileArchive,
+  Loader2,
+  PackageCheck,
+  RotateCcw,
+  SearchCheck,
+  Send,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
+import { T, Var } from 'gt-next';
+import { getQaPhasePresentation } from '@/lib/qa/presentation';
+import { cn } from '@/lib/utils';
+import type { QaLiveLog, QaLivePhase } from '@/types/qa';
+
+interface TimelineStep {
+  phase: Exclude<QaLivePhase, 'queued'>;
+  label: string;
+  description: string;
+  tasks: string[];
+  Icon: LucideIcon;
+}
+
+const STEPS: TimelineStep[] = [
+  {
+    phase: 'preparing_package',
+    label: 'Prepare the package',
+    description: 'Download the verified installer and build the exact PSADT package.',
+    tasks: ['Validate the installer source', 'Apply the selected PSADT configuration'],
+    Icon: FileArchive,
+  },
+  {
+    phase: 'restoring_vm',
+    label: 'Restore the clean VM',
+    description: 'Revert to the golden checkpoint and start an isolated Windows session.',
+    tasks: ['Revert the golden checkpoint', 'Connect through PowerShell Direct'],
+    Icon: RotateCcw,
+  },
+  {
+    phase: 'installing',
+    label: 'Install the application',
+    description: 'Transfer the package and run it in the configured security context.',
+    tasks: ['Launch the PSADT package', 'Observe installer and system activity'],
+    Icon: PackageCheck,
+  },
+  {
+    phase: 'detecting_install',
+    label: 'Verify installation',
+    description: 'Apply the exact Intune detection rule to the installed application.',
+    tasks: ['Evaluate the detection rule', 'Capture installed-state evidence'],
+    Icon: SearchCheck,
+  },
+  {
+    phase: 'uninstalling',
+    label: 'Remove the application',
+    description: 'Run the packaged silent uninstall path and capture its result.',
+    tasks: ['Resolve the registered uninstall command', 'Run unattended removal'],
+    Icon: Trash2,
+  },
+  {
+    phase: 'verifying_removal',
+    label: 'Verify removal',
+    description: 'Confirm the app is no longer detected and compare residual changes.',
+    tasks: ['Re-run detection', 'Compare files and registry changes'],
+    Icon: ClipboardCheck,
+  },
+  {
+    phase: 'publishing',
+    label: 'Publish the result',
+    description: 'Sanitize the evidence, save the compact result, and clean the test VM.',
+    tasks: ['Write the QA result', 'Restore the clean checkpoint'],
+    Icon: Send,
+  },
+];
+
+function latestActivity(log: QaLiveLog | null): string | null {
+  const line = log?.lines.at(-1);
+  if (!line) return null;
+  return line
+    .replace(/^\[[^\]]+\]\s*::\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function QaLiveStepTimeline({
+  phase,
+  log,
+  className,
+}: {
+  phase: QaLivePhase;
+  log: QaLiveLog | null;
+  className?: string;
+}) {
+  const phasePresentation = getQaPhasePresentation(phase);
+  const activeIndex = STEPS.findIndex((step) => step.phase === phase);
+  const activity = latestActivity(log);
+
+  return (
+    <section
+      className={cn(
+        'flex min-h-[36rem] flex-col rounded-xl border border-overlay/10 bg-bg-surface/45 p-4 sm:p-5',
+        className
+      )}
+      aria-labelledby="qa-test-progress-heading"
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 id="qa-test-progress-heading" className="text-base font-semibold text-text-primary">
+            <T>Test progress</T>
+          </h3>
+          <p className="mt-1 text-xs text-text-muted">
+            <T>Live tasks inside the isolated Windows VM</T>
+          </p>
+        </div>
+        <span className="rounded-full bg-accent-cyan/10 px-2.5 py-1 text-xs font-medium text-accent-cyan">
+          <T>Step <Var>{phasePresentation.step}</Var> of <Var>{phasePresentation.totalSteps}</Var></T>
+        </span>
+      </div>
+
+      <ol className="min-h-0 flex-1" aria-label="QA test steps">
+        {STEPS.map((step, index) => {
+          const isComplete = activeIndex >= 0 && index < activeIndex;
+          const isActive = index === activeIndex;
+          const isUpcoming = !isComplete && !isActive;
+          const StepIcon = step.Icon;
+
+          return (
+            <li
+              key={step.phase}
+              className={cn('flex gap-3 transition-opacity duration-500', isUpcoming && 'opacity-45')}
+              aria-current={isActive ? 'step' : undefined}
+            >
+              <div className="flex w-9 shrink-0 flex-col items-center">
+                <span
+                  className={cn(
+                    'relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-all duration-500',
+                    isComplete && 'border-status-success bg-status-success text-white',
+                    isActive && 'border-accent-cyan bg-accent-cyan/10 text-accent-cyan shadow-[0_0_0_5px_rgba(6,182,212,0.08)]',
+                    isUpcoming && 'border-overlay/25 text-text-muted'
+                  )}
+                  aria-hidden="true"
+                >
+                  {isActive ? (
+                    <>
+                      <span className="absolute inset-0 animate-ping rounded-full border border-accent-cyan/40 motion-reduce:animate-none" />
+                      <span className="animate-spin motion-reduce:animate-none">
+                        <Loader2 className="h-4 w-4" />
+                      </span>
+                    </>
+                  ) : isComplete ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <StepIcon className="h-4 w-4" />
+                  )}
+                </span>
+                {index < STEPS.length - 1 ? (
+                  <span
+                    className={cn(
+                      'my-1 min-h-4 w-px flex-1 transition-colors duration-500',
+                      isComplete ? 'bg-status-success' : isActive ? 'bg-gradient-to-b from-accent-cyan to-overlay/15' : 'bg-overlay/15'
+                    )}
+                    aria-hidden="true"
+                  />
+                ) : null}
+              </div>
+
+              <div
+                className={cn(
+                  'mb-2 min-w-0 flex-1 rounded-xl border px-3 py-2.5 transition-all duration-500',
+                  isActive ? 'border-accent-cyan/25 bg-accent-cyan/[0.05]' : 'border-transparent'
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-text-muted">
+                      <T>Step <Var>{index + 1}</Var></T>
+                    </p>
+                    <p className={cn('mt-0.5 text-sm font-medium', isUpcoming ? 'text-text-muted' : 'text-text-primary')}>
+                      <T>{step.label}</T>
+                    </p>
+                  </div>
+                  <span className={cn('shrink-0 text-[10px] font-medium', isComplete ? 'text-status-success' : isActive ? 'text-accent-cyan' : 'text-text-muted')}>
+                    <T>{isComplete ? 'Complete' : isActive ? 'In progress' : 'Waiting'}</T>
+                  </span>
+                </div>
+
+                {isActive ? (
+                  <div className="mt-2.5 space-y-2" aria-live="polite">
+                    <p className="text-xs leading-relaxed text-text-secondary"><T>{step.description}</T></p>
+                    <ul className="space-y-1.5">
+                      {step.tasks.map((task) => (
+                        <li key={task} className="flex items-center gap-2 text-[11px] text-text-muted">
+                          <span className="h-1 w-1 shrink-0 rounded-full bg-accent-cyan" aria-hidden="true" />
+                          <T>{task}</T>
+                        </li>
+                      ))}
+                    </ul>
+                    {activity ? (
+                      <div className="rounded-lg border border-overlay/10 bg-black/10 px-2.5 py-2">
+                        <p className="text-[9px] font-medium uppercase tracking-[0.12em] text-text-muted"><T>Latest activity</T></p>
+                        <p className="mt-1 line-clamp-2 font-mono text-[10px] leading-relaxed text-text-secondary">{activity}</p>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
Moves live QA execution details into an animated seven-step timeline beside the larger frameless VM preview. System-change evidence and sanitized PSADT logs now open from a compact control below the preview in a responsive dialog with full paths. Validation: focused ESLint and git diff checks passed; the production build passed before the final CSS-only responsive width correction.