### PR TITLE
Fix Burn bundle uninstall identity selection

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1562,6 +1562,17 @@ if ($useRegistryUninstall) {
     # StrictMode would turn the fallback check into a post-install 60001 failure.
     if ($originalInstallerType -eq 'burn') {
         $lines += @(
+            '        if ($selectedApplications.Count -gt 1) {'
+            '            # A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
+            '            # Prefer the single non-MSI entry from the already identity-matched set; never widen'
+            '            # an ambiguous match to an unrelated uninstall entry.'
+            '            $bundleCandidates = @($selectedApplications | Where-Object {'
+            '                $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+            '                $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+            '                $isVisibleApplication -and -not $_.WindowsInstaller'
+            '            })'
+            '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
+            '        }'
             '        if ($selectedApplications.Count -eq 0) {'
             '            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
             '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
+  packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -26,6 +26,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
   'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
   'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -290,7 +290,40 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain(
       '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
     );
+    expect(packager).toContain(
+      '$bundleCandidates = @($selectedApplications | Where-Object {'
+    );
+    expect(packager).toContain(
+      '$isVisibleApplication -and -not $_.WindowsInstaller'
+    );
   });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'narrows an ambiguous Burn display-name match to the single bundle entry',
+    () => {
+      const generated = generateRegistryUninstallPackage('burn', 'PreForm');
+
+      expect(generated).toContain('if ($selectedApplications.Count -gt 1)');
+      expect(generated).toContain(
+        '$bundleCandidates = @($selectedApplications | Where-Object {'
+      );
+      expect(generated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
+      expect(generated.indexOf('if ($selectedApplications.Count -gt 1)')).toBeLessThan(
+        generated.indexOf('if ($selectedApplications.Count -eq 1) { break }')
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'does not emit Burn-only duplicate-entry narrowing for non-Burn packages',
+    () => {
+      const generated = generateRegistryUninstallPackage('inno', 'Example App');
+
+      expect(generated).not.toContain(
+        'A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
+      );
+    }
+  );
 
   it.runIf(canRunWindowsPowerShellPackager)(
     'does not leak generator-only installer type state into generated scripts',
@@ -302,6 +335,10 @@ describe('PSADT registry uninstall identity contract', () => {
       expect(burnGenerated).not.toContain('$originalInstallerType');
       expect(burnGenerated).toContain(
         '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+      );
+      expect(burnGenerated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
+      expect(burnGenerated).toContain(
+        'A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
       );
     }
   );

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,11 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '430f817da1120f6a14f421b7016b628a06854aba': [
+    'Adobe.CreativeCloud',
+    'Elgato.StreamDeck',
+    'Formlabs.PreForm',
+  ],
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440': ['Figma.Figma'],
   'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028': [
     'Figma.Figma',

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1009,6 +1009,16 @@ ${steps}
             })
             if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
         }
+        if ($selectedApplications.Count -gt 1 -and '${job.installer_type.toLowerCase()}' -eq 'burn') {
+            # A Burn bundle and its chained MSI can intentionally share the same ARP display name.
+            # Narrow only the already identity-matched set to its single non-MSI bundle entry.
+            $bundleCandidates = @($selectedApplications | Where-Object {
+                $systemComponentProperty = $_.PSObject.Properties['SystemComponent']
+                $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value
+                $isVisibleApplication -and -not $_.WindowsInstaller
+            })
+            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
+        }
         if ($selectedApplications.Count -eq 0 -and '${job.installer_type.toLowerCase()}' -eq 'burn') {
             $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })
             if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -327,6 +327,50 @@ describe('Burn bundle PSADT generation', () => {
     expect(script).toContain('foreach ($verificationAttempt in 1..5)');
     expect(script).not.toContain("Start-ADTMsiProcess -Action 'Uninstall'");
   });
+
+  it('narrows duplicate bundle and chained-MSI display names to the bundle entry', () => {
+    const job = packagingJob({
+      winget_id: 'Formlabs.PreForm',
+      display_name: 'PreForm',
+      installer_type: 'burn',
+      uninstall_command: 'REGISTRY_UNINSTALL:PreForm',
+    });
+
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'PreForm'
+    );
+
+    expect(verification).toContain(
+      "if ($selectedApplications.Count -gt 1 -and 'burn' -eq 'burn')"
+    );
+    expect(verification).toContain(
+      '$bundleCandidates = @($selectedApplications | Where-Object {'
+    );
+    expect(verification).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
+    expect(verification.indexOf('$selectedApplications.Count -gt 1')).toBeLessThan(
+      verification.indexOf('$selectedApplications.Count -eq 1) { break }')
+    );
+  });
+
+  it('keeps Burn-only duplicate-entry narrowing disabled for non-Burn packages', () => {
+    const job = packagingJob({
+      installer_type: 'inno',
+      uninstall_command: 'REGISTRY_UNINSTALL:Example App',
+    });
+
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'Example App'
+    );
+
+    expect(verification).toContain("$selectedApplications.Count -gt 1 -and 'inno' -eq 'burn'");
+    expect(verification).not.toContain(
+      "$selectedApplications.Count -gt 1 -and 'inno' -eq 'inno'"
+    );
+  });
 });
 
 describe('EXE product identity PSADT generation', () => {


### PR DESCRIPTION
## Summary
- disambiguate Burn bundle and chained MSI entries that share an ARP display name
- apply the same fail-closed selection to hosted QA and Docker/customer packaging
- prefer a single visible non-MSI identity match without widening to unrelated entries
- pin QA profiles to the immutable packager commit and retry Formlabs, Adobe, and Elgato

## Validation
- 844 tests passed
- ESLint passed
- packager TypeScript build passed
- PowerShell parser passed
- Next.js production build passed
- two bounded Claude Opus review passes completed with no blocking findings