### PR TITLE
Pin MSI COM output packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
+  packagerCommit: '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -24,6 +24,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
   'de49775e759b693b92db09bc99aa116f197c4850',
 ] as const;
 


### PR DESCRIPTION
Advances the protected QA/customer package profile to the merged MSI COM-output fix (99edd0a9f4b7e10d4cc4272f90d763f3bd681440). Existing compatible passes from c603 and de497 remain checkpointed.\n\nValidation: 57 focused tests passed; ESLint passed.