### PR TITLE
Pin QA to corrected ARP identity packager

### DIFF
--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -159,7 +159,7 @@ describe('PSADT QA package identity', () => {
       psadtConfig: { detectionRules: Array<Record<string, unknown>> };
     };
 
-    expect(profile.schemaVersion).toBe(3);
+    expect(profile.schemaVersion).toBe(QA_PACKAGE_PROFILE_SCHEMA_VERSION);
     expect(profile.detectionRules[0]).toMatchObject({
       keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Asana_Asana',
       detectionValue: '2.8.0',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c4609782be26123a519858ea39b653e6f00a96a0',
+  packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -19,7 +19,7 @@ export const QA_PSADT_TOOLCHAIN = {
  * and update the protected workflow verifier in the same rollout. Existing candidates
  * then fail closed and are rebuilt before they can be dispatched.
  */
-export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 3;
+export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 4;
 
 export interface QaPackageProfileInput {
   profileKind: 'catalog-default' | 'deployment-config';


### PR DESCRIPTION
## Summary
- pin QA/customer package identity to IntuneGet commit de49775e759b693b92db09bc99aa116f197c4850`n- bump package profile schema to 4 so older results cannot gate the corrected customer package
- remove a brittle hard-coded schema expectation from the marker regression

## Validation
- 104 focused identity/dispatch/enqueue/packager tests passed
- 782 tests passed across 64 files
- lint passed
- Next.js production build passed (141 routes)

## Rollout
IntuneGet-Workflows PR #385 already accepts schema 4.