### PR TITLE
Harden exact EXE product identity lifecycle

### DIFF
--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -847,8 +847,51 @@ describe('generateUninstallCommand', () => {
     const command = generateUninstallCommand(installer, 'Python 3.14');
 
     expect(command).toBe(
-      'REGISTRY_UNINSTALL_PRODUCT:{97b6de30-6082-48d1-9bb4-9f43296531a4}:Python 3.14'
+      'REGISTRY_UNINSTALL_PRODUCT:{97B6DE30-6082-48D1-9BB4-9F43296531A4}:Python 3.14'
     );
+  });
+
+  it('should preserve an EXE wrapper product code in the registry uninstall marker', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/reader.exe',
+      sha256: 'abc123',
+      type: 'exe',
+      productCode: '{AC76BA86-1033-FF00-7760-BC15014EA700}',
+    };
+
+    const command = generateUninstallCommand(
+      installer,
+      'Adobe Acrobat Reader (64-bit)'
+    );
+
+    expect(command).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Adobe Acrobat Reader (64-bit)'
+    );
+  });
+
+  it('should canonicalize a braceless product code and reject malformed GUID shapes', () => {
+    const base: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.exe',
+      sha256: 'abc123',
+      type: 'exe',
+    };
+
+    expect(
+      generateUninstallCommand(
+        { ...base, productCode: 'ac76ba86-1033-ff00-7760-bc15014ea700' },
+        'Reader'
+      )
+    ).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Reader'
+    );
+    expect(
+      generateUninstallCommand(
+        { ...base, productCode: '{------------------------------------}' },
+        'Reader'
+      )
+    ).toBe('REGISTRY_UNINSTALL:Reader');
   });
 
   it('should delegate Inno uninstall to registry lookup when display name is provided', () => {
@@ -876,6 +919,18 @@ describe('generateUninstallCommand', () => {
     const command = generateUninstallCommand(installer);
 
     expect(command).toBe('uninstall.exe /S');
+  });
+
+  it('should not emit an exact product marker without a usable display name', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.exe',
+      sha256: 'abc123',
+      type: 'exe',
+      productCode: '{AC76BA86-1033-FF00-7760-BC15014EA700}',
+    };
+
+    expect(generateUninstallCommand(installer, '   ')).toBe('# Manual uninstall required');
   });
 });
 

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -584,6 +584,56 @@ describe('normalizeManifestInstallers', () => {
     );
   });
 
+  it('normalizes installer and root AppsAndFeatures product identities', () => {
+    const installerIdentity = normalizeManifestInstallers({
+      InstallerType: 'exe',
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/reader.exe',
+        InstallerSha256: 'abc123',
+        AppsAndFeaturesEntries: [{
+          ProductCode: 'ac76ba86-1033-ff00-7760-bc15014ea700',
+        }],
+      }],
+    });
+    const inheritedIdentity = normalizeManifestInstallers({
+      InstallerType: 'exe',
+      AppsAndFeaturesEntries: [{
+        ProductCode: '{97b6de30-6082-48d1-9bb4-9f43296531a4}',
+      }],
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/bundle.exe',
+        InstallerSha256: 'def456',
+      }],
+    });
+
+    expect(installerIdentity[0].ProductCode).toBe(
+      '{AC76BA86-1033-FF00-7760-BC15014EA700}'
+    );
+    expect(normalizeInstaller(installerIdentity[0]).productCode).toBe(
+      '{AC76BA86-1033-FF00-7760-BC15014EA700}'
+    );
+    expect(inheritedIdentity[0].ProductCode).toBe(
+      '{97B6DE30-6082-48D1-9BB4-9F43296531A4}'
+    );
+  });
+
+  it('does not replace an explicit non-GUID installer identity with an inherited product code', () => {
+    const [installer] = normalizeManifestInstallers({
+      InstallerType: 'inno',
+      ProductCode: '{11111111-1111-1111-1111-111111111111}',
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/setup.exe',
+        InstallerSha256: 'abc123',
+        ProductCode: '{22222222-2222-2222-2222-222222222222}_is1',
+      }],
+    });
+
+    expect(installer.ProductCode).toBeUndefined();
+  });
+
   it('inherits root nested installer semantics before normalization', () => {
     const installers = normalizeManifestInstallers({
       InstallerType: 'zip',

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -397,7 +397,7 @@ export function generateUninstallCommand(
       // registration after installation instead of emitting a literal GUID
       // placeholder that msiexec will reject with exit code 1619.
       if (displayName) {
-        return generateRegistryUninstallCommand(displayName, installer.type);
+        return generateRegistryUninstallCommand(displayName);
       }
       return 'MSI_UNINSTALL_IDENTITY_REQUIRED';
 
@@ -420,7 +420,6 @@ export function generateUninstallCommand(
       if (displayName) {
         return generateRegistryUninstallCommand(
           displayName,
-          installer.type,
           installer.productCode
         );
       }
@@ -432,7 +431,7 @@ export function generateUninstallCommand(
 
     default:
       if (displayName) {
-        return generateRegistryUninstallCommand(displayName, 'exe');
+        return generateRegistryUninstallCommand(displayName);
       }
       return '# Manual uninstall required';
   }
@@ -448,19 +447,25 @@ export function generateUninstallCommand(
  */
 function generateRegistryUninstallCommand(
   displayName: string,
-  installerType: string,
   productCode?: string
 ): string {
-  // Burn bundles commonly register one bundle plus several child MSI entries.
-  // Preserve the manifest product code so the packager can select the bundle's
-  // exact uninstall registry key instead of matching every similarly named item.
-  if (
-    installerType === 'burn' &&
-    /^\{[0-9A-Fa-f-]{36}\}$/.test(productCode || '')
-  ) {
-    return `REGISTRY_UNINSTALL_PRODUCT:${productCode}:${displayName}`;
+  const normalizedDisplayName = displayName.trim();
+  if (!normalizedDisplayName) {
+    return '# Manual uninstall required';
   }
-  return `REGISTRY_UNINSTALL:${displayName}`;
+  // EXE-family installers can wrap MSI products or register bundles whose ARP
+  // name differs from the catalog display name. A manifest ProductCode or
+  // AppsAndFeatures ProductCode is the authoritative uninstall identity, so
+  // preserve it for every EXE-family installer instead of falling back to a
+  // human-readable name that may be normalized or localized differently.
+  const productCodeMatch = productCode?.trim().match(
+    /^\{?([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})\}?$/
+  );
+  if (productCodeMatch) {
+    const canonicalProductCode = `{${productCodeMatch[1].toUpperCase()}}`;
+    return `REGISTRY_UNINSTALL_PRODUCT:${canonicalProductCode}:${normalizedDisplayName}`;
+  }
+  return `REGISTRY_UNINSTALL:${normalizedDisplayName}`;
 }
 
 /**

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -18,6 +18,26 @@ import { getCatalogSource } from '@/lib/catalog';
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests';
 const GITHUB_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests';
 
+function normalizeProductCode(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const match = value.trim().match(
+    /^\{?([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})\}?$/
+  );
+  return match ? `{${match[1].toUpperCase()}}` : undefined;
+}
+
+function appsAndFeaturesProductCode(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const productCode = normalizeProductCode(
+      (entry as Record<string, unknown>).ProductCode
+    );
+    if (productCode) return productCode;
+  }
+  return undefined;
+}
+
 function githubReadHeaders(accept: string): Record<string, string> {
   const headers: Record<string, string> = {
     'User-Agent': 'IntuneGet',
@@ -407,7 +427,12 @@ function coerceInstallersArray(
     return [];
   }
 
-  return installerArray.map((inst) => ({
+  return installerArray.map((inst) => {
+    const explicitProductCode = typeof inst.ProductCode === 'string'
+      ? inst.ProductCode.trim()
+      : '';
+
+    return ({
     Architecture: (inst.Architecture as WingetInstaller['Architecture']) || 'x64',
     InstallerUrl: (inst.InstallerUrl as string) || '',
     InstallerSha256: (inst.InstallerSha256 as string) || '',
@@ -419,11 +444,14 @@ function coerceInstallersArray(
       defaultSilentArgs ? { Silent: defaultSilentArgs } : undefined,
       inst.InstallerSwitches
     ),
-    ProductCode: inst.ProductCode as string,
+    ProductCode: explicitProductCode
+      ? normalizeProductCode(explicitProductCode)
+      : appsAndFeaturesProductCode(inst.AppsAndFeaturesEntries),
     PackageFamilyName: inst.PackageFamilyName as string,
     UpgradeBehavior: inst.UpgradeBehavior as WingetInstaller['UpgradeBehavior'],
     Dependencies: inst.Dependencies as WingetInstaller['Dependencies'],
-  }));
+    });
+  });
 }
 
 function inferArchitectureFromInstallerUrl(installerUrl: string): WingetInstaller['Architecture'] {
@@ -560,10 +588,20 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
   const defaultMinOS = manifest.MinimumOSVersion as string;
   const defaultUpgrade = manifest.UpgradeBehavior as string;
   const defaultDependencies = manifest.Dependencies as WingetInstaller['Dependencies'];
-  const defaultProductCode = manifest.ProductCode as string;
+  const defaultProductCode =
+    normalizeProductCode(manifest.ProductCode) ||
+    appsAndFeaturesProductCode(manifest.AppsAndFeaturesEntries);
   const defaultPackageFamilyName = manifest.PackageFamilyName as string;
 
-  return rawInstallers.map((installer) => ({
+  return rawInstallers.map((installer) => {
+    const explicitInstallerProductCode = typeof installer.ProductCode === 'string'
+      ? installer.ProductCode.trim()
+      : '';
+    const installerProductCode = explicitInstallerProductCode
+      ? normalizeProductCode(explicitInstallerProductCode)
+      : appsAndFeaturesProductCode(installer.AppsAndFeaturesEntries) || defaultProductCode;
+
+    return ({
     Architecture: (installer.Architecture as WingetInstaller['Architecture']) || 'x64',
     InstallerUrl: (installer.InstallerUrl as string) || '',
     InstallerSha256: (installer.InstallerSha256 as string) || '',
@@ -580,7 +618,10 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     // WinGet inherits installer switches per field. An installer-level Custom
     // value must not discard a root-level Silent value (Vivaldi is one example).
     InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
-    ProductCode: (installer.ProductCode as string) || defaultProductCode,
+    // A non-empty installer-level ProductCode is authoritative. If it is an
+    // Inno/EXE registry key rather than a canonical GUID, do not replace it
+    // with an unrelated inherited identity; name-based discovery is safer.
+    ProductCode: installerProductCode,
     PackageFamilyName:
       (installer.PackageFamilyName as string) || defaultPackageFamilyName,
     UpgradeBehavior: (installer.UpgradeBehavior as WingetInstaller['UpgradeBehavior']) ||
@@ -590,7 +631,8 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     MinimumOSVersion: (installer.MinimumOSVersion as string) || defaultMinOS,
     Dependencies: (installer.Dependencies as WingetInstaller['Dependencies']) ||
                   defaultDependencies,
-  }));
+    });
+  });
 }
 
 /**
@@ -705,7 +747,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     nestedInstallerPath: installer.NestedInstallerFiles?.[0]?.RelativeFilePath,
     scope: installer.Scope,
     silentArgs,
-    productCode: installer.ProductCode,
+    productCode: normalizeProductCode(installer.ProductCode),
     packageFamilyName: installer.PackageFamilyName,
     packageDependencies: packageDependencies.length > 0 ? packageDependencies : undefined,
   };

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -26,7 +26,8 @@ describe('buildQaCatalogTestConfig', () => {
       sourceInstallerType: 'inno',
       silentArgs: '/VERYSILENT',
       productCode: '{00000000-0000-0000-0000-000000000001}',
-      uninstallCommand: 'REGISTRY_UNINSTALL:Example',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{00000000-0000-0000-0000-000000000001}:Example',
       profileKind: 'catalog-default',
     });
     expect(config.psadtConfig).toMatchObject({
@@ -186,6 +187,32 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('uses an EXE AppsAndFeatures product code as the exact uninstall identity', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Adobe.Acrobat.Reader.64-bit',
+        name: 'Adobe Acrobat Reader (64-bit)',
+        publisher: 'Adobe',
+        version: '26.001.21771',
+      },
+      manifest: { InstallerType: 'exe' },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'exe',
+        AppsAndFeaturesEntries: [
+          { ProductCode: '{AC76BA86-1033-FF00-7760-BC15014EA700}' },
+        ],
+      },
+    });
+
+    expect(config.productCode).toBe(
+      '{AC76BA86-1033-FF00-7760-BC15014EA700}'
+    );
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Adobe Acrobat Reader (64-bit)'
+    );
+  });
+
   it('prefers architecture-specific AppsAndFeatures identity over a root product code', () => {
     const config = buildQaCatalogTestConfig({
       app: {
@@ -208,6 +235,51 @@ describe('buildQaCatalogTestConfig', () => {
     });
 
     expect(config.productCode).toBe('{22222222-2222-2222-2222-222222222222}');
+  });
+
+  it('skips malformed AppsAndFeatures identities and uses the next canonical GUID', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.MultiEntry',
+        name: 'Contoso Multi Entry',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: { InstallerType: 'exe' },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'exe',
+        AppsAndFeaturesEntries: [
+          { ProductCode: 'not-a-guid' },
+          { ProductCode: '{33333333-3333-3333-3333-333333333333}' },
+        ],
+      },
+    });
+
+    expect(config.productCode).toBe('{33333333-3333-3333-3333-333333333333}');
+  });
+
+  it('does not replace an explicit Inno registry key with an inherited MSI-style GUID', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Contoso.InnoApp',
+        name: 'Contoso Inno App',
+        publisher: 'Contoso',
+        version: '2.0.0',
+      },
+      manifest: {
+        InstallerType: 'inno',
+        ProductCode: '{11111111-1111-1111-1111-111111111111}',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'inno',
+        ProductCode: '{22222222-2222-2222-2222-222222222222}_is1',
+      },
+    });
+
+    expect(config.productCode).toBe('');
+    expect(config.uninstallCommand).toBe('REGISTRY_UNINSTALL:Contoso Inno App');
   });
 
   it('inherits a root package family name for user-scoped MSIX handling', () => {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -48,7 +48,7 @@ function appsAndFeaturesProductCode(installer: ManifestRecord): string {
     ? installer.AppsAndFeaturesEntries
     : [];
   for (const entry of entries) {
-    const productCode = text(record(entry).ProductCode);
+    const productCode = msiProductCode(record(entry).ProductCode);
     if (productCode) return productCode;
   }
   return '';
@@ -56,11 +56,10 @@ function appsAndFeaturesProductCode(installer: ManifestRecord): string {
 
 function msiProductCode(value: unknown): string {
   const candidate = text(value);
-  return /^\{?[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}?$/.test(
-    candidate
-  )
-    ? candidate
-    : '';
+  const match = candidate.match(
+    /^\{?([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})\}?$/
+  );
+  return match ? `{${match[1].toUpperCase()}}` : '';
 }
 
 export function buildQaCatalogTestConfig({
@@ -115,11 +114,12 @@ export function buildQaCatalogTestConfig({
     : undefined;
   const rawScope = text(installer.Scope) || text(manifest.Scope);
   const scope: WingetScope = rawScope.toLowerCase() === 'user' ? 'user' : 'machine';
-  const productCode =
-    msiProductCode(installer.ProductCode) ||
-    msiProductCode(appsAndFeaturesProductCode(installer)) ||
-    msiProductCode(manifest.ProductCode) ||
-    msiProductCode(appsAndFeaturesProductCode(manifest));
+  const explicitInstallerProductCode = text(installer.ProductCode);
+  const productCode = explicitInstallerProductCode
+    ? msiProductCode(explicitInstallerProductCode)
+    : appsAndFeaturesProductCode(installer) ||
+      msiProductCode(manifest.ProductCode) ||
+      appsAndFeaturesProductCode(manifest);
   const packageFamilyName =
     text(installer.PackageFamilyName) || text(manifest.PackageFamilyName);
   const inheritedInstaller: WingetInstaller = {

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -707,6 +707,13 @@ ${steps}
 `;
   }
 
+  private getRegistryProductCode(job: PackagingJob): string | null {
+    const match = job.uninstall_command?.match(
+      /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$/
+    );
+    return match?.[1] || null;
+  }
+
   /**
    * Generate PowerShell code to verify the application appears in Add/Remove
    * Programs after install, failing the deployment before the detection
@@ -714,6 +721,22 @@ ${steps}
    * Opt-in via package_config.psadtConfig.verifyInstall; returns '' when disabled
    */
   private getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string {
+    const registryProductCode = this.getRegistryProductCode(job);
+    if (registryProductCode) {
+      return `
+    ## Verify the exact manifest/AppsAndFeatures uninstall identity before writing the marker
+    $verifyApps = @()
+    foreach ($verificationAttempt in 1..30) {
+        $verifyApps = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${registryProductCode}' } -ErrorAction SilentlyContinue)
+        if ($verifyApps.Count -eq 1) { break }
+        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }
+    }
+    if ($verifyApps.Count -ne 1) {
+        throw "Post-install verification failed: exact uninstall identity [${registryProductCode}] was found $($verifyApps.Count) time(s)."
+    }
+    Write-ADTLogEntry -Message "Post-install verification passed for exact uninstall identity [${registryProductCode}]" -Source 'Install-ADTDeployment'
+`;
+    }
     const psadtConfig = this.getPsadtConfig(job);
     if (psadtConfig?.verifyInstall !== true) {
       return '';
@@ -1004,7 +1027,7 @@ ${steps}
     }
 
     const registryProductMatch = job.uninstall_command.match(
-      /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9-]{36}\}):(.+)$/
+      /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$/
     );
     if (registryProductMatch && job.installer_type.toLowerCase() === 'burn') {
       const productCode = registryProductMatch[1];
@@ -1021,7 +1044,7 @@ ${steps}
     } else {
         throw "The captured Burn bundle does not provide an uninstall command."
     }
-    [string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList")
+    [string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList" | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
     if ($registeredUninstallArguments.Count -eq 0) {
         $registeredUninstallArguments = @('/uninstall', '/quiet', '/norestart')
     }
@@ -1030,7 +1053,67 @@ ${steps}
         throw "The packaged Burn uninstaller was not found: $bundledUninstaller"
     }
     Write-ADTLogEntry -Message "Using packaged Burn bundle because the registered vendor cache may be disposable." -Source 'Uninstall-ADTDeployment'
-    Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -CreateNoWindow -WaitForMsiExec -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)`;
+    Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -CreateNoWindow -WaitForMsiExec -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+    $nextUninstallProgressLog = [DateTime]::UtcNow
+    do {
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        if ($remainingApplications.Count -eq 0) { break }
+        if ([DateTime]::UtcNow -ge $uninstallDeadline) { break }
+        if ([DateTime]::UtcNow -ge $nextUninstallProgressLog) {
+            Write-ADTLogEntry -Message "Waiting for Burn uninstall registration [${productCode}] to be removed; a child process may still be working." -Source 'Uninstall-ADTDeployment'
+            $nextUninstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
+        }
+        Start-Sleep -Seconds 5
+    } while ($true)
+    $remainingApplications = @()
+    foreach ($verificationAttempt in 1..5) {
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        if ($remainingApplications.Count -eq 0) { break }
+        if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
+    }
+    if ($remainingApplications.Count -gt 0) {
+        throw "The exact Burn uninstall registration [${productCode}] still exists after the vendor command completion deadline."
+    }`;
+    }
+
+    if (registryProductMatch) {
+      const productCode = registryProductMatch[1];
+      return `$installedApps = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+    if ($installedApps.Count -ne 1) {
+        throw "Could not find one exact vendor uninstall entry [${productCode}]. Found $($installedApps.Count); refusing broad removal."
+    }
+    $registeredApplication = $installedApps[0]
+    if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {
+        Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $registeredApplication.ProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+    } else {
+        Uninstall-ADTApplication -InstalledApplication $registeredApplication -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+    }
+    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+    $nextUninstallProgressLog = [DateTime]::UtcNow
+    do {
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        if ($remainingApplications.Count -eq 0) { break }
+        if ([DateTime]::UtcNow -ge $uninstallDeadline) { break }
+        if ([DateTime]::UtcNow -ge $nextUninstallProgressLog) {
+            Write-ADTLogEntry -Message "Waiting for vendor uninstall registration [${productCode}] to be removed; a child process may still be working." -Source 'Uninstall-ADTDeployment'
+            $nextUninstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
+        }
+        Start-Sleep -Seconds 5
+    } while ($true)
+    $remainingApplications = @()
+    foreach ($verificationAttempt in 1..5) {
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        if ($remainingApplications.Count -eq 0) { break }
+        if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
+    }
+    if ($remainingApplications.Count -gt 0) {
+        throw "The exact vendor uninstall registration [${productCode}] still exists after the vendor command completion deadline."
+    }`;
+    }
+
+    if (/^REGISTRY_UNINSTALL_PRODUCT:/.test(job.uninstall_command)) {
+      return 'throw "The exact vendor uninstall identity is malformed; refusing to interpret any embedded GUID as an MSI product code."';
     }
 
     // MSI uninstall: use the product code with Start-ADTMsiProcess

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -7,6 +7,7 @@ import type { PackagingJob } from '../src/job-poller';
 type ScriptGenerator = {
   getInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string;
   getUninstallCommand(job: PackagingJob, fileName: string): string;
+  getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string;
 };
 
 const generator = JobProcessor.prototype as unknown as ScriptGenerator;
@@ -200,11 +201,86 @@ describe('Burn bundle PSADT generation', () => {
 
     expect(script).toContain("$_.PSChildName -eq '{97b6de30-6082-48d1-9bb4-9f43296531a4}'");
     expect(script).toContain(
-      '[string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList")'
+      '[string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList" | Where-Object'
     );
     expect(script).toContain("Join-Path $adtSession.DirFiles 'python-3.14.7-amd64.exe'");
     expect(script).toContain('-WorkingDirectory $adtSession.DirFiles -CreateNoWindow');
+    expect(script).toContain(
+      "The exact Burn uninstall registration [{97b6de30-6082-48d1-9bb4-9f43296531a4}] still exists"
+    );
+    expect(script).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
+    expect(script).toContain('foreach ($verificationAttempt in 1..5)');
     expect(script).not.toContain("Start-ADTMsiProcess -Action 'Uninstall'");
+  });
+});
+
+describe('EXE product identity PSADT generation', () => {
+  it('verifies and removes only the exact AppsAndFeatures product identity', () => {
+    const job = packagingJob({
+      winget_id: 'Adobe.Acrobat.Reader.64-bit',
+      display_name: 'Adobe Acrobat Reader (64-bit)',
+      installer_type: 'exe',
+      uninstall_command:
+        'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Adobe Acrobat Reader (64-bit)',
+    });
+
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'Adobe Acrobat Reader (64-bit)'
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'reader.exe'
+    );
+
+    expect(verification).toContain(
+      "$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
+    );
+    expect(verification).toContain('foreach ($verificationAttempt in 1..30)');
+    expect(uninstall).toContain(
+      "$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
+    );
+    expect(uninstall).toContain('$registeredApplication.WindowsInstaller');
+    expect(uninstall).toContain('Uninstall-ADTApplication -InstalledApplication $registeredApplication');
+    expect(uninstall).toContain(
+      'The exact vendor uninstall registration [{AC76BA86-1033-FF00-7760-BC15014EA700}] still exists'
+    );
+    expect(uninstall).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
+    expect(uninstall).toContain('foreach ($verificationAttempt in 1..5)');
+    expect(uninstall).toContain('refusing broad removal');
+    expect(uninstall).not.toContain(
+      "Start-ADTMsiProcess -Action 'Uninstall' -ProductCode '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
+    );
+  });
+
+  it('always verifies an exact product identity even when generic verification is disabled', () => {
+    const job = packagingJob({
+      installer_type: 'exe',
+      uninstall_command:
+        'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Adobe Acrobat Reader (64-bit)',
+      package_config: { psadtConfig: { verifyInstall: false } },
+    });
+
+    expect(
+      generator.getPostInstallVerificationBlock.call(generator, job, 'Adobe Acrobat Reader (64-bit)')
+    ).toContain("$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'");
+  });
+
+  it('fails closed when an exact product marker is malformed', () => {
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'exe',
+        uninstall_command:
+          'REGISTRY_UNINSTALL_PRODUCT:not-a-guid:Vendor app {AC76BA86-1033-FF00-7760-BC15014EA700}',
+      }),
+      'vendor.exe'
+    );
+
+    expect(uninstall).toContain('exact vendor uninstall identity is malformed');
+    expect(uninstall).not.toContain("Start-ADTMsiProcess -Action 'Uninstall'");
   });
 });
 


### PR DESCRIPTION
## Summary
- preserve canonical AppsAndFeatures product identities for EXE-family installers in both customer and QA packaging
- resolve and remove the exact ARP entry, with bounded registration/removal retries for installer child-process handoffs
- fail closed on malformed identities and avoid inheriting unrelated GUIDs for Inno-style registry keys
- keep the self-hosted packager behavior aligned with the shared PowerShell packager

## Validation
- 769 tests passed
- targeted ESLint passed
- full pre-commit lint passed
- Next.js production build passed
- bounded Claude Code Opus 5 reviews completed; all verified findings addressed

The existing untracked local data directory was not included.