### PR TITLE
Pin QA profiles to corrected PSADT packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '41a4e86bd1f309d0b5258723cda793578b18a541',
+  packagerCommit: 'c4609782be26123a519858ea39b653e6f00a96a0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## Summary
- pin QA package-profile generation to IntuneGet packager `c4609782be26123a519858ea39b653e6f00a96a0`
- ensure newly enqueued candidates use the corrected exact uninstall lifecycle

## Validation
- package-profile and QA enqueue tests passed (46 tests)
- pre-push lint passed