### PR TITLE
Fix exact PSADT uninstall lifecycle parity

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -273,7 +273,8 @@ function Get-PSADTAssetFileName {
 # silently change valid vendor arguments.
 $silentSwitchesEscaped = $SilentSwitches -replace "'", "''"
 $versionSingleQuoteEscaped = $Version -replace "'", "''"
-$uninstallCmd = $UninstallCommand -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+$uninstallCmd = [string]$UninstallCommand
+$uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $sanitizedWingetId = $WingetId -replace '[\.\-]', '_'
@@ -475,13 +476,15 @@ $msixPackageName = ''
 if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
     $usePortableUninstall = $true
     Write-Host "Using portable uninstall (folder removal)"
-} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9-]{36}\}):(.+)$') {
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$') {
     $useRegistryUninstall = $true
     $registryUninstallProductCode = $Matches[1]
     $registryUninstallDisplayName = $Matches[2]
 } elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
     $useRegistryUninstall = $true
     $registryUninstallDisplayName = $Matches[1]
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_PRODUCT:') {
+    throw 'The exact vendor uninstall identity is malformed; refusing to interpret any embedded GUID as an MSI product code.'
 } elseif ($installerTypeLower -in @('msi', 'wix') -and $uninstallCmd -match '(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\})') {
     # Deployment profiles commonly carry the concrete msiexec uninstall command
     # instead of the internal REGISTRY_UNINSTALL_PRODUCT marker. Treat its product
@@ -509,6 +512,7 @@ if ($useRegistryUninstall) {
         $registryUninstallDisplayName = $registryUninstallDisplayName -replace $suffix, ''
     }
     $registryUninstallDisplayName = $registryUninstallDisplayName.Trim()
+    $registryUninstallDisplayNameEscaped = $registryUninstallDisplayName -replace "'", "''"
 
     $registryIdentity = if ($registryUninstallProductCode) { "product $registryUninstallProductCode" } else { 'display name fallback' }
     Write-Host "Using registry-based uninstall for: $registryUninstallDisplayName ($registryIdentity)"
@@ -932,7 +936,7 @@ if ($useRegistryUninstall) {
         '    # Snapshot uninstall entries so the exact vendor entry created or updated by this installer can be reused later.'
         '    $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
         "    `$configuredUninstallProductCode = '$registryUninstallProductCode'"
-        "    `$configuredUninstallDisplayName = '$registryUninstallDisplayName'"
+        "    `$configuredUninstallDisplayName = '$registryUninstallDisplayNameEscaped'"
         '    $capturedUninstallKey = $null'
         '    $capturedUninstallName = $null'
         ''
@@ -1263,34 +1267,42 @@ $lines += @(
 if ($useRegistryUninstall) {
     $lines += @(
         '    # Capture the registry uninstall entry created or version-updated by this installer.'
-        '    $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
-        '    $changedApplications = @($postInstallApplications | Where-Object {'
-        '        $candidateApplication = $_'
-        '        $previousApplication = $preInstallApplications | Where-Object { $_.PSPath -eq $candidateApplication.PSPath } | Select-Object -First 1'
-        '        (-not $previousApplication) -or ($previousApplication.DisplayVersion -ne $candidateApplication.DisplayVersion)'
-        '    })'
+        '    # Manifest identity is a preference; the observed ARP delta is authoritative when metadata is stale.'
         '    $selectedApplications = @()'
-        '    if ($configuredUninstallProductCode) {'
-        '        $selectedApplications = @($changedApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
-        '        Write-ADTLogEntry -Message "Manifest product code matched $($selectedApplications.Count) changed uninstall entry/entries." -Source ''Install-ADTDeployment'''
-        '    }'
-        '    if ($selectedApplications.Count -eq 0) {'
-        '        $selectedApplications = @($changedApplications | Where-Object { [string]$_.DisplayName -eq $configuredUninstallDisplayName })'
-        '    }'
-        '    if ($selectedApplications.Count -eq 0) {'
-        '        $bundleCandidates = @($changedApplications | Where-Object {'
-        '            -not $_.WindowsInstaller -and [string]$_.DisplayName -like "$configuredUninstallDisplayName*"'
+        '    $changedApplications = @()'
+        '    foreach ($verificationAttempt in 1..30) {'
+        '        $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
+        '        $changedApplications = @($postInstallApplications | Where-Object {'
+        '            $candidateApplication = $_'
+        '            $previousApplication = $preInstallApplications | Where-Object { $_.PSPath -eq $candidateApplication.PSPath } | Select-Object -First 1'
+        '            (-not $previousApplication) -or ($previousApplication.DisplayVersion -ne $candidateApplication.DisplayVersion)'
         '        })'
-        '        if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
-        '    }'
-        '    if ($selectedApplications.Count -eq 0 -and $originalInstallerType -eq ''burn'') {'
-        '        # A Burn bootstrapper can register a bundle name that differs from the manifest display name.'
-        '        # Select it only when the install produced exactly one non-MSI entry; ambiguity still fails closed.'
-        '        $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
-        '        if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
-        '    }'
-        '    if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1) {'
-        '        $selectedApplications = @($changedApplications[0])'
+        '        $selectedApplications = @()'
+        '        if ($configuredUninstallProductCode) {'
+        '            $selectedApplications = @($changedApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0) {'
+        '            $selectedApplications = @($changedApplications | Where-Object { [string]$_.DisplayName -eq $configuredUninstallDisplayName })'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0) {'
+        '            $bundleCandidates = @($changedApplications | Where-Object {'
+        '                -not $_.WindowsInstaller -and [string]$_.DisplayName -like "$configuredUninstallDisplayName*"'
+        '            })'
+        '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0 -and $originalInstallerType -eq ''burn'') {'
+        '            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+        '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0 -and $configuredUninstallProductCode) {'
+        '            $configuredMatches = @($postInstallApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
+        '            if ($configuredMatches.Count -eq 1) { $selectedApplications = $configuredMatches }'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1) {'
+        '            $selectedApplications = @($changedApplications[0])'
+        '        }'
+        '        if ($selectedApplications.Count -eq 1) { break }'
+        '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'
         '    }'
         '    if ($selectedApplications.Count -eq 1) {'
         '        $capturedUninstallKey = [string]$selectedApplications[0].PSChildName'
@@ -1448,7 +1460,7 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
         '    # Use PSADT v4 Uninstall-ADTApplication to find and uninstall'
         '    # This handles the registry lookup, MSI vs EXE detection, and silent'
         '    # switches automatically using the app''s registered QuietUninstallString'
-        "    `$appName = '$registryUninstallDisplayName'"
+        "    `$appName = '$registryUninstallDisplayNameEscaped'"
         "    `$configuredProductCode = '$registryUninstallProductCode'"
         "    `$markerProviderPath = '$markerProviderPath'"
         ''
@@ -1501,15 +1513,15 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '    }'
             '    Write-ADTLogEntry -Message "Using packaged Burn bundle because the registered vendor cache may be disposable." -Source ''Uninstall-ADTDeployment'''
             '    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName'
-            '    $uninstallHandle = Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
             '    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)'
+            '    $uninstallHandle = Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
             '    $uninstallProcessExitLogged = $false'
             '    $nextUninstallProgressLog = [DateTime]::UtcNow'
             '    do {'
             '        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })'
             '        if ($remainingApplications.Count -eq 0) { break }'
             '        $uninstallProcessExited = $false'
-            '        try { $uninstallProcessExited = $uninstallHandle.Process.HasExited } catch { }'
+            '        try { $uninstallProcessExited = $uninstallHandle.Task.IsCompleted } catch { }'
             '        if ($uninstallProcessExited -and -not $uninstallProcessExitLogged) {'
             '            $uninstallProcessExitLogged = $true'
             '            Write-ADTLogEntry -Message "The Burn uninstall parent process exited; continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
@@ -1522,7 +1534,13 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '        Start-Sleep -Seconds 5'
             '    } while ($true)'
             '    $uninstallProcessExitCode = $null'
-            '    try { if ($uninstallHandle.Process.HasExited) { $uninstallProcessExitCode = $uninstallHandle.Process.ExitCode } } catch { }'
+            '    try {'
+            '        if ($uninstallHandle.Task.IsCompleted) {'
+            '            $uninstallProcessExitCode = $uninstallHandle.Task.GetAwaiter().GetResult().ExitCode'
+            '        }'
+            '    } catch {'
+            '        Write-ADTLogEntry -Message "The Burn uninstall task completed without a readable exit code: $_" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '    }'
             '    if ($uninstallProcessExitCode -in @(1641, 3010)) {'
             '        $script:UninstallRebootExitCode = 3010'
             '        Write-ADTLogEntry -Message "The Burn uninstaller requested a reboot with exit code [$uninstallProcessExitCode]." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
@@ -1544,9 +1562,9 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '    $registeredApplication = $installedApps[0]'
             "    `$registeredInstallerType = '$installerTypeLower'"
             '    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName'
-            '    $capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'') -and $registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {'
+            '    $capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {'
             '        $registeredApplication.ProductCode'
-            '    } elseif ($registeredInstallerType -in @(''msi'', ''wix'') -and [string]$registeredApplication.PSChildName -match ''^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$'') {'
+            '    } elseif ($registeredApplication.WindowsInstaller -and [string]$registeredApplication.PSChildName -match ''^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$'') {'
             '        [string]$registeredApplication.PSChildName'
             '    } else {'
             '        $null'
@@ -1606,10 +1624,9 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '            $registeredUninstallArguments = @(''--uninstall'', ''--vivaldi'', ''--force-uninstall'')'
             '            Write-ADTLogEntry -Message "Executing the vendor-documented Vivaldi silent uninstall command." -Source ''Uninstall-ADTDeployment'''
             '        }'
-            '        if (-not (Test-Path -LiteralPath $registeredUninstallFile -PathType Leaf)) {'
-            '            throw "The registered vendor uninstaller was not found: $registeredUninstallFile"'
-            '        }'
-            '        if ((Split-Path -Leaf $registeredUninstallFile) -ieq ''msiexec.exe'') {'
+            '        $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile'
+            '        $isRegisteredMsiExec = $registeredUninstallLeaf -in @(''msiexec'', ''msiexec.exe'')'
+            '        if ($isRegisteredMsiExec) {'
             '            $registeredMsiProductCode = if ($registeredUninstallRegistryKey -match ''(?i)^\{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\}$'') {'
             '                $registeredUninstallRegistryKey'
             '            } elseif (($registeredUninstallArguments -join '' '') -match ''(?i)(?:^|\s)[/-](?:x|i)\s*(\{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\})(?=\s|$)'') {'
@@ -1617,9 +1634,15 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '            } else {'
             '                throw "The registered msiexec uninstall command does not expose an exact product code; refusing to reuse install or repair arguments."'
             '            }'
+            '            $registeredUninstallFile = Join-Path $env:SystemRoot ''System32\msiexec.exe'''
             '            $registeredUninstallArguments = @(''/x'', $registeredMsiProductCode, ''/qn'', ''/norestart'')'
-            '        } elseif (-not $hasQuietUninstall -and -not $isVivaldiUninstall) {'
-            '            $registeredUninstallArguments += $additionalUninstallArguments'
+            '        } else {'
+            '            if (-not (Test-Path -LiteralPath $registeredUninstallFile -PathType Leaf)) {'
+            '                throw "The registered vendor uninstaller was not found: $registeredUninstallFile"'
+            '            }'
+            '            if (-not $hasQuietUninstall -and -not $isVivaldiUninstall) {'
+            '                $registeredUninstallArguments += $additionalUninstallArguments'
+            '            }'
             '        }'
             '        if (-not $hasQuietUninstall -and -not $isVivaldiUninstall -and $additionalUninstallArguments.Count -gt 0) {'
             '            Write-ADTLogEntry -Message "The vendor registered no quiet uninstall; applying verified unattended arguments [$($additionalUninstallArguments -join '' '')]." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
@@ -1635,15 +1658,15 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '        if ($registeredUninstallArguments.Count -gt 0) {'
             '            $uninstallProcessParameters.ArgumentList = $registeredUninstallArguments'
             '        }'
-            '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
             '        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)'
+            '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
             '        $uninstallProcessExitLogged = $false'
             '        $nextUninstallProgressLog = [DateTime]::UtcNow'
             '        do {'
             '            $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })'
             '            if ($remainingApplications.Count -eq 0) { break }'
             '            $uninstallProcessExited = $false'
-            '            try { $uninstallProcessExited = $uninstallHandle.Process.HasExited } catch { }'
+            '            try { $uninstallProcessExited = $uninstallHandle.Task.IsCompleted } catch { }'
             '            if ($uninstallProcessExited -and -not $uninstallProcessExitLogged) {'
             '                $uninstallProcessExitLogged = $true'
             '                Write-ADTLogEntry -Message "The vendor uninstall parent process exited; continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
@@ -1656,7 +1679,13 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '            Start-Sleep -Seconds 5'
             '        } while ($true)'
             '        $uninstallProcessExitCode = $null'
-            '        try { if ($uninstallHandle.Process.HasExited) { $uninstallProcessExitCode = $uninstallHandle.Process.ExitCode } } catch { }'
+            '        try {'
+            '            if ($uninstallHandle.Task.IsCompleted) {'
+            '                $uninstallProcessExitCode = $uninstallHandle.Task.GetAwaiter().GetResult().ExitCode'
+            '            }'
+            '        } catch {'
+            '            Write-ADTLogEntry -Message "The vendor uninstall task completed without a readable exit code: $_" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '        }'
             '        if ($uninstallProcessExitCode -in @(1641, 3010)) {'
             '            $script:UninstallRebootExitCode = 3010'
             '            Write-ADTLogEntry -Message "The vendor uninstaller requested a reboot with exit code [$uninstallProcessExitCode]." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
@@ -1740,7 +1769,7 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
     $lines += @(
         ''
         '    # Execute uninstall command'
-        "    `$uninstallCmd = '$uninstallCmd'"
+        "    `$uninstallCmd = '$uninstallCmdSingleQuoteEscaped'"
         ''
         '    # Check if this is an MSI uninstall (contains product code GUID)'
         '    if ($uninstallCmd -match ''\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}'') {'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -29,7 +29,8 @@ const canRunWindowsPowerShellPackager =
   ]).status === 0;
 
 function generateRegistryUninstallPackage(
-  installerType: 'inno' | 'burn'
+  installerType: 'inno' | 'burn',
+  displayName = 'Contract Test App'
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -59,14 +60,14 @@ function generateRegistryUninstallPackage(
         GITHUB_WORKSPACE: fixtureRoot,
         INPUT_JOB_ID: 'contract-test',
         INPUT_CALLBACK_URL: 'https://example.invalid/callback',
-        INPUT_DISPLAY_NAME: 'Contract Test App',
+        INPUT_DISPLAY_NAME: displayName,
         INPUT_PUBLISHER: 'IntuneGet',
         INPUT_VERSION: '1.0.0',
         INPUT_WINGET_ID: 'IntuneGet.ContractTest',
         INPUT_INSTALLER_TYPE: installerType,
         INPUT_INSTALL_SCOPE: 'machine',
         INPUT_SILENT_SWITCHES: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
-        INPUT_UNINSTALL_COMMAND: 'REGISTRY_UNINSTALL:Contract Test App',
+        INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${displayName}`,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
         PSADT_CONFIG: '{}',
@@ -171,7 +172,10 @@ describe.skipIf(!canRunWindowsPowerShellPackager)(
 describe('PSADT registry uninstall identity contract', () => {
   it('parses and persists a manifest product code for multi-entry installers', () => {
     expect(packager).toContain(
-      "^REGISTRY_UNINSTALL_PRODUCT:(\\{[A-Fa-f0-9-]{36}\\}):(.+)$"
+      "^REGISTRY_UNINSTALL_PRODUCT:(\\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\\}):(.+)$"
+    );
+    expect(packager).toContain(
+      "throw 'The exact vendor uninstall identity is malformed; refusing to interpret any embedded GUID as an MSI product code.'"
     );
     expect(packager).toContain(
       "[string]$_.PSChildName -eq $configuredUninstallProductCode"
@@ -179,6 +183,9 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain(
       "Set-ADTRegistryKey -LiteralPath $regPath -Name ''UninstallRegistryKey''"
     );
+    expect(packager).toContain('foreach ($verificationAttempt in 1..30)');
+    expect(packager).toContain('$configuredMatches = @($postInstallApplications');
+    expect(packager).not.toContain('$existingNameMatches');
   });
 
   it('promotes a concrete MSI/WiX uninstall command to exact registry identity handling', () => {
@@ -187,6 +194,15 @@ describe('PSADT registry uninstall identity contract', () => {
     );
     expect(packager).toContain('$registryUninstallProductCode = $Matches[1]');
     expect(packager).toContain('$registryUninstallDisplayName = $DisplayName');
+    expect(packager).toContain('$registryUninstallDisplayNameEscaped = $registryUninstallDisplayName -replace');
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)('emits apostrophe-safe registry identity strings', () => {
+    const generated = generateRegistryUninstallPackage('inno', "Contoso O'Brien Agent");
+
+    expect(generated).toContain("$configuredUninstallDisplayName = 'Contoso O''Brien Agent'");
+    expect(generated).toContain("$appName = 'Contoso O''Brien Agent'");
+    expect(generated).not.toContain("Contoso O''''Brien Agent");
   });
 
   it('never sends an ambiguous display-name result set to a vendor uninstaller', () => {
@@ -212,6 +228,7 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain(
       'Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles'
     );
+    expect(packager).toContain('-WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru');
     expect(packager).toContain(
       "$selectedApplications.Count -eq 0 -and $originalInstallerType -eq ''burn''"
     );
@@ -262,7 +279,10 @@ describe('PSADT registry uninstall identity contract', () => {
     );
     expect(packager).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
     expect(packager).toContain('Waiting for vendor uninstall registration');
-    expect(packager).toContain('$uninstallHandle.Process.HasExited');
+    expect(packager).toContain('$uninstallHandle.Task.IsCompleted');
+    expect(packager).toContain('$uninstallHandle.Task.GetAwaiter().GetResult().ExitCode');
+    expect(packager).toContain("$isRegisteredMsiExec = $registeredUninstallLeaf -in @(''msiexec'', ''msiexec.exe'')");
+    expect(packager).toContain("$registeredUninstallFile = Join-Path $env:SystemRoot ''System32\\msiexec.exe''");
     expect(packager).toContain(
       'continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working'
     );
@@ -295,7 +315,7 @@ describe('PSADT registry uninstall identity contract', () => {
   });
 
   it('rebuilds misregistered msiexec commands as exact quiet product-code removal', () => {
-    expect(packager).toContain("(Split-Path -Leaf $registeredUninstallFile) -ieq ''msiexec.exe''");
+    expect(packager).toContain("$isRegisteredMsiExec = $registeredUninstallLeaf -in @(''msiexec'', ''msiexec.exe'')");
     expect(packager).toContain('$registeredMsiProductCode');
     expect(packager).toContain(
       "$registeredUninstallArguments = @(''/x'', $registeredMsiProductCode, ''/qn'', ''/norestart'')"
@@ -334,8 +354,9 @@ describe('PSADT registry uninstall identity contract', () => {
 
   it('uses a captured MSI product code instead of an executable uninstall string', () => {
     expect(packager).toContain(
-      "$capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'') -and $registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode)"
+      '$capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode)'
     );
+    expect(packager).not.toContain("$capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'')");
     expect(packager).toContain(
       "Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode"
     );

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -473,6 +473,7 @@ function Install-ADTDeployment
 {
     [CmdletBinding()]
     param ()
+${this.getRegistryInstallSnapshotBlock(job, appName)}
 ${this.getPreInstallRemovalBlock(job, appName)}
     ## Install the application
     ${this.getInstallCommand(job, installerFileName, silentSwitches)}
@@ -508,6 +509,7 @@ function Repair-ADTDeployment
 
 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
 $ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+$script:UninstallRebootExitCode = $null
 Set-StrictMode -Version 1
 
 try
@@ -539,7 +541,11 @@ catch
 try
 {
     & "$($adtSession.DeploymentType)-ADTDeployment"
-    Close-ADTSession
+    if ($script:UninstallRebootExitCode) {
+        Close-ADTSession -ExitCode $script:UninstallRebootExitCode
+    } else {
+        Close-ADTSession
+    }
 }
 catch
 {
@@ -707,11 +713,50 @@ ${steps}
 `;
   }
 
-  private getRegistryProductCode(job: PackagingJob): string | null {
-    const match = job.uninstall_command?.match(
+  private getRegistryUninstallIdentity(job: PackagingJob): {
+    productCode: string;
+    displayName: string;
+  } | null {
+    const exactProductMatch = job.uninstall_command?.match(
       /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$/
     );
-    return match?.[1] || null;
+    if (exactProductMatch) {
+      return {
+        productCode: exactProductMatch[1],
+        displayName: exactProductMatch[2].replace(/'/g, "''"),
+      };
+    }
+
+    const displayNameMatch = job.uninstall_command?.match(/^REGISTRY_UNINSTALL:(.+)$/);
+    if (displayNameMatch) {
+      return {
+        productCode: '',
+        displayName: displayNameMatch[1].replace(/'/g, "''"),
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Snapshot ARP before install so the exact entry created or version-updated by
+   * an EXE-family installer can be persisted and reused during uninstall.
+   */
+  private getRegistryInstallSnapshotBlock(job: PackagingJob, escapedAppName: string): string {
+    const identity = this.getRegistryUninstallIdentity(job);
+    if (!identity) {
+      return '';
+    }
+
+    return `
+    # Snapshot uninstall entries before install. Manifest identity is a preference,
+    # while the observed registry delta remains authoritative when metadata is stale.
+    $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)
+    $configuredUninstallProductCode = '${identity.productCode}'
+    $configuredUninstallDisplayName = '${identity.displayName || escapedAppName}'
+    $capturedUninstallKey = $null
+    $capturedUninstallName = $null
+`;
   }
 
   /**
@@ -721,20 +766,52 @@ ${steps}
    * Opt-in via package_config.psadtConfig.verifyInstall; returns '' when disabled
    */
   private getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string {
-    const registryProductCode = this.getRegistryProductCode(job);
-    if (registryProductCode) {
+    const identity = this.getRegistryUninstallIdentity(job);
+    if (identity) {
       return `
-    ## Verify the exact manifest/AppsAndFeatures uninstall identity before writing the marker
-    $verifyApps = @()
+    ## Capture and verify the exact uninstall identity observed for this installation.
+    $selectedApplications = @()
+    $changedApplications = @()
     foreach ($verificationAttempt in 1..30) {
-        $verifyApps = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${registryProductCode}' } -ErrorAction SilentlyContinue)
-        if ($verifyApps.Count -eq 1) { break }
+        $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)
+        $changedApplications = @($postInstallApplications | Where-Object {
+            $candidateApplication = $_
+            $previousApplication = $preInstallApplications | Where-Object { $_.PSPath -eq $candidateApplication.PSPath } | Select-Object -First 1
+            (-not $previousApplication) -or ($previousApplication.DisplayVersion -ne $candidateApplication.DisplayVersion)
+        })
+        $selectedApplications = @()
+        if ($configuredUninstallProductCode) {
+            $selectedApplications = @($changedApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })
+        }
+        if ($selectedApplications.Count -eq 0) {
+            $selectedApplications = @($changedApplications | Where-Object { [string]$_.DisplayName -eq $configuredUninstallDisplayName })
+        }
+        if ($selectedApplications.Count -eq 0) {
+            $bundleCandidates = @($changedApplications | Where-Object {
+                -not $_.WindowsInstaller -and [string]$_.DisplayName -like "$configuredUninstallDisplayName*"
+            })
+            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
+        }
+        if ($selectedApplications.Count -eq 0 -and '${job.installer_type.toLowerCase()}' -eq 'burn') {
+            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })
+            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
+        }
+        if ($selectedApplications.Count -eq 0 -and $configuredUninstallProductCode) {
+            $configuredMatches = @($postInstallApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })
+            if ($configuredMatches.Count -eq 1) { $selectedApplications = $configuredMatches }
+        }
+        if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1) {
+            $selectedApplications = @($changedApplications[0])
+        }
+        if ($selectedApplications.Count -eq 1) { break }
         if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }
     }
-    if ($verifyApps.Count -ne 1) {
-        throw "Post-install verification failed: exact uninstall identity [${registryProductCode}] was found $($verifyApps.Count) time(s)."
+    if ($selectedApplications.Count -ne 1) {
+        throw "Post-install verification failed: the installer changed $($changedApplications.Count) uninstall entries and $($selectedApplications.Count) could be selected unambiguously."
     }
-    Write-ADTLogEntry -Message "Post-install verification passed for exact uninstall identity [${registryProductCode}]" -Source 'Install-ADTDeployment'
+    $capturedUninstallKey = [string]$selectedApplications[0].PSChildName
+    $capturedUninstallName = [string]$selectedApplications[0].DisplayName
+    Write-ADTLogEntry -Message "Captured and verified vendor uninstall entry [$capturedUninstallName] ($capturedUninstallKey)." -Source 'Install-ADTDeployment'
 `;
     }
     const psadtConfig = this.getPsadtConfig(job);
@@ -1026,17 +1103,38 @@ ${steps}
     }`;
     }
 
-    const registryProductMatch = job.uninstall_command.match(
-      /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$/
-    );
-    if (registryProductMatch && job.installer_type.toLowerCase() === 'burn') {
-      const productCode = registryProductMatch[1];
+    const registryIdentity = this.getRegistryUninstallIdentity(job);
+    if (registryIdentity) {
+      const installerType = job.installer_type.toLowerCase();
       const fileNameEscaped = installerFileName.replace(/'/g, "''");
-      return `$installedApps = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+      const silentSwitches = this.extractSilentSwitches(
+        job.install_command,
+        job.installer_type
+      ).replace(/'/g, "''");
+      const hiveLongName = job.install_scope === 'user' ? 'HKEY_CURRENT_USER' : 'HKEY_LOCAL_MACHINE';
+      const markerProviderPath = `Registry::${hiveLongName}\\${this.getRegistryMarkerPath(job)}\\${this.sanitizeWingetId(job.winget_id)}`;
+      const selectionBlock = `$configuredProductCode = '${registryIdentity.productCode}'
+    $configuredDisplayName = '${registryIdentity.displayName}'
+    $markerProviderPath = '${markerProviderPath}'
+    $capturedUninstallKey = (Get-ItemProperty -LiteralPath $markerProviderPath -ErrorAction SilentlyContinue).UninstallRegistryKey
+    $installedApps = if ($capturedUninstallKey) {
+        @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $capturedUninstallKey })
+    } elseif ($configuredProductCode) {
+        @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $configuredProductCode })
+    } else {
+        @(Get-ADTApplication -Name $configuredDisplayName -NameMatch 'Exact')
+    }
+    if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey) {
+        $installedApps = @(Get-ADTApplication -Name $configuredDisplayName -NameMatch 'Exact')
+    }
     if ($installedApps.Count -ne 1) {
-        throw "Could not find one unambiguous Burn bundle uninstall entry. Found $($installedApps.Count); refusing broad removal."
+        throw "Could not find one exact vendor uninstall entry. Found $($installedApps.Count); refusing broad removal."
     }
     $registeredApplication = $installedApps[0]
+    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName`;
+
+      if (installerType === 'burn') {
+        return `${selectionBlock}
     $registeredUninstallProperty = if (-not [string]::IsNullOrWhiteSpace($registeredApplication.QuietUninstallStringFilePath)) {
         'QuietUninstallString'
     } elseif (-not [string]::IsNullOrWhiteSpace($registeredApplication.UninstallStringFilePath)) {
@@ -1053,62 +1151,175 @@ ${steps}
         throw "The packaged Burn uninstaller was not found: $bundledUninstaller"
     }
     Write-ADTLogEntry -Message "Using packaged Burn bundle because the registered vendor cache may be disposable." -Source 'Uninstall-ADTDeployment'
-    Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -CreateNoWindow -WaitForMsiExec -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+    $uninstallProcessParameters = @{
+        FilePath = $bundledUninstaller
+        ArgumentList = $registeredUninstallArguments
+        WorkingDirectory = $adtSession.DirFiles
+        WindowStyle = 'Hidden'
+        WaitForMsiExec = $true
+        NoWait = $true
+        PassThru = $true
+    }
     $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+    $uninstallHandle = Start-ADTProcess @uninstallProcessParameters
+    $uninstallProcessExitLogged = $false
     $nextUninstallProgressLog = [DateTime]::UtcNow
     do {
-        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })
         if ($remainingApplications.Count -eq 0) { break }
+        $uninstallProcessExited = $false
+        try { $uninstallProcessExited = $uninstallHandle.Task.IsCompleted } catch { }
+        if ($uninstallProcessExited -and -not $uninstallProcessExitLogged) {
+            $uninstallProcessExitLogged = $true
+            Write-ADTLogEntry -Message "The Burn uninstall parent process exited; continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+        }
         if ([DateTime]::UtcNow -ge $uninstallDeadline) { break }
         if ([DateTime]::UtcNow -ge $nextUninstallProgressLog) {
-            Write-ADTLogEntry -Message "Waiting for Burn uninstall registration [${productCode}] to be removed; a child process may still be working." -Source 'Uninstall-ADTDeployment'
+            Write-ADTLogEntry -Message "Waiting for Burn uninstall registration [$registeredUninstallRegistryKey] to be removed." -Source 'Uninstall-ADTDeployment'
             $nextUninstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
         }
         Start-Sleep -Seconds 5
     } while ($true)
+    $uninstallProcessExitCode = $null
+    try {
+        if ($uninstallHandle.Task.IsCompleted) {
+            $uninstallProcessExitCode = $uninstallHandle.Task.GetAwaiter().GetResult().ExitCode
+        }
+    } catch {
+        Write-ADTLogEntry -Message "The Burn uninstall task completed without a readable exit code: $_" -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+    }
+    if ($uninstallProcessExitCode -in @(1641, 3010)) {
+        $script:UninstallRebootExitCode = 3010
+    } elseif ($null -ne $uninstallProcessExitCode -and $uninstallProcessExitCode -notin @(0, 1605, 1614)) {
+        Write-ADTLogEntry -Message "The Burn uninstall parent process exited with code [$uninstallProcessExitCode]; exact removal verification remains authoritative." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+    }
     $remainingApplications = @()
     foreach ($verificationAttempt in 1..5) {
-        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })
         if ($remainingApplications.Count -eq 0) { break }
         if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
     }
     if ($remainingApplications.Count -gt 0) {
-        throw "The exact Burn uninstall registration [${productCode}] still exists after the vendor command completion deadline."
+        throw "The Burn uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."
     }`;
-    }
+      }
 
-    if (registryProductMatch) {
-      const productCode = registryProductMatch[1];
-      return `$installedApps = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
-    if ($installedApps.Count -ne 1) {
-        throw "Could not find one exact vendor uninstall entry [${productCode}]. Found $($installedApps.Count); refusing broad removal."
-    }
-    $registeredApplication = $installedApps[0]
-    if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {
-        Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $registeredApplication.ProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+      return `${selectionBlock}
+    $capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {
+        $registeredApplication.ProductCode
+    } elseif ($registeredApplication.WindowsInstaller -and [string]$registeredApplication.PSChildName -match '^\\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\\}$') {
+        [string]$registeredApplication.PSChildName
     } else {
-        Uninstall-ADTApplication -InstalledApplication $registeredApplication -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+        $null
     }
-    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
-    $nextUninstallProgressLog = [DateTime]::UtcNow
-    do {
-        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
-        if ($remainingApplications.Count -eq 0) { break }
-        if ([DateTime]::UtcNow -ge $uninstallDeadline) { break }
-        if ([DateTime]::UtcNow -ge $nextUninstallProgressLog) {
-            Write-ADTLogEntry -Message "Waiting for vendor uninstall registration [${productCode}] to be removed; a child process may still be working." -Source 'Uninstall-ADTDeployment'
-            $nextUninstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
+    if ($capturedMsiProductCode) {
+        Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+    } else {
+        $hasQuietUninstall = -not [string]::IsNullOrWhiteSpace($registeredApplication.QuietUninstallStringFilePath)
+        $registeredUninstallProperty = if ($hasQuietUninstall) { 'QuietUninstallString' } else { 'UninstallString' }
+        $registeredUninstallFile = [string]$registeredApplication."$($registeredUninstallProperty)FilePath"
+        [string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList" | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+        [string[]]$additionalUninstallArguments = @()
+        $isVivaldiUninstall = $false
+        if (-not $hasQuietUninstall) {
+            $registeredArgumentText = ($registeredUninstallArguments -join ' ').Trim()
+            if ((Split-Path -Leaf $registeredUninstallFile) -ieq 'setup.exe' -and $registeredArgumentText -match '(?i)(^|\\s)--vivaldi(\\s|$)') {
+                $isVivaldiUninstall = $true
+            } elseif ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${installerType}' -eq 'inno') {
+                foreach ($argument in @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-')) {
+                    if ($registeredArgumentText -notmatch "(?i)(^|\\s)$([regex]::Escape($argument))(\\s|$)") {
+                        $additionalUninstallArguments += $argument
+                    }
+                }
+            } elseif ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${installerType}' -eq 'nullsoft' -and $registeredArgumentText -notmatch '(?i)(^|\\s)/S(\\s|$)') {
+                $additionalUninstallArguments += '/S'
+            }
+            if ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and $registeredArgumentText -match '(?i)(^|\\s)(/uninstall|-uninstall|--uninstall|/x)(\\s|$|\\{)') {
+                $safeManifestUninstallArguments = @('${silentSwitches}' -split '\\s+' | Where-Object { $_ -match '^(?i:/q[nbrfu]?|/quiet|/silent|/verysilent|/norestart|/s|--quiet|--silent)$' })
+                foreach ($argument in $safeManifestUninstallArguments) {
+                    if ($registeredArgumentText -notmatch "(?i)(^|\\s)$([regex]::Escape($argument))(\\s|$)") {
+                        $additionalUninstallArguments += $argument
+                    }
+                }
+            }
         }
-        Start-Sleep -Seconds 5
-    } while ($true)
+        if ($isVivaldiUninstall) {
+            $registeredUninstallFile = [string]$registeredApplication.UninstallStringFilePath
+            $registeredUninstallArguments = @('--uninstall', '--vivaldi', '--force-uninstall')
+        }
+        $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile
+        $isRegisteredMsiExec = $registeredUninstallLeaf -in @('msiexec', 'msiexec.exe')
+        if ($isRegisteredMsiExec) {
+            $registeredMsiProductCode = if ($registeredUninstallRegistryKey -match '(?i)^\\{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\\}$') {
+                $registeredUninstallRegistryKey
+            } elseif (($registeredUninstallArguments -join ' ') -match '(?i)(?:^|\\s)[/-](?:x|i)\\s*(\\{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\\})(?=\\s|$)') {
+                $Matches[1]
+            } else {
+                throw "The registered msiexec uninstall command does not expose an exact product code; refusing to reuse install or repair arguments."
+            }
+            $registeredUninstallFile = Join-Path $env:SystemRoot 'System32\\msiexec.exe'
+            $registeredUninstallArguments = @('/x', $registeredMsiProductCode, '/qn', '/norestart')
+        } else {
+            if (-not (Test-Path -LiteralPath $registeredUninstallFile -PathType Leaf)) {
+                throw "The registered vendor uninstaller was not found: $registeredUninstallFile"
+            }
+            if (-not $hasQuietUninstall -and -not $isVivaldiUninstall) {
+                $registeredUninstallArguments += $additionalUninstallArguments
+            }
+        }
+        $registeredUninstallWorkingDirectory = Split-Path -Parent $registeredUninstallFile
+        $uninstallProcessParameters = @{
+            FilePath = $registeredUninstallFile
+            WorkingDirectory = $registeredUninstallWorkingDirectory
+            WindowStyle = 'Hidden'
+            NoWait = $true
+            PassThru = $true
+        }
+        if ($registeredUninstallArguments.Count -gt 0) {
+            $uninstallProcessParameters.ArgumentList = $registeredUninstallArguments
+        }
+        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters
+        $uninstallProcessExitLogged = $false
+        $nextUninstallProgressLog = [DateTime]::UtcNow
+        do {
+            $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })
+            if ($remainingApplications.Count -eq 0) { break }
+            $uninstallProcessExited = $false
+            try { $uninstallProcessExited = $uninstallHandle.Task.IsCompleted } catch { }
+            if ($uninstallProcessExited -and -not $uninstallProcessExitLogged) {
+                $uninstallProcessExitLogged = $true
+                Write-ADTLogEntry -Message "The vendor uninstall parent process exited; continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+            }
+            if ([DateTime]::UtcNow -ge $uninstallDeadline) { break }
+            if ([DateTime]::UtcNow -ge $nextUninstallProgressLog) {
+                Write-ADTLogEntry -Message "Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed." -Source 'Uninstall-ADTDeployment'
+                $nextUninstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
+            }
+            Start-Sleep -Seconds 5
+        } while ($true)
+        $uninstallProcessExitCode = $null
+        try {
+            if ($uninstallHandle.Task.IsCompleted) {
+                $uninstallProcessExitCode = $uninstallHandle.Task.GetAwaiter().GetResult().ExitCode
+            }
+        } catch {
+            Write-ADTLogEntry -Message "The vendor uninstall task completed without a readable exit code: $_" -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+        }
+        if ($uninstallProcessExitCode -in @(1641, 3010)) {
+            $script:UninstallRebootExitCode = 3010
+        } elseif ($null -ne $uninstallProcessExitCode -and $uninstallProcessExitCode -notin @(0, 1605, 1614)) {
+            Write-ADTLogEntry -Message "The vendor uninstall parent process exited with code [$uninstallProcessExitCode]; exact removal verification remains authoritative." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+        }
+    }
     $remainingApplications = @()
     foreach ($verificationAttempt in 1..5) {
-        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq '${productCode}' })
+        $remainingApplications = @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey })
         if ($remainingApplications.Count -eq 0) { break }
         if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
     }
     if ($remainingApplications.Count -gt 0) {
-        throw "The exact vendor uninstall registration [${productCode}] still exists after the vendor command completion deadline."
+        throw "The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."
     }`;
     }
 
@@ -1184,6 +1395,13 @@ ${steps}
     const hive = this.getRegistryHive(job.install_scope);
     const markerPath = this.getRegistryMarkerPath(job);
     const regPath = `${hive}\\${markerPath}\\${sanitizedId}`;
+    const capturedIdentityValues = this.getRegistryUninstallIdentity(job)
+      ? `
+        if (-not [string]::IsNullOrWhiteSpace($capturedUninstallKey)) {
+            Set-ADTRegistryKey -LiteralPath $regPath -Name 'UninstallRegistryKey' -Value $capturedUninstallKey -Type String
+            Set-ADTRegistryKey -LiteralPath $regPath -Name 'UninstallDisplayName' -Value $capturedUninstallName -Type String
+        }`
+      : '';
 
     return `try {
         $regPath = '${regPath}'
@@ -1192,6 +1410,7 @@ ${steps}
         Set-ADTRegistryKey -LiteralPath $regPath -Name 'Publisher' -Value '${job.publisher.replace(/'/g, "''")}' -Type String
         Set-ADTRegistryKey -LiteralPath $regPath -Name 'WingetId' -Value '${job.winget_id.replace(/'/g, "''")}' -Type String
         Set-ADTRegistryKey -LiteralPath $regPath -Name 'InstalledDate' -Value (Get-Date -Format 'o') -Type String
+${capturedIdentityValues}
         Write-ADTLogEntry -Message "IntuneGet detection marker written to $regPath" -Severity 'Success' -Source 'Install-ADTDeployment'
     } catch {
         Write-ADTLogEntry -Message "Warning: Could not write detection marker: $_" -Severity 'Warning' -Source 'Install-ADTDeployment'

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -5,6 +5,7 @@ import { JobProcessor } from '../src/job-processor';
 import type { PackagingJob } from '../src/job-poller';
 
 type ScriptGenerator = {
+  generateDeployScript(job: PackagingJob, fileName: string): string;
   getInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string;
   getUninstallCommand(job: PackagingJob, fileName: string): string;
   getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string;
@@ -176,7 +177,8 @@ describe('hosted PSADT portable generator', () => {
     expect(script).toContain(
       '$uninstallHandle = Start-ADTProcess @uninstallProcessParameters',
     );
-    expect(script).toContain('$uninstallHandle.Process.HasExited');
+    expect(script).toContain('$uninstallHandle.Task.IsCompleted');
+    expect(script).toContain('$uninstallHandle.Task.GetAwaiter().GetResult().ExitCode');
     expect(script).not.toContain('Start-ADTProcess -FilePath $wingetExe');
     expect(script).not.toContain('uninstall --id $wingetId');
   });
@@ -199,16 +201,26 @@ describe('Burn bundle PSADT generation', () => {
       'python-3.14.7-amd64.exe'
     );
 
-    expect(script).toContain("$_.PSChildName -eq '{97b6de30-6082-48d1-9bb4-9f43296531a4}'");
+    expect(script).toContain(
+      "$configuredProductCode = '{97b6de30-6082-48d1-9bb4-9f43296531a4}'"
+    );
+    expect(script).toContain(
+      '$_.PSChildName -eq $registeredUninstallRegistryKey'
+    );
     expect(script).toContain(
       '[string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList" | Where-Object'
     );
     expect(script).toContain("Join-Path $adtSession.DirFiles 'python-3.14.7-amd64.exe'");
-    expect(script).toContain('-WorkingDirectory $adtSession.DirFiles -CreateNoWindow');
+    expect(script).toContain('WorkingDirectory = $adtSession.DirFiles');
+    expect(script).toContain("WindowStyle = 'Hidden'");
     expect(script).toContain(
-      "The exact Burn uninstall registration [{97b6de30-6082-48d1-9bb4-9f43296531a4}] still exists"
+      'The Burn uninstall command did not remove registration [$registeredUninstallRegistryKey]'
     );
     expect(script).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
+    expect(script).toContain('NoWait = $true');
+    expect(script).toContain('WaitForMsiExec = $true');
+    expect(script).toContain('$uninstallHandle = Start-ADTProcess @uninstallProcessParameters');
+    expect(script).toContain('The Burn uninstall parent process exited with code');
     expect(script).toContain('foreach ($verificationAttempt in 1..5)');
     expect(script).not.toContain("Start-ADTMsiProcess -Action 'Uninstall'");
   });
@@ -229,6 +241,12 @@ describe('EXE product identity PSADT generation', () => {
       job,
       'Adobe Acrobat Reader (64-bit)'
     );
+    const snapshot = generator.getRegistryInstallSnapshotBlock.call(
+      generator,
+      job,
+      'Adobe Acrobat Reader (64-bit)'
+    );
+    const marker = generator.getRegistryMarkerCreation.call(generator, job);
     const uninstall = generator.getUninstallCommand.call(
       generator,
       job,
@@ -236,16 +254,28 @@ describe('EXE product identity PSADT generation', () => {
     );
 
     expect(verification).toContain(
-      "$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
+      '$_.PSChildName -eq $configuredUninstallProductCode'
     );
+    expect(verification).toContain('$capturedUninstallKey = [string]$selectedApplications[0].PSChildName');
     expect(verification).toContain('foreach ($verificationAttempt in 1..30)');
+    expect(verification).not.toContain('$existingNameMatches');
+    expect(snapshot).toContain('$preInstallApplications = @(Get-ADTApplication');
+    expect(marker).toContain("-Name 'UninstallRegistryKey' -Value $capturedUninstallKey");
     expect(uninstall).toContain(
-      "$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
+      "$configuredProductCode = '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
     );
     expect(uninstall).toContain('$registeredApplication.WindowsInstaller');
-    expect(uninstall).toContain('Uninstall-ADTApplication -InstalledApplication $registeredApplication');
+    expect(uninstall).toContain('$capturedMsiProductCode');
+    expect(uninstall).toContain('[string]$registeredApplication.PSChildName');
+    expect(uninstall).toContain('$uninstallHandle = Start-ADTProcess @uninstallProcessParameters');
+    expect(uninstall).toContain('NoWait = $true');
+    expect(uninstall).toContain("$isRegisteredMsiExec = $registeredUninstallLeaf -in @('msiexec', 'msiexec.exe')");
+    expect(uninstall).toContain("$registeredUninstallFile = Join-Path $env:SystemRoot 'System32\\msiexec.exe'");
+    expect(uninstall.indexOf('if ($isRegisteredMsiExec)')).toBeLessThan(
+      uninstall.indexOf('if (-not (Test-Path -LiteralPath $registeredUninstallFile -PathType Leaf))')
+    );
     expect(uninstall).toContain(
-      'The exact vendor uninstall registration [{AC76BA86-1033-FF00-7760-BC15014EA700}] still exists'
+      'The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey]'
     );
     expect(uninstall).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
     expect(uninstall).toContain('foreach ($verificationAttempt in 1..5)');
@@ -253,6 +283,22 @@ describe('EXE product identity PSADT generation', () => {
     expect(uninstall).not.toContain(
       "Start-ADTMsiProcess -Action 'Uninstall' -ProductCode '{AC76BA86-1033-FF00-7760-BC15014EA700}'"
     );
+
+    const deployScript = generator.generateDeployScript.call(generator, job, 'reader.exe');
+    expect(deployScript).toContain('$script:UninstallRebootExitCode = $null');
+    expect(deployScript).toContain('Close-ADTSession -ExitCode $script:UninstallRebootExitCode');
+  });
+
+  it('emits apostrophe-safe registry identity strings', () => {
+    const job = packagingJob({
+      display_name: "Contoso O'Brien Agent",
+      installer_type: 'exe',
+      uninstall_command: "REGISTRY_UNINSTALL:Contoso O'Brien Agent",
+    });
+
+    const deployScript = generator.generateDeployScript.call(generator, job, 'setup.exe');
+    expect(deployScript).toContain("$configuredUninstallDisplayName = 'Contoso O''Brien Agent'");
+    expect(deployScript).toContain("$configuredDisplayName = 'Contoso O''Brien Agent'");
   });
 
   it('always verifies an exact product identity even when generic verification is disabled', () => {
@@ -265,7 +311,33 @@ describe('EXE product identity PSADT generation', () => {
 
     expect(
       generator.getPostInstallVerificationBlock.call(generator, job, 'Adobe Acrobat Reader (64-bit)')
-    ).toContain("$_.PSChildName -eq '{AC76BA86-1033-FF00-7760-BC15014EA700}'");
+    ).toContain('$_.PSChildName -eq $configuredUninstallProductCode');
+  });
+
+  it('adds verified unattended switches when an EXE publishes only an interactive uninstall command', () => {
+    const inno = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'inno',
+        install_command: 'vendor.exe /VERYSILENT /NORESTART',
+        uninstall_command:
+          'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Vendor app',
+      }),
+      'vendor.exe'
+    );
+    const nullsoft = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'nullsoft',
+        uninstall_command:
+          'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FF00-7760-BC15014EA700}:Vendor app',
+      }),
+      'vendor.exe'
+    );
+
+    expect(inno).toContain("@('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-')");
+    expect(nullsoft).toContain("$additionalUninstallArguments += '/S'");
+    expect(inno).toContain("$safeManifestUninstallArguments = @('/VERYSILENT /NORESTART' -split '\\s+'");
   });
 
   it('fails closed when an exact product marker is malformed', () => {


### PR DESCRIPTION
## Summary
- capture the exact ARP identity observed after install instead of trusting stale manifest metadata
- keep hosted and workflow PSADT 4.1.8 generators behaviorally equivalent
- recognize command-name `MsiExec.exe` before literal-path validation and rebuild exact quiet MSI removal
- apply verified vendor-family silent uninstall arguments with registry-authoritative completion and a five-minute deadline
- propagate reboot exit codes and consume PSADT `-NoWait -PassThru` through its returned Task
- fail closed on malformed or ambiguous uninstall identities
- add generated-script coverage for apostrophes and lifecycle parity

## Validation
- `npm test` (772 tests)
- `npm run lint`
- `npm run build:ci`
- `packager: npm run build`
- PowerShell parser validation
- bounded Claude Code Opus 5 correctness review: no Blocking/High/Medium findings