### PR TITLE
Reconcile managed detection markers before packaging

### DIFF
--- a/lib/__tests__/registry-marker.test.ts
+++ b/lib/__tests__/registry-marker.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_REGISTRY_MARKER_PATH,
   normalizeMarkerPath,
+  reconcileManagedMarkerDetectionRules,
   rewriteMarkerKeyPath,
 } from '../registry-marker';
 
@@ -160,5 +161,117 @@ describe('rewriteMarkerKeyPath', () => {
     expect(
       rewriteMarkerKeyPath('HKEY_LOCAL_MACHINE\\Publisher_App', 'Publisher_App', 'X')
     ).toBeNull();
+  });
+});
+
+describe('reconcileManagedMarkerDetectionRules', () => {
+  it('moves a saved IntuneGet marker to the current user scope and version', () => {
+    expect(
+      reconcileManagedMarkerDetectionRules({
+        detectionRules: [
+          {
+            type: 'registry',
+            keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+            valueName: 'Version',
+            check32BitOn64System: false,
+            detectionType: 'version',
+            operator: 'greaterThanOrEqual',
+            detectionValue: '2.7.1',
+          },
+        ],
+        wingetId: 'Asana.Asana',
+        version: '2.8.0',
+        installScope: 'user',
+      })
+    ).toEqual([
+      {
+        type: 'registry',
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+        valueName: 'Version',
+        check32BitOn64System: false,
+        detectionType: 'version',
+        operator: 'greaterThanOrEqual',
+        detectionValue: '2.8.0',
+      },
+    ]);
+  });
+
+  it('uses exact string detection for an opaque current version', () => {
+    const [rule] = reconcileManagedMarkerDetectionRules({
+      detectionRules: [
+        {
+          type: 'registry',
+          keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Example_App',
+          valueName: 'Version',
+          detectionType: 'version',
+          operator: 'greaterThanOrEqual',
+          detectionValue: '1.0.0',
+        },
+      ],
+      wingetId: 'Example.App',
+      version: '2026.08-beta',
+      installScope: 'machine',
+    });
+
+    expect(rule).toMatchObject({
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Example_App',
+      detectionType: 'string',
+      operator: 'equal',
+      detectionValue: '2026.08-beta',
+    });
+  });
+
+  it('reconciles the configured marker root without touching unrelated rules', () => {
+    const unrelated = {
+      type: 'registry' as const,
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Vendor\\Asana_Asana',
+      valueName: 'Version',
+      detectionType: 'version' as const,
+      operator: 'greaterThanOrEqual' as const,
+      detectionValue: '2.7.1',
+    };
+    const result = reconcileManagedMarkerDetectionRules({
+      detectionRules: [
+        unrelated,
+        {
+          type: 'registry',
+          keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Contoso\\Apps\\Asana_Asana',
+          valueName: 'Version',
+          detectionType: 'version',
+          operator: 'greaterThanOrEqual',
+          detectionValue: '2.7.1',
+        },
+      ],
+      wingetId: 'Asana.Asana',
+      version: '2.8.0',
+      installScope: 'user',
+      markerPath: 'SOFTWARE\\Contoso\\Apps',
+    });
+
+    expect(result[0]).toBe(unrelated);
+    expect(result[1]).toMatchObject({
+      keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\Contoso\\Apps\\Asana_Asana',
+      detectionValue: '2.8.0',
+    });
+  });
+
+  it('preserves a manually authored value under the marker key', () => {
+    const customRule = {
+      type: 'registry' as const,
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+      valueName: 'Channel',
+      detectionType: 'string' as const,
+      operator: 'equal' as const,
+      detectionValue: 'stable',
+    };
+
+    const [result] = reconcileManagedMarkerDetectionRules({
+      detectionRules: [customRule],
+      wingetId: 'Asana.Asana',
+      version: '2.8.0',
+      installScope: 'user',
+    });
+
+    expect(result).toBe(customRule);
   });
 });

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -4,6 +4,7 @@ import {
   type GitHubActionsConfig,
   type WorkflowInputs,
 } from './github-actions';
+import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
 
 const { enforceInstallerPreflightMock, enforceQaGateMock } = vi.hoisted(() => ({
   enforceInstallerPreflightMock: vi.fn(),
@@ -95,6 +96,91 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     const request = fetchMock.mock.calls[0][1] as RequestInit;
     const payload = JSON.parse(String(request.body));
     expect(payload.client_payload.installer.hashValidationMode).toBe('strict');
+  });
+
+  it('dispatches the same reconciled marker rules that are used for the QA gate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const inputs = workflowInputs({
+      wingetId: 'Asana.Asana',
+      version: '2.8.0',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installScope: 'user',
+      detectionRules: JSON.stringify([
+        {
+          type: 'registry',
+          keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+          valueName: 'Version',
+          detectionType: 'version',
+          operator: 'greaterThanOrEqual',
+          detectionValue: '2.7.1',
+        },
+      ]),
+      psadtConfig: JSON.stringify({ brandingCompanyName: 'Contoso' }),
+    });
+
+    await triggerPackagingWorkflow(
+      inputs,
+      config,
+      { skipRunCapture: true }
+    );
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    const dispatchedRules = JSON.parse(payload.client_payload.config.detectionRules);
+    const dispatchedConfig = JSON.parse(payload.client_payload.config.psadtConfig);
+
+    expect(dispatchedRules[0]).toMatchObject({
+      keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+      detectionValue: '2.8.0',
+    });
+    expect(dispatchedConfig).toMatchObject({
+      brandingCompanyName: 'Contoso',
+      detectionRules: dispatchedRules,
+    });
+    const dispatchedIdentity = buildQaPackageIdentityFromWorkflowInput({
+      ...inputs,
+      psadtConfig: payload.client_payload.config.psadtConfig,
+      detectionRules: payload.client_payload.config.detectionRules,
+    });
+    expect(enforceQaGateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageProfileSha256: dispatchedIdentity.packageProfileSha256,
+      })
+    );
+  });
+
+  it('does not reconcile custom-installer detection rules', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const detectionRules = JSON.stringify([
+      {
+        type: 'registry',
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Custom_Example_App',
+        valueName: 'Version',
+        detectionType: 'version',
+        operator: 'equal',
+        detectionValue: '1.0.0',
+      },
+    ]);
+    const psadtConfig = JSON.stringify({ detectionRules, brandingCompanyName: 'Custom' });
+
+    await triggerPackagingWorkflow(
+      workflowInputs({
+        sourceType: 'custom',
+        installScope: 'user',
+        detectionRules,
+        psadtConfig,
+      }),
+      config,
+      { skipRunCapture: true }
+    );
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.config.detectionRules).toBe(detectionRules);
+    expect(payload.client_payload.config.psadtConfig).toBe(psadtConfig);
   });
 
   it('does not call GitHub when installer preflight blocks dispatch', async () => {

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -7,7 +7,9 @@
 import { applyInstallerUrlOverride } from './installer-url-overrides';
 import { enforceInstallerPreflight } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
-import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
+import {
+  normalizeQaWorkflowPackageInput,
+} from './qa/package-profile';
 
 export interface WorkflowInputs {
   jobId: string;
@@ -43,7 +45,7 @@ export interface WorkflowInputs {
   autoSupersede?: boolean; // Mark the new app as superseding the previous app
   supersedenceType?: string; // Supersedence type for auto-supersede ('update' | 'replace')
   sourceType?: 'winget' | 'custom'; // Custom installers are outside winget-pkgs trust validation
-  packageProfileSha256?: string; // Exact generated PSADT package identity; computed server-side when absent
+  packageProfileSha256?: string; // Upstream QA identity; final dispatch recalculates from effective inputs
 }
 
 export interface GitHubActionsConfig {
@@ -116,6 +118,8 @@ export async function triggerPackagingWorkflow(
     inputs.architecture ?? '',
     inputs.installerUrl,
   );
+  const normalizedPackageInput =
+    inputs.sourceType === 'custom' ? null : normalizeQaWorkflowPackageInput(inputs);
 
   // This is the final dispatch boundary shared by manual, MSP, update-policy,
   // and auto-update paths. Never create a packaging run for a known-bad tuple.
@@ -129,11 +133,8 @@ export async function triggerPackagingWorkflow(
     installScope: inputs.installScope,
     sourceType: inputs.sourceType,
   });
-  const packageProfileSha256 =
-    inputs.sourceType === 'custom'
-      ? undefined
-      : inputs.packageProfileSha256 ||
-        buildQaPackageIdentityFromWorkflowInput(inputs).packageProfileSha256;
+  const calculatedPackageProfileSha256 = normalizedPackageInput?.identity.packageProfileSha256;
+  const packageProfileSha256 = calculatedPackageProfileSha256;
   await enforceQaGate({
     wingetId: inputs.wingetId,
     version: inputs.version,
@@ -188,8 +189,9 @@ export async function triggerPackagingWorkflow(
           uninstallCommand: inputs.uninstallCommand,
         },
         config: {
-          psadtConfig: inputs.psadtConfig || '{}',
-          detectionRules: inputs.detectionRules || '[]',
+          psadtConfig: normalizedPackageInput?.psadtConfigJson || inputs.psadtConfig || '{}',
+          detectionRules:
+            normalizedPackageInput?.detectionRulesJson || inputs.detectionRules || '[]',
           requirementRules: inputs.requirementRules || '[]',
           assignments: inputs.assignments || '[]',
           categories: inputs.categories || '[]',

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import {
   buildQaPackageIdentity,
+  buildQaPackageIdentityFromWorkflowInput,
   canonicalQaJson,
+  normalizeQaWorkflowPackageInput,
   QA_PACKAGE_PROFILE_SCHEMA_VERSION,
   QA_PSADT_TOOLCHAIN,
   qaSha256,
+  splitQaPsadtConfig,
   validateCurrentQaPackageProfile,
 } from './package-profile';
 
@@ -119,6 +122,56 @@ describe('PSADT QA package identity', () => {
       buildQaPackageIdentity({ ...input, profileKind: 'deployment-config' })
         .packageProfileSha256
     ).not.toBe(buildQaPackageIdentity(input).packageProfileSha256);
+  });
+
+  it('reconciles an IntuneGet marker with the current workflow scope and version', () => {
+    const workflowInput = {
+      wingetId: 'Asana.Asana',
+      displayName: 'Asana',
+      publisher: 'Asana',
+      version: '2.8.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Asana',
+      installScope: 'user' as const,
+      detectionRules: JSON.stringify([
+        {
+          type: 'registry',
+          keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+          valueName: 'Version',
+          detectionType: 'version',
+          operator: 'greaterThanOrEqual',
+          detectionValue: '2.7.1',
+        },
+      ]),
+      psadtConfig: JSON.stringify({
+        detectionRules: [],
+        brandingCompanyName: 'Contoso',
+      }),
+    };
+    const normalized = normalizeQaWorkflowPackageInput(workflowInput);
+    const identity = buildQaPackageIdentityFromWorkflowInput(workflowInput);
+    const profile = identity.profile as {
+      schemaVersion: number;
+      detectionRules: Array<Record<string, unknown>>;
+      psadtConfig: { detectionRules: Array<Record<string, unknown>> };
+    };
+
+    expect(profile.schemaVersion).toBe(3);
+    expect(profile.detectionRules[0]).toMatchObject({
+      keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
+      detectionValue: '2.8.0',
+    });
+    expect(profile.psadtConfig.detectionRules).toEqual(profile.detectionRules);
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      brandingCompanyName: 'Contoso',
+      detectionRules: profile.detectionRules,
+    });
+    expect(
+      splitQaPsadtConfig(JSON.parse(normalized.psadtConfigJson)).execution
+    ).toEqual(profile.psadtConfig);
   });
 });
 

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
@@ -18,7 +19,7 @@ export const QA_PSADT_TOOLCHAIN = {
  * and update the protected workflow verifier in the same rollout. Existing candidates
  * then fail closed and are rebuilt before they can be dispatched.
  */
-export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 2;
+export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 3;
 
 export interface QaPackageProfileInput {
   profileKind: 'catalog-default' | 'deployment-config';
@@ -403,13 +404,29 @@ function parseJsonObject<T>(value: string | undefined, fallback: T): T {
   }
 }
 
-export function buildQaPackageIdentityFromWorkflowInput(
-  input: QaWorkflowPackageInput
-): QaPackageIdentity {
-  const detectionRules = parseJsonObject<DetectionRule[]>(input.detectionRules, []);
-  const rawConfig = parseJsonObject<Partial<PSADTConfig>>(input.psadtConfig, {});
+export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): {
+  detectionRules: DetectionRule[];
+  psadtConfig: PSADTConfig;
+  detectionRulesJson: string;
+  psadtConfigJson: string;
+  identity: QaPackageIdentity;
+} {
+  const parsedDetectionRulesValue = parseJsonObject<unknown>(input.detectionRules, []);
+  const parsedDetectionRules = Array.isArray(parsedDetectionRulesValue)
+    ? (parsedDetectionRulesValue as DetectionRule[])
+    : [];
+  const parsedConfig = parseJsonObject<unknown>(input.psadtConfig, {});
+  const rawConfig = (record(parsedConfig) || {}) as Partial<PSADTConfig>;
+  const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, parsedDetectionRules);
+  const detectionRules = reconcileManagedMarkerDetectionRules({
+    detectionRules: parsedDetectionRules,
+    wingetId: input.wingetId,
+    version: input.version,
+    installScope: input.installScope || 'machine',
+    markerPath: preliminaryConfig.registryMarkerPath,
+  });
   const psadtConfig = normalizeQaPsadtConfig(rawConfig, detectionRules);
-  return buildQaPackageIdentity({
+  const identity = buildQaPackageIdentity({
     profileKind: 'deployment-config',
     wingetId: input.wingetId,
     displayName: input.displayName,
@@ -426,4 +443,18 @@ export function buildQaPackageIdentityFromWorkflowInput(
     psadtConfig,
     detectionRules,
   });
+
+  return {
+    detectionRules,
+    psadtConfig,
+    detectionRulesJson: JSON.stringify(detectionRules),
+    psadtConfigJson: JSON.stringify(psadtConfig),
+    identity,
+  };
+}
+
+export function buildQaPackageIdentityFromWorkflowInput(
+  input: QaWorkflowPackageInput
+): QaPackageIdentity {
+  return normalizeQaWorkflowPackageInput(input).identity;
 }

--- a/lib/registry-marker.ts
+++ b/lib/registry-marker.ts
@@ -1,3 +1,5 @@
+import type { DetectionRule, RegistryDetectionRule } from '@/types/intune';
+
 /**
  * Registry Marker Path Helpers
  *
@@ -15,6 +17,10 @@
 
 /** Default marker root: subpath under the hive, no hive prefix */
 export const DEFAULT_REGISTRY_MARKER_PATH = 'SOFTWARE\\IntuneGet\\Apps';
+
+export function sanitizeWingetIdForRegistry(wingetId: string): string {
+  return wingetId.replace(/[.\-]/g, '_');
+}
 
 /**
  * Normalize a user-supplied registry marker path into a safe subpath under
@@ -81,4 +87,69 @@ export function rewriteMarkerKeyPath(
   }
 
   return `${hive.toUpperCase()}\\${normalizeMarkerPath(markerPath)}\\${sanitizedWingetId}`;
+}
+
+/**
+ * Reconcile only IntuneGet-owned marker rules with the package that will
+ * actually be generated. Saved deployment profiles can outlive a WinGet
+ * install-scope or version change; without this reconciliation a user-scoped
+ * package writes HKCU while Intune continues looking in HKLM (or vice versa).
+ *
+ * The complete default/current marker path, sanitized WinGet id, and Version
+ * value form the ownership signature. A rule with that exact signature is
+ * internal IntuneGet state and is normalized completely; every other registry
+ * rule is returned by reference and remains byte-for-byte intact.
+ */
+export function reconcileManagedMarkerDetectionRules({
+  detectionRules,
+  wingetId,
+  version,
+  installScope,
+  markerPath,
+}: {
+  detectionRules: DetectionRule[];
+  wingetId: string;
+  version: string;
+  installScope?: string;
+  markerPath?: string | null;
+}): DetectionRule[] {
+  const sanitizedWingetId = sanitizeWingetIdForRegistry(wingetId);
+  const currentMarkerPath = normalizeMarkerPath(markerPath);
+  const managedSubPaths = new Set(
+    [DEFAULT_REGISTRY_MARKER_PATH, currentMarkerPath].map(
+      (path) => `${path}\\${sanitizedWingetId}`.toUpperCase()
+    )
+  );
+  const hive =
+    installScope?.toLowerCase() === 'user' ? 'HKEY_CURRENT_USER' : 'HKEY_LOCAL_MACHINE';
+  const versionParts = /^\d+(?:\.\d+){1,3}$/.test(version) ? version.split('.') : [];
+  const useVersionComparison =
+    versionParts.length >= 2 &&
+    versionParts.length <= 4 &&
+    versionParts.every((part) => Number(part) <= 2_147_483_647);
+
+  return detectionRules.map((rule) => {
+    if (
+      rule.type !== 'registry' ||
+      rule.valueName?.toUpperCase() !== 'VERSION' ||
+      typeof rule.keyPath !== 'string'
+    ) {
+      return rule;
+    }
+
+    const match = /^(HKEY_LOCAL_MACHINE|HKEY_CURRENT_USER)\\(.+)$/i.exec(rule.keyPath);
+    if (!match || !managedSubPaths.has(match[2].toUpperCase())) {
+      return rule;
+    }
+
+    return {
+      ...rule,
+      keyPath: `${hive}\\${currentMarkerPath}\\${sanitizedWingetId}`,
+      valueName: 'Version',
+      check32BitOn64System: false,
+      detectionType: useVersionComparison ? 'version' : 'string',
+      operator: useVersionComparison ? 'greaterThanOrEqual' : 'equal',
+      detectionValue: version,
+    } satisfies RegistryDetectionRule;
+  });
 }


### PR DESCRIPTION
## Summary
- normalize only IntuneGet-owned registry marker rules to the current app version, install scope, and configured marker root
- use the same normalized profile for QA identity and final non-custom customer dispatch
- preserve custom installer payloads without rewriting
- bump QA package profiles to schema 3 so older results cannot satisfy the corrected gate

## Validation
- 779 tests passed across 64 files
- lint passed
- Next.js production build passed (141 routes)
- focused marker/profile/customer-dispatch tests: 71 passed

## Runtime evidence
This generalizes the Asana failure where a saved HKLM marker for version 2.7.1 was reused for a current per-user 2.8.0 package.