### PR TITLE
Validate installer contracts before QA

### DIFF
--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -15,6 +15,7 @@ import {
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
+import { evaluatePackagingContract } from '@/lib/packaging-contract';
 import {
   QA_PSADT_TOOLCHAIN,
   buildQaPackageIdentity,
@@ -568,6 +569,13 @@ export async function GET(request: Request) {
               psadtConfig: testConfig.psadtConfig,
               detectionRules: testConfig.detectionRules,
             });
+            const packagingContract = evaluatePackagingContract({
+              wingetId: app.winget_id,
+              installerType: sourceInstallerType,
+              silentArgs: testConfig.silentArgs,
+              nestedInstallerType: testConfig.nestedInstallerType,
+              nestedInstallerFiles: testConfig.nestedInstallerFiles,
+            });
             testConfig.packageProfileCanonicalJson = packageIdentity.canonicalJson;
             testConfig.packageProfileSha256 = packageIdentity.packageProfileSha256;
             testConfig.psadtConfigSha256 = packageIdentity.psadtConfigSha256;
@@ -583,11 +591,13 @@ export async function GET(request: Request) {
                   packageIdentity.packageProfileSha256
             );
             const now = new Date().toISOString();
-            const initialStatus = previousMatches
-              ? previous?.outcome === 'Passed'
-                ? 'passed'
-                : 'failed'
-              : 'queued';
+            const initialStatus = !packagingContract.valid
+              ? 'failed'
+              : previousMatches
+                ? previous?.outcome === 'Passed'
+                  ? 'passed'
+                  : 'failed'
+                : 'queued';
             const { data: inserted, error: insertError } = await supabase!
               .from('qa_candidates')
               .insert({
@@ -608,7 +618,14 @@ export async function GET(request: Request) {
                 demand_source: policies.some((policy) => policy.winget_id === app.winget_id)
                   ? 'auto_update'
                   : 'managed',
-                finished_at: initialStatus === 'queued' ? null : previous?.tested_at_utc || now,
+                failure_summary: !packagingContract.valid
+                  ? `Packaging preflight: ${packagingContract.message}`
+                  : null,
+                finished_at: initialStatus === 'queued'
+                  ? null
+                  : !packagingContract.valid
+                    ? now
+                    : previous?.tested_at_utc || now,
                 updated_at: now,
               })
               .select('id')

--- a/lib/msp/silent-switches.test.ts
+++ b/lib/msp/silent-switches.test.ts
@@ -26,6 +26,20 @@ describe('extractSilentSwitches', () => {
     )).toBe('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-');
   });
 
+  it('keeps positional operands required by vendor switches', () => {
+    expect(extractSilentSwitches(
+      '"setup.exe" /configure https://aka.ms/fhlwingetconfig',
+      'exe'
+    )).toBe('/configure https://aka.ms/fhlwingetconfig');
+  });
+
+  it('keeps MSI properties after removing the install action target', () => {
+    expect(extractSilentSwitches(
+      'msiexec.exe /i "agent.msi" /qn REBOOT=ReallySuppress ALLUSERS=1',
+      'msi'
+    )).toBe('/qn REBOOT=ReallySuppress ALLUSERS=1');
+  });
+
   it('fails closed for an archive with no nested installer type', () => {
     expect(extractSilentSwitches(
       'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -47,10 +47,15 @@ export function extractSilentSwitches(
     .replace(/\/[ixp]\s+\S+\.(msi|msp)\s*/gi, '') // /i filename.msi
     .replace(/\/[ixp]\s+/gi, ''); // /i alone (leftover)
 
-  // Extract switches from remaining string (starts with / or -)
-  const switchMatch = cleaned.match(/(?:\/\S+|-{1,2}\S+)(?:\s+(?:\/\S+|-{1,2}\S+))*/);
-  if (switchMatch && switchMatch[0] !== '-DeploymentType') {
-    return switchMatch[0];
+  // Preserve the complete vendor argument tail, including positional operands.
+  // Commands such as Office Deployment Tool's
+  //   /configure https://aka.ms/fhlwingetconfig
+  // are incomplete (and silently do nothing) if we retain only slash-prefixed
+  // tokens. The executable token and MSI action target were removed above, so
+  // everything remaining belongs to the vendor's install contract.
+  cleaned = cleaned.trim();
+  if (/^(?:\/\S+|-{1,2}\S+)/.test(cleaned) && cleaned !== '-DeploymentType') {
+    return cleaned;
   }
 
   return defaultSwitches[effectiveType] ?? (sourceType === 'zip' ? '' : '/S');

--- a/lib/packaging-contract.test.ts
+++ b/lib/packaging-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePackagingContract } from './packaging-contract';
+
+describe('evaluatePackagingContract', () => {
+  it('recognizes complete Office Deployment Tool configuration arguments', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Microsoft.Office',
+      installerType: 'exe',
+      silentArgs: '/configure https://aka.ms/fhlwingetconfig',
+    })).toEqual({
+      valid: true,
+      family: 'vendor-bootstrapper',
+      dependencyMode: 'remote-configuration',
+    });
+  });
+
+  it('rejects Office when the configuration operand was discarded', () => {
+    const result = evaluatePackagingContract({
+      wingetId: 'Microsoft.Office',
+      installerType: 'exe',
+      silentArgs: '/configure',
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe('required-argument-missing');
+  });
+
+  it('rejects an archive without an explicit nested installer contract', () => {
+    const result = evaluatePackagingContract({
+      wingetId: 'Contoso.Archive',
+      installerType: 'zip',
+      silentArgs: '/S',
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe('archive-contract-incomplete');
+  });
+
+  it('accepts a typed archive with a nested installer path', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Contoso.Archive',
+      installerType: 'zip',
+      silentArgs: '/S',
+      nestedInstallerType: 'nullsoft',
+      nestedInstallerFiles: ['setup.exe'],
+    }).valid).toBe(true);
+  });
+
+  it('rejects installer types without an adapter', () => {
+    const result = evaluatePackagingContract({
+      wingetId: 'Contoso.Unknown',
+      installerType: 'script',
+      silentArgs: '--silent',
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe('unsupported-installer-type');
+  });
+});

--- a/lib/packaging-contract.ts
+++ b/lib/packaging-contract.ts
@@ -1,0 +1,165 @@
+export type InstallerContractFamily =
+  | 'msi'
+  | 'msix'
+  | 'portable'
+  | 'archive'
+  | 'standard-exe'
+  | 'vendor-bootstrapper';
+
+export type PackagingContractResult =
+  | {
+      valid: true;
+      family: InstallerContractFamily;
+      dependencyMode: 'self-contained' | 'remote-configuration';
+    }
+  | {
+      valid: false;
+      family: InstallerContractFamily;
+      code:
+        | 'unsupported-installer-type'
+        | 'archive-contract-incomplete'
+        | 'required-argument-missing'
+        | 'unsafe-argument-syntax';
+      message: string;
+    };
+
+export interface PackagingContractInput {
+  wingetId: string;
+  installerType: string;
+  silentArgs: string;
+  nestedInstallerType?: string;
+  nestedInstallerFiles?: readonly string[];
+}
+
+const KNOWN_TYPES = new Set([
+  'appx',
+  'burn',
+  'exe',
+  'inno',
+  'msi',
+  'msix',
+  'nullsoft',
+  'portable',
+  'wix',
+  'zip',
+]);
+
+const VENDOR_BOOTSTRAPPERS = new Set([
+  'microsoft.office',
+  'microsoft.visualstudio.2022.community',
+  'microsoft.visualstudio.2022.enterprise',
+  'microsoft.visualstudio.2022.professional',
+  'microsoft.visualstudio.community',
+  'microsoft.visualstudio.enterprise',
+  'microsoft.visualstudio.professional',
+]);
+
+function familyFor(input: PackagingContractInput): InstallerContractFamily {
+  const type = input.installerType.trim().toLowerCase();
+  if (type === 'msi' || type === 'wix') return 'msi';
+  if (type === 'msix' || type === 'appx') return 'msix';
+  if (type === 'portable') return 'portable';
+  if (type === 'zip') return 'archive';
+  if (VENDOR_BOOTSTRAPPERS.has(input.wingetId.trim().toLowerCase())) {
+    return 'vendor-bootstrapper';
+  }
+  return 'standard-exe';
+}
+
+/**
+ * Validate the semantic installer contract before a package consumes VM time.
+ *
+ * PSADT can reliably execute a complete vendor command, but it cannot invent a
+ * missing operand (for example Office Deployment Tool's configuration XML) or
+ * infer an archive's nested installer. This gate deliberately fails closed for
+ * those incomplete shapes while allowing vendor-specific arguments to remain
+ * intact.
+ */
+export function evaluatePackagingContract(
+  input: PackagingContractInput
+): PackagingContractResult {
+  const type = input.installerType.trim().toLowerCase();
+  const family = familyFor(input);
+  const args = input.silentArgs.trim();
+
+  if (!KNOWN_TYPES.has(type)) {
+    return {
+      valid: false,
+      family,
+      code: 'unsupported-installer-type',
+      message: `Installer type [${input.installerType || 'unknown'}] does not have a tested packaging adapter.`,
+    };
+  }
+
+  if (/\0|[\r\n]/.test(args)) {
+    return {
+      valid: false,
+      family,
+      code: 'unsafe-argument-syntax',
+      message: 'Installer arguments contain a null byte or line break.',
+    };
+  }
+
+  if (family === 'archive') {
+    const nestedType = input.nestedInstallerType?.trim().toLowerCase() || '';
+    const nestedFiles = (input.nestedInstallerFiles || []).filter((value) => value.trim());
+    if (!nestedType || nestedFiles.length === 0) {
+      return {
+        valid: false,
+        family,
+        code: 'archive-contract-incomplete',
+        message: 'Archive package is missing its nested installer type or path.',
+      };
+    }
+  }
+
+  // These switches are commands that require a following file/URL operand.
+  // A terminal match means an upstream parser discarded part of the vendor
+  // command; running it would at best be a silent no-op.
+  if (/(?:^|\s)(?:\/configure|\/config|--config|-config|\/loadinf|\/apply|\/unattend(?:ed)?)(?:\s*)$/i.test(args)) {
+    return {
+      valid: false,
+      family,
+      code: 'required-argument-missing',
+      message: 'A vendor configuration switch is missing its required file or URL operand.',
+    };
+  }
+
+  if (input.wingetId.trim().toLowerCase() === 'microsoft.office') {
+    const officeConfiguration = args.match(/(?:^|\s)\/configure\s+("[^"]+"|'[^']+'|\S+)/i)?.[1];
+    if (!officeConfiguration) {
+      return {
+        valid: false,
+        family,
+        code: 'required-argument-missing',
+        message: 'Microsoft Office requires an Office Deployment Tool configuration file or URL.',
+      };
+    }
+    return {
+      valid: true,
+      family,
+      dependencyMode: /^['"]?https:\/\//i.test(officeConfiguration)
+        ? 'remote-configuration'
+        : 'self-contained',
+    };
+  }
+
+  return { valid: true, family, dependencyMode: 'self-contained' };
+}
+
+export class PackagingContractError extends Error {
+  readonly code: Exclude<PackagingContractResult, { valid: true }>['code'];
+  readonly family: InstallerContractFamily;
+
+  constructor(result: Exclude<PackagingContractResult, { valid: true }>) {
+    super(result.message);
+    this.name = 'PackagingContractError';
+    this.code = result.code;
+    this.family = result.family;
+  }
+}
+
+export function assertPackagingContract(input: PackagingContractInput): void {
+  const result = evaluatePackagingContract(input);
+  if (!result.valid) throw new PackagingContractError(result);
+}

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
+import { assertPackagingContract } from '@/lib/packaging-contract';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
@@ -449,6 +450,13 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
   psadtConfigJson: string;
   identity: QaPackageIdentity;
 } {
+  assertPackagingContract({
+    wingetId: input.wingetId,
+    installerType: input.installerType,
+    silentArgs: input.silentSwitches,
+    nestedInstallerType: input.nestedInstallerType,
+    nestedInstallerFiles: input.nestedInstallerPath ? [input.nestedInstallerPath] : [],
+  });
   const parsedDetectionRulesValue = parseJsonObject<unknown>(input.detectionRules, []);
   const parsedDetectionRules = Array.isArray(parsedDetectionRulesValue)
     ? (parsedDetectionRulesValue as DetectionRule[])


### PR DESCRIPTION
## Summary
- classify installer contracts before VM execution
- preserve required positional operands in vendor commands
- enforce the same semantic preflight for customer uploads, auto-updates, and catalog QA
- fail incomplete archive/bootstrapper contracts without consuming runner time

## Verification
- full suite: 805 relevant tests passed; unrelated translation timeout passed on isolated retry
- focused shared-flow tests: 50 passed
- ESLint passed
- Next.js production build passed