### PR TITLE
Bump QA packager to verification fixes

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2bffe7f5c3b146c98316b02235a10dde62df58e6',
+  packagerCommit: '5763369d10853be695d1ce69db548f2d71826df6',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Points new QA identities at the merged packager commit containing captured-identity verification and safe Burn bundle selection.

Verification: 43 targeted tests passed.