### PR TITLE
Deploy Adobe QA packaging adapter

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -458,12 +458,18 @@ describe('GET /api/cron/qa-enqueue', () => {
 
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
-      supportedApps: [{ winget_id: 'Figma.Figma', name: 'Figma', publisher: 'Figma' }],
+      supportedApps: [
+        {
+          winget_id: 'Adobe.CreativeCloud',
+          name: 'Adobe Creative Cloud',
+          publisher: 'Adobe',
+        },
+      ],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Figma.Figma',
-          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          wingetId: 'Adobe.CreativeCloud',
+          packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
           status: 'failed',
         }),
       ],
@@ -484,7 +490,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Figma.Figma',
+      winget_id: 'Adobe.CreativeCloud',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -6,7 +6,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
+  packagerCommit: 'c414b88589edca2d3d82401525091db9417fbae0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -25,6 +25,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
   'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
   'de49775e759b693b92db09bc99aa116f197c4850',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -16,6 +16,7 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'HP.ImageAssistant',
     'Microsoft.Office',
   ],
+  'c414b88589edca2d3d82401525091db9417fbae0': ['Adobe.CreativeCloud'],
 };
 
 export function shouldRetryTerminalToolchainCandidate(


### PR DESCRIPTION
Advances the canonical QA package profile to the reviewed Adobe Creative Cloud uninstall adapter. Preserves previously passing packages as compatible background coverage, while selectively retrying only Adobe's affected terminal failure.\n\nVerification:\n- npx vitest run app/api/cron/qa-enqueue/route.test.ts lib/qa/package-profile.test.ts (50 passed)\n- npx eslint changed files\n- git diff --check\n\nBoth customer and QA workflows already pin c414b885 through IntuneGet-Workflows PR #468.