### PR TITLE
Fix zero-day PSADT deferrals

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -750,7 +750,12 @@ if ($psadtConfig.ContainsKey('deferDays') -and $null -ne $psadtConfig.deferDays)
         ) -or $parsedDeferDays -lt 0 -or $parsedDeferDays -gt 3650) {
         throw 'PSADT deferDays must be a number from 0 through 3650.'
     }
-    $deferDays = [Convert]::ToString($parsedDeferDays, [System.Globalization.CultureInfo]::InvariantCulture)
+    # IntuneGet uses zero as the UI/API sentinel for no day-based limit. PSADT
+    # v4.1 rejects an explicitly supplied DeferDays value of zero, so omit the
+    # parameter unless the configured duration is positive.
+    if ($parsedDeferDays -gt 0) {
+        $deferDays = [Convert]::ToString($parsedDeferDays, [System.Globalization.CultureInfo]::InvariantCulture)
+    }
 }
 $forceCloseCountdown = $null
 if ($psadtConfig.ContainsKey('forceCloseProcessesCountdown') -and

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -484,6 +484,41 @@ describe('PSADT registry uninstall identity contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'treats zero defer days as no day-based limit for PSADT v4.1',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Zero Defer Days Contract App',
+        [],
+        {
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+          allowDefer: true,
+          deferTimes: 3,
+          deferDays: 0,
+        }
+      );
+
+      expect(generated).toContain('-AllowDeferCloseProcesses');
+      expect(generated).not.toContain('-DeferDays 0');
+
+      const positive = generateRegistryUninstallPackage(
+        'inno',
+        'Positive Defer Days Contract App',
+        [],
+        { allowDefer: true, deferDays: 1.5 }
+      );
+      expect(positive).toContain('-DeferDays 1.5');
+
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Negative Defer Days Contract App',
+        [],
+        { allowDefer: true, deferDays: -1 }
+      )).toThrow('deferDays must be a number from 0 through 3650');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects non-object configs and string booleans before generation',
     () => {
       expect(() => generateRegistryUninstallPackage(

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -687,6 +687,9 @@ catch
       if (!Number.isFinite(deferDays) || deferDays < 0 || deferDays > 3_650) {
         throw new Error('PSADT deferDays must be a number from 0 through 3650');
       }
+      // Zero is IntuneGet's UI/API sentinel for no day-based limit. PSADT
+      // v4.1 rejects an explicitly supplied -DeferDays 0 value.
+      if (deferDays === 0) deferDays = null;
     }
     let deferDeadline: string | null = null;
     if (config?.deferDeadline !== undefined && config.deferDeadline !== null) {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -127,6 +127,43 @@ describe('nested portable PSADT generation', () => {
       .toThrow('Invalid PSADT process name');
   });
 
+  it('treats zero defer days as no day-based limit for PSADT v4.1', () => {
+    const script = generator.generateDeployScript.call(generator, packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: {
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+          allowDefer: true,
+          deferTimes: 3,
+          deferDays: 0,
+        },
+      },
+    }), 'piicrawler.zip');
+
+    expect(script).toContain('-AllowDeferCloseProcesses');
+    expect(script).not.toContain('-DeferDays 0');
+
+    const positiveScript = generator.generateDeployScript.call(generator, packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: { allowDefer: true, deferDays: 1.5 },
+      },
+    }), 'piicrawler.zip');
+    expect(positiveScript).toContain('-DeferDays 1.5');
+
+    const negativeJob = packagingJob({
+      package_config: {
+        nestedInstallerType: 'portable',
+        nestedInstallerPath: 'piicrawler.exe',
+        psadtConfig: { allowDefer: true, deferDays: -1 },
+      },
+    });
+    expect(() => generator.generateDeployScript.call(generator, negativeJob, 'piicrawler.zip'))
+      .toThrow('deferDays must be a number from 0 through 3650');
+  });
+
   it('rejects string booleans and malformed deferral deadlines', () => {
     const stringBooleanJob = packagingJob({
       package_config: {


### PR DESCRIPTION
## Summary
- normalize `deferDays: 0` to an omitted PSADT parameter instead of emitting invalid `-DeferDays 0`
- apply the same behavior to the GitHub/customer packaging script and the self-hosted Docker packager
- retain positive fractional values and fail closed for negative or out-of-range values
- add executable parity regression tests for both packaging paths

## Root cause
PSADT 4.1.8 validates `DeferDays` as strictly greater than zero. IntuneGet accepts zero as the UI/API sentinel for no day-based limit, but both packagers emitted it literally. This caused `Show-ADTInstallationWelcome` to terminate packages with exit code 60001 before the vendor installer started.

## Validation
- 72 focused Vitest tests passed
- PowerShell parser passed
- focused ESLint passed
- git diff check passed

A bounded Opus read-only review was requested but reached the four-minute CLI limit without returning findings or changing files.