### PR TITLE
Preserve manifest-declared installer success codes

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -23,6 +23,23 @@
 $JobId = $env:INPUT_JOB_ID
 $CallbackUrl = $env:INPUT_CALLBACK_URL
 $SilentSwitches = $env:INPUT_SILENT_SWITCHES
+$InstallerSuccessCodes = @()
+if (-not [string]::IsNullOrWhiteSpace($env:INPUT_INSTALLER_SUCCESS_CODES)) {
+    try {
+        $InstallerSuccessCodes = @($env:INPUT_INSTALLER_SUCCESS_CODES | ConvertFrom-Json -ErrorAction Stop)
+    }
+    catch {
+        throw 'INPUT_INSTALLER_SUCCESS_CODES must be a JSON array of integer exit codes.'
+    }
+}
+$InstallerSuccessCodes = @($InstallerSuccessCodes | ForEach-Object {
+    $parsedCode = 0
+    if (-not [int]::TryParse([string]$_, [ref]$parsedCode) -or $parsedCode -lt 0 -or $parsedCode -gt 65535) {
+        throw "Invalid installer success exit code: $_"
+    }
+    $parsedCode
+} | Sort-Object -Unique)
+$appSuccessExitCodesLiteral = (@(0) + $InstallerSuccessCodes | Sort-Object -Unique) -join ', '
 $UninstallCommand = $env:INPUT_UNINSTALL_COMMAND
 $DisplayName = $env:INPUT_DISPLAY_NAME
 $Publisher = $env:INPUT_PUBLISHER
@@ -962,7 +979,7 @@ $lines = @(
     '    AppArch = '''''
     '    AppLang = ''EN'''
     '    AppRevision = ''01'''
-    '    AppSuccessExitCodes = @(0)'
+    "    AppSuccessExitCodes = @($appSuccessExitCodesLiteral)"
     '    AppRebootExitCodes = @(1641, 3010)'
     '    AppScriptVersion = ''1.0.0'''
     '    AppScriptDate = (Get-Date -Format ''yyyy-MM-dd'')'

--- a/.github/scripts/update_app_info.py
+++ b/.github/scripts/update_app_info.py
@@ -281,6 +281,7 @@ def save_app_info(app_id, app_name, installer_data, architecture):
         "Scope": installer_data.get('Scope'),
         "InstallModes": installer_data.get('InstallModes', []),
         "InstallerSwitches": installer_data.get('InstallerSwitches', {}),
+        "InstallerSuccessCodes": installer_data.get('InstallerSuccessCodes', []),
         "InstallerUrl": installer.get('InstallerUrl'),
         "InstallerSha256": installer.get('InstallerSha256'),
         "Architecture": architecture

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -397,6 +397,8 @@ jobs:
                       ...(rootSwitches || {}),
                       ...(inst.InstallerSwitches || {}),
                     } : undefined,
+                    InstallerSuccessCodes:
+                      inst.InstallerSuccessCodes || installerManifest.InstallerSuccessCodes,
                     ProductCode: inst.ProductCode || installerManifest.ProductCode,
                     PackageFamilyName: inst.PackageFamilyName || installerManifest.PackageFamilyName,
                     AppsAndFeaturesEntries: inst.AppsAndFeaturesEntries || installerManifest.AppsAndFeaturesEntries,

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -562,6 +562,7 @@ export async function GET(request: Request) {
               installerSha256,
               sourceInstallerType: testConfig.sourceInstallerType,
               silentArgs: testConfig.silentArgs,
+              successCodes: testConfig.successCodes,
               uninstallCommand: testConfig.uninstallCommand,
               installScope: testConfig.scope,
               nestedInstallerType: testConfig.nestedInstallerType,

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -68,6 +68,7 @@ export async function GET(request: Request) {
           installerType,
           item.nestedInstallerType
         ),
+        installerSuccessCodes: item.installerSuccessCodes,
         uninstallCommand: job.uninstall_command || item.uninstallCommand,
         installScope: job.install_scope || item.installScope,
         psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,
@@ -186,6 +187,7 @@ export async function GET(request: Request) {
           job.installer_type || item.installerType,
           item.nestedInstallerType
         ),
+        installerSuccessCodes: item.installerSuccessCodes,
         uninstallCommand: job.uninstall_command || item.uninstallCommand,
         callbackUrl,
         psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -415,6 +415,7 @@ export async function POST(request: NextRequest) {
                     item.installerType,
                     item.nestedInstallerType
                   ),
+                  installerSuccessCodes: item.installerSuccessCodes,
                   uninstallCommand: item.uninstallCommand,
                   installScope: item.installScope,
                   psadtConfig: JSON.stringify(item.psadtConfig),
@@ -545,6 +546,7 @@ export async function POST(request: NextRequest) {
                 item.installerType,
                 item.nestedInstallerType
               ),
+              installerSuccessCodes: item.installerSuccessCodes,
               uninstallCommand: item.uninstallCommand,
               callbackUrl,
               psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -430,6 +430,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
           installerType: selectedInstaller!.type,
           installerUrl: selectedInstaller!.url,
           installerSha256: selectedInstaller!.sha256,
+          installerSuccessCodes: selectedInstaller!.installerSuccessCodes,
           nestedInstallerType: selectedInstaller!.nestedInstallerType,
           nestedInstallerPath: selectedInstaller!.nestedInstallerPath,
           manifestDependencies: selectedInstaller!.packageDependencies,

--- a/components/PackageDetails.tsx
+++ b/components/PackageDetails.tsx
@@ -116,6 +116,7 @@ export function PackageDetails({ package: pkg, onClose }: PackageDetailsProps) {
       installerType: selectedInstaller.type,
       installerUrl: selectedInstaller.url,
       installerSha256: selectedInstaller.sha256,
+      installerSuccessCodes: selectedInstaller.installerSuccessCodes,
       nestedInstallerType: selectedInstaller.nestedInstallerType,
       nestedInstallerPath: selectedInstaller.nestedInstallerPath,
       manifestDependencies: selectedInstaller.packageDependencies,

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -584,6 +584,20 @@ describe('normalizeManifestInstallers', () => {
     );
   });
 
+  it('preserves manifest-declared installer success codes', () => {
+    const [installer] = normalizeManifestInstallers({
+      InstallerType: 'exe',
+      InstallerSuccessCodes: [1168, 1168, '3010'],
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/installer.exe',
+        InstallerSha256: 'abc123',
+      }],
+    });
+    expect(installer.InstallerSuccessCodes).toEqual([1168, 3010]);
+    expect(normalizeInstaller(installer).installerSuccessCodes).toEqual([1168, 3010]);
+  });
+
   it('normalizes installer and root AppsAndFeatures product identities', () => {
     const installerIdentity = normalizeManifestInstallers({
       InstallerType: 'exe',

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -47,6 +47,7 @@ interface UpdateInfo {
   installerType: string;
   installCommand?: string;
   silentSwitches?: string;
+  installerSuccessCodes?: number[];
   installScope?: WingetScope;
   nestedInstallerType?: string;
   nestedInstallerPath?: string;
@@ -230,6 +231,7 @@ export class AutoUpdateTrigger {
               sourceInstallerType,
               updateInfo.nestedInstallerType
             ),
+        installerSuccessCodes: updateInfo.installerSuccessCodes,
         uninstallCommand: deploymentConfig.uninstallCommand || '',
         installScope: updateInfo.installScope ||
           (deploymentConfig.installScope === 'user' ? 'user' : 'machine'),
@@ -626,6 +628,7 @@ export class AutoUpdateTrigger {
         psadtConfig: config.psadtConfig,
         nestedInstallerType: updateInfo.nestedInstallerType,
         nestedInstallerPath: updateInfo.nestedInstallerPath,
+        installerSuccessCodes: updateInfo.installerSuccessCodes,
         forceCreate: config.forceCreateNewApp !== false,
         sourceIntuneAppId,
         autoSupersede,
@@ -897,6 +900,7 @@ export async function getLatestInstallerInfo(
     installerType: installerType || 'exe',
     installCommand: buildCurrentVersionInstallCommand(normalizedInstaller),
     silentSwitches: normalizedInstaller.silentArgs,
+    installerSuccessCodes: normalizedInstaller.installerSuccessCodes,
     installScope: normalizedInstaller.scope,
     nestedInstallerType,
     nestedInstallerPath,

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -27,6 +27,7 @@ export interface WorkflowInputs {
   nestedInstallerType?: string; // Nested installer type for zip installers
   nestedInstallerPath?: string; // Relative path to the nested installer inside the zip
   silentSwitches: string;
+  installerSuccessCodes?: number[];
   uninstallCommand: string;
   callbackUrl: string;
   psadtConfig?: string; // JSON-serialized PSADTConfig
@@ -186,6 +187,7 @@ export async function triggerPackagingWorkflow(
           nestedInstallerType: inputs.nestedInstallerType || '',
           nestedInstallerPath: inputs.nestedInstallerPath || '',
           silentSwitches: inputs.silentSwitches,
+          successCodes: JSON.stringify(inputs.installerSuccessCodes || []),
           uninstallCommand: inputs.uninstallCommand,
         },
         config: {

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -444,6 +444,7 @@ function coerceInstallersArray(
       defaultSilentArgs ? { Silent: defaultSilentArgs } : undefined,
       inst.InstallerSwitches
     ),
+    InstallerSuccessCodes: normalizeInstallerSuccessCodes(inst.InstallerSuccessCodes),
     ProductCode: explicitProductCode
       ? normalizeProductCode(explicitProductCode)
       : appsAndFeaturesProductCode(inst.AppsAndFeaturesEntries),
@@ -592,6 +593,7 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     normalizeProductCode(manifest.ProductCode) ||
     appsAndFeaturesProductCode(manifest.AppsAndFeaturesEntries);
   const defaultPackageFamilyName = manifest.PackageFamilyName as string;
+  const defaultSuccessCodes = normalizeInstallerSuccessCodes(manifest.InstallerSuccessCodes);
 
   return rawInstallers.map((installer) => {
     const explicitInstallerProductCode = typeof installer.ProductCode === 'string'
@@ -618,6 +620,8 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     // WinGet inherits installer switches per field. An installer-level Custom
     // value must not discard a root-level Silent value (Vivaldi is one example).
     InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
+    InstallerSuccessCodes:
+      normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) || defaultSuccessCodes,
     // A non-empty installer-level ProductCode is authoritative. If it is an
     // Inno/EXE registry key rather than a canonical GUID, do not replace it
     // with an unrelated inherited identity; name-based discovery is safer.
@@ -633,6 +637,14 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
                   defaultDependencies,
     });
   });
+}
+
+function normalizeInstallerSuccessCodes(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const codes = Array.from(new Set(value
+    .map((code) => typeof code === 'number' ? code : Number(code))
+    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)));
+  return codes.length > 0 ? codes : undefined;
 }
 
 /**
@@ -747,6 +759,9 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     nestedInstallerPath: installer.NestedInstallerFiles?.[0]?.RelativeFilePath,
     scope: installer.Scope,
     silentArgs,
+    ...(normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes)
+      ? { installerSuccessCodes: normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) }
+      : {}),
     productCode: normalizeProductCode(installer.ProductCode),
     packageFamilyName: installer.PackageFamilyName,
     packageDependencies: packageDependencies.length > 0 ? packageDependencies : undefined,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -124,6 +124,14 @@ describe('PSADT QA package identity', () => {
     ).not.toBe(buildQaPackageIdentity(input).packageProfileSha256);
   });
 
+  it('hashes manifest-declared success exit codes without changing empty profiles', () => {
+    const baseline = buildQaPackageIdentity(input);
+    const withSuccessCode = buildQaPackageIdentity({ ...input, successCodes: [1168] });
+    expect(withSuccessCode.packageProfileSha256).not.toBe(baseline.packageProfileSha256);
+    expect(withSuccessCode.profile.installer).toMatchObject({ successCodes: [1168] });
+    expect(buildQaPackageIdentity({ ...input, successCodes: [] })).toEqual(baseline);
+  });
+
   it('reconciles an IntuneGet marker with the current workflow scope and version', () => {
     const workflowInput = {
       wingetId: 'Asana.Asana',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -47,6 +47,7 @@ export interface QaPackageProfileInput {
   installerSha256: string;
   sourceInstallerType: string;
   silentArgs: string;
+  successCodes?: readonly number[];
   uninstallCommand: string;
   installScope: string;
   nestedInstallerType: string;
@@ -156,6 +157,7 @@ export interface QaWorkflowPackageInput {
   nestedInstallerType?: string;
   nestedInstallerPath?: string;
   silentSwitches: string;
+  installerSuccessCodes?: number[];
   uninstallCommand: string;
   installScope?: string;
   psadtConfig?: string;
@@ -411,6 +413,9 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
       sha256: input.installerSha256.toUpperCase(),
       sourceType: input.sourceInstallerType.toLowerCase(),
       silentArgs: input.silentArgs,
+      ...(normalizeSuccessCodes(input.successCodes).length > 0
+        ? { successCodes: normalizeSuccessCodes(input.successCodes) }
+        : {}),
       uninstallCommand: input.uninstallCommand,
       installScope: input.installScope || 'machine',
       nestedInstallerType: input.nestedInstallerType.toLowerCase(),
@@ -441,6 +446,13 @@ function parseJsonObject<T>(value: string | undefined, fallback: T): T {
   } catch {
     return fallback;
   }
+}
+
+function normalizeSuccessCodes(value: readonly number[] | undefined): number[] {
+  return Array.from(new Set((value || [])
+    .map((code) => Number(code))
+    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)))
+    .sort((left, right) => left - right);
 }
 
 export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): {
@@ -482,6 +494,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     installerSha256: input.installerSha256,
     sourceInstallerType: input.installerType,
     silentArgs: input.silentSwitches,
+    successCodes: input.installerSuccessCodes,
     uninstallCommand: input.uninstallCommand,
     installScope: input.installScope || 'machine',
     nestedInstallerType: input.nestedInstallerType || '',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -30,7 +30,8 @@ const canRunWindowsPowerShellPackager =
 
 function generateRegistryUninstallPackage(
   installerType: 'inno' | 'burn',
-  displayName = 'Contract Test App'
+  displayName = 'Contract Test App',
+  installerSuccessCodes: number[] = []
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -67,6 +68,7 @@ function generateRegistryUninstallPackage(
         INPUT_INSTALLER_TYPE: installerType,
         INPUT_INSTALL_SCOPE: 'machine',
         INPUT_SILENT_SWITCHES: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+        INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
         INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${displayName}`,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
@@ -136,6 +138,16 @@ describe('PSADT Inno packaging contract', () => {
 });
 
 describe('PSADT vendor argument contract', () => {
+  it('honors additional success exit codes declared by the WinGet manifest', () => {
+    if (!canRunWindowsPowerShellPackager) return;
+    const generated = generateRegistryUninstallPackage(
+      'inno',
+      'Exit Code Contract App',
+      [1168]
+    );
+    expect(generated).toContain('AppSuccessExitCodes = @(0, 1168)');
+  });
+
   it('does not rewrite dollar signs or backticks in generic silent switches', () => {
     expect(packager).toContain('$silentSwitchesEscaped = $SilentSwitches -replace "\'", "\'\'"');
     const assignment = packager.match(/^\$silentSwitchesEscaped\s*=.*$/m)?.[0] ?? '';

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -187,6 +187,20 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('inherits installer success codes from the manifest contract', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'HP.ImageAssistant',
+        name: 'HP Image Assistant',
+        publisher: 'HP',
+        version: '5.3.6',
+      },
+      manifest: { InstallerType: 'exe', InstallerSuccessCodes: [1168] },
+      installer: { Architecture: 'x64', InstallerType: 'exe' },
+    });
+    expect(config.successCodes).toEqual([1168]);
+  });
+
   it('uses an EXE AppsAndFeatures product code as the exact uninstall identity', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -17,6 +17,7 @@ export interface QaCatalogTestConfig {
   publisher: string;
   sourceInstallerType: string;
   silentArgs: string;
+  successCodes: number[];
   productCode: string;
   scope: string;
   nestedInstallerType: string;
@@ -134,6 +135,9 @@ export function buildQaCatalogTestConfig({
     })),
     Scope: scope,
     InstallerSwitches: normalizeInstallerSwitches(effectiveSwitches),
+    InstallerSuccessCodes: normalizeSuccessCodes(
+      installer.InstallerSuccessCodes ?? manifest.InstallerSuccessCodes
+    ),
     ProductCode: productCode || undefined,
     PackageFamilyName: packageFamilyName || undefined,
   };
@@ -165,6 +169,7 @@ export function buildQaCatalogTestConfig({
     publisher: app.publisher,
     sourceInstallerType,
     silentArgs: normalizedInstaller.silentArgs || '',
+    successCodes: normalizedInstaller.installerSuccessCodes || [],
     productCode,
     scope,
     nestedInstallerType: nestedInstallerType || '',
@@ -174,6 +179,14 @@ export function buildQaCatalogTestConfig({
     detectionRules,
     profileKind: 'catalog-default',
   };
+}
+
+function normalizeSuccessCodes(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const codes = Array.from(new Set(value
+    .map((code) => typeof code === 'number' ? code : Number(code))
+    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)));
+  return codes.length > 0 ? codes : undefined;
 }
 
 function isRecord(value: unknown): value is ManifestRecord {

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -411,6 +411,7 @@ export class JobProcessor {
    */
   private generateDeployScript(job: PackagingJob, installerFileName: string): string {
     const silentSwitches = this.extractSilentSwitches(job.install_command, job.installer_type).replace(/'/g, "''");
+    const successExitCodes = this.getInstallerSuccessCodes(job);
     const psadtVersion = '4.1.8';
     const appVendor = job.publisher.replace(/'/g, "''");
     const appName = job.display_name.replace(/'/g, "''");
@@ -456,7 +457,7 @@ $adtSession = @{
     AppArch = '${appArch}'
     AppLang = 'EN'
     AppRevision = '01'
-    AppSuccessExitCodes = @(0)
+    AppSuccessExitCodes = @(${successExitCodes.join(', ')})
     AppRebootExitCodes = @(1641, 3010)
     AppScriptVersion = '1.0.0'
     AppScriptDate = (Get-Date -Format 'yyyy-MM-dd')
@@ -1462,13 +1463,29 @@ ${capturedIdentityValues}
       msix: '',
     };
 
-    // Try to extract switches from the install command
-    const switchMatch = installCommand.match(/(?:\/\S+|-\S+)(?:\s+(?:\/\S+|-\S+))*/);
-    if (switchMatch && switchMatch[0] !== '-DeploymentType') {
-      return switchMatch[0];
+    const cleaned = installCommand
+      .replace(/^"[^"]+"\s*/, '')
+      .replace(/^\S+\.(exe|msi|msix|appx)\s*/i, '')
+      .replace(/\/[ixp]\s+"[^"]+"\s*/gi, '')
+      .replace(/\/[ixp]\s+\{[^}]+\}\s*/gi, '')
+      .replace(/\/[ixp]\s+\S+\.(msi|msp)\s*/gi, '')
+      .trim();
+    if (/^(?:\/\S+|-{1,2}\S+)/.test(cleaned) && cleaned !== '-DeploymentType') {
+      return cleaned;
     }
 
     return defaultSwitches[installerType] || '/S';
+  }
+
+  private getInstallerSuccessCodes(job: PackagingJob): number[] {
+    const config = job.package_config && typeof job.package_config === 'object' && !Array.isArray(job.package_config)
+      ? job.package_config as Record<string, unknown>
+      : {};
+    const raw = Array.isArray(config.installerSuccessCodes) ? config.installerSuccessCodes : [];
+    return Array.from(new Set([0, ...raw
+      .map((code) => typeof code === 'number' ? code : Number(code))
+      .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)]))
+      .sort((left, right) => left - right);
   }
 
   /**

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -52,6 +52,18 @@ function uninstallScript(job: PackagingJob): string {
 }
 
 describe('nested portable PSADT generation', () => {
+  it('preserves manifest-declared installer success exit codes', () => {
+    const script = generator.generateDeployScript.call(generator, packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        installerSuccessCodes: [1168],
+        psadtConfig: {},
+      },
+    }), 'piicrawler.zip');
+    expect(script).toContain('AppSuccessExitCodes = @(0, 1168)');
+  });
+
   it('safely stages the full archive and never executes the nested portable file', () => {
     const script = installScript(packagingJob());
 

--- a/stores/cart-store.ts
+++ b/stores/cart-store.ts
@@ -269,6 +269,7 @@ export function createCartItem(
     nestedInstallerPath: installer.nestedInstallerPath,
     installerUrl: installer.url,
     installerSha256: installer.sha256,
+    installerSuccessCodes: installer.installerSuccessCodes,
     installCommand: generateInstallCommand(installer, installScope),
     uninstallCommand: generateUninstallCommand(installer, displayName),
     detectionRules,

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -25,6 +25,7 @@ export interface StagedPackage {
   intunewinSizeBytes?: number;
   installerUrl: string;
   installerSha256: string;
+  installerSuccessCodes?: number[];
 
   // Commands
   installCommand: string;
@@ -176,6 +177,7 @@ export interface Win32CartItem extends CartItemBase {
   nestedInstallerPath?: string;
   installerUrl: string;
   installerSha256: string;
+  installerSuccessCodes?: number[];
   installCommand: string;
   uninstallCommand: string;
   detectionRules: DetectionRule[];

--- a/types/winget.ts
+++ b/types/winget.ts
@@ -37,6 +37,7 @@ export interface WingetInstaller {
   NestedInstallerFiles?: Array<{ RelativeFilePath: string; PortableCommandAlias?: string }>;
   Scope?: WingetScope;
   InstallerSwitches?: WingetInstallerSwitches;
+  InstallerSuccessCodes?: number[];
   ProductCode?: string;
   PackageFamilyName?: string;
   UpgradeBehavior?: 'install' | 'uninstallPrevious';
@@ -171,6 +172,7 @@ export interface NormalizedInstaller {
   nestedInstallerPath?: string;
   scope?: WingetScope;
   silentArgs?: string;
+  installerSuccessCodes?: number[];
   productCode?: string;
   packageFamilyName?: string;
   packageDependencies?: Array<{ packageIdentifier: string; minimumVersion?: string }>;


### PR DESCRIPTION
## Summary
- preserve WinGet InstallerSuccessCodes through catalog, upload, auto-update, QA identity, and both packagers
- emit accepted codes into PSADT AppSuccessExitCodes
- preserve complete vendor argument tails in the local packager
- add regression coverage for HP Image Assistant exit code 1168

## Verification
- npm test (811 passed)
- npm run lint
- npm run build:ci
- packager TypeScript build
- PowerShell parser validation