### PR TITLE
Close Adobe desktop processes before package lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -3,6 +3,42 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { applyApplicationPackagingAdapter } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Adobe.CreativeCloud',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'Creative Cloud', description: 'Adobe Creative Cloud' },
+      { name: 'AdobeDesktopService', description: 'Adobe Desktop Service' },
+      { name: 'AdobeCEFHelper', description: 'Adobe CEF Helper' },
+      { name: 'AdobeInstaller', description: 'Adobe Installer' },
+      { name: 'AdobeUpdateService', description: 'Adobe Update Service' },
+      { name: 'CCLibrary', description: 'Adobe Creative Cloud Library' },
+      { name: 'CCXProcess', description: 'Adobe Creative Cloud Experience' },
+      { name: 'CoreSync', description: 'Adobe CoreSync' },
+      { name: 'AdobeIPCBroker', description: 'Adobe IPC Broker' },
+      { name: 'AdobeNotificationClient', description: 'Adobe Notification Client' },
+      { name: 'CreativeCloudHelper', description: 'Adobe Creative Cloud Helper' },
+    ]);
+  });
+
+  it('preserves a customer Adobe process description while filling missing lifecycle entries', () => {
+    const adapted = applyApplicationPackagingAdapter('Adobe.CreativeCloud', {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: 'Creative Cloud.exe', description: 'Customer-managed sync client' },
+      ],
+    });
+
+    expect(adapted.processesToClose[0]).toEqual({
+      name: 'Creative Cloud',
+      description: 'Customer-managed sync client',
+    });
+    expect(adapted.processesToClose).toHaveLength(11);
+  });
+
   it('adds the reviewed Stream Deck lifecycle process to the exact app', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Elgato.StreamDeck',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -13,6 +13,22 @@ interface ApplicationPackagingAdapter {
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
   {
+    wingetId: 'Adobe.CreativeCloud',
+    requiredProcessesToClose: [
+      { name: 'Creative Cloud', description: 'Adobe Creative Cloud' },
+      { name: 'AdobeDesktopService', description: 'Adobe Desktop Service' },
+      { name: 'AdobeCEFHelper', description: 'Adobe CEF Helper' },
+      { name: 'AdobeInstaller', description: 'Adobe Installer' },
+      { name: 'AdobeUpdateService', description: 'Adobe Update Service' },
+      { name: 'CCLibrary', description: 'Adobe Creative Cloud Library' },
+      { name: 'CCXProcess', description: 'Adobe Creative Cloud Experience' },
+      { name: 'CoreSync', description: 'Adobe CoreSync' },
+      { name: 'AdobeIPCBroker', description: 'Adobe IPC Broker' },
+      { name: 'AdobeNotificationClient', description: 'Adobe Notification Client' },
+      { name: 'CreativeCloudHelper', description: 'Adobe Creative Cloud Helper' },
+    ],
+  },
+  {
     wingetId: 'Elgato.StreamDeck',
     requiredProcessesToClose: [
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -352,4 +352,38 @@ describe('buildQaCatalogTestConfig', () => {
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ]);
   });
+
+  it('includes the reviewed Creative Cloud process adapter in the catalog profile', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Adobe.CreativeCloud',
+        name: 'Adobe Creative Cloud',
+        publisher: 'Adobe',
+        version: '6.10.0.252.3',
+      },
+      manifest: {
+        InstallerType: 'exe',
+        Scope: 'machine',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'exe',
+        InstallerSwitches: { Silent: '--mode=stub' },
+      },
+    });
+
+    expect(config.psadtConfig.processesToClose.map(({ name }) => name)).toEqual([
+      'Creative Cloud',
+      'AdobeDesktopService',
+      'AdobeCEFHelper',
+      'AdobeInstaller',
+      'AdobeUpdateService',
+      'CCLibrary',
+      'CCXProcess',
+      'CoreSync',
+      'AdobeIPCBroker',
+      'AdobeNotificationClient',
+      'CreativeCloudHelper',
+    ]);
+  });
 });


### PR DESCRIPTION
## What changed
- Adds an exact Adobe Creative Cloud packaging adapter for the desktop processes Adobe documents as safe to end.
- Applies the same derived PSADT process lifecycle to customer packages and QA packages.
- Preserves customer-defined process descriptions and remains isolated to Adobe.CreativeCloud.

## Root cause
The Adobe installer completed, but its registered desktop uninstaller left the exact uninstall registration behind for five minutes. The Creative Cloud background process family was still eligible to block removal.

## Validation
- 840 Vitest tests passed
- Focused ESLint passed
- Next.js production build passed
- Claude Opus read-only correctness review found no blocking issues