### PR TITLE
Pin QA to zero-day deferral fix

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -459,15 +459,15 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Elgato.StreamDeck',
-        name: 'Elgato Stream Deck',
-        publisher: 'Elgato',
+        winget_id: 'Google.Chrome',
+        name: 'Google Chrome',
+        publisher: 'Google',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Elgato.StreamDeck',
-          packagerCommit: 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
+          wingetId: 'Google.Chrome',
+          packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
           status: 'failed',
         }),
       ],
@@ -488,7 +488,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Elgato.StreamDeck',
+      winget_id: 'Google.Chrome',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
+  packagerCommit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -26,6 +26,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  '430f817da1120f6a14f421b7016b628a06854aba',
   '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
   'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
   '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,8 +3,8 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each(['Adobe.CreativeCloud', 'Elgato.StreamDeck'])(
-    'retries the terminal %s failure for the lifecycle-adapter toolchain',
+  it.each(['Google.Chrome'])(
+    'retries the terminal %s failure for the zero-day deferral toolchain',
     (wingetId) => {
       expect(shouldRetryTerminalToolchainCandidate(
         QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,7 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '66448ea49841c2c9f3ebf56e455ce8797e2b2abb': ['Google.Chrome'],
   '430f817da1120f6a14f421b7016b628a06854aba': [
     'Adobe.CreativeCloud',
     'Elgato.StreamDeck',


### PR DESCRIPTION
## Summary
- advance the canonical QA package profile to packager commit `66448ea`
- keep passing results from the previous commit compatible because the new change only fixes an invalid failure path
- target Google Chrome for automatic terminal-failure retry under the corrected toolchain
- update enqueue/backfill tests to cover the exact affected app

## Validation
- 56 focused QA profile, toolchain backfill, and enqueue tests passed
- focused ESLint passed
- git diff check passed