### PR TITLE
Pin QA to success-code-aware packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -6,7 +6,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
+  packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -25,6 +25,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
   'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
   'de49775e759b693b92db09bc99aa116f197c4850',
 ] as const;

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -11,6 +11,11 @@ export interface QaToolchainBackfillCandidate {
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440': ['Figma.Figma'],
+  'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028': [
+    'Figma.Figma',
+    'HP.ImageAssistant',
+    'Microsoft.Office',
+  ],
 };
 
 export function shouldRetryTerminalToolchainCandidate(


### PR DESCRIPTION
## Summary
- pin QA profile generation to packager commit c1fe66c04b11f595bfaf4c9ca7cc1444186ea028
- retain compatibility with previously successful catalog runs
- selectively retry only Figma, HP Image Assistant, and Office terminal failures

## Verification
- 50 focused QA enqueue/profile tests passed
- git diff --check