### PR TITLE
Simplify QA progress and result details

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -288,7 +288,6 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           </div>
           <QaLiveStepTimeline
             phase={data.current.phase}
-            log={data.log}
             className="lg:col-start-2 lg:row-span-2 lg:row-start-1"
           />
           <div className="lg:col-start-1 lg:row-start-2">

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -269,15 +269,6 @@ export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }
                 </section>
               ) : null}
 
-              {data.classification ? (
-                <section className="rounded-xl border border-status-warning/20 bg-status-warning/10 p-4">
-                  <h4 className="text-sm font-semibold text-status-warning"><T>Automated heuristic — not a verified root cause</T></h4>
-                  <p className="mt-2 text-sm text-text-primary">{data.classification.bucket.replace('_', ' ')} · {data.classification.confidence} confidence</p>
-                  <p className="mt-1 text-xs text-text-secondary">{data.classification.evidence}</p>
-                  <p className="mt-2 text-xs text-text-secondary">{data.classification.remediation}</p>
-                </section>
-              ) : null}
-
               <section className="grid gap-3 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 text-xs text-text-secondary sm:grid-cols-2">
                 <div><span className="block text-text-muted"><T>Execution context</T></span><code>{data.environment?.executionContext || <T>Not recorded</T>}</code></div>
                 <div><span className="block text-text-muted"><T>Relevant Windows events</T></span>{data.relevantEventCount ?? <T>Not recorded</T>}</div>

--- a/components/qa/QaLiveStepTimeline.tsx
+++ b/components/qa/QaLiveStepTimeline.tsx
@@ -15,7 +15,7 @@ import {
 import { T, Var } from 'gt-next';
 import { getQaPhasePresentation } from '@/lib/qa/presentation';
 import { cn } from '@/lib/utils';
-import type { QaLiveLog, QaLivePhase } from '@/types/qa';
+import type { QaLivePhase } from '@/types/qa';
 
 interface TimelineStep {
   phase: Exclude<QaLivePhase, 'queued'>;
@@ -77,27 +77,15 @@ const STEPS: TimelineStep[] = [
   },
 ];
 
-function latestActivity(log: QaLiveLog | null): string | null {
-  const line = log?.lines.at(-1);
-  if (!line) return null;
-  return line
-    .replace(/^\[[^\]]+\]\s*::\s*/, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
 export function QaLiveStepTimeline({
   phase,
-  log,
   className,
 }: {
   phase: QaLivePhase;
-  log: QaLiveLog | null;
   className?: string;
 }) {
   const phasePresentation = getQaPhasePresentation(phase);
   const activeIndex = STEPS.findIndex((step) => step.phase === phase);
-  const activity = latestActivity(log);
 
   return (
     <section
@@ -199,12 +187,6 @@ export function QaLiveStepTimeline({
                         </li>
                       ))}
                     </ul>
-                    {activity ? (
-                      <div className="rounded-lg border border-overlay/10 bg-black/10 px-2.5 py-2">
-                        <p className="text-[9px] font-medium uppercase tracking-[0.12em] text-text-muted"><T>Latest activity</T></p>
-                        <p className="mt-1 line-clamp-2 font-mono text-[10px] leading-relaxed text-text-secondary">{activity}</p>
-                      </div>
-                    ) : null}
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
Removes the Latest activity panel from the shared seven-step timeline, including its log prop and formatting helper, so it is gone from every phase. Also removes the speculative automated-heuristic card from installation test details while retaining factual phase results, exit codes, durations, system changes, and execution metadata. Validation: focused ESLint passed; no remaining matching UI strings; diff check passed.