### PR TITLE
Harden MSI and MSIX QA packaging

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -272,6 +272,7 @@ function Get-PSADTAssetFileName {
 # Only a single quote needs escaping; changing backticks or dollar signs would
 # silently change valid vendor arguments.
 $silentSwitchesEscaped = $SilentSwitches -replace "'", "''"
+$versionSingleQuoteEscaped = $Version -replace "'", "''"
 $uninstallCmd = $UninstallCommand -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
@@ -503,10 +504,23 @@ if ($useRegistryUninstall) {
 } elseif (-not $usePortableUninstall -and $uninstallCmd -match '^MSIX_UNINSTALL:(.+)$') {
     $useMsixUninstall = $true
     $msixPackageName = $Matches[1]
+    if ($msixPackageName -notmatch '^[A-Za-z0-9.-]+$') {
+        throw "The MSIX/APPX package identity is missing or unsafe; refusing an ambiguous deployment."
+    }
     Write-Host "Using MSIX uninstall for package: $msixPackageName"
+} elseif (-not $usePortableUninstall -and $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED') {
+    if ([string]::IsNullOrWhiteSpace($customUninstallCommand)) {
+        throw "The MSI/WiX package has neither a product code nor a display name for safe uninstall discovery."
+    }
 } elseif ($installerTypeLower -eq 'zip') {
     $usePortableUninstall = $true
     Write-Host "Using portable uninstall (folder removal)"
+}
+
+if ($installerTypeLower -in @('msix', 'appx') -and
+    [string]::IsNullOrWhiteSpace($msixPackageName) -and
+    ([string]::IsNullOrWhiteSpace($customInstallCommand) -or [string]::IsNullOrWhiteSpace($customUninstallCommand))) {
+    throw "The MSIX/APPX package identity is missing; refusing to generate install or uninstall commands from a display-name guess."
 }
 
 # Extract app close configuration
@@ -861,7 +875,7 @@ $lines = @(
     '$adtSession = @{'
     "    AppVendor = '$publisherEscaped'"
     "    AppName = '$displayNameEscaped'"
-    "    AppVersion = '$Version'"
+    "    AppVersion = '$versionSingleQuoteEscaped'"
     '    AppArch = '''''
     '    AppLang = ''EN'''
     '    AppRevision = ''01'''
@@ -968,17 +982,63 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
             }
         }
         { $_ -in 'msix', 'appx' } {
-            $lines += @(
-                "    `$msixPath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
-                '    Write-ADTLogEntry -Message "Provisioning MSIX/APPX package for all users: $msixPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
-                '    try {'
-                '        Add-AppxProvisionedPackage -Online -PackagePath $msixPath -SkipLicense -ErrorAction Stop'
-                '        Write-ADTLogEntry -Message "MSIX/APPX package provisioned successfully" -Severity ''Success'' -Source ''Install-ADTDeployment'''
-                '    } catch {'
-                '        Write-ADTLogEntry -Message "Failed to provision MSIX/APPX package: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
-                '        throw'
-                '    }'
-            )
+            if ($IsUserScope) {
+                $lines += @(
+                    "    `$msixPath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
+                    "    `$packageName = '$msixPackageName'"
+                    "    `$targetVersion = '$versionSingleQuoteEscaped'"
+                    '    Write-ADTLogEntry -Message "Registering user-scoped MSIX/APPX package: $msixPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                    '    try {'
+                    '        $existingPackage = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1'
+                    '        $shouldInstallPackage = $true'
+                    '        if ($existingPackage) {'
+                    '            try {'
+                    '                $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion'
+                    '            } catch {'
+                    '                $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion'
+                    '            }'
+                    '            if (-not $shouldInstallPackage) {'
+                    '                Write-ADTLogEntry -Message "MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]; no registration change is required." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                    '            }'
+                    '        }'
+                    '        if ($shouldInstallPackage) {'
+                    '            Add-AppxPackage -Path $msixPath -ForceApplicationShutdown -ErrorAction Stop'
+                    '            Write-ADTLogEntry -Message "User-scoped MSIX/APPX package registered successfully" -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                    '        }'
+                    '    } catch {'
+                    '        Write-ADTLogEntry -Message "Failed to register user-scoped MSIX/APPX package: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
+                    '        throw'
+                    '    }'
+                )
+            } else {
+                $lines += @(
+                    "    `$msixPath = `"`$(`$adtSession.DirFiles)\$installerFileName`""
+                    "    `$packageName = '$msixPackageName'"
+                    "    `$targetVersion = '$versionSingleQuoteEscaped'"
+                    '    Write-ADTLogEntry -Message "Provisioning machine-scoped MSIX/APPX package for all users: $msixPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                    '    try {'
+                    '        $existingPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $packageName } | Sort-Object Version -Descending | Select-Object -First 1'
+                    '        $shouldInstallPackage = $true'
+                    '        if ($existingPackage) {'
+                    '            try {'
+                    '                $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion'
+                    '            } catch {'
+                    '                $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion'
+                    '            }'
+                    '            if (-not $shouldInstallPackage) {'
+                    '                Write-ADTLogEntry -Message "Provisioned MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                    '            }'
+                    '        }'
+                    '        if ($shouldInstallPackage) {'
+                    '            Add-AppxProvisionedPackage -Online -PackagePath $msixPath -SkipLicense -ErrorAction Stop'
+                    '            Write-ADTLogEntry -Message "Machine-scoped MSIX/APPX package provisioned successfully" -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                    '        }'
+                    '    } catch {'
+                    '        Write-ADTLogEntry -Message "Failed to provision machine-scoped MSIX/APPX package: $_" -Severity ''Error'' -Source ''Install-ADTDeployment'''
+                    '        throw'
+                    '    }'
+                )
+            }
         }
         'zip' {
             # Zip archives carry a nested installer (winget nestedInstallerType/nestedInstallerPath)
@@ -1373,7 +1433,8 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
         '        @(Get-ADTApplication -Name $appName -NameMatch ''Exact'')'
         '    }'
         ''
-        '    if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey -and -not $configuredProductCode) {'
+        "    `$allowContainsFallback = '$installerTypeLower' -notin @('msi', 'wix')"
+        '    if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey -and -not $configuredProductCode -and $allowContainsFallback) {'
         '        $containsMatches = @(Get-ADTApplication -Name $appName -NameMatch ''Contains'')'
         '        $bundleMatches = @($containsMatches | Where-Object { -not $_.WindowsInstaller })'
         '        if ($bundleMatches.Count -eq 1) {'
@@ -1413,13 +1474,21 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
     } else {
         $lines += @(
             '    $registeredApplication = $installedApps[0]'
+            "    `$registeredInstallerType = '$installerTypeLower'"
+            '    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName'
+            '    $capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'') -and $registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {'
+            '        $registeredApplication.ProductCode'
+            '    } elseif ($registeredInstallerType -in @(''msi'', ''wix'') -and [string]$registeredApplication.PSChildName -match ''^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$'') {'
+            '        [string]$registeredApplication.PSChildName'
+            '    } else {'
+            '        $null'
+            '    }'
             '    [string[]]$additionalUninstallArguments = @()'
             '    $isVivaldiUninstall = $false'
             '    $hasQuietUninstall = -not [string]::IsNullOrWhiteSpace($registeredApplication.QuietUninstallStringFilePath)'
             '    if (-not $hasQuietUninstall) {'
             '        $registeredUninstallFile = [string]$registeredApplication.UninstallStringFilePath'
             '        $registeredArgumentText = (@($registeredApplication.UninstallStringArgumentList) -join '' '').Trim()'
-            "        `$registeredInstallerType = '$installerTypeLower'"
             ''
             '        # PSADT correctly prefers QuietUninstallString. Some vendors only publish an interactive'
             '        # UninstallString, so add narrowly verified unattended arguments for known signatures.'
@@ -1438,7 +1507,10 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '        }'
             '    }'
             ''
-            '    if ($isVivaldiUninstall) {'
+            '    if ($capturedMsiProductCode) {'
+            '        Write-ADTLogEntry -Message "Executing MSI uninstall with captured product code [$capturedMsiProductCode]." -Source ''Uninstall-ADTDeployment'''
+            '        Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)'
+            '    } elseif ($isVivaldiUninstall) {'
             '        # Vivaldi documents this exact command for silent removal. Execute it directly instead of'
             '        # appending to the registered command so argument ordering and duplicate switches cannot'
             '        # fall back to the vendor confirmation dialog.'
@@ -1455,33 +1527,60 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '    } else {'
             '        Uninstall-ADTApplication -InstalledApplication $registeredApplication -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)'
             '    }'
+            '    $remainingApplications = @()'
+            '    foreach ($verificationAttempt in 1..5) {'
+            '        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })'
+            '        if ($remainingApplications.Count -eq 0) { break }'
+            '        if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }'
+            '    }'
+            '    if ($remainingApplications.Count -gt 0) {'
+            '        throw "The vendor uninstall command returned, but uninstall registration [$registeredUninstallRegistryKey] still exists."'
+            '    }'
         )
     }
 } elseif ($useMsixUninstall) {
-    $lines += @(
-        ''
-        '    # Remove MSIX/APPX provisioned package and installed instances'
-        "    `$packageName = '$msixPackageName'"
-        '    Write-ADTLogEntry -Message "Removing MSIX package: $packageName" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
-        '    try {'
-        '        $provPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -like "*$packageName*" }'
-        '        if ($provPackage) {'
-        '            Write-ADTLogEntry -Message "Removing provisioned package: $($provPackage.DisplayName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
-        '            $provPackage | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue'
-        '        }'
-        '        $packages = Get-AppxPackage -Name "*$packageName*" -AllUsers -ErrorAction SilentlyContinue'
-        '        if ($packages) {'
-        '            foreach ($pkg in $packages) {'
-        '                Write-ADTLogEntry -Message "Removing installed package: $($pkg.PackageFullName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
-        '                Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction SilentlyContinue'
-        '            }'
-        '        }'
-        '        Write-ADTLogEntry -Message "MSIX package removal completed" -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
-        '    } catch {'
-        '        Write-ADTLogEntry -Message "Failed to remove MSIX package: $_" -Severity ''Error'' -Source ''Uninstall-ADTDeployment'''
-        '        throw'
-        '    }'
-    )
+    if ($IsUserScope) {
+        $lines += @(
+            ''
+            '    # Remove the MSIX/APPX registration for the current user only.'
+            "    `$packageName = '$msixPackageName'"
+            '    Write-ADTLogEntry -Message "Removing user-scoped MSIX package: $packageName" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+            '    try {'
+            '        $packages = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue'
+            '        foreach ($pkg in @($packages)) {'
+            '            Write-ADTLogEntry -Message "Removing current-user package: $($pkg.PackageFullName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+            '            Remove-AppxPackage -Package $pkg.PackageFullName -ErrorAction Stop'
+            '        }'
+            '        Write-ADTLogEntry -Message "User-scoped MSIX package removal completed" -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+            '    } catch {'
+            '        Write-ADTLogEntry -Message "Failed to remove user-scoped MSIX package: $_" -Severity ''Error'' -Source ''Uninstall-ADTDeployment'''
+            '        throw'
+            '    }'
+        )
+    } else {
+        $lines += @(
+            ''
+            '    # Remove the machine provision and all registered package instances.'
+            "    `$packageName = '$msixPackageName'"
+            '    Write-ADTLogEntry -Message "Removing machine-scoped MSIX package: $packageName" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+            '    try {'
+            '        $provPackages = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $packageName }'
+            '        foreach ($provPackage in @($provPackages)) {'
+            '            Write-ADTLogEntry -Message "Removing provisioned package: $($provPackage.DisplayName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+            '            Remove-AppxProvisionedPackage -Online -PackageName $provPackage.PackageName -ErrorAction Stop | Out-Null'
+            '        }'
+            '        $packages = Get-AppxPackage -Name $packageName -AllUsers -ErrorAction SilentlyContinue'
+            '        foreach ($pkg in @($packages)) {'
+            '            Write-ADTLogEntry -Message "Removing installed package: $($pkg.PackageFullName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+            '            Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop'
+            '        }'
+            '        Write-ADTLogEntry -Message "Machine-scoped MSIX package removal completed" -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+            '    } catch {'
+            '        Write-ADTLogEntry -Message "Failed to remove machine-scoped MSIX package: $_" -Severity ''Error'' -Source ''Uninstall-ADTDeployment'''
+            '        throw'
+            '    }'
+        )
+    }
 } elseif ($usePortableUninstall) {
     $lines += @(
         ''

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -393,7 +393,19 @@ jobs:
                     ...inst,
                     InstallerType: inst.InstallerType || rootType,
                     Scope: inst.Scope || rootScope,
-                    InstallerSwitches: inst.InstallerSwitches || rootSwitches,
+                    InstallerSwitches: (rootSwitches || inst.InstallerSwitches) ? {
+                      ...(rootSwitches || {}),
+                      ...(inst.InstallerSwitches || {}),
+                    } : undefined,
+                    ProductCode: inst.ProductCode || installerManifest.ProductCode,
+                    PackageFamilyName: inst.PackageFamilyName || installerManifest.PackageFamilyName,
+                    AppsAndFeaturesEntries: inst.AppsAndFeaturesEntries || installerManifest.AppsAndFeaturesEntries,
+                    NestedInstallerType: inst.NestedInstallerType || installerManifest.NestedInstallerType,
+                    NestedInstallerFiles: inst.NestedInstallerFiles || installerManifest.NestedInstallerFiles,
+                    UpgradeBehavior: inst.UpgradeBehavior || installerManifest.UpgradeBehavior,
+                    Dependencies: inst.Dependencies || installerManifest.Dependencies,
+                    Platform: inst.Platform || installerManifest.Platform,
+                    MinimumOSVersion: inst.MinimumOSVersion || installerManifest.MinimumOSVersion,
                   }));
 
                   const versionRecord = {

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -374,6 +374,46 @@ describe('generateDetectionRules', () => {
       expect(rules).toHaveLength(1);
       expect(rules[0].type).toBe('script');
     });
+
+    it('should query the current user and fall back only when running as SYSTEM', () => {
+      const installer: NormalizedInstaller = {
+        architecture: 'x64',
+        url: 'https://example.com/terminal.msixbundle',
+        sha256: 'abc123',
+        type: 'msix',
+        scope: 'user',
+        packageFamilyName: 'Microsoft.WindowsTerminal_8wekyb3d8bbwe',
+      };
+
+      const rules = generateDetectionRules(installer, 'Windows Terminal');
+      const script = (rules[0] as ScriptDetectionRule).scriptContent;
+
+      expect(script).toContain('Get-AppxPackage -Name "Microsoft.WindowsTerminal"');
+      expect(script).toContain(
+        '[Security.Principal.WindowsIdentity]::GetCurrent().IsSystem'
+      );
+      expect(script).toContain(
+        'if (-not $package -and $runningAsSystem) { $package = Get-AppxPackage -Name "Microsoft.WindowsTerminal" -AllUsers }'
+      );
+      expect(script).not.toContain('Get-AppxProvisionedPackage');
+    });
+
+    it('should check installed and provisioned identities for a machine-scoped package', () => {
+      const installer: NormalizedInstaller = {
+        architecture: 'x64',
+        url: 'https://example.com/app.msix',
+        sha256: 'abc123',
+        type: 'msix',
+        scope: 'machine',
+        packageFamilyName: 'Contoso.App_abc123',
+      };
+
+      const rules = generateDetectionRules(installer, 'Contoso App');
+      const script = (rules[0] as ScriptDetectionRule).scriptContent;
+
+      expect(script).toContain('Get-AppxPackage -Name "Contoso.App" -AllUsers');
+      expect(script).toContain('Get-AppxProvisionedPackage -Online');
+    });
   });
 
   describe('Folder detection rules', () => {
@@ -644,7 +684,7 @@ describe('generateUninstallCommand', () => {
     expect(command).toContain('/norestart');
   });
 
-  it('should generate placeholder MSI uninstall command without product code', () => {
+  it('should resolve MSI uninstall registration without a product code', () => {
     const installer: NormalizedInstaller = {
       architecture: 'x64',
       url: 'https://example.com/installer.msi',
@@ -652,9 +692,23 @@ describe('generateUninstallCommand', () => {
       type: 'msi',
     };
 
-    const command = generateUninstallCommand(installer);
+    const command = generateUninstallCommand(installer, 'Codeless MSI App');
 
-    expect(command).toContain('{PRODUCT_CODE}');
+    expect(command).toBe('REGISTRY_UNINSTALL:Codeless MSI App');
+    expect(command).not.toContain('{PRODUCT_CODE}');
+  });
+
+  it('should fail safely when MSI uninstall identity cannot be determined', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/installer.msi',
+      sha256: 'abc123',
+      type: 'msi',
+    };
+
+    expect(generateUninstallCommand(installer)).toBe(
+      'MSI_UNINSTALL_IDENTITY_REQUIRED'
+    );
   });
 
   it('should generate MSIX uninstall marker with package family name', () => {
@@ -670,6 +724,19 @@ describe('generateUninstallCommand', () => {
 
     expect(command).toContain('MSIX_UNINSTALL:');
     expect(command).toContain('Microsoft.VSCode');
+  });
+
+  it('should not guess an MSIX package identity from its display name', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/installer.msix',
+      sha256: 'abc123',
+      type: 'msix',
+    };
+
+    expect(generateUninstallCommand(installer, 'Windows Terminal')).toBe(
+      'MSIX_UNINSTALL:{PACKAGE_NAME}'
+    );
   });
 
   it('should generate registry uninstall command for EXE with display name', () => {

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -555,6 +555,34 @@ describe('normalizeManifestInstallers', () => {
       '--vivaldi-silent --do-not-launch-chrome'
     );
   });
+
+  it('inherits root MSI and MSIX identity fields', () => {
+    const msiInstallers = normalizeManifestInstallers({
+      InstallerType: 'wix',
+      ProductCode: '{D1827F05-CDAB-444B-90E3-D52ACB111CBD}',
+      Installers: [{
+        Architecture: 'x86',
+        InstallerUrl: 'https://example.com/exclaimer.msi',
+        InstallerSha256: 'abc123',
+      }],
+    });
+    const msixInstallers = normalizeManifestInstallers({
+      InstallerType: 'msix',
+      PackageFamilyName: 'Microsoft.WindowsTerminal_8wekyb3d8bbwe',
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/terminal.msixbundle',
+        InstallerSha256: 'def456',
+      }],
+    });
+
+    expect(msiInstallers[0].ProductCode).toBe(
+      '{D1827F05-CDAB-444B-90E3-D52ACB111CBD}'
+    );
+    expect(msixInstallers[0].PackageFamilyName).toBe(
+      'Microsoft.WindowsTerminal_8wekyb3d8bbwe'
+    );
+  });
 });
 
 describe('getManifestPaths logic', () => {

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -187,7 +187,10 @@ function generateMsixDetectionRules(
     return [
       {
         type: 'script',
-        scriptContent: generateMsixDetectionScript(installer.packageFamilyName),
+        scriptContent: generateMsixDetectionScript(
+          installer.packageFamilyName,
+          installer.scope
+        ),
         enforceSignatureCheck: false,
         runAs32Bit: false,
       } as ScriptDetectionRule,
@@ -263,16 +266,32 @@ function getBasePath(scope?: WingetScope, architecture?: string): string {
  * Generate MSIX detection script
  * MSIX apps are detected via Get-AppxPackage
  */
-function generateMsixDetectionScript(packageFamilyName: string): string {
+function generateMsixDetectionScript(
+  packageFamilyName: string,
+  scope?: WingetScope
+): string {
   // Extract the package name (before the underscore in family name)
   const packageName = packageFamilyName.split('_')[0];
+  const packageLookup =
+    scope === 'user'
+      ? [
+          `$package = Get-AppxPackage -Name "${packageName}"`,
+          '$runningAsSystem = [Security.Principal.WindowsIdentity]::GetCurrent().IsSystem',
+          `if (-not $package -and $runningAsSystem) { $package = Get-AppxPackage -Name "${packageName}" -AllUsers }`,
+        ].join('\n')
+      : `$package = Get-AppxPackage -Name "${packageName}" -AllUsers`;
 
   const lines = [
     '# MSIX Detection Script',
     `# Package Family Name: ${packageFamilyName}`,
     '',
     '$ErrorActionPreference = "SilentlyContinue"',
-    `$package = Get-AppxPackage -Name "*${packageName}*" -AllUsers`,
+    packageLookup,
+    ...(scope === 'user'
+      ? []
+      : [
+          `if (-not $package) { $package = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq "${packageName}" } }`,
+        ]),
     'if ($package) {',
     '    Write-Output "Installed"',
     '    exit 0',
@@ -338,7 +357,14 @@ export function generateUninstallCommand(
       if (installer.productCode) {
         return `msiexec /x "${installer.productCode}" /qn /norestart`;
       }
-      return 'msiexec /x {PRODUCT_CODE} /qn /norestart';
+      // Some manifests omit ProductCode even though Windows Installer creates
+      // an authoritative uninstall registration at install time. Resolve that
+      // registration after installation instead of emitting a literal GUID
+      // placeholder that msiexec will reject with exit code 1619.
+      if (displayName) {
+        return generateRegistryUninstallCommand(displayName, installer.type);
+      }
+      return 'MSI_UNINSTALL_IDENTITY_REQUIRED';
 
     case 'msix':
     case 'appx':
@@ -346,10 +372,8 @@ export function generateUninstallCommand(
       if (installer.packageFamilyName) {
         return `MSIX_UNINSTALL:${installer.packageFamilyName.split('_')[0]}`;
       }
-      // Fallback using display name
-      if (displayName) {
-        return `MSIX_UNINSTALL:${displayName}`;
-      }
+      // A display name is not an AppX package identity. Keep the marker
+      // intentionally invalid so both packagers reject it before deployment.
       return 'MSIX_UNINSTALL:{PACKAGE_NAME}';
 
     case 'exe':

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -315,11 +315,28 @@ async function getManifestFromSupabase(
     // Parse installers from JSONB, recover malformed stringified JSON, or fetch fresh installer manifest
     let installers: WingetInstaller[] = [];
 
-    const parsedInstallers = coerceInstallersArray(
-      versionData.installers,
-      versionData.installer_type,
-      versionData.silent_args
-    );
+    let manifestInstallers: WingetInstaller[] = [];
+    if (typeof versionData.manifest_yaml === 'string' && versionData.manifest_yaml.trim()) {
+      try {
+        const storedManifest = YAML.parse(versionData.manifest_yaml);
+        if (storedManifest && typeof storedManifest === 'object') {
+          manifestInstallers = normalizeManifestInstallers(
+            storedManifest as Record<string, unknown>
+          );
+        }
+      } catch {
+        // Fall back to the flattened installer cache below. Older rows can
+        // contain incomplete or malformed manifest_yaml values.
+      }
+    }
+
+    const parsedInstallers = manifestInstallers.length > 0
+      ? manifestInstallers
+      : coerceInstallersArray(
+          versionData.installers,
+          versionData.installer_type,
+          versionData.silent_args
+        );
 
     if (parsedInstallers.length > 0) {
       installers = parsedInstallers;
@@ -543,6 +560,8 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
   const defaultMinOS = manifest.MinimumOSVersion as string;
   const defaultUpgrade = manifest.UpgradeBehavior as string;
   const defaultDependencies = manifest.Dependencies as WingetInstaller['Dependencies'];
+  const defaultProductCode = manifest.ProductCode as string;
+  const defaultPackageFamilyName = manifest.PackageFamilyName as string;
 
   return rawInstallers.map((installer) => ({
     Architecture: (installer.Architecture as WingetInstaller['Architecture']) || 'x64',
@@ -561,8 +580,9 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     // WinGet inherits installer switches per field. An installer-level Custom
     // value must not discard a root-level Silent value (Vivaldi is one example).
     InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
-    ProductCode: installer.ProductCode as string,
-    PackageFamilyName: installer.PackageFamilyName as string,
+    ProductCode: (installer.ProductCode as string) || defaultProductCode,
+    PackageFamilyName:
+      (installer.PackageFamilyName as string) || defaultPackageFamilyName,
     UpgradeBehavior: (installer.UpgradeBehavior as WingetInstaller['UpgradeBehavior']) ||
                      (defaultUpgrade as WingetInstaller['UpgradeBehavior']),
     InstallerLocale: installer.InstallerLocale as string,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -101,4 +101,41 @@ describe('PSADT registry uninstall identity contract', () => {
       'Uninstall-ADTApplication -InstalledApplication $registeredApplication -AdditionalArgumentList $additionalUninstallArguments'
     );
   });
+
+  it('uses a captured MSI product code instead of an executable uninstall string', () => {
+    expect(packager).toContain(
+      "$capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'') -and $registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode)"
+    );
+    expect(packager).toContain(
+      "Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode"
+    );
+    expect(packager).toContain(
+      'foreach ($verificationAttempt in 1..5)'
+    );
+    expect(packager).toContain(
+      'if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }'
+    );
+  });
+
+  it('rejects missing MSI and unsafe MSIX identities during package creation', () => {
+    expect(packager).toContain("$uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED'");
+    expect(packager).toContain("$msixPackageName -notmatch '^[A-Za-z0-9.-]+$'");
+    expect(packager).toContain("$installerTypeLower -in @('msix', 'appx') -and");
+    expect(packager).toContain('[string]::IsNullOrWhiteSpace($msixPackageName) -and');
+    expect(packager).toContain('[string]::IsNullOrWhiteSpace($customUninstallCommand)');
+  });
+});
+
+describe('PSADT MSIX scope contract', () => {
+  it('registers user-scoped packages in the current user context', () => {
+    expect(packager).toContain('Add-AppxPackage -Path $msixPath -ForceApplicationShutdown');
+    expect(packager).toContain('Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue');
+    expect(packager).toContain('Remove-AppxPackage -Package $pkg.PackageFullName -ErrorAction Stop');
+  });
+
+  it('reserves online provisioning and all-user removal for machine scope', () => {
+    expect(packager).toContain('Add-AppxProvisionedPackage -Online -PackagePath $msixPath');
+    expect(packager).toContain('Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers');
+    expect(packager).toContain('if ($IsUserScope)');
+  });
 });

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -160,4 +160,86 @@ describe('buildQaCatalogTestConfig', () => {
 
     expect(config.silentArgs).toBe('');
   });
+
+  it('inherits a root MSI product code for exact silent uninstall', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Exclaimer.CloudSignatureUpdateAgent',
+        name: 'Exclaimer Cloud Signature Update Agent',
+        publisher: 'Exclaimer',
+        version: '1.21.0.0',
+      },
+      manifest: {
+        InstallerType: 'wix',
+        ProductCode: '{D1827F05-CDAB-444B-90E3-D52ACB111CBD}',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'wix',
+        Scope: 'machine',
+      },
+    });
+
+    expect(config.productCode).toBe('{D1827F05-CDAB-444B-90E3-D52ACB111CBD}');
+    expect(config.uninstallCommand).toBe(
+      'msiexec /x "{D1827F05-CDAB-444B-90E3-D52ACB111CBD}" /qn /norestart'
+    );
+  });
+
+  it('prefers architecture-specific AppsAndFeatures identity over a root product code', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.MultiArch',
+        name: 'Contoso MultiArch',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: {
+        InstallerType: 'wix',
+        ProductCode: '{11111111-1111-1111-1111-111111111111}',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'wix',
+        AppsAndFeaturesEntries: [
+          { ProductCode: '{22222222-2222-2222-2222-222222222222}' },
+        ],
+      },
+    });
+
+    expect(config.productCode).toBe('{22222222-2222-2222-2222-222222222222}');
+  });
+
+  it('inherits a root package family name for user-scoped MSIX handling', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Microsoft.WindowsTerminal',
+        name: 'Windows Terminal',
+        publisher: 'Microsoft',
+        version: '1.24.11911.0',
+      },
+      manifest: {
+        InstallerType: 'msix',
+        Scope: 'user',
+        PackageFamilyName: 'Microsoft.WindowsTerminal_8wekyb3d8bbwe',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'msix',
+      },
+    });
+
+    expect(config.uninstallCommand).toBe('MSIX_UNINSTALL:Microsoft.WindowsTerminal');
+    expect(config.detectionRules[0]).toMatchObject({ type: 'script' });
+    const script = 'scriptContent' in config.detectionRules[0]
+      ? config.detectionRules[0].scriptContent
+      : '';
+    expect(script).toContain('Get-AppxPackage -Name "Microsoft.WindowsTerminal"');
+    expect(script).toContain(
+      '[Security.Principal.WindowsIdentity]::GetCurrent().IsSystem'
+    );
+    expect(script).toContain(
+      'if (-not $package -and $runningAsSystem) { $package = Get-AppxPackage -Name "Microsoft.WindowsTerminal" -AllUsers }'
+    );
+  });
 });

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -117,7 +117,11 @@ export function buildQaCatalogTestConfig({
   const scope: WingetScope = rawScope.toLowerCase() === 'user' ? 'user' : 'machine';
   const productCode =
     msiProductCode(installer.ProductCode) ||
-    msiProductCode(appsAndFeaturesProductCode(installer));
+    msiProductCode(appsAndFeaturesProductCode(installer)) ||
+    msiProductCode(manifest.ProductCode) ||
+    msiProductCode(appsAndFeaturesProductCode(manifest));
+  const packageFamilyName =
+    text(installer.PackageFamilyName) || text(manifest.PackageFamilyName);
   const inheritedInstaller: WingetInstaller = {
     Architecture: (text(installer.Architecture).toLowerCase() ||
       'x64') as WingetInstaller['Architecture'],
@@ -131,7 +135,7 @@ export function buildQaCatalogTestConfig({
     Scope: scope,
     InstallerSwitches: normalizeInstallerSwitches(effectiveSwitches),
     ProductCode: productCode || undefined,
-    PackageFamilyName: text(installer.PackageFamilyName) || undefined,
+    PackageFamilyName: packageFamilyName || undefined,
   };
   const normalizedInstaller = normalizeInstaller(inheritedInstaller);
   const detectionRules = generateDetectionRules(

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -756,6 +756,14 @@ ${steps}
       return `Start-ADTMsiProcess -Action 'Install' -FilePath '${fileName}'`;
     }
 
+    if (
+      ['.msix', '.msixbundle', '.appx', '.appxbundle'].includes(ext) ||
+      installerType === 'msix' ||
+      installerType === 'appx'
+    ) {
+      return this.getMsixInstallCommand(job, fileName);
+    }
+
     if (installerType === 'portable') {
       const fileNameEscaped = fileName.replace(/'/g, "''");
       return `${this.getPortableInstallPathLine(job)}
@@ -790,6 +798,52 @@ ${steps}
       .filter((token) => token && !/^\/(q[nbrfu]?|quiet|norestart|i|x)$/i.test(token))
       .join(' ')
       .trim();
+  }
+
+  private getMsixPackageName(job: PackagingJob): string | null {
+    const match = job.uninstall_command?.match(/^MSIX_UNINSTALL:([A-Za-z0-9.-]+)$/);
+    return match?.[1] || null;
+  }
+
+  private getMsixInstallCommand(job: PackagingJob, fileName: string): string {
+    const packageName = this.getMsixPackageName(job);
+    if (!packageName) {
+      return 'throw "The MSIX/APPX package identity is missing or unsafe; refusing an ambiguous deployment."';
+    }
+
+    const escapedFileName = fileName.replace(/'/g, "''");
+    const escapedVersion = job.version.replace(/'/g, "''");
+    const common = `$msixPath = Join-Path $adtSession.DirFiles '${escapedFileName}'
+    $packageName = '${packageName}'
+    $targetVersion = '${escapedVersion}'`;
+
+    if (job.install_scope === 'user') {
+      return `${common}
+    $existingPackage = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1
+    $shouldInstallPackage = $true
+    if ($existingPackage) {
+        try { $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion }
+        catch { $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion }
+    }
+    if ($shouldInstallPackage) {
+        Add-AppxPackage -Path $msixPath -ForceApplicationShutdown -ErrorAction Stop
+    } else {
+        Write-ADTLogEntry -Message "MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]." -Severity 'Success' -Source 'Install-ADTDeployment'
+    }`;
+    }
+
+    return `${common}
+    $existingPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $packageName } | Sort-Object Version -Descending | Select-Object -First 1
+    $shouldInstallPackage = $true
+    if ($existingPackage) {
+        try { $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion }
+        catch { $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion }
+    }
+    if ($shouldInstallPackage) {
+        Add-AppxProvisionedPackage -Online -PackagePath $msixPath -SkipLicense -ErrorAction Stop
+    } else {
+        Write-ADTLogEntry -Message "Provisioned MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]." -Severity 'Success' -Source 'Install-ADTDeployment'
+    }`;
   }
 
   /**
@@ -926,6 +980,27 @@ ${steps}
 
     if (!job.uninstall_command) {
       return "Write-ADTLogEntry -Message 'No uninstall command specified' -Severity 'Warning' -Source 'Uninstall-ADTDeployment'";
+    }
+
+    if (/^MSIX_UNINSTALL:/.test(job.uninstall_command)) {
+      const packageName = this.getMsixPackageName(job);
+      if (!packageName) {
+        return 'throw "The MSIX/APPX package identity is missing or unsafe; refusing an ambiguous removal."';
+      }
+      if (job.install_scope === 'user') {
+        return `$packages = Get-AppxPackage -Name '${packageName}' -ErrorAction SilentlyContinue
+    foreach ($pkg in @($packages)) {
+        Remove-AppxPackage -Package $pkg.PackageFullName -ErrorAction Stop
+    }`;
+      }
+      return `$provPackages = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq '${packageName}' }
+    foreach ($provPackage in @($provPackages)) {
+        Remove-AppxProvisionedPackage -Online -PackageName $provPackage.PackageName -ErrorAction Stop | Out-Null
+    }
+    $packages = Get-AppxPackage -Name '${packageName}' -AllUsers -ErrorAction SilentlyContinue
+    foreach ($pkg in @($packages)) {
+        Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop
+    }`;
     }
 
     const registryProductMatch = job.uninstall_command.match(

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -206,3 +206,67 @@ describe('Burn bundle PSADT generation', () => {
     expect(script).not.toContain("Start-ADTMsiProcess -Action 'Uninstall'");
   });
 });
+
+describe('self-hosted MSIX PSADT generation', () => {
+  const msixJob = (scope: 'user' | 'machine'): PackagingJob => packagingJob({
+    winget_id: 'Microsoft.WindowsTerminal',
+    display_name: 'Windows Terminal',
+    version: '1.24.11911.0',
+    installer_type: 'msix',
+    installer_url: 'https://example.com/terminal.msixbundle',
+    uninstall_command: 'MSIX_UNINSTALL:Microsoft.WindowsTerminal',
+    install_scope: scope,
+  });
+
+  it('uses current-user AppX commands for user-scoped packages', () => {
+    const job = msixJob('user');
+    const install = generator.getInstallCommand.call(
+      generator,
+      job,
+      'terminal.msixbundle',
+      ''
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'terminal.msixbundle'
+    );
+
+    expect(install).toContain('Add-AppxPackage -Path $msixPath');
+    expect(install).not.toContain('Add-AppxProvisionedPackage');
+    expect(uninstall).toContain("Get-AppxPackage -Name 'Microsoft.WindowsTerminal'");
+    expect(uninstall).not.toContain('-AllUsers');
+    expect(uninstall).not.toContain('Get-AppxProvisionedPackage');
+  });
+
+  it('uses online provisioning only for machine-scoped packages', () => {
+    const job = msixJob('machine');
+    const install = generator.getInstallCommand.call(
+      generator,
+      job,
+      'terminal.msixbundle',
+      ''
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'terminal.msixbundle'
+    );
+
+    expect(install).toContain('Add-AppxProvisionedPackage -Online');
+    expect(uninstall).toContain('Get-AppxProvisionedPackage -Online');
+    expect(uninstall).toContain('Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers');
+  });
+
+  it('refuses a display-name fallback that is not an exact package identity', () => {
+    const job = msixJob('user');
+    job.uninstall_command = 'MSIX_UNINSTALL:Windows Terminal';
+
+    expect(
+      generator.getInstallCommand.call(generator, job, 'terminal.msixbundle', '')
+    ).toContain('identity is missing or unsafe');
+    expect(
+      generator.getUninstallCommand.call(generator, job, 'terminal.msixbundle')
+    ).toContain('refusing an ambiguous removal');
+  });
+});


### PR DESCRIPTION
## Summary
- preserve inherited WinGet ProductCode and PackageFamilyName metadata end to end
- install, detect, and uninstall AppX/MSIX packages according to user or machine scope
- replace unsafe MSI/MSIX identity guesses with exact metadata or fail-safe validation
- verify registry-based uninstalls and keep hosted and self-hosted packagers aligned

## Failure evidence
- Exclaimer Cloud Signature Update Agent used a literal {PRODUCT_CODE} and returned 1619 because its root ProductCode was dropped
- Windows Terminal was treated as a machine-provisioned package despite its user scope, and its root PackageFamilyName was dropped
- several other recent red runs were protected-toolchain rejections before VM execution, not application failures

## Verification
- 166 focused Vitest tests passed
- standalone packager TypeScript build passed
- targeted ESLint passed
- PowerShell parser and git diff checks passed
- Next.js production build passed
- Claude Code Fable completed initial and narrow follow-up reviews; evidence-backed findings were addressed

The full Vitest suite has one unrelated Windows-only timeout in scripts/maybe-translate.test.ts; 732 other tests passed.