### PR TITLE
Pin hardened PSADT uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '50de88aa44e853645b2c761bd93fe148cad4a7b8',
+  packagerCommit: '6a0e092b6bc6e23340b34f85fd91e13a0bd1796a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Pins the customer-facing and QA execution profile to shared packager commit `6a0e092b6bc6e23340b34f85fd91e13a0bd1796a`.

This ensures new queue candidates and customer packages use the registry-aware uninstall lifecycle merged in #316.

Verification: 758/758 tests passed; local lint hook passed.