### PR TITLE
Retry only QA failures targeted by packager fixes

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -456,13 +456,13 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(pollRunUpdates[0]).toMatchObject({ status: 'failed', error_count: 1 });
   });
 
-  it('queues a catalog app when its most recent QA profile used an older packager', async () => {
+  it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
-      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      supportedApps: [{ winget_id: 'Figma.Figma', name: 'Figma', publisher: 'Figma' }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Example.App',
+          wingetId: 'Figma.Figma',
           packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
           status: 'failed',
         }),
@@ -484,7 +484,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Example.App',
+      winget_id: 'Figma.Figma',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
@@ -496,6 +496,29 @@ describe('GET /api/cron/qa-enqueue', () => {
       String((candidateInserts[0].test_config as Record<string, unknown>).packageProfileCanonicalJson)
     );
     expect(canonical.toolchain.packagerCommit).toBe(CURRENT_PACKAGER_COMMIT);
+  });
+
+  it('preserves an unrelated terminal failure across a packager release', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
+      candidates: [
+        profileCandidate({
+          id: 'unrelated-failed-candidate',
+          wingetId: 'Example.App',
+          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          status: 'failed',
+        }),
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 0, queued: 0, toolchainBackfillCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
   it('preserves a passing catalog result from an explicitly compatible packager', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -16,12 +16,14 @@ import {
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
 import {
+  QA_PSADT_TOOLCHAIN,
   buildQaPackageIdentity,
   validateCompatiblePassedCatalogQaProfile,
   validateCurrentQaPackageProfile,
 } from '@/lib/qa/package-profile';
 import {
   prioritizeToolchainBackfill,
+  shouldRetryTerminalToolchainCandidate,
   type QaToolchainBackfillCandidate,
 } from '@/lib/qa/toolchain-backfill';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
@@ -125,6 +127,14 @@ async function findToolchainBackfillIds(
           })
         : null;
       const hasCompatiblePassedProfile = compatiblePassedValidation?.valid === true;
+      if (
+        !shouldRetryTerminalToolchainCandidate(QA_PSADT_TOOLCHAIN.packagerCommit, {
+          wingetId: row.winget_id,
+          status: row.status,
+        })
+      ) {
+        continue;
+      }
       if (
         (!validation.valid && !hasCompatiblePassedProfile) ||
         !hasInteractiveCatalogQaProfile(row.test_config)

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -5,6 +5,24 @@ export interface QaToolchainBackfillCandidate {
   enqueuedAt: string;
 }
 
+// A packager release should not automatically re-run every known vendor or
+// application failure. Record only the apps whose previously failing path is
+// changed by the current packager release. Successful and never-tested apps
+// continue through the normal compatibility/backfill logic.
+const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '99edd0a9f4b7e10d4cc4272f90d763f3bd681440': ['Figma.Figma'],
+};
+
+export function shouldRetryTerminalToolchainCandidate(
+  packagerCommit: string,
+  candidate: Pick<QaToolchainBackfillCandidate, 'wingetId' | 'status'>
+): boolean {
+  if (!['failed', 'error'].includes(candidate.status)) return true;
+  return (TOOLCHAIN_TERMINAL_RETRY_TARGETS[packagerCommit] || []).includes(
+    candidate.wingetId
+  );
+}
+
 function timestamp(value: string): number {
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : 0;


### PR DESCRIPTION
Prevents unrelated packager releases from restarting every known failed/error QA app. Terminal failures remain durable checkpoints and are re-run only when the current packager release explicitly targets that app. The 99edd MSI COM-output fix targets Figma.Figma; Adobe Creative Cloud and Elgato remain terminal until a relevant safe fix exists.\n\nValidation: 65 test files / 799 tests passed; ESLint passed.