### PR TITLE
Pin QA profiles to hardened MSI and MSIX packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'a113ab2ea94e6ba02c9b22aa00706317d7bd82d2',
+  packagerCommit: '2bffe7f5c3b146c98316b02235a10dde62df58e6',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Advances the website-generated QA package profile to reviewed IntuneGet packager commit 2bffe7f5c3b146c98316b02235a10dde62df58e6, matching IntuneGet-Workflows main after PR #326. This prevents new candidates from being rejected by the protected workflow as stale.