### PR TITLE
Pin QA candidates to Vivaldi packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '90b9a62446621395f7da57504273221c71210341',
+  packagerCommit: 'a113ab2ea94e6ba02c9b22aa00706317d7bd82d2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Updates the website-side QA package profile to the same immutable IntuneGet packager commit already deployed in IntuneGet-Workflows. This makes newly enqueued candidate identities use the direct Vivaldi silent-uninstall fix and prevents stale toolchain hashes. Validation: package-profile and candidate tests passed (40/40); focused ESLint and diff checks passed.