### PR TITLE
Resolve MSI product-code placeholders

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -583,11 +583,11 @@ if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
     $registryUninstallDisplayName = $DisplayName
 }
 
-# WinGet metadata can omit, decorate, or stale-cache an MSI ProductCode. Read
-# the authoritative identity from the downloaded MSI so the customer package
-# and QA both target the exact Windows Installer product. This also repairs the
-# explicit missing-identity sentinel without guessing from a display name.
-if ($fileExtension -eq '.msi' -and ($useRegistryUninstall -or $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED')) {
+# WinGet metadata can omit, decorate, stale-cache, or leave a literal
+# {PRODUCT_CODE} placeholder in an MSI uninstall command. Always read the
+# authoritative identity from the downloaded MSI so neither customer packages
+# nor QA can execute an unresolved template such as `msiexec /x {PRODUCT_CODE}`.
+if ($fileExtension -eq '.msi') {
     $msiProductCode = [string](Get-MsiPropertyValue -Path $env:INSTALLER_PATH -Property 'ProductCode')
     if ($msiProductCode -match '^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$') {
         $useRegistryUninstall = $true

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -651,6 +651,10 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain(
       "$msiProductCode = [string](Get-MsiPropertyValue -Path $env:INSTALLER_PATH -Property 'ProductCode')"
     );
+    expect(packager).toContain("if ($fileExtension -eq '.msi') {");
+    expect(packager).not.toContain(
+      "$fileExtension -eq '.msi' -and ($useRegistryUninstall -or $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED')"
+    );
     expect(packager).toContain(
       'Using MSI database product code for registry identity'
     );
@@ -682,9 +686,7 @@ describe('PSADT registry uninstall identity contract', () => {
   });
 
   it('repairs missing MSI identities and rejects unresolved MSI or unsafe MSIX identities', () => {
-    expect(packager).toContain(
-      "$useRegistryUninstall -or $uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED'"
-    );
+    expect(packager).toContain("if ($fileExtension -eq '.msi') {");
     expect(packager).toContain("$uninstallCmd -eq 'MSI_UNINSTALL_IDENTITY_REQUIRED'");
     expect(packager).toContain(
       'The MSI database did not expose a valid ProductCode; refusing ambiguous detection or removal.'

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -946,6 +946,17 @@ ${steps}
       };
     }
 
+    const installerType = job.installer_type.toLowerCase();
+    if (installerType === 'msi' || installerType === 'wix') {
+      const productCodeMatch = job.uninstall_command?.match(
+        /\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}/
+      );
+      return {
+        productCode: productCodeMatch?.[0] || '',
+        displayName: job.display_name.replace(/'/g, "''"),
+      };
+    }
+
     return null;
   }
 
@@ -1308,11 +1319,7 @@ ${steps}
     }`;
     }
 
-    if (!job.uninstall_command) {
-      return "Write-ADTLogEntry -Message 'No uninstall command specified' -Severity 'Warning' -Source 'Uninstall-ADTDeployment'";
-    }
-
-    if (/^MSIX_UNINSTALL:/.test(job.uninstall_command)) {
+    if (/^MSIX_UNINSTALL:/.test(job.uninstall_command || '')) {
       const packageName = this.getMsixPackageName(job);
       if (!packageName) {
         return 'throw "The MSIX/APPX package identity is missing or unsafe; refusing an ambiguous removal."';
@@ -1354,6 +1361,7 @@ ${steps}
     } else {
         @(Get-ADTApplication -Name $configuredDisplayName -NameMatch 'Exact')
     }
+
     if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey) {
         $installedApps = @(Get-ADTApplication -Name $configuredDisplayName -NameMatch 'Exact')
     }
@@ -1556,6 +1564,10 @@ ${steps}
     if ($remainingApplications.Count -gt 0) {
         throw "The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."
     }`;
+    }
+
+    if (!job.uninstall_command) {
+      return "Write-ADTLogEntry -Message 'No uninstall command specified' -Severity 'Warning' -Source 'Uninstall-ADTDeployment'";
     }
 
     if (/^REGISTRY_UNINSTALL_PRODUCT:/.test(job.uninstall_command)) {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -411,6 +411,25 @@ describe('Burn bundle PSADT generation', () => {
 });
 
 describe('EXE product identity PSADT generation', () => {
+  it('captures MSI identity when Winget leaves a PRODUCT_CODE placeholder', () => {
+    const job = packagingJob({
+      winget_id: 'Yealink.YealinkUSBConnect',
+      display_name: 'Yealink USB Connect',
+      installer_type: 'msi',
+      uninstall_command: 'msiexec /x {PRODUCT_CODE} /qn /norestart',
+    });
+
+    const script = generator.generateDeployScript.call(generator, job, 'yealink.msi');
+    const uninstall = generator.getUninstallCommand.call(generator, job, 'yealink.msi');
+
+    expect(script).toContain('$preInstallApplications = @(Get-ADTApplication');
+    expect(script).toContain('$capturedUninstallKey = [string]$selectedApplications[0].PSChildName');
+    expect(uninstall).toContain('$capturedMsiProductCode');
+    expect(uninstall).toContain("Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode");
+    expect(uninstall).not.toContain('{PRODUCT_CODE}');
+    expect(uninstall).not.toContain("-ArgumentList '/c msiexec");
+  });
+
   it('uses the same fail-closed architecture-label comparison as hosted packaging', () => {
     const verification = generator.getPostInstallVerificationBlock.call(
       generator,


### PR DESCRIPTION
## Summary
- always extract the authoritative ProductCode from downloaded MSI packages
- prevent literal Winget {PRODUCT_CODE} templates from reaching msiexec
- make the worker packager capture and remove the exact installed MSI identity
- add Yealink-shaped regression coverage

## Validation
- 73 focused Vitest tests
- standalone packager TypeScript build
- targeted ESLint
- PowerShell parser and git diff checks