### PR TITLE
Show exact QA runs and prioritize failed backfill

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/winget-sync-resolution.mjs', () => ({
 }));
 
 import { GET } from './route';
+import { prioritizeToolchainBackfill } from '@/lib/qa/toolchain-backfill';
 import {
   buildQaPackageIdentity,
   canonicalQaJson,
@@ -183,6 +184,8 @@ function profileCandidate(options: {
   profileKind?: string;
   toolchainOverrides?: Record<string, unknown>;
   interactive?: boolean;
+  status?: string;
+  priority?: number;
 }): Record<string, unknown> {
   const profileKind = options.profileKind || 'catalog-default';
   const version = '1.0.0';
@@ -232,6 +235,8 @@ function profileCandidate(options: {
     architecture,
     installer_sha256: installerSha256,
     enqueued_at: options.enqueuedAt || '2026-08-08T10:00:00.000Z',
+    status: options.status || 'superseded',
+    priority: options.priority ?? 1,
     package_profile_sha256: packageProfileSha256,
     test_config: {
       profileKind,
@@ -680,5 +685,39 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({ winget_id: 'Supported.App' });
+  });
+
+  it('prioritizes failed stale profiles before ordinary toolchain backfill', async () => {
+    expect(prioritizeToolchainBackfill([
+      {
+        wingetId: 'Newest.App',
+        status: 'superseded',
+        priority: 1,
+        enqueuedAt: '2026-08-08T10:04:00.000Z',
+      },
+      {
+        wingetId: 'Failed.Low',
+        status: 'failed',
+        priority: 1,
+        enqueuedAt: '2026-08-08T10:01:00.000Z',
+      },
+      {
+        wingetId: 'Failed.High',
+        status: 'failed',
+        priority: 2,
+        enqueuedAt: '2026-08-08T10:00:00.000Z',
+      },
+      {
+        wingetId: 'Error.App',
+        status: 'error',
+        priority: 1,
+        enqueuedAt: '2026-08-08T10:03:00.000Z',
+      },
+    ])).toEqual([
+      'Failed.High',
+      'Failed.Low',
+      'Error.App',
+      'Newest.App',
+    ]);
   });
 });

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -19,6 +19,10 @@ import {
   buildQaPackageIdentity,
   validateCurrentQaPackageProfile,
 } from '@/lib/qa/package-profile';
+import {
+  prioritizeToolchainBackfill,
+  type QaToolchainBackfillCandidate,
+} from '@/lib/qa/toolchain-backfill';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
@@ -43,6 +47,8 @@ interface QaCandidateProfileRow {
   enqueued_at: string;
   package_profile_sha256: string | null;
   test_config: unknown;
+  status: string;
+  priority: number;
 }
 
 function object(value: unknown): Record<string, unknown> {
@@ -68,7 +74,7 @@ async function findToolchainBackfillIds(
   supabase: ReturnType<typeof createServerClient>
 ): Promise<{ ids: string[]; pagesScanned: number }> {
   const decidedIds = new Set<string>();
-  const supportedStaleIds: string[] = [];
+  const supportedStaleCandidates: QaToolchainBackfillCandidate[] = [];
   let cursor: { enqueuedAt: string; id: string } | null = null;
   let pagesScanned = 0;
 
@@ -76,7 +82,7 @@ async function findToolchainBackfillIds(
     let candidateQuery = supabase
       .from('qa_candidates')
       .select(
-        'id, winget_id, version, architecture, installer_sha256, enqueued_at, package_profile_sha256, test_config'
+        'id, winget_id, version, architecture, installer_sha256, enqueued_at, package_profile_sha256, test_config, status, priority'
       )
       .eq('test_level', 'psadt-package')
       .not('package_profile_sha256', 'is', null)
@@ -94,7 +100,7 @@ async function findToolchainBackfillIds(
     const rows = (data || []) as QaCandidateProfileRow[];
     pagesScanned++;
 
-    const pageStaleIds: string[] = [];
+    const pageStaleRows: QaCandidateProfileRow[] = [];
     for (const row of rows) {
       const config = object(row.test_config);
       if (config.profileKind !== 'catalog-default' || decidedIds.has(row.winget_id)) continue;
@@ -108,11 +114,12 @@ async function findToolchainBackfillIds(
         candidateInstallerSha256: row.installer_sha256,
       });
       if (!validation.valid || !hasInteractiveCatalogQaProfile(row.test_config)) {
-        pageStaleIds.push(row.winget_id);
+        pageStaleRows.push(row);
       }
     }
 
-    if (pageStaleIds.length > 0) {
+    if (pageStaleRows.length > 0) {
+      const pageStaleIds = pageStaleRows.map((row) => row.winget_id);
       const [supportedResult, policyResult, deployedResult] = await Promise.all([
         supabase
           .from('curated_apps')
@@ -147,21 +154,32 @@ async function findToolchainBackfillIds(
         ...(policyResult.data || []).map((row) => row.winget_id),
         ...(deployedResult.data || []).map((row) => row.winget_id),
       ]);
-      for (const wingetId of pageStaleIds) {
-        if (supportedIds.has(wingetId) && demandedIds.has(wingetId)) {
-          supportedStaleIds.push(wingetId);
+      for (const row of pageStaleRows) {
+        if (supportedIds.has(row.winget_id) && demandedIds.has(row.winget_id)) {
+          supportedStaleCandidates.push({
+            wingetId: row.winget_id,
+            status: typeof row.status === 'string' ? row.status : '',
+            priority: Number.isFinite(row.priority) ? row.priority : 0,
+            enqueuedAt: row.enqueued_at,
+          });
         }
       }
     }
 
-    if (supportedStaleIds.length >= TOOLCHAIN_BACKFILL_BATCH_SIZE) {
+    if (supportedStaleCandidates.length >= TOOLCHAIN_BACKFILL_BATCH_SIZE) {
       return {
-        ids: supportedStaleIds.slice(0, TOOLCHAIN_BACKFILL_BATCH_SIZE),
+        ids: prioritizeToolchainBackfill(supportedStaleCandidates).slice(
+          0,
+          TOOLCHAIN_BACKFILL_BATCH_SIZE
+        ),
         pagesScanned,
       };
     }
     if (rows.length < TOOLCHAIN_BACKFILL_PAGE_SIZE) {
-      return { ids: supportedStaleIds, pagesScanned };
+      return {
+        ids: prioritizeToolchainBackfill(supportedStaleCandidates),
+        pagesScanned,
+      };
     }
 
     const last = rows.at(-1);

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -46,12 +46,12 @@ interface PollRow {
 
 interface ResultRow {
   winget_id: string;
-  display_name: string;
+  display_name?: string | null;
   tested_version: string;
   architecture: string;
   outcome: string;
   tested_at_utc: string;
-  overall_duration_seconds: number | null;
+  overall_duration_seconds?: number | null;
 }
 
 interface AppRow {
@@ -344,7 +344,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       architecture: architecture(result.architecture),
       outcome: result.outcome === 'Passed' ? 'Passed' : ('Failed' as QaOutcome),
       testedAtUtc: result.tested_at_utc,
-      durationSeconds: result.overall_duration_seconds,
+      durationSeconds: result.overall_duration_seconds ?? null,
     })),
   };
 }
@@ -383,11 +383,10 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
       .order('started_at', { ascending: false })
       .limit(10),
     supabase
-      .from('qa_results')
+      .from('qa_package_results')
       .select(
-        'winget_id, display_name, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds'
+        'winget_id, tested_version, architecture, outcome, tested_at_utc'
       )
-      .eq('test_level', 'psadt-package')
       .order('tested_at_utc', { ascending: false })
       .limit(10),
   ]);

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1,0 +1,25 @@
+export interface QaToolchainBackfillCandidate {
+  wingetId: string;
+  status: string;
+  priority: number;
+  enqueuedAt: string;
+}
+
+function timestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function prioritizeToolchainBackfill(
+  candidates: QaToolchainBackfillCandidate[]
+): string[] {
+  return [...candidates]
+    .sort((left, right) => {
+      const leftFailureRank = left.status === 'failed' ? 0 : left.status === 'error' ? 1 : 2;
+      const rightFailureRank = right.status === 'failed' ? 0 : right.status === 'error' ? 1 : 2;
+      if (leftFailureRank !== rightFailureRank) return leftFailureRank - rightFailureRank;
+      if (left.priority !== right.priority) return right.priority - left.priority;
+      return timestamp(right.enqueuedAt) - timestamp(left.enqueuedAt);
+    })
+    .map((candidate) => candidate.wingetId);
+}


### PR DESCRIPTION
## Summary
- read /QA Recent results from exact PSADT package-profile results so completed runs such as Google Chrome appear
- prioritize failed/error stale-toolchain profiles during bounded catalog backfill
- keep customer upload priority and batch size unchanged

## Validation
- focused Vitest: 18 passed
- focused ESLint passed
- Next.js production build passed (141 routes)
- bounded Claude Code Fable review of Recent results: no blocking findings