### PR TITLE
Relink waiting uploads after QA toolchain upgrades

### DIFF
--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -4,11 +4,13 @@ const {
   createServerClientMock,
   getFeatureFlagsMock,
   handleAutoUpdateJobCompletionMock,
+  ensureQaDemandMock,
   triggerPackagingWorkflowMock,
 } = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
   getFeatureFlagsMock: vi.fn(),
   handleAutoUpdateJobCompletionMock: vi.fn(),
+  ensureQaDemandMock: vi.fn(),
   triggerPackagingWorkflowMock: vi.fn(),
 }));
 
@@ -19,6 +21,7 @@ vi.mock('@/lib/github-actions', () => ({ triggerPackagingWorkflow: triggerPackag
 vi.mock('@/lib/auto-update/cleanup', () => ({
   handleAutoUpdateJobCompletion: handleAutoUpdateJobCompletionMock,
 }));
+vi.mock('@/lib/qa/demand', () => ({ ensureQaDemand: ensureQaDemandMock }));
 
 import { GET } from './route';
 
@@ -136,6 +139,79 @@ describe('GET /api/cron/qa-resume', () => {
       'failed',
       'Installer remained interactive.'
     );
+  });
+
+  it('rebuilds and relinks a superseded exact QA profile without failing the upload job', async () => {
+    const job = {
+      id: 'job-superseded',
+      qa_candidate_id: 'candidate-old',
+      execution_profile_sha256: 'A'.repeat(64),
+      status_message: 'Waiting',
+      created_at: '2026-08-09T12:00:00Z',
+      winget_id: 'Example.App',
+      display_name: 'Example App',
+      publisher: 'Example',
+      version: '2.0.0',
+      architecture: 'x64',
+      installer_url: 'https://example.test/installer.msi',
+      installer_sha256: 'C'.repeat(64),
+      installer_type: 'wix',
+      install_command: 'msiexec /i installer.msi /qn',
+      uninstall_command: 'msiexec /x {11111111-1111-1111-1111-111111111111} /qn',
+      install_scope: 'machine',
+      package_config: { psadtConfig: {}, detectionRules: [] },
+      is_auto_update: false,
+    };
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'waiting',
+      candidateId: 'candidate-current',
+      identity: {
+        executionProfileSha256: 'B'.repeat(64),
+        presentationProfileSha256: 'D'.repeat(64),
+      },
+    });
+    const relinkUpdate = chain({ data: null, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          packagingCall++;
+          if (packagingCall === 1) return chain({ data: [job], error: null });
+          return relinkUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-old',
+              status: 'superseded',
+              failure_summary: null,
+              package_profile_sha256: 'A'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 0, failed: 0, waiting: 1 });
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(client, expect.objectContaining({
+      wingetId: 'Example.App',
+      priority: 2000,
+      demandSource: 'customer',
+    }));
+    expect(relinkUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      qa_candidate_id: 'candidate-current',
+      execution_profile_sha256: 'B'.repeat(64),
+      presentation_profile_sha256: 'D'.repeat(64),
+    }));
   });
 
   it('finalizes auto-update tracking when packaging dispatch fails after QA passes', async () => {

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -6,6 +6,7 @@ import { buildIntuneAppDescription } from '@/lib/intune-description';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { triggerPackagingWorkflow, type WorkflowInputs } from '@/lib/github-actions';
 import { handleAutoUpdateJobCompletion } from '@/lib/auto-update/cleanup';
+import { ensureQaDemand } from '@/lib/qa/demand';
 import type { Win32CartItem } from '@/types/upload';
 
 const RESUME_BATCH_SIZE = 25;
@@ -43,13 +44,60 @@ export async function GET(request: Request) {
       .eq('id', job.qa_candidate_id!)
       .maybeSingle();
     if (candidateError) throw candidateError;
-    if (!candidate || ['failed', 'error'].includes(candidate.status)) {
+
+    let candidateStatus = candidate?.status;
+    let candidateFailureSummary = candidate?.failure_summary;
+    let executionProfileSha256 = job.execution_profile_sha256;
+
+    if (candidateStatus === 'superseded') {
+      const item = job.package_config as unknown as Win32CartItem;
+      const installerType = job.installer_type || item.installerType;
+      const demand = await ensureQaDemand(supabase, {
+        wingetId: job.winget_id,
+        displayName: job.display_name,
+        publisher: job.publisher || item.publisher || 'Unknown Publisher',
+        version: job.version,
+        architecture: job.architecture || item.architecture,
+        installerUrl: job.installer_url || item.installerUrl,
+        installerSha256: job.installer_sha256 || item.installerSha256 || '',
+        installerType,
+        nestedInstallerType: item.nestedInstallerType,
+        nestedInstallerPath: item.nestedInstallerPath,
+        silentSwitches: extractSilentSwitches(job.install_command || item.installCommand, installerType),
+        uninstallCommand: job.uninstall_command || item.uninstallCommand,
+        installScope: job.install_scope || item.installScope,
+        psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,
+        detectionRules: item.detectionRules ? JSON.stringify(item.detectionRules) : undefined,
+        priority: 2000,
+        demandSource: job.is_auto_update ? 'auto_update' : 'customer',
+      });
+      executionProfileSha256 = demand.identity.executionProfileSha256;
+      candidateStatus = demand.state === 'waiting' ? 'queued' : demand.state;
+      candidateFailureSummary = demand.failureSummary || null;
+
+      const { error: relinkError } = await supabase
+        .from('packaging_jobs')
+        .update({
+          qa_candidate_id: demand.candidateId || job.qa_candidate_id,
+          execution_profile_sha256: demand.identity.executionProfileSha256,
+          presentation_profile_sha256: demand.identity.presentationProfileSha256,
+          qa_requested_at: new Date().toISOString(),
+          status_message: demand.state === 'waiting'
+            ? 'Running an isolated installation test to make sure this app works before deployment'
+            : job.status_message,
+        })
+        .eq('id', job.id)
+        .eq('status', 'awaiting_qa');
+      if (relinkError) throw new Error(`Could not relink superseded QA demand: ${relinkError.message}`);
+    }
+
+    if (!candidateStatus || ['failed', 'error'].includes(candidateStatus)) {
       const now = new Date().toISOString();
       const { data: updated } = await supabase
         .from('packaging_jobs')
         .update({
           status: 'qa_failed',
-          status_message: candidate?.failure_summary || 'The required installation test could not complete.',
+          status_message: candidateFailureSummary || 'The required installation test could not complete.',
           error_code: 'QA_FAILED_EXECUTION_PROFILE',
           error_stage: 'validation',
           error_category: 'installer',
@@ -65,12 +113,12 @@ export async function GET(request: Request) {
         await handleAutoUpdateJobCompletion(
           job.id,
           'failed',
-          candidate?.failure_summary || 'The required installation test could not complete.'
+          candidateFailureSummary || 'The required installation test could not complete.'
         );
       }
       continue;
     }
-    if (candidate.status !== 'passed') {
+    if (candidateStatus !== 'passed') {
       waiting++;
       continue;
     }
@@ -78,7 +126,7 @@ export async function GET(request: Request) {
     const { data: result, error: resultError } = await supabase
       .from('qa_package_results')
       .select('outcome')
-      .eq('package_profile_sha256', job.execution_profile_sha256!)
+      .eq('package_profile_sha256', executionProfileSha256!)
       .maybeSingle();
     if (resultError) throw resultError;
     if (result?.outcome !== 'Passed') {


### PR DESCRIPTION
## Summary
- rebuild exact QA demand when an upload's prior candidate was superseded
- atomically relink current execution/presentation hashes and candidate id
- preserve customer priority and resume automatically after the current profile passes

## Verification
- 51 focused Vitest checks passed
- changed files introduce no TypeScript diagnostics (repository-wide tsc still has unrelated pre-existing test-fixture errors)
- bounded Opus review was attempted but reached its turn limit without a result; it was not treated as approval