### PR TITLE
Pin QA to MSI identity fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
+  packagerCommit: 'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -26,6 +26,7 @@ export const QA_PSADT_TOOLCHAIN = {
  */
 export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
   QA_PSADT_TOOLCHAIN.packagerCommit,
+  '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
   '430f817da1120f6a14f421b7016b628a06854aba',
   '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
   'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,8 +3,8 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each(['Google.Chrome'])(
-    'retries the terminal %s failure for the zero-day deferral toolchain',
+  it.each(['Google.Chrome', 'Yealink.YealinkUSBConnect'])(
+    'retries the terminal %s failure for the current cumulative toolchain fixes',
     (wingetId) => {
       expect(shouldRetryTerminalToolchainCandidate(
         QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,10 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ef75edee9fcabaf904bcf80e02ead9aa58490dc9': [
+    'Google.Chrome',
+    'Yealink.YealinkUSBConnect',
+  ],
   '66448ea49841c2c9f3ebf56e455ce8797e2b2abb': ['Google.Chrome'],
   '430f817da1120f6a14f421b7016b628a06854aba': [
     'Adobe.CreativeCloud',


### PR DESCRIPTION
## Summary
- pin the canonical QA profile to merged packager commit ef75edee
- retain successful 66448ea runs as compatible because the new change affects only unresolved MSI failure paths
- target clean retries for Google Chrome and Yealink USB Connect

## Validation
- 57 focused tests
- targeted ESLint
- git diff check