### PR TITLE
Fix exact MSI identity handling in PSADT packages

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -127,6 +127,50 @@ function ConvertTo-PSADTAccentValue {
     return "'" + ($trimmed -replace "'", "''") + "'"
 }
 
+function Get-MsiPropertyValue {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Property
+    )
+
+    $installer = $null
+    $database = $null
+    $view = $null
+    $record = $null
+
+    try {
+        $installer = New-Object -ComObject WindowsInstaller.Installer
+        $database = $installer.GetType().InvokeMember(
+            'OpenDatabase',
+            [System.Reflection.BindingFlags]::InvokeMethod,
+            $null,
+            $installer,
+            @($Path, 0)
+        )
+        $escapedProperty = $Property -replace "'", "''"
+        $view = $database.OpenView("SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = '$escapedProperty'")
+        $view.Execute()
+        $record = $view.Fetch()
+
+        if ($record) {
+            return [string]$record.StringData(1)
+        }
+    } catch {
+        Write-Warning "Could not read MSI property [$Property] from [$Path]: $($_.Exception.Message)"
+    } finally {
+        if ($view) {
+            try { $view.Close() } catch { }
+        }
+        foreach ($comObject in @($record, $view, $database, $installer)) {
+            if ($comObject -and [System.Runtime.InteropServices.Marshal]::IsComObject($comObject)) {
+                [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($comObject)
+            }
+        }
+    }
+
+    return $null
+}
+
 function Update-PowerShellDataSetting {
     param(
         [string]$Path,
@@ -493,6 +537,24 @@ if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
     $useRegistryUninstall = $true
     $registryUninstallProductCode = $Matches[1]
     $registryUninstallDisplayName = $DisplayName
+}
+
+# WinGet metadata can omit, decorate, or stale-cache an MSI ProductCode. Read
+# the authoritative identity from the downloaded MSI so the customer package
+# and QA both target the exact Windows Installer product. This also repairs the
+# explicit missing-identity sentinel without guessing from a display name.
+if ($fileExtension -eq '.msi' -and ($useRegistryUninstall -or $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED')) {
+    $msiProductCode = Get-MsiPropertyValue -Path $env:INSTALLER_PATH -Property 'ProductCode'
+    if ($msiProductCode -match '^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$') {
+        $useRegistryUninstall = $true
+        $registryUninstallProductCode = $msiProductCode.ToUpperInvariant()
+        if (-not $registryUninstallDisplayName) {
+            $registryUninstallDisplayName = $DisplayName
+        }
+        Write-Host "Using MSI database product code for registry identity: $registryUninstallProductCode"
+    } else {
+        throw 'The MSI database did not expose a valid ProductCode; refusing ambiguous detection or removal.'
+    }
 }
 
 if ($useRegistryUninstall) {
@@ -1295,14 +1357,27 @@ if ($useRegistryUninstall) {
         '        }'
         '        if ($selectedApplications.Count -eq 0) {'
         '            $bundleCandidates = @($changedApplications | Where-Object {'
-        '                -not $_.WindowsInstaller -and [string]$_.DisplayName -like "$configuredUninstallDisplayName*"'
+        '                $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+        '                $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+        '                $isVisibleApplication -and -not $_.WindowsInstaller -and [string]$_.DisplayName -like "$configuredUninstallDisplayName*"'
         '            })'
         '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
         '        }'
-        '        if ($selectedApplications.Count -eq 0 -and $originalInstallerType -eq ''burn'') {'
-        '            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
-        '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
-        '        }'
+    )
+
+    # This is a packager-time decision. Do not emit $originalInstallerType into the
+    # generated deployment script: that variable exists only in this generator and
+    # StrictMode would turn the fallback check into a post-install 60001 failure.
+    if ($originalInstallerType -eq 'burn') {
+        $lines += @(
+            '        if ($selectedApplications.Count -eq 0) {'
+            '            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+            '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
+            '        }'
+        )
+    }
+
+    $lines += @(
         '        if ($selectedApplications.Count -eq 0 -and $configuredUninstallProductCode) {'
         '            $configuredMatches = @($postInstallApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
         '            if ($configuredMatches.Count -eq 1) { $selectedApplications = $configuredMatches }'
@@ -1488,7 +1563,11 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
         "    `$allowContainsFallback = '$installerTypeLower' -notin @('msi', 'wix')"
         '    if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey -and -not $configuredProductCode -and $allowContainsFallback) {'
         '        $containsMatches = @(Get-ADTApplication -Name $appName -NameMatch ''Contains'')'
-        '        $bundleMatches = @($containsMatches | Where-Object { -not $_.WindowsInstaller })'
+        '        $bundleMatches = @($containsMatches | Where-Object {'
+        '            $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+        '            $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+        '            $isVisibleApplication -and -not $_.WindowsInstaller'
+        '        })'
         '        if ($bundleMatches.Count -eq 1) {'
         '            $installedApps = $bundleMatches'
         '        } elseif ($containsMatches.Count -eq 1) {'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -275,11 +275,26 @@ describe('PSADT registry uninstall identity contract', () => {
     );
     expect(packager).toContain('-WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru');
     expect(packager).toContain(
-      "$selectedApplications.Count -eq 0 -and $originalInstallerType -eq ''burn''"
-    );
-    expect(packager).toContain(
       '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
     );
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'does not leak generator-only installer type state into generated scripts',
+    () => {
+      const innoGenerated = generateRegistryUninstallPackage('inno');
+      const burnGenerated = generateRegistryUninstallPackage('burn');
+
+      expect(innoGenerated).not.toContain('$originalInstallerType');
+      expect(burnGenerated).not.toContain('$originalInstallerType');
+      expect(burnGenerated).toContain(
+        '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+      );
+    }
+  );
+
+  it('never emits the generator-only installer type variable as a quoted script line', () => {
+    expect(packager).not.toMatch(/^\s*'.*\$originalInstallerType.*'\s*$/m);
   });
 
   it('verifies registry installers by their captured vendor identity', () => {
@@ -399,6 +414,12 @@ describe('PSADT registry uninstall identity contract', () => {
 
   it('uses a captured MSI product code instead of an executable uninstall string', () => {
     expect(packager).toContain(
+      "Get-MsiPropertyValue -Path $env:INSTALLER_PATH -Property 'ProductCode'"
+    );
+    expect(packager).toContain(
+      'Using MSI database product code for registry identity'
+    );
+    expect(packager).toContain(
       '$capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode)'
     );
     expect(packager).not.toContain("$capturedMsiProductCode = if ($registeredInstallerType -in @(''msi'', ''wix'')");
@@ -413,8 +434,40 @@ describe('PSADT registry uninstall identity contract', () => {
     );
   });
 
-  it('rejects missing MSI and unsafe MSIX identities during package creation', () => {
+  it('keeps non-MSI fallback visible, non-WindowsInstaller, and fail-closed', () => {
+    expect(packager).toContain(
+      "$allowContainsFallback = '$installerTypeLower' -notin @('msi', 'wix')"
+    );
+    expect(packager).toContain(
+      "$systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']"
+    );
+    expect(packager).toContain(
+      '$isVisibleApplication -and -not $_.WindowsInstaller'
+    );
+  });
+
+  it('repairs missing MSI identities and rejects unresolved MSI or unsafe MSIX identities', () => {
+    expect(packager).toContain(
+      "$useRegistryUninstall -or $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED'"
+    );
     expect(packager).toContain("$uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED'");
+    expect(packager).toContain(
+      'The MSI database did not expose a valid ProductCode; refusing ambiguous detection or removal.'
+    );
+    const repairIndex = packager.indexOf(
+      "if ($fileExtension -eq '.msi'"
+    );
+    const repairedRegistryBranchIndex = packager.indexOf(
+      'if ($useRegistryUninstall) {',
+      repairIndex
+    );
+    const unresolvedSentinelIndex = packager.indexOf(
+      "elseif (-not $usePortableUninstall -and $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED')",
+      repairedRegistryBranchIndex
+    );
+    expect(repairIndex).toBeGreaterThan(-1);
+    expect(repairedRegistryBranchIndex).toBeGreaterThan(repairIndex);
+    expect(unresolvedSentinelIndex).toBeGreaterThan(repairedRegistryBranchIndex);
     expect(packager).toContain("$msixPackageName -notmatch '^[A-Za-z0-9.-]+$'");
     expect(packager).toContain("$installerTypeLower -in @('msix', 'appx') -and");
     expect(packager).toContain('[string]::IsNullOrWhiteSpace($msixPackageName) -and');


### PR DESCRIPTION
## What changed

- read the authoritative ProductCode directly from downloaded MSI databases
- repair missing/malformed Winget MSI identity metadata without guessing
- fail packaging when an MSI still has no exact ProductCode
- keep MSI/WiX uninstall matching fail-closed
- prevent generator-only `$originalInstallerType` from leaking into generated PSADT scripts
- safely ignore hidden ARP helper entries for non-MSI fallback
- add regression coverage for generated scripts and identity-selection ordering

## Root cause

Figma's MSI installed successfully, but its Winget ProductCode was decorated and discarded. The generated PSADT script then reached a Burn-only fallback containing the generator-local `$originalInstallerType` variable. Under StrictMode this became exit code 60001 before managed detection metadata was written.

## Impact

The shared package generator is used by both customer Intune packages and QA, so the fix applies one-to-one to both paths. Existing successful campaign results remain valid; only the affected failure class needs re-testing.

## Validation

- 65 Vitest files / 797 tests passed
- focused PSADT contract suite: 28/28
- full ESLint passed
- PowerShell parser passed
- read-only Windows Installer COM ProductCode query passed
- Claude Opus narrow re-review: no remaining blocking findings