### PR TITLE
Fix MSI product-code verification in shared packager

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -479,6 +479,14 @@ if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
 } elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
     $useRegistryUninstall = $true
     $registryUninstallDisplayName = $Matches[1]
+} elseif ($installerTypeLower -in @('msi', 'wix') -and $uninstallCmd -match '(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\})') {
+    # Deployment profiles commonly carry the concrete msiexec uninstall command
+    # instead of the internal REGISTRY_UNINSTALL_PRODUCT marker. Treat its product
+    # code as the same immutable registry identity so install verification and
+    # removal never fall back to a human/Winget display name.
+    $useRegistryUninstall = $true
+    $registryUninstallProductCode = $Matches[1]
+    $registryUninstallDisplayName = $DisplayName
 }
 
 if ($useRegistryUninstall) {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -54,6 +54,14 @@ describe('PSADT registry uninstall identity contract', () => {
     );
   });
 
+  it('promotes a concrete MSI/WiX uninstall command to exact registry identity handling', () => {
+    expect(packager).toContain(
+      "$installerTypeLower -in @('msi', 'wix') -and $uninstallCmd -match"
+    );
+    expect(packager).toContain('$registryUninstallProductCode = $Matches[1]');
+    expect(packager).toContain('$registryUninstallDisplayName = $DisplayName');
+  });
+
   it('never sends an ambiguous display-name result set to PSADT uninstall', () => {
     expect(packager).toContain("Get-ADTApplication -Name $appName -NameMatch ''Exact''");
     expect(packager).toContain('if ($installedApps.Count -ne 1)');


### PR DESCRIPTION
## Summary
- recognize concrete MSI/WiX uninstall GUIDs as exact registry identities
- use the same captured identity for install verification and removal
- prevent Winget-style display labels from causing false install failures

## Scope
This shared packager is pinned by both QA and customer packaging workflows.

## Verification
- 60 targeted Vitest checks passed
- PowerShell parser validation passed