### PR TITLE
Pin QA profiles to exact MSI identity packager

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -463,7 +463,8 @@ describe('GET /api/cron/qa-enqueue', () => {
         profileCandidate({
           id: 'old-candidate',
           wingetId: 'Example.App',
-          packagerCommit: '1'.repeat(40),
+          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          status: 'failed',
         }),
       ],
     });
@@ -495,6 +496,29 @@ describe('GET /api/cron/qa-enqueue', () => {
       String((candidateInserts[0].test_config as Record<string, unknown>).packageProfileCanonicalJson)
     );
     expect(canonical.toolchain.packagerCommit).toBe(CURRENT_PACKAGER_COMMIT);
+  });
+
+  it('preserves a passing catalog result from an explicitly compatible packager', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'compatible-passed-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          status: 'passed',
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 0, queued: 0, toolchainBackfillCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
   it('does not backfill an app that already has a current catalog profile', async () => {
@@ -563,6 +587,7 @@ describe('GET /api/cron/qa-enqueue', () => {
           wingetId: 'Example.App',
           packagerCommit: CURRENT_PACKAGER_COMMIT,
           toolchainOverrides: { templateSha256: 'B'.repeat(64) },
+          status: 'passed',
         }),
       ],
     });

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -17,6 +17,7 @@ import {
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
 import {
   buildQaPackageIdentity,
+  validateCompatiblePassedCatalogQaProfile,
   validateCurrentQaPackageProfile,
 } from '@/lib/qa/package-profile';
 import {
@@ -113,7 +114,21 @@ async function findToolchainBackfillIds(
         candidateArchitecture: row.architecture,
         candidateInstallerSha256: row.installer_sha256,
       });
-      if (!validation.valid || !hasInteractiveCatalogQaProfile(row.test_config)) {
+      const compatiblePassedValidation = row.status === 'passed'
+        ? validateCompatiblePassedCatalogQaProfile({
+            testConfig: row.test_config,
+            candidatePackageProfileSha256: row.package_profile_sha256,
+            candidateWingetId: row.winget_id,
+            candidateVersion: row.version,
+            candidateArchitecture: row.architecture,
+            candidateInstallerSha256: row.installer_sha256,
+          })
+        : null;
+      const hasCompatiblePassedProfile = compatiblePassedValidation?.valid === true;
+      if (
+        (!validation.valid && !hasCompatiblePassedProfile) ||
+        !hasInteractiveCatalogQaProfile(row.test_config)
+      ) {
         pageStaleRows.push(row);
       }
     }

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,6 +14,20 @@ export const QA_PSADT_TOOLCHAIN = {
 } as const;
 
 /**
+ * Successful catalog runs produced by these packager commits remain valid for
+ * background coverage. Only add a commit when every change after it is limited
+ * to a failure path that a passing package could not have exercised.
+ *
+ * This compatibility is deliberately not used for customer deployment
+ * profiles or queued-candidate dispatch: those continue to require the exact
+ * current package profile.
+ */
+export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
+  QA_PSADT_TOOLCHAIN.packagerCommit,
+  'de49775e759b693b92db09bc99aa116f197c4850',
+] as const;
+
+/**
  * Increment this whenever profile-building semantics change without a corresponding
  * toolchain-pin change (for example, default PSADT settings or detection derivation),
  * and update the protected workflow verifier in the same rollout. Existing candidates
@@ -202,14 +216,19 @@ export function qaSha256(value: string): string {
  * The hash is calculated over the stored canonical string itself; parsing and re-serializing it
  * would make the result dependent on object key order.
  */
-export function validateCurrentQaPackageProfile(input: {
+type QaPackageProfileValidationInput = {
   testConfig: unknown;
   candidatePackageProfileSha256: unknown;
   candidateWingetId: unknown;
   candidateVersion: unknown;
   candidateArchitecture: unknown;
   candidateInstallerSha256: unknown;
-}): QaPackageProfileValidation {
+};
+
+function validateQaPackageProfile(
+  input: QaPackageProfileValidationInput,
+  acceptedPackagerCommits: readonly string[]
+): QaPackageProfileValidation {
   const config = record(input.testConfig);
   if (!config) return { valid: false, reason: 'test-config-invalid' };
   if (config.profileKind !== 'catalog-default' && config.profileKind !== 'deployment-config') {
@@ -254,6 +273,12 @@ export function validateCurrentQaPackageProfile(input: {
   const toolchain = record(profile.toolchain);
   if (!toolchain) return { valid: false, reason: 'toolchain-missing' };
   for (const [field, expected] of Object.entries(QA_PSADT_TOOLCHAIN)) {
+    if (field === 'packagerCommit') {
+      if (!acceptedPackagerCommits.includes(textValue(toolchain[field]))) {
+        return { valid: false, reason: `toolchain-mismatch:${field}` };
+      }
+      continue;
+    }
     if (toolchain[field] !== expected) {
       return { valid: false, reason: `toolchain-mismatch:${field}` };
     }
@@ -320,6 +345,18 @@ export function validateCurrentQaPackageProfile(input: {
     canonicalJson,
     packageProfileSha256: calculatedSha256,
   };
+}
+
+export function validateCurrentQaPackageProfile(
+  input: QaPackageProfileValidationInput
+): QaPackageProfileValidation {
+  return validateQaPackageProfile(input, [QA_PSADT_TOOLCHAIN.packagerCommit]);
+}
+
+export function validateCompatiblePassedCatalogQaProfile(
+  input: QaPackageProfileValidationInput
+): QaPackageProfileValidation {
+  return validateQaPackageProfile(input, QA_COMPATIBLE_PASSED_PACKAGER_COMMITS);
 }
 
 export function normalizeQaPsadtConfig(

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+  packagerCommit: 'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Updates the canonical QA package profile to IntuneGet packager commit `c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33`.

This makes new customer-requested and retry profiles match the corrected customer/QA PSADT package bytes while preserving already successful campaign results.

Validation: package-profile tests passed (34/34); commit hook full ESLint passed.