### PR TITLE
Add versioned PSADT lifecycle adapters

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -100,10 +100,31 @@ Copy-Item -LiteralPath $env:INSTALLER_PATH -Destination $filesDir
 $psadtConfig = @{}
 if ($env:PSADT_CONFIG -and $env:PSADT_CONFIG -ne '{}') {
     try {
-        $psadtConfig = $env:PSADT_CONFIG | ConvertFrom-Json -AsHashtable
+        $psadtConfig = $env:PSADT_CONFIG | ConvertFrom-Json -AsHashtable -NoEnumerate
+        if ($psadtConfig -isnot [System.Collections.IDictionary]) {
+            throw 'The top-level PSADT_CONFIG value must be a JSON object.'
+        }
     } catch {
-        Write-Host "Warning: Could not parse PSADT config, using defaults"
+        throw "PSADT_CONFIG must be valid JSON; refusing to package with different defaults. $($_.Exception.Message)"
     }
+}
+
+function Get-StrictPSADTBoolean {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Config,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [bool]$Default = $false
+    )
+
+    if (-not $Config.Contains($Name) -or $null -eq $Config[$Name]) {
+        return $Default
+    }
+    if ($Config[$Name] -isnot [bool]) {
+        throw "PSADT $Name must be a JSON boolean."
+    }
+    return [bool]$Config[$Name]
 }
 
 function ConvertTo-PSADTConfigValue {
@@ -623,27 +644,140 @@ if ($installerTypeLower -in @('msix', 'appx') -and
     throw "The MSIX/APPX package identity is missing; refusing to generate install or uninstall commands from a display-name guess."
 }
 
-# Extract app close configuration
+# Validate and normalize app close configuration before embedding it in the
+# generated deployment script. Invalid entries must fail packaging rather than
+# silently omitting a required lifecycle action.
 $processesToClose = @()
-if ($psadtConfig.processesToClose -and $psadtConfig.processesToClose.Count -gt 0) {
-    $processesToClose = $psadtConfig.processesToClose | Where-Object { $_.name -and $_.name.Trim() -ne '' }
+if ($psadtConfig.ContainsKey('processesToClose') -and $null -ne $psadtConfig.processesToClose) {
+    if ($psadtConfig.processesToClose -isnot [System.Array]) {
+        throw 'PSADT processesToClose must be a JSON array.'
+    }
+    $rawProcessesToClose = @($psadtConfig.processesToClose)
+    if ($rawProcessesToClose.Count -gt 50) {
+        throw 'PSADT processesToClose cannot contain more than 50 entries.'
+    }
+
+    $configuredProcessNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($process in $rawProcessesToClose) {
+        if ($process -isnot [System.Collections.IDictionary] -or
+            -not $process.Contains('name') -or
+            $process.name -isnot [string]) {
+            throw 'Each PSADT process entry must contain a string name.'
+        }
+        $procName = ([string]$process.name).Trim() -replace '(?i)\.exe$', ''
+        if ([string]::IsNullOrWhiteSpace($procName) -or
+            $procName.Length -gt 260 -or
+            $procName -match '[\x00-\x1F\x7F\\/:*?"<>|]') {
+            throw "Invalid PSADT process name [$($process.name)]. Use an executable name without a path or .exe suffix."
+        }
+
+        $procDesc = $procName
+        if ($process.Contains('description') -and $null -ne $process.description) {
+            if ($process.description -isnot [string]) {
+                throw "The PSADT process description for [$procName] must be a string."
+            }
+            if (-not [string]::IsNullOrWhiteSpace([string]$process.description)) {
+                $procDesc = ([string]$process.description).Trim() -replace '[\x00-\x1F\x7F]+', ' '
+            }
+        }
+        if ($procDesc.Length -gt 260) {
+            throw "The PSADT process description for [$procName] cannot exceed 260 characters."
+        }
+
+        if ($configuredProcessNames.Add($procName)) {
+            $processesToClose += [pscustomobject]@{
+                name = $procName
+                description = $procDesc
+            }
+        }
+    }
 }
-$showClosePrompt = if ($psadtConfig.showClosePrompt) { $true } else { $false }
-$closeCountdown = if ($psadtConfig.closeCountdown) { [int]$psadtConfig.closeCountdown } else { 60 }
-$allowDefer = if ($psadtConfig.ContainsKey('allowDefer')) { [bool]$psadtConfig.allowDefer } else { $false }
-$deferTimes = if ($psadtConfig.deferTimes) { [int]$psadtConfig.deferTimes } else { 3 }
+$showClosePrompt = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'showClosePrompt'
+$closeCountdown = 60
+if ($psadtConfig.ContainsKey('closeCountdown') -and $null -ne $psadtConfig.closeCountdown) {
+    $parsedCloseCountdown = 0L
+    if (-not [long]::TryParse([string]$psadtConfig.closeCountdown, [ref]$parsedCloseCountdown) -or
+        $parsedCloseCountdown -lt 0 -or $parsedCloseCountdown -gt 86400) {
+        throw 'PSADT closeCountdown must be an integer from 0 through 86400.'
+    }
+    $closeCountdown = [int]$parsedCloseCountdown
+}
+$allowDefer = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'allowDefer'
+$deferTimes = 3
+if ($psadtConfig.ContainsKey('deferTimes') -and $null -ne $psadtConfig.deferTimes) {
+    $parsedDeferTimes = 0L
+    if (-not [long]::TryParse([string]$psadtConfig.deferTimes, [ref]$parsedDeferTimes) -or
+        $parsedDeferTimes -lt 0 -or $parsedDeferTimes -gt 1000) {
+        throw 'PSADT deferTimes must be an integer from 0 through 1000.'
+    }
+    $deferTimes = [int]$parsedDeferTimes
+}
 
 # Extended welcome parameters
-$blockExecution = if ($psadtConfig.blockExecution) { $true } else { $false }
-$promptToSave = if ($psadtConfig.promptToSave) { $true } else { $false }
-$deferDeadline = if ($psadtConfig.deferDeadline) { ([string]$psadtConfig.deferDeadline) -replace "'", "''" -replace '`', '``' -replace '\$', '`$' } else { $null }
-$deferDays = $psadtConfig.deferDays
-$forceCloseCountdown = $psadtConfig.forceCloseProcessesCountdown
-$persistPrompt = if ($psadtConfig.persistPrompt) { $true } else { $false }
-$minimizeWindows = if ($psadtConfig.minimizeWindows) { $true } else { $false }
-$windowLocation = if ($psadtConfig.windowLocation) { ([string]$psadtConfig.windowLocation) -replace "'", "''" -replace '`', '``' -replace '\$', '`$' } else { 'Default' }
-$checkDiskSpace = if ($psadtConfig.checkDiskSpace) { $true } else { $false }
-$requiredDiskSpace = $psadtConfig.requiredDiskSpace
+$blockExecution = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'blockExecution'
+$promptToSave = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'promptToSave'
+$deferDeadline = $null
+if ($psadtConfig.ContainsKey('deferDeadline') -and $null -ne $psadtConfig.deferDeadline) {
+    if ($psadtConfig.deferDeadline -isnot [string]) {
+        throw 'PSADT deferDeadline must be an ISO date string.'
+    }
+    $candidateDeferDeadline = ([string]$psadtConfig.deferDeadline).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($candidateDeferDeadline)) {
+        $parsedDeferDeadline = [DateTimeOffset]::MinValue
+        if ($candidateDeferDeadline.Length -gt 64 -or
+            $candidateDeferDeadline -notmatch '^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,7})?)?(?:Z|[+-]\d{2}:\d{2})?)?$' -or
+            -not [DateTimeOffset]::TryParse(
+                $candidateDeferDeadline,
+                [System.Globalization.CultureInfo]::InvariantCulture,
+                [System.Globalization.DateTimeStyles]::AllowWhiteSpaces,
+                [ref]$parsedDeferDeadline
+            )) {
+            throw 'PSADT deferDeadline must be a valid ISO date or date-time string.'
+        }
+        $deferDeadline = $candidateDeferDeadline
+    }
+}
+$deferDays = $null
+if ($psadtConfig.ContainsKey('deferDays') -and $null -ne $psadtConfig.deferDays) {
+    $parsedDeferDays = 0.0
+    if (-not [double]::TryParse(
+            [string]$psadtConfig.deferDays,
+            [System.Globalization.NumberStyles]::Float,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$parsedDeferDays
+        ) -or $parsedDeferDays -lt 0 -or $parsedDeferDays -gt 3650) {
+        throw 'PSADT deferDays must be a number from 0 through 3650.'
+    }
+    $deferDays = [Convert]::ToString($parsedDeferDays, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+$forceCloseCountdown = $null
+if ($psadtConfig.ContainsKey('forceCloseProcessesCountdown') -and
+    $null -ne $psadtConfig.forceCloseProcessesCountdown) {
+    $parsedForceCloseCountdown = 0L
+    if (-not [long]::TryParse([string]$psadtConfig.forceCloseProcessesCountdown, [ref]$parsedForceCloseCountdown) -or
+        $parsedForceCloseCountdown -lt 0 -or $parsedForceCloseCountdown -gt 86400) {
+        throw 'PSADT forceCloseProcessesCountdown must be an integer from 0 through 86400.'
+    }
+    $forceCloseCountdown = [int]$parsedForceCloseCountdown
+}
+$persistPrompt = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'persistPrompt'
+$minimizeWindows = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'minimizeWindows'
+$windowLocation = if ($psadtConfig.windowLocation) { [string]$psadtConfig.windowLocation } else { 'Default' }
+if ($windowLocation -notin @('Default', 'Center', 'Top', 'Bottom', 'TopLeft', 'TopRight', 'BottomLeft', 'BottomRight')) {
+    throw "Unsupported PSADT windowLocation [$windowLocation]."
+}
+$checkDiskSpace = Get-StrictPSADTBoolean -Config $psadtConfig -Name 'checkDiskSpace'
+$requiredDiskSpace = $null
+if ($psadtConfig.ContainsKey('requiredDiskSpace') -and $null -ne $psadtConfig.requiredDiskSpace) {
+    $parsedRequiredDiskSpace = 0L
+    if (-not [long]::TryParse([string]$psadtConfig.requiredDiskSpace, [ref]$parsedRequiredDiskSpace) -or
+        $parsedRequiredDiskSpace -lt 0 -or $parsedRequiredDiskSpace -gt [uint32]::MaxValue) {
+        throw 'PSADT requiredDiskSpace must be an unsigned 32-bit integer.'
+    }
+    $requiredDiskSpace = [long]$parsedRequiredDiskSpace
+}
 $welcomeTitle = if ([string]::IsNullOrWhiteSpace($brandingWelcomeTitle)) { "$displayNameEscaped Installation" } else { $brandingWelcomeTitle -replace "'", "''" -replace '`', '``' -replace '\$', '`$' }
 $welcomeMessageEscaped = if ($brandingWelcomeMessage) { $brandingWelcomeMessage -replace "'", "''" -replace '`', '``' -replace '\$', '`$' } else { '' }
 $welcomeMessageEscaped = $welcomeMessageEscaped -replace "`r`n", "`r`n"
@@ -661,9 +795,8 @@ if ($processesToClose.Count -gt 0) {
     Write-Host "  - $($processesToClose | ForEach-Object { $_.name } | Join-String -Separator ', ')"
 }
 
-# Build processes array as separate script-level variable
+# Build the PSADT v4.1 AppProcessesToClose session value.
 $processesArrayStr = '@()'
-$processesVarBlock = ''
 if ($processesToClose.Count -gt 0) {
     $processEntries = $processesToClose | ForEach-Object {
         $procName = $_.name -replace "'", "''"
@@ -671,51 +804,89 @@ if ($processesToClose.Count -gt 0) {
         "@{ Name = '$procName'; Description = '$procDesc' }"
     }
     $processesArrayStr = "@(`n    $($processEntries -join ",`n    ")`n)"
-    $processesVarBlock = "`$script:ProcessesToClose = $processesArrayStr"
 }
 
 # Build Show-ADTInstallationWelcome call if enabled
 $welcomeCall = ''
-if ($allowDefer -or ($showClosePrompt -and $processesToClose.Count -gt 0) -or $blockExecution -or $checkDiskSpace) {
+if ($allowDefer -or $processesToClose.Count -gt 0 -or $checkDiskSpace) {
     $welcomeParams = @()
-
-    if (-not [string]::IsNullOrWhiteSpace($welcomeMessageEscaped)) {
-        $welcomeParams += '-CustomText'
-    }
+    $interactiveWelcome = $allowDefer -or ($processesToClose.Count -gt 0 -and $showClosePrompt)
 
     # Handle parameter sets correctly for PSADT v4
-    # When both deferrals AND close prompts are enabled, use -AllowDeferCloseProcesses
+    # Deferral is interactive even when showClosePrompt is false because the
+    # user must be able to choose whether to defer.
     if ($processesToClose.Count -gt 0 -and $allowDefer) {
-        $welcomeParams += '-CloseProcesses $script:ProcessesToClose'
+        $welcomeParams += '-CloseProcesses $adtSession.AppProcessesToClose'
         $welcomeParams += '-AllowDeferCloseProcesses'
-        $welcomeParams += "-ForceCloseProcessesCountdown $closeCountdown"
+        if ($null -ne $forceCloseCountdown) {
+            $welcomeParams += "-ForceCloseProcessesCountdown $forceCloseCountdown"
+        } else {
+            $welcomeParams += "-CloseProcessesCountdown $closeCountdown"
+        }
         $welcomeParams += "-DeferTimes $deferTimes"
+        if ($deferDeadline) { $welcomeParams += "-DeferDeadline '$deferDeadline'" }
+        if ($null -ne $deferDays) { $welcomeParams += "-DeferDays $deferDays" }
         if ($blockExecution) { $welcomeParams += '-BlockExecution' }
     } elseif ($processesToClose.Count -gt 0) {
-        # Only close prompts, no deferrals
-        $welcomeParams += '-CloseProcesses $script:ProcessesToClose'
-        $welcomeParams += "-CloseProcessesCountdown $closeCountdown"
+        $welcomeParams += '-CloseProcesses $adtSession.AppProcessesToClose'
+        if ($showClosePrompt) {
+            if ($null -ne $forceCloseCountdown) {
+                $welcomeParams += "-ForceCloseProcessesCountdown $forceCloseCountdown"
+            } else {
+                $welcomeParams += "-CloseProcessesCountdown $closeCountdown"
+            }
+        } else {
+            $welcomeParams += '-Silent'
+        }
         if ($blockExecution) { $welcomeParams += '-BlockExecution' }
     } elseif ($allowDefer) {
         # Only deferrals, no close prompts
         $welcomeParams += '-AllowDefer'
         $welcomeParams += "-DeferTimes $deferTimes"
         if ($deferDeadline) { $welcomeParams += "-DeferDeadline '$deferDeadline'" }
-        if ($deferDays) { $welcomeParams += "-DeferDays $deferDays" }
+        if ($null -ne $deferDays) { $welcomeParams += "-DeferDays $deferDays" }
     }
-    if ($forceCloseCountdown) { $welcomeParams += "-ForceCloseProcessesCountdown $forceCloseCountdown" }
-    if ($persistPrompt) { $welcomeParams += '-PersistPrompt' }
-    if ($minimizeWindows) { $welcomeParams += '-MinimizeWindows' }
-    if ($windowLocation -ne 'Default') { $welcomeParams += "-WindowLocation '$windowLocation'" }
+    if ($interactiveWelcome) {
+        if (-not [string]::IsNullOrWhiteSpace($welcomeMessageEscaped)) { $welcomeParams += '-CustomText' }
+        if ($promptToSave -and $processesToClose.Count -gt 0) { $welcomeParams += '-PromptToSave' }
+        if ($persistPrompt) { $welcomeParams += '-PersistPrompt' }
+        if ($minimizeWindows) { $welcomeParams += '-MinimizeWindows' }
+        if ($windowLocation -ne 'Default') { $welcomeParams += "-WindowLocation '$windowLocation'" }
+    }
     if ($checkDiskSpace) {
         $welcomeParams += '-CheckDiskSpace'
-        if ($requiredDiskSpace) { $welcomeParams += "-RequiredDiskSpace $requiredDiskSpace" }
+        if ($null -ne $requiredDiskSpace) { $welcomeParams += "-RequiredDiskSpace $requiredDiskSpace" }
     }
 
     $welcomeCall = @(
         ''
         '    # Show installation welcome dialog (for deferrals and/or close prompts)'
         "    Show-ADTInstallationWelcome $($welcomeParams -join ' ')"
+        ''
+    ) -join "`r`n"
+}
+
+$uninstallWelcomeCall = ''
+if ($processesToClose.Count -gt 0) {
+    $uninstallWelcomeParameters = @('-CloseProcesses $adtSession.AppProcessesToClose')
+    if ($showClosePrompt) {
+        if ($null -ne $forceCloseCountdown) {
+            $uninstallWelcomeParameters += "-ForceCloseProcessesCountdown $forceCloseCountdown"
+        } else {
+            $uninstallWelcomeParameters += "-CloseProcessesCountdown $closeCountdown"
+        }
+        if ($promptToSave) { $uninstallWelcomeParameters += '-PromptToSave' }
+        if ($persistPrompt) { $uninstallWelcomeParameters += '-PersistPrompt' }
+        if ($minimizeWindows) { $uninstallWelcomeParameters += '-MinimizeWindows' }
+        if ($windowLocation -ne 'Default') { $uninstallWelcomeParameters += "-WindowLocation '$windowLocation'" }
+    } else {
+        $uninstallWelcomeParameters += '-Silent'
+    }
+    if ($blockExecution) { $uninstallWelcomeParameters += '-BlockExecution' }
+    $uninstallWelcomeCall = @(
+        ''
+        '    # Apply the PSADT v4.1 application process lifecycle before removal.'
+        "    Show-ADTInstallationWelcome $($uninstallWelcomeParameters -join ' ')"
         ''
     ) -join "`r`n"
 }
@@ -969,9 +1140,6 @@ $lines = @(
     '## MARK: Variables'
     '##================================================'
     ''
-    "# Processes to close before installation"
-    "$processesVarBlock"
-    ''
     '$adtSession = @{'
     "    AppVendor = '$publisherEscaped'"
     "    AppName = '$displayNameEscaped'"
@@ -981,6 +1149,7 @@ $lines = @(
     '    AppRevision = ''01'''
     "    AppSuccessExitCodes = @($appSuccessExitCodesLiteral)"
     '    AppRebootExitCodes = @(1641, 3010)'
+    "    AppProcessesToClose = $processesArrayStr"
     '    AppScriptVersion = ''1.0.0'''
     '    AppScriptDate = (Get-Date -Format ''yyyy-MM-dd'')'
     '    AppScriptAuthor = ''IntuneGet'''
@@ -1541,6 +1710,10 @@ $lines += @(
     '    [CmdletBinding()]'
     '    param ()'
 )
+
+if ($uninstallWelcomeCall) {
+    $lines += $uninstallWelcomeCall
+}
 
 # Add pre-uninstall prompts
 if ($preUninstallPromptCalls) {

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -458,12 +458,16 @@ describe('GET /api/cron/qa-enqueue', () => {
 
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
-      supportedApps: [{ winget_id: 'Figma.Figma', name: 'Figma', publisher: 'Figma' }],
+      supportedApps: [{
+        winget_id: 'Elgato.StreamDeck',
+        name: 'Elgato Stream Deck',
+        publisher: 'Elgato',
+      }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Figma.Figma',
-          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          wingetId: 'Elgato.StreamDeck',
+          packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
           status: 'failed',
         }),
       ],
@@ -484,7 +488,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Figma.Figma',
+      winget_id: 'Elgato.StreamDeck',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -94,6 +94,7 @@ vi.mock('@/lib/store-app-deploy', () => ({
 
 import { GET, POST } from '@/app/api/package/route';
 import { InstallerPreflightError } from '@/lib/installer-preflight';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 function makeJob(overrides: Partial<PackagingJob>): PackagingJob {
   const now = new Date().toISOString();
@@ -342,6 +343,39 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
     expect(triggerPackagingWorkflowMock.mock.calls[0][0].relationships).toBeUndefined();
+  });
+
+  it('uses the reviewed app adapter for both QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Elgato.StreamDeck',
+          displayName: 'Elgato Stream Deck',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG, processesToClose: [] },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedProcesses = [
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ];
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject({
+      processesToClose: expectedProcesses,
+    });
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject({
+      processesToClose: expectedProcesses,
+    });
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: { processesToClose: expectedProcesses },
+    });
   });
 
   it('parks a customer deployment until its exact execution profile passes QA', async () => {

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -37,6 +37,7 @@ import {
   InstallerPreflightError,
 } from '@/lib/installer-preflight';
 import { ensureQaDemand } from '@/lib/qa/demand';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const maxDuration = 300;
 
@@ -395,6 +396,12 @@ export async function POST(request: NextRequest) {
         // Phase 1: Create all win32 job records
         for (const item of win32Items) {
           try {
+            if (item.sourceType !== 'custom') {
+              item.psadtConfig = applyApplicationPackagingAdapter(
+                item.wingetId,
+                item.psadtConfig
+              );
+            }
             const jobId = crypto.randomUUID();
             const installerSha256 = item.installerSha256?.trim() || '';
             const qaDemand = item.sourceType === 'custom'

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -251,6 +251,73 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     expect(candidateInsertSpy).not.toHaveBeenCalled();
   });
 
+  it('applies the same app adapter to auto-update QA and customer packaging', async () => {
+    const candidateInsertSpy = vi.fn();
+    const supabase = createSupabaseMock({
+      qa_package_results: {
+        maybeSingleResult: { data: null, error: null },
+      },
+      qa_candidates: {
+        insertSpy: candidateInsertSpy,
+        maybeSingleResult: {
+          data: { id: 'candidate-elgato', status: 'queued', failure_summary: null },
+          error: null,
+        },
+      },
+    });
+    const trigger = makeTrigger(supabase);
+    const storedConfig: DeploymentConfig = {
+      displayName: 'Elgato Stream Deck',
+      publisher: 'Elgato',
+      architecture: 'x64',
+      installerType: 'msi',
+      installCommand: 'msiexec /i setup.msi /qn',
+      uninstallCommand: 'msiexec /x {PRODUCT-CODE} /qn',
+      installScope: 'machine',
+      detectionRules: [],
+      psadtConfig: { ...DEFAULT_PSADT_CONFIG, processesToClose: [] },
+    };
+    const policy = makePolicy(storedConfig);
+    policy.original_upload_history_id = 'prior-upload';
+    policy.consecutive_failures = 0;
+
+    vi.spyOn(trigger as never, 'verifyTenantConsent' as never).mockResolvedValue(true as never);
+    vi.spyOn(trigger as never, 'ensurePsadtConfig' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'ensureCurrentPackageDefaults' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'createHistoryRecord' as never)
+      .mockResolvedValue({ id: 'history-elgato' } as never);
+    const createPackagingJobSpy = vi.spyOn(trigger as never, 'createPackagingJob' as never)
+      .mockResolvedValue({ id: 'job-elgato' } as never);
+    vi.spyOn(trigger as never, 'updateHistoryRecord' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'updatePolicyTracking' as never).mockResolvedValue(undefined as never);
+
+    const result = await trigger.triggerAutoUpdate(policy, {
+      ...UPDATE_INFO,
+      wingetId: 'elgato.streamdeck',
+      displayName: 'Elgato Stream Deck',
+      installerType: 'msi',
+      nestedInstallerType: undefined,
+      nestedInstallerPath: undefined,
+    }, { skipRateLimits: true });
+
+    expect(result).toMatchObject({ success: true, packagingJobId: 'job-elgato' });
+    const candidateRow = candidateInsertSpy.mock.calls[0][0] as {
+      test_config: { psadtConfig: { processesToClose: unknown[] } };
+    };
+    expect(candidateRow.test_config.psadtConfig.processesToClose).toEqual([
+      // Presentation-only descriptions are deliberately normalized in the QA
+      // execution profile; the process name and lifecycle behavior are exact.
+      { name: 'StreamDeck', description: 'StreamDeck' },
+    ]);
+    const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
+    expect(
+      (effectivePolicy.deployment_config as DeploymentConfig).psadtConfig?.processesToClose
+    ).toEqual([
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ]);
+    expect(storedConfig.psadtConfig?.processesToClose).toEqual([]);
+  });
+
   describe('ensurePsadtConfig', () => {
     it('backfills psadtConfig from the most recent packaging job and persists it', async () => {
       const updateSpy = vi.fn();

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -24,7 +24,9 @@ import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { generateInstallCommand } from '@/lib/detection-rules';
 import { normalizeInstaller } from '@/lib/manifest-api';
 import { upgradeLegacyPackageDefaults } from '@/lib/update-policies/upgrade-legacy-package-defaults';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 import type { NormalizedInstaller, WingetInstaller, WingetScope } from '@/types/winget';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 interface TriggerResult {
   success: boolean;
@@ -204,7 +206,18 @@ export class AutoUpdateTrigger {
       // later used by both GitHub Actions and the self-hosted packager.
       await this.ensureCurrentPackageDefaults(policy, updateInfo);
 
-      const deploymentConfig = policy.deployment_config as DeploymentConfig;
+      const storedDeploymentConfig = policy.deployment_config as DeploymentConfig;
+      const deploymentConfig: DeploymentConfig = {
+        ...storedDeploymentConfig,
+        psadtConfig: applyApplicationPackagingAdapter(
+        updateInfo.wingetId,
+          storedDeploymentConfig.psadtConfig || DEFAULT_PSADT_CONFIG
+        ),
+      };
+      // Keep the effective adapter in this update attempt so QA and the job
+      // receive the same config, without persisting derived adapter output into
+      // the customer's policy. A later adapter revision is therefore reapplied.
+      policy.deployment_config = deploymentConfig;
       const sourceInstallerType =
         updateInfo.installerType || deploymentConfig.installerType || 'exe';
       const customInstallCommand = deploymentConfig.psadtConfig?.installCommand?.trim();

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { applyApplicationPackagingAdapter } from './packaging-adapters';
+
+describe('application packaging adapters', () => {
+  it('adds the reviewed Stream Deck lifecycle process to the exact app', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Elgato.StreamDeck',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ]);
+    expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
+  });
+
+  it('matches WinGet identities case-insensitively', () => {
+    expect(
+      applyApplicationPackagingAdapter('  elgato.streamdeck  ', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ]);
+  });
+
+  it('preserves customer processes and deduplicates names with an exe suffix', () => {
+    const adapted = applyApplicationPackagingAdapter('Elgato.StreamDeck', {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: 'streamdeck.exe', description: 'Customer description' },
+        { name: 'companion', description: 'Companion app' },
+      ],
+    });
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'streamdeck', description: 'Customer description' },
+      { name: 'companion', description: 'Companion app' },
+    ]);
+  });
+
+  it('does not attach an adapter to a different application identity', () => {
+    const config = { ...DEFAULT_PSADT_CONFIG, processesToClose: [] };
+    expect(applyApplicationPackagingAdapter('Example.StreamDeck', config)).toBe(config);
+  });
+});

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1,0 +1,57 @@
+import type { ProcessToClose, PSADTConfig } from '@/types/psadt';
+
+interface ApplicationPackagingAdapter {
+  wingetId: string;
+  requiredProcessesToClose?: readonly ProcessToClose[];
+}
+
+/**
+ * Reviewed application-specific behavior that cannot be derived safely from a
+ * WinGet manifest. Keep this registry declarative: executable implementation
+ * remains in the shared PSADT packagers and every effective value is included
+ * in the QA execution-profile hash.
+ */
+export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
+  {
+    wingetId: 'Elgato.StreamDeck',
+    requiredProcessesToClose: [
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ],
+  },
+];
+
+function normalizeProcessName(name: string): string {
+  return name.trim().replace(/\.exe$/i, '');
+}
+
+export function applyApplicationPackagingAdapter(
+  wingetId: string,
+  config: PSADTConfig
+): PSADTConfig {
+  const normalizedWingetId = wingetId.trim().toLowerCase();
+  const adapter = APPLICATION_PACKAGING_ADAPTERS.find(
+    ({ wingetId: adapterWingetId }) => adapterWingetId.toLowerCase() === normalizedWingetId
+  );
+  if (!adapter?.requiredProcessesToClose?.length) return config;
+
+  const processesToClose = (config.processesToClose || []).map((process) => {
+    const name = normalizeProcessName(process.name);
+    if (!name) {
+      throw new Error(`Invalid empty PSADT process name for ${adapter.wingetId}`);
+    }
+    return { ...process, name };
+  });
+  const configuredNames = new Set(
+    processesToClose.map(({ name }) => name.toLowerCase())
+  );
+
+  for (const required of adapter.requiredProcessesToClose) {
+    const normalizedName = normalizeProcessName(required.name);
+    if (!configuredNames.has(normalizedName.toLowerCase())) {
+      processesToClose.push({ ...required, name: normalizedName });
+      configuredNames.add(normalizedName.toLowerCase());
+    }
+  }
+
+  return { ...config, processesToClose };
+}

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -5,10 +5,12 @@ import {
   buildQaPackageIdentityFromWorkflowInput,
   canonicalQaJson,
   normalizeQaWorkflowPackageInput,
+  QA_COMPATIBLE_PASSED_PACKAGER_COMMITS,
   QA_PACKAGE_PROFILE_SCHEMA_VERSION,
   QA_PSADT_TOOLCHAIN,
   qaSha256,
   splitQaPsadtConfig,
+  validateCompatiblePassedCatalogQaProfile,
   validateCurrentQaPackageProfile,
 } from './package-profile';
 
@@ -184,6 +186,38 @@ describe('PSADT QA package identity', () => {
 });
 
 describe('current catalog QA package validation', () => {
+  function candidateFromIdentity(identity: ReturnType<typeof buildQaPackageIdentity>) {
+    const profile = identity.profile as {
+      app: { wingetId: string; version: string; architecture: string };
+      installer: { sha256: string };
+    };
+    return {
+      testConfig: {
+        profileKind: 'catalog-default',
+        packageProfileCanonicalJson: identity.canonicalJson,
+        packageProfileSha256: identity.packageProfileSha256,
+      },
+      candidatePackageProfileSha256: identity.packageProfileSha256,
+      candidateWingetId: profile.app.wingetId,
+      candidateVersion: profile.app.version,
+      candidateArchitecture: profile.app.architecture,
+      candidateInstallerSha256: profile.installer.sha256,
+    };
+  }
+
+  function identityWithPackagerCommit(
+    identity: ReturnType<typeof buildQaPackageIdentity>,
+    packagerCommit: string
+  ) {
+    const profile = {
+      ...identity.profile,
+      toolchain: { ...QA_PSADT_TOOLCHAIN, packagerCommit },
+    };
+    const canonicalJson = canonicalQaJson(profile);
+    const packageProfileSha256 = qaSha256(canonicalJson);
+    return { ...identity, profile, canonicalJson, packageProfileSha256 };
+  }
+
   function currentCandidate() {
     const identity = buildQaPackageIdentity(input);
     return {
@@ -204,6 +238,58 @@ describe('current catalog QA package validation', () => {
     expect(validateCurrentQaPackageProfile(currentCandidate())).toMatchObject({
       valid: true,
     });
+  });
+
+  it('reuses an older catalog pass only when lifecycle behavior is unaffected', () => {
+    const priorCommit = QA_COMPATIBLE_PASSED_PACKAGER_COMMITS.find(
+      (commit) => commit !== QA_PSADT_TOOLCHAIN.packagerCommit
+    );
+    expect(priorCommit).toBeTruthy();
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity(input),
+      priorCommit!
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toMatchObject({ valid: true });
+  });
+
+  it('does not reuse an older pass with configured process lifecycle behavior', () => {
+    const priorCommit = QA_COMPATIBLE_PASSED_PACKAGER_COMMITS.find(
+      (commit) => commit !== QA_PSADT_TOOLCHAIN.packagerCommit
+    )!;
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        psadtConfig: {
+          ...DEFAULT_PSADT_CONFIG,
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+        },
+      }),
+      priorCommit
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toEqual({ valid: false, reason: 'compatible-process-lifecycle-changed' });
+  });
+
+  it('does not reuse an older pass when the current app adapter adds behavior', () => {
+    const priorCommit = QA_COMPATIBLE_PASSED_PACKAGER_COMMITS.find(
+      (commit) => commit !== QA_PSADT_TOOLCHAIN.packagerCommit
+    )!;
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        wingetId: 'Elgato.StreamDeck',
+      }),
+      priorCommit
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
   });
 
   it('normalizes case and whitespace on both sides of candidate bindings', () => {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
+  packagerCommit: '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -26,6 +26,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
   'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
   'de49775e759b693b92db09bc99aa116f197c4850',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -3,6 +3,7 @@ import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
 import { assertPackagingContract } from '@/lib/packaging-contract';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
@@ -361,7 +362,41 @@ export function validateCurrentQaPackageProfile(
 export function validateCompatiblePassedCatalogQaProfile(
   input: QaPackageProfileValidationInput
 ): QaPackageProfileValidation {
-  return validateQaPackageProfile(input, QA_COMPATIBLE_PASSED_PACKAGER_COMMITS);
+  const validation = validateQaPackageProfile(
+    input,
+    QA_COMPATIBLE_PASSED_PACKAGER_COMMITS
+  );
+  if (!validation.valid || !validation.canonicalJson) return validation;
+
+  // Older successful catalog profiles remain reusable only when this
+  // lifecycle change cannot affect their generated script. Customer and
+  // queued deployment profiles always require the exact current commit.
+  const profile = record(JSON.parse(validation.canonicalJson));
+  const toolchain = record(profile?.toolchain);
+  if (textValue(toolchain?.packagerCommit) === QA_PSADT_TOOLCHAIN.packagerCommit) {
+    return validation;
+  }
+
+  const psadtConfig = record(profile?.psadtConfig);
+  const configuredProcesses = Array.isArray(psadtConfig?.processesToClose)
+    ? psadtConfig.processesToClose
+    : [];
+  if (configuredProcesses.length > 0) {
+    return { valid: false, reason: 'compatible-process-lifecycle-changed' };
+  }
+
+  const app = record(profile?.app);
+  const wingetId = textValue(app?.wingetId);
+  if (!wingetId || !psadtConfig) {
+    return { valid: false, reason: 'compatible-profile-invalid' };
+  }
+  const typedPsadtConfig = psadtConfig as unknown as PSADTConfig;
+  const adapted = applyApplicationPackagingAdapter(wingetId, typedPsadtConfig);
+  if (adapted !== typedPsadtConfig) {
+    return { valid: false, reason: 'compatible-application-adapter-changed' };
+  }
+
+  return validation;
 }
 
 export function normalizeQaPsadtConfig(
@@ -484,7 +519,10 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     installScope: input.installScope || 'machine',
     markerPath: preliminaryConfig.registryMarkerPath,
   });
-  const psadtConfig = normalizeQaPsadtConfig(rawConfig, detectionRules);
+  const psadtConfig = applyApplicationPackagingAdapter(
+    input.wingetId,
+    normalizeQaPsadtConfig(rawConfig, detectionRules)
+  );
   const identity = buildQaPackageIdentity({
     profileKind: 'deployment-config',
     wingetId: input.wingetId,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -31,7 +31,8 @@ const canRunWindowsPowerShellPackager =
 function generateRegistryUninstallPackage(
   installerType: 'inno' | 'burn',
   displayName = 'Contract Test App',
-  installerSuccessCodes: number[] = []
+  installerSuccessCodes: number[] = [],
+  psadtConfig: unknown = {}
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -72,7 +73,7 @@ function generateRegistryUninstallPackage(
         INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${displayName}`,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
-        PSADT_CONFIG: '{}',
+        PSADT_CONFIG: JSON.stringify(psadtConfig),
       },
     });
 
@@ -350,6 +351,131 @@ describe('PSADT registry uninstall identity contract', () => {
       'never forward the install-only --mode=stub value'
     );
   });
+
+  it('uses the PSADT v4.1 process lifecycle for install and uninstall', () => {
+    expect(packager).toContain('AppProcessesToClose = $processesArrayStr');
+    expect(packager).toContain(
+      '-CloseProcesses $adtSession.AppProcessesToClose'
+    );
+    expect(packager).toContain(
+      'Apply the PSADT v4.1 application process lifecycle before removal.'
+    );
+    expect(packager).not.toContain('$script:ProcessesToClose');
+
+    const uninstallFunction = packager.indexOf("'function Uninstall-ADTDeployment'");
+    const uninstallLifecycle = packager.indexOf(
+      'if ($uninstallWelcomeCall)',
+      uninstallFunction
+    );
+    expect(uninstallFunction).toBeGreaterThan(-1);
+    expect(uninstallLifecycle).toBeGreaterThan(uninstallFunction);
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits the configured process lifecycle inside both generated functions',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Lifecycle Contract App',
+        [],
+        {
+          processesToClose: [
+            { name: 'StreamDeck.exe', description: "Elgato's Stream Deck" },
+          ],
+          showClosePrompt: false,
+        }
+      );
+
+      expect(generated).toContain(
+        "AppProcessesToClose = @(\n    @{ Name = 'StreamDeck'; Description = 'Elgato''s Stream Deck' }\n)"
+      );
+      expect(
+        generated.match(
+          /Show-ADTInstallationWelcome -CloseProcesses \$adtSession\.AppProcessesToClose -Silent/g
+        )
+      ).toHaveLength(2);
+      expect(generated.indexOf('Show-ADTInstallationWelcome')).toBeGreaterThan(
+        generated.indexOf('function Install-ADTDeployment')
+      );
+      const uninstallFunction = generated.indexOf('function Uninstall-ADTDeployment');
+      expect(generated.indexOf('Show-ADTInstallationWelcome', uninstallFunction)).toBeGreaterThan(
+        uninstallFunction
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits one valid force-countdown parameter set and never combines it with Silent',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Deferral Contract App',
+        [],
+        {
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+          showClosePrompt: false,
+          allowDefer: true,
+          deferTimes: 2,
+          forceCloseProcessesCountdown: 45,
+        }
+      );
+
+      expect(generated).toContain(
+        'Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -AllowDeferCloseProcesses -ForceCloseProcessesCountdown 45 -DeferTimes 2'
+      );
+      expect(generated).not.toContain(
+        '-ForceCloseProcessesCountdown 45 -ForceCloseProcessesCountdown'
+      );
+      expect(generated).not.toContain(
+        '-Silent -ForceCloseProcessesCountdown'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'fails packaging instead of dropping an unsafe process entry',
+    () => {
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Unsafe Process Contract App',
+        [],
+        {
+          processesToClose: [{ name: '..\\unsafe.exe', description: 'Unsafe' }],
+        }
+      )).toThrow('Invalid PSADT process name');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects non-object configs and string booleans before generation',
+    () => {
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Array Config Contract App',
+        [],
+        [{ processesToClose: [] }]
+      )).toThrow('top-level PSADT_CONFIG value');
+
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Boolean Config Contract App',
+        [],
+        { showClosePrompt: 'false' }
+      )).toThrow('showClosePrompt must be a JSON boolean');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects a malformed deferral deadline during packaging',
+    () => {
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Deadline Contract App',
+        [],
+        { allowDefer: true, deferDeadline: 'next Tuesday' }
+      )).toThrow('deferDeadline must be a valid ISO date');
+    }
+  );
 
   it('adds verified silent arguments when other vendors only register an interactive uninstall', () => {
     expect(packager).toContain("$registeredInstallerType -eq ''inno''");

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -328,4 +328,28 @@ describe('buildQaCatalogTestConfig', () => {
       'if (-not $package -and $runningAsSystem) { $package = Get-AppxPackage -Name "Microsoft.WindowsTerminal" -AllUsers }'
     );
   });
+
+  it('includes the reviewed Stream Deck process adapter in the catalog profile', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Elgato.StreamDeck',
+        name: 'Elgato Stream Deck',
+        publisher: 'Elgato',
+        version: '7.5.1.22901',
+      },
+      manifest: {
+        InstallerType: 'wix',
+        Scope: 'machine',
+        ProductCode: '{ED591028-8D85-4D44-AA11-B2D8EC905F91}',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'wix',
+      },
+    });
+
+    expect(config.psadtConfig.processesToClose).toEqual([
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+    ]);
+  });
 });

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -2,6 +2,7 @@ import { generateDetectionRules, generateUninstallCommand } from '@/lib/detectio
 import { normalizeInstaller } from '@/lib/manifest-api';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 import { normalizeQaPsadtConfig } from './package-profile';
 import type {
   WingetInstaller,
@@ -149,18 +150,21 @@ export function buildQaCatalogTestConfig({
     app.version,
     DEFAULT_PSADT_CONFIG.registryMarkerPath
   );
-  const psadtConfig: PSADTConfig = normalizeQaPsadtConfig(
-    {
-      ...DEFAULT_PSADT_CONFIG,
-      deployMode: 'Auto',
-      progressDialog: {
-        ...DEFAULT_PSADT_CONFIG.progressDialog,
-        enabled: true,
-        statusMessage: 'IntuneGet is validating this application package.',
-        windowLocation: 'BottomRight',
+  const psadtConfig: PSADTConfig = applyApplicationPackagingAdapter(
+    app.wingetId,
+    normalizeQaPsadtConfig(
+      {
+        ...DEFAULT_PSADT_CONFIG,
+        deployMode: 'Auto',
+        progressDialog: {
+          ...DEFAULT_PSADT_CONFIG.progressDialog,
+          enabled: true,
+          statusMessage: 'IntuneGet is validating this application package.',
+          windowLocation: 'BottomRight',
+        },
       },
-    },
-    detectionRules
+      detectionRules
+    )
   );
 
   return {

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { QA_PSADT_TOOLCHAIN } from './package-profile';
+import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
+
+describe('QA toolchain targeted retries', () => {
+  it.each(['Adobe.CreativeCloud', 'Elgato.StreamDeck'])(
+    'retries the terminal %s failure for the lifecycle-adapter toolchain',
+    (wingetId) => {
+      expect(shouldRetryTerminalToolchainCandidate(
+        QA_PSADT_TOOLCHAIN.packagerCommit,
+        { wingetId, status: 'failed' }
+      )).toBe(true);
+    }
+  );
+
+  it('does not replay an unrelated terminal failure', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('still rebuilds a non-terminal stale candidate', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'superseded' }
+    )).toBe(true);
+  });
+});

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -16,6 +16,10 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'HP.ImageAssistant',
     'Microsoft.Office',
   ],
+  '42bf6e2af604a5e6bb44f2feff38e941ab2222c1': [
+    'Adobe.CreativeCloud',
+    'Elgato.StreamDeck',
+  ],
 };
 
 export function shouldRetryTerminalToolchainCandidate(

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -416,6 +416,7 @@ export class JobProcessor {
     const appVendor = job.publisher.replace(/'/g, "''");
     const appName = job.display_name.replace(/'/g, "''");
     const appArch = job.architecture ?? '';
+    const processLifecycle = this.getProcessLifecycle(job);
 
     return `<#
 .SYNOPSIS
@@ -459,6 +460,7 @@ $adtSession = @{
     AppRevision = '01'
     AppSuccessExitCodes = @(${successExitCodes.join(', ')})
     AppRebootExitCodes = @(1641, 3010)
+    AppProcessesToClose = ${processLifecycle.sessionLiteral}
     AppScriptVersion = '1.0.0'
     AppScriptDate = (Get-Date -Format 'yyyy-MM-dd')
     AppScriptAuthor = 'IntuneGet'
@@ -474,6 +476,7 @@ function Install-ADTDeployment
 {
     [CmdletBinding()]
     param ()
+${processLifecycle.installBlock}
 ${this.getRegistryInstallSnapshotBlock(job, appName)}
 ${this.getPreInstallRemovalBlock(job, appName)}
     ## Install the application
@@ -488,6 +491,7 @@ function Uninstall-ADTDeployment
 {
     [CmdletBinding()]
     param ()
+${processLifecycle.uninstallBlock}
 
     ## Uninstall the application
     ${this.getUninstallCommand(job, installerFileName)}
@@ -570,6 +574,209 @@ catch
       return null;
     }
     return psadtConfig as Record<string, unknown>;
+  }
+
+  private getProcessLifecycle(job: PackagingJob): {
+    sessionLiteral: string;
+    installBlock: string;
+    uninstallBlock: string;
+  } {
+    const config = this.getPsadtConfig(job);
+    const configuredProcesses = config?.processesToClose;
+    if (configuredProcesses !== undefined && configuredProcesses !== null &&
+        !Array.isArray(configuredProcesses)) {
+      throw new Error('PSADT processesToClose must be an array');
+    }
+    const rawProcesses = Array.isArray(configuredProcesses) ? configuredProcesses : [];
+    if (rawProcesses.length > 50) {
+      throw new Error('PSADT processesToClose cannot contain more than 50 entries');
+    }
+
+    const configuredNames = new Set<string>();
+    const processes: Array<{ name: string; description: string }> = [];
+    for (const raw of rawProcesses) {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new Error('Each PSADT process entry must be an object');
+      }
+      const process = raw as Record<string, unknown>;
+      if (typeof process.name !== 'string') {
+        throw new Error('Each PSADT process entry must contain a string name');
+      }
+      const name = process.name.trim().replace(/\.exe$/i, '');
+      if (!name || name.length > 260 || /[\x00-\x1F\x7F\\/:*?"<>|]/.test(name)) {
+        throw new Error(
+          `Invalid PSADT process name [${process.name}]; use an executable name without a path or .exe suffix`
+        );
+      }
+      if (process.description !== undefined && process.description !== null &&
+          typeof process.description !== 'string') {
+        throw new Error(`The PSADT process description for [${name}] must be a string`);
+      }
+      const description = typeof process.description === 'string' && process.description.trim()
+        ? process.description.replace(/[\x00-\x1F\x7F]+/g, ' ').trim()
+        : name;
+      if (description.length > 260) {
+        throw new Error(`The PSADT process description for [${name}] cannot exceed 260 characters`);
+      }
+      const normalizedName = name.toLowerCase();
+      if (!configuredNames.has(normalizedName)) {
+        processes.push({ name, description });
+        configuredNames.add(normalizedName);
+      }
+    }
+
+    const sessionLiteral = processes.length === 0 ? '@()' : `@(${processes
+      .map(({ name, description }) =>
+        `@{ Name = '${name.replace(/'/g, "''")}'; Description = '${description.replace(/'/g, "''")}' }`
+      )
+      .join(', ')})`;
+
+    const boundedInteger = (
+      value: unknown,
+      setting: string,
+      fallback: number | null,
+      maximum: number
+    ): number | null => {
+      if (value === undefined || value === null) return fallback;
+      if (typeof value === 'string' && !value.trim()) {
+        throw new Error(`PSADT ${setting} must be an integer from 0 through ${maximum}`);
+      }
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed < 0 || parsed > maximum) {
+        throw new Error(`PSADT ${setting} must be an integer from 0 through ${maximum}`);
+      }
+      return parsed;
+    };
+
+    const strictBoolean = (setting: string, fallback = false): boolean => {
+      const value = config?.[setting];
+      if (value === undefined || value === null) return fallback;
+      if (typeof value !== 'boolean') {
+        throw new Error(`PSADT ${setting} must be a boolean`);
+      }
+      return value;
+    };
+
+    const showClosePrompt = strictBoolean('showClosePrompt');
+    const closeCountdown = boundedInteger(config?.closeCountdown, 'closeCountdown', 60, 86_400)!;
+    const forceCloseCountdown = boundedInteger(
+      config?.forceCloseProcessesCountdown,
+      'forceCloseProcessesCountdown',
+      null,
+      86_400
+    );
+    const allowDefer = strictBoolean('allowDefer');
+    const deferTimes = boundedInteger(config?.deferTimes, 'deferTimes', 3, 1_000)!;
+    const blockExecution = strictBoolean('blockExecution');
+    const promptToSave = strictBoolean('promptToSave');
+    const persistPrompt = strictBoolean('persistPrompt');
+    const minimizeWindows = strictBoolean('minimizeWindows');
+    const allowedWindowLocations = new Set([
+      'Default', 'Center', 'Top', 'Bottom', 'TopLeft', 'TopRight', 'BottomLeft', 'BottomRight',
+    ]);
+    const windowLocation = typeof config?.windowLocation === 'string' && config.windowLocation
+      ? config.windowLocation
+      : 'Default';
+    if (!allowedWindowLocations.has(windowLocation)) {
+      throw new Error(`Unsupported PSADT windowLocation [${windowLocation}]`);
+    }
+
+    let deferDays: number | null = null;
+    if (config?.deferDays !== undefined && config.deferDays !== null) {
+      deferDays = Number(config.deferDays);
+      if (!Number.isFinite(deferDays) || deferDays < 0 || deferDays > 3_650) {
+        throw new Error('PSADT deferDays must be a number from 0 through 3650');
+      }
+    }
+    let deferDeadline: string | null = null;
+    if (config?.deferDeadline !== undefined && config.deferDeadline !== null) {
+      if (typeof config.deferDeadline !== 'string') {
+        throw new Error('PSADT deferDeadline must be a valid ISO date or date-time string');
+      }
+      const candidateDeferDeadline = config.deferDeadline.trim();
+      if (candidateDeferDeadline && (
+          candidateDeferDeadline.length > 64 ||
+          !/^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,7})?)?(?:Z|[+-]\d{2}:\d{2})?)?$/.test(
+            candidateDeferDeadline
+          ) ||
+          Number.isNaN(Date.parse(candidateDeferDeadline)))) {
+        throw new Error('PSADT deferDeadline must be a valid ISO date or date-time string');
+      }
+      deferDeadline = candidateDeferDeadline || null;
+    }
+    const checkDiskSpace = strictBoolean('checkDiskSpace');
+    const requiredDiskSpace = boundedInteger(
+      config?.requiredDiskSpace,
+      'requiredDiskSpace',
+      null,
+      0xFFFF_FFFF
+    );
+
+    const addInteractiveOptions = (parameters: string[]): void => {
+      if (promptToSave && processes.length > 0) parameters.push('-PromptToSave');
+      if (persistPrompt) parameters.push('-PersistPrompt');
+      if (minimizeWindows) parameters.push('-MinimizeWindows');
+      if (windowLocation !== 'Default') parameters.push(`-WindowLocation '${windowLocation}'`);
+    };
+
+    const installParameters: string[] = [];
+    const interactiveInstall = allowDefer || (processes.length > 0 && showClosePrompt);
+    if (processes.length > 0) {
+      installParameters.push('-CloseProcesses $adtSession.AppProcessesToClose');
+      if (allowDefer) {
+        installParameters.push('-AllowDeferCloseProcesses');
+        installParameters.push(forceCloseCountdown !== null
+          ? `-ForceCloseProcessesCountdown ${forceCloseCountdown}`
+          : `-CloseProcessesCountdown ${closeCountdown}`);
+        installParameters.push(`-DeferTimes ${deferTimes}`);
+        if (deferDeadline) installParameters.push(`-DeferDeadline '${deferDeadline}'`);
+        if (deferDays !== null) installParameters.push(`-DeferDays ${deferDays}`);
+      } else if (showClosePrompt) {
+        installParameters.push(forceCloseCountdown !== null
+          ? `-ForceCloseProcessesCountdown ${forceCloseCountdown}`
+          : `-CloseProcessesCountdown ${closeCountdown}`);
+      } else {
+        installParameters.push('-Silent');
+      }
+      if (blockExecution) installParameters.push('-BlockExecution');
+    } else if (allowDefer) {
+      installParameters.push('-AllowDefer', `-DeferTimes ${deferTimes}`);
+      if (deferDeadline) installParameters.push(`-DeferDeadline '${deferDeadline}'`);
+      if (deferDays !== null) installParameters.push(`-DeferDays ${deferDays}`);
+    }
+    if (interactiveInstall) addInteractiveOptions(installParameters);
+    if (checkDiskSpace) {
+      installParameters.push('-CheckDiskSpace');
+      if (requiredDiskSpace !== null) {
+        installParameters.push(`-RequiredDiskSpace ${requiredDiskSpace}`);
+      }
+    }
+
+    const uninstallParameters: string[] = [];
+    if (processes.length > 0) {
+      uninstallParameters.push('-CloseProcesses $adtSession.AppProcessesToClose');
+      if (showClosePrompt) {
+        uninstallParameters.push(forceCloseCountdown !== null
+          ? `-ForceCloseProcessesCountdown ${forceCloseCountdown}`
+          : `-CloseProcessesCountdown ${closeCountdown}`);
+        addInteractiveOptions(uninstallParameters);
+      } else {
+        uninstallParameters.push('-Silent');
+      }
+      if (blockExecution) uninstallParameters.push('-BlockExecution');
+    }
+
+    const welcomeBlock = (parameters: string[], phase: string): string =>
+      parameters.length === 0 ? '' : `
+    ## Apply the PSADT v4.1 application process lifecycle for ${phase}
+    Show-ADTInstallationWelcome ${parameters.join(' ')}
+`;
+
+    return {
+      sessionLiteral,
+      installBlock: welcomeBlock(installParameters, 'installation'),
+      uninstallBlock: welcomeBlock(uninstallParameters, 'uninstallation'),
+    };
   }
 
   /**

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -64,6 +64,97 @@ describe('nested portable PSADT generation', () => {
     expect(script).toContain('AppSuccessExitCodes = @(0, 1168)');
   });
 
+  it('applies configured PSADT v4.1 processes before install and uninstall', () => {
+    const script = generator.generateDeployScript.call(generator, packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: {
+          processesToClose: [
+            { name: 'StreamDeck.exe', description: "Elgato's Stream Deck" },
+          ],
+          showClosePrompt: false,
+        },
+      },
+    }), 'piicrawler.zip');
+
+    expect(script).toContain(
+      "AppProcessesToClose = @(@{ Name = 'StreamDeck'; Description = 'Elgato''s Stream Deck' })"
+    );
+    expect(
+      script.match(
+        /Show-ADTInstallationWelcome -CloseProcesses \$adtSession\.AppProcessesToClose -Silent/g
+      )
+    ).toHaveLength(2);
+  });
+
+  it('uses a valid interactive deferral parameter set without duplicate countdowns', () => {
+    const script = generator.generateDeployScript.call(generator, packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: {
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+          showClosePrompt: false,
+          allowDefer: true,
+          deferTimes: 2,
+          forceCloseProcessesCountdown: 45,
+        },
+      },
+    }), 'piicrawler.zip');
+
+    expect(script).toContain(
+      'Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -AllowDeferCloseProcesses -ForceCloseProcessesCountdown 45 -DeferTimes 2'
+    );
+    expect(script).not.toContain(
+      '-ForceCloseProcessesCountdown 45 -ForceCloseProcessesCountdown'
+    );
+    expect(script).not.toContain('-Silent -ForceCloseProcessesCountdown');
+  });
+
+  it('fails closed instead of dropping malformed process lifecycle entries', () => {
+    const job = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: {
+          processesToClose: [{ name: '..\\unsafe.exe', description: 'Unsafe' }],
+        },
+      },
+    });
+
+    expect(() => generator.generateDeployScript.call(generator, job, 'piicrawler.zip'))
+      .toThrow('Invalid PSADT process name');
+  });
+
+  it('rejects string booleans and malformed deferral deadlines', () => {
+    const stringBooleanJob = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: { showClosePrompt: 'false' },
+      },
+    });
+    expect(() => generator.generateDeployScript.call(
+      generator,
+      stringBooleanJob,
+      'piicrawler.zip'
+    )).toThrow('showClosePrompt must be a boolean');
+
+    const invalidDeadlineJob = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: { allowDefer: true, deferDeadline: 'next Tuesday' },
+      },
+    });
+    expect(() => generator.generateDeployScript.call(
+      generator,
+      invalidDeadlineJob,
+      'piicrawler.zip'
+    )).toThrow('deferDeadline must be a valid ISO date');
+  });
+
   it('safely stages the full archive and never executes the nested portable file', () => {
     const script = installScript(packagingJob());
 


### PR DESCRIPTION
## What changed
- added a version-controlled application adapter registry keyed by WinGet ID
- added the Elgato Stream Deck process lifecycle adapter
- applied the same effective adapter to catalog QA, customer uploads, and automatic updates
- added PSADT 4.1 process handling before both installation and uninstallation in both packagers
- made lifecycle configuration validation fail closed and constrained PowerShell values
- conditionally preserves old successful catalog runs only when lifecycle behavior and current adapters cannot affect them
- targets Adobe Creative Cloud and Elgato Stream Deck for retry under the new toolchain

## Root cause
Elgato's uninstaller could hang in its WiX close-application custom action because Stream Deck was still running. Process-close configuration was not applied consistently before uninstall, and the two packagers had drifted lifecycle behavior. Invalid config shapes and string booleans could also change behavior after QA.

## Impact
QA and customer packaging now use the same versioned lifecycle correction. Silent deployments close explicitly configured processes without prompting; interactive/deferral combinations use valid PSADT 4.1 parameter sets.

## Validation
- 122 focused frontend/QA tests
- 36 real Windows PowerShell generator contract tests
- 35 self-hosted packager tests and TypeScript build
- ESLint on changed TypeScript
- PowerShell parser and git diff checks
- full Next.js production build (141 routes)
- bounded Claude Code Opus correctness review; no blocking/high adapter/profile findings after fixes