### PR TITLE
Fix nested installer packaging semantics

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -432,11 +432,10 @@ if ($extensionTypeMap.ContainsKey($fileExtension)) {
     }
 }
 
-$isNestedPortable = $installerTypeLower -eq 'zip' -and
-    -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
-    $NestedInstallerType.Trim().ToLowerInvariant() -eq 'portable'
-
 if ($installerTypeLower -eq 'zip' -and -not [string]::IsNullOrWhiteSpace($NestedInstallerPath)) {
+    if ([string]::IsNullOrWhiteSpace($NestedInstallerType)) {
+        throw "Zip package declares a nested installer path but no nested installer type; refusing unsafe default execution."
+    }
     $NestedInstallerPath = $NestedInstallerPath.Trim() -replace '/', '\'
     $nestedPathSegments = @($NestedInstallerPath -split '\\')
     $nestedPathIsUnsafe = [System.IO.Path]::IsPathRooted($NestedInstallerPath) -or
@@ -448,6 +447,10 @@ if ($installerTypeLower -eq 'zip' -and -not [string]::IsNullOrWhiteSpace($Nested
         throw "Unsafe nested installer path: $NestedInstallerPath"
     }
 }
+
+$isNestedPortable = $installerTypeLower -eq 'zip' -and
+    -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
+    $NestedInstallerType.Trim().ToLowerInvariant() -eq 'portable'
 
 $portableFolderName = ($DisplayName -replace '[<>:"/\\|?*\x00-\x1f]', '_').Trim().TrimEnd('.')
 if ([string]::IsNullOrWhiteSpace($portableFolderName) -or

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -63,7 +63,11 @@ export async function GET(request: Request) {
         installerType,
         nestedInstallerType: item.nestedInstallerType,
         nestedInstallerPath: item.nestedInstallerPath,
-        silentSwitches: extractSilentSwitches(job.install_command || item.installCommand, installerType),
+        silentSwitches: extractSilentSwitches(
+          job.install_command || item.installCommand,
+          installerType,
+          item.nestedInstallerType
+        ),
         uninstallCommand: job.uninstall_command || item.uninstallCommand,
         installScope: job.install_scope || item.installScope,
         psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,
@@ -179,7 +183,8 @@ export async function GET(request: Request) {
         nestedInstallerPath: item.nestedInstallerPath,
         silentSwitches: extractSilentSwitches(
           job.install_command || item.installCommand,
-          job.installer_type || item.installerType
+          job.installer_type || item.installerType,
+          item.nestedInstallerType
         ),
         uninstallCommand: job.uninstall_command || item.uninstallCommand,
         callbackUrl,

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -410,7 +410,11 @@ export async function POST(request: NextRequest) {
                   installerType: item.installerType,
                   nestedInstallerType: item.nestedInstallerType,
                   nestedInstallerPath: item.nestedInstallerPath,
-                  silentSwitches: extractSilentSwitches(item.installCommand, item.installerType),
+                  silentSwitches: extractSilentSwitches(
+                    item.installCommand,
+                    item.installerType,
+                    item.nestedInstallerType
+                  ),
                   uninstallCommand: item.uninstallCommand,
                   installScope: item.installScope,
                   psadtConfig: JSON.stringify(item.psadtConfig),
@@ -536,7 +540,11 @@ export async function POST(request: NextRequest) {
               installerType: item.installerType,
               nestedInstallerType: item.nestedInstallerType,
               nestedInstallerPath: item.nestedInstallerPath,
-              silentSwitches: extractSilentSwitches(item.installCommand, item.installerType),
+              silentSwitches: extractSilentSwitches(
+                item.installCommand,
+                item.installerType,
+                item.nestedInstallerType
+              ),
               uninstallCommand: item.uninstallCommand,
               callbackUrl,
               psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -351,7 +351,8 @@ export async function POST(request: NextRequest) {
               nestedInstallerPath: installerInfo.nestedInstallerPath,
               silentSwitches: extractSilentSwitches(
                 deploymentConfig.installCommand || '',
-                installerInfo.installerType || deploymentConfig.installerType || 'exe'
+                installerInfo.installerType || deploymentConfig.installerType || 'exe',
+                installerInfo.nestedInstallerType
               ),
               uninstallCommand: deploymentConfig.uninstallCommand || '',
               callbackUrl,

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -664,6 +664,88 @@ describe('generateInstallCommand', () => {
     expect(command).toContain('Expand-Archive');
     expect(command).toContain('-Force');
   });
+
+  it('should generate a nested installer command for non-portable zip packages', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'inno',
+      nestedInstallerPath: 'setup.exe',
+      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+    };
+
+    expect(generateInstallCommand(installer)).toBe(
+      '"setup.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+    );
+  });
+
+  it('should use msiexec for a nested MSI package', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'msi',
+      nestedInstallerPath: 'payload\\setup.msi',
+      silentArgs: '/qn /norestart',
+    };
+
+    expect(generateInstallCommand(installer)).toBe(
+      'msiexec /i "payload\\setup.msi" /qn /norestart ALLUSERS=1'
+    );
+  });
+
+  it('should not launch a nested portable executable', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'portable',
+      nestedInstallerPath: 'app.exe',
+    };
+
+    expect(generateInstallCommand(installer)).toContain('Expand-Archive');
+  });
+
+  it('should reject a nested path without a nested installer type', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerPath: 'setup.exe',
+    };
+
+    expect(() => generateInstallCommand(installer)).toThrow(/no nested installer type/i);
+  });
+
+  it('should treat a whitespace-only nested path as an archive-only package', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerPath: '   ',
+    };
+
+    expect(generateInstallCommand(installer)).toContain('Expand-Archive');
+  });
+
+  it('should reject an unsafe nested installer path', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerPath: '..\\setup.exe',
+    };
+
+    expect(() => generateInstallCommand(installer)).toThrow(/unsafe nested installer path/i);
+  });
 });
 
 describe('generateUninstallCommand', () => {

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -583,6 +583,28 @@ describe('normalizeManifestInstallers', () => {
       'Microsoft.WindowsTerminal_8wekyb3d8bbwe'
     );
   });
+
+  it('inherits root nested installer semantics before normalization', () => {
+    const installers = normalizeManifestInstallers({
+      InstallerType: 'zip',
+      NestedInstallerType: 'inno',
+      Scope: 'machine',
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/app.zip',
+        InstallerSha256: 'abc123',
+        NestedInstallerFiles: [{ RelativeFilePath: 'setup.exe' }],
+      }],
+    });
+
+    expect(installers[0].NestedInstallerType).toBe('inno');
+    expect(normalizeInstaller(installers[0])).toMatchObject({
+      type: 'zip',
+      nestedInstallerType: 'inno',
+      nestedInstallerPath: 'setup.exe',
+      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+    });
+  });
 });
 
 describe('getManifestPaths logic', () => {

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -217,7 +217,11 @@ export class AutoUpdateTrigger {
         // generated command saved with the previous deployment.
         silentSwitches: updateInfo.silentSwitches && !customInstallCommand
           ? updateInfo.silentSwitches
-          : extractSilentSwitches(effectiveInstallCommand, sourceInstallerType),
+          : extractSilentSwitches(
+              effectiveInstallCommand,
+              sourceInstallerType,
+              updateInfo.nestedInstallerType
+            ),
         uninstallCommand: deploymentConfig.uninstallCommand || '',
         installScope: updateInfo.installScope ||
           (deploymentConfig.installScope === 'user' ? 'user' : 'machine'),

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -310,7 +310,10 @@ export function generateInstallCommand(
   scope: WingetScope = 'machine'
 ): string {
   const installerName = resolveInstallerFileName(installer.url, installer.type);
-  const silentArgs = installer.silentArgs || getDefaultSilentArgs(installer.type);
+  const effectiveType = installer.type === 'zip' && installer.nestedInstallerType
+    ? installer.nestedInstallerType
+    : installer.type;
+  const silentArgs = installer.silentArgs || getDefaultSilentArgs(effectiveType);
 
   switch (installer.type) {
     case 'msi':
@@ -329,6 +332,38 @@ export function generateInstallCommand(
       return `"${installerName}" ${silentArgs}`.trim();
 
     case 'zip':
+      const declaredNestedPath = installer.nestedInstallerPath?.trim();
+      if (declaredNestedPath) {
+        const nestedPath = declaredNestedPath.replace(/\//g, '\\');
+        if (!installer.nestedInstallerType) {
+          throw new Error('Zip package declares a nested installer path but no nested installer type');
+        }
+        if (
+          /^[\\/]/.test(nestedPath) ||
+          /^[A-Za-z]:/.test(nestedPath) ||
+          nestedPath.split('\\').includes('..') ||
+          /[\x00-\x1f]/.test(nestedPath)
+        ) {
+          throw new Error(`Unsafe nested installer path: ${installer.nestedInstallerPath}`);
+        }
+
+        switch (installer.nestedInstallerType) {
+          case 'msi':
+          case 'wix': {
+            const nestedMsiScope = scope === 'user' ? 'ALLUSERS=""' : 'ALLUSERS=1';
+            return `msiexec /i "${nestedPath}" ${silentArgs} ${nestedMsiScope}`.trim();
+          }
+          case 'msix':
+          case 'appx':
+            return `Add-AppxPackage -Path "${nestedPath}"`;
+          case 'portable':
+            return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${installerName.replace(/\.[^/.]+$/, '')}" -Force`;
+          default:
+            return `"${nestedPath}" ${silentArgs}`.trim();
+        }
+      }
+      return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${installerName.replace(/\.[^/.]+$/, '')}" -Force`;
+
     case 'portable':
       return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${installerName.replace(/\.[^/.]+$/, '')}" -Force`;
 

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -723,7 +723,12 @@ export async function getInstallers(
     return [];
   }
 
-  return manifest.Installers.map(normalizeInstaller);
+  // WinGet allows installer type, nested installer type/files, scope, switches,
+  // and identity fields at the manifest root. Normalize that inheritance before
+  // converting individual installers or archive packages lose their nested
+  // execution semantics.
+  return normalizeManifestInstallers(manifest as unknown as Record<string, unknown>)
+    .map(normalizeInstaller);
 }
 
 /**

--- a/lib/msp/silent-switches.test.ts
+++ b/lib/msp/silent-switches.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { extractSilentSwitches } from './silent-switches';
+
+describe('extractSilentSwitches', () => {
+  it('does not mistake PowerShell archive parameters for vendor switches', () => {
+    expect(extractSilentSwitches(
+      'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',
+      'zip',
+      'inno'
+    )).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
+  });
+
+  it('does not mistake wrapped PowerShell archive parameters for vendor switches', () => {
+    expect(extractSilentSwitches(
+      'powershell.exe -Command Expand-Archive -Path app.zip -DestinationPath app',
+      'zip',
+      'inno'
+    )).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
+  });
+
+  it('keeps explicit nested installer switches', () => {
+    expect(extractSilentSwitches(
+      '"setup.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      'zip',
+      'inno'
+    )).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
+  });
+
+  it('fails closed for an archive with no nested installer type', () => {
+    expect(extractSilentSwitches(
+      'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',
+      'zip'
+    )).toBe('');
+  });
+
+  it('does not return archive parameters for a portable package', () => {
+    expect(extractSilentSwitches(
+      'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',
+      'portable'
+    )).toBe('');
+  });
+});

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -6,7 +6,11 @@
 /**
  * Extract silent switches from the install command
  */
-export function extractSilentSwitches(installCommand: string, installerType: string): string {
+export function extractSilentSwitches(
+  installCommand: string,
+  installerType: string,
+  nestedInstallerType?: string
+): string {
   // Common silent switches by installer type
   const defaultSwitches: Record<string, string> = {
     msi: '/qn /norestart',
@@ -17,6 +21,17 @@ export function extractSilentSwitches(installCommand: string, installerType: str
     burn: '/q /norestart',
     msix: '', // MSIX doesn't need switches
   };
+
+  const sourceType = installerType.toLowerCase();
+  const effectiveType = sourceType === 'zip' && nestedInstallerType
+    ? nestedInstallerType.toLowerCase()
+    : sourceType;
+
+  // Archive extraction parameters are not vendor silent switches. Never pass
+  // values such as "-Archive -Path" to a nested executable.
+  if (/\bExpand-Archive\b/i.test(installCommand)) {
+    return defaultSwitches[effectiveType] ?? '';
+  }
 
   // Strip executable path first (handles paths with hyphens like "7z2501-x64.exe")
   // This removes everything up to and including common installer extensions
@@ -38,5 +53,5 @@ export function extractSilentSwitches(installCommand: string, installerType: str
     return switchMatch[0];
   }
 
-  return defaultSwitches[installerType] || '/S';
+  return defaultSwitches[effectiveType] ?? (sourceType === 'zip' ? '' : '/S');
 }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -149,6 +149,14 @@ describe('PSADT registry uninstall identity contract', () => {
   });
 });
 
+describe('PSADT nested archive contract', () => {
+  it('rejects a nested path when its installer type was lost', () => {
+    expect(packager).toContain(
+      'Zip package declares a nested installer path but no nested installer type; refusing unsafe default execution.'
+    );
+  });
+});
+
 describe('PSADT MSIX scope contract', () => {
   it('registers user-scoped packages in the current user context', () => {
     expect(packager).toContain('Add-AppxPackage -Path $msixPath -ForceApplicationShutdown');


### PR DESCRIPTION
## What changed
- inherit root-level WinGet nested-installer metadata before normalizing installers
- generate type-correct commands for nested EXE/Inno/MSI/MSIX/portable packages
- prevent archive extraction flags from becoming vendor silent arguments
- fail closed on missing or unsafe nested installer metadata in the shared PSADT packager
- pass nested installer type through QA, uploads, updates, and resume flows

## Why
MPC-BE exposed a generic ZIP+nested-Inno failure: root-level metadata was discarded and `Expand-Archive -Path` was misread as installer switches. The resulting package launched an interactive installer and stalled QA. These changes apply to both customer and QA packaging.

## Validation
- 198 focused Vitest tests passed
- ESLint passed for all changed runtime TypeScript files
- PowerShell parser passed
- `git diff --check` passed
- bounded Claude Code Opus review completed; no blocking findings remain