### PR TITLE
Fix QA reruns with behavior-scoped compatibility and maintenance pause

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -33,6 +33,7 @@ import type { QaLivePhase, QaLiveResponse } from '@/types/qa';
 
 function healthTone(state: string): StatusTone {
   if (state === 'healthy' || state === 'testing') return 'success';
+  if (state === 'paused') return 'warning';
   if (state === 'degraded') return 'warning';
   if (state === 'stalled') return 'error';
   return 'neutral';
@@ -43,6 +44,7 @@ function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): strin
   if (issue === 'partial_failure') return 'Some package checks failed';
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
+  if (issue === 'maintenance') return 'Testing is temporarily paused for maintenance';
   return null;
 }
 
@@ -94,7 +96,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
   const runnerAge = formatRelativeTime(data.runner.heartbeatAt, data.serverTime);
   const pollAge = formatRelativeTime(data.scheduler.lastPollAt, data.serverTime);
   const schedulerIssue = schedulerIssueLabel(data.scheduler.issue);
-  const hasIncident = data.runner.state === 'stalled' || data.scheduler.state === 'degraded';
+  const hasIncident = data.runner.state === 'stalled' || data.scheduler.state === 'degraded' || data.scheduler.state === 'paused';
   const passCount = data.recent.filter((item) => item.outcome === 'Passed').length;
 
   return (
@@ -104,7 +106,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
         'overflow-hidden rounded-2xl border bg-bg-elevated',
         data.runner.state === 'stalled'
           ? 'border-status-error/30 bg-status-error/[0.04]'
-          : data.scheduler.state === 'degraded'
+          : data.scheduler.state === 'degraded' || data.scheduler.state === 'paused'
             ? 'border-status-warning/30 bg-status-warning/[0.04]'
             : 'border-overlay/10'
       )}
@@ -131,7 +133,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
             <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>WinGet polling</T></p>
             <div className="mt-1 flex flex-wrap items-center gap-2">
               <StatusBadge tone={healthTone(data.scheduler.state)}>
-                <T>{data.scheduler.state === 'healthy' ? 'Healthy' : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
+                <T>{data.scheduler.state === 'healthy' ? 'Healthy' : data.scheduler.state === 'paused' ? 'Paused' : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
               </StatusBadge>
               <span className="text-xs text-text-muted">
                 {pollAge ? <T>Last scan <Var>{pollAge}</Var></T> : <T>No scan recorded yet</T>}
@@ -167,6 +169,9 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
         <div className="border-t border-status-warning/20 px-4 py-2 text-xs text-status-warning" role="status">
           <AlertTriangle className="mr-1.5 inline h-3.5 w-3.5" aria-hidden="true" />
           <T>{schedulerIssue}</T>
+          {data.scheduler.issue === 'maintenance' && data.scheduler.maintenanceReason
+            ? <> · <T>{data.scheduler.maintenanceReason}</T></>
+            : null}
           {data.scheduler.consecutiveFailures > 1
             ? data.scheduler.issue === 'github_rate_limit'
               ? <> · <T><Var>{data.scheduler.consecutiveFailures}</Var> affected scans</T></>

--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -54,7 +54,7 @@ function candidate(profileKind: 'catalog-default' | 'deployment-config') {
     nestedInstallerFiles: [],
     psadtConfig: DEFAULT_PSADT_CONFIG,
     detectionRules: [],
-  } as const;
+  };
   const identity = buildQaPackageIdentity(profileInput);
   return {
     id: profileKind === 'deployment-config' ? DEPLOYMENT_ID : CATALOG_ID,
@@ -80,6 +80,7 @@ function createSupabaseStub(
   queued: Array<ReturnType<typeof candidate>>,
   additionalPages: Array<Array<ReturnType<typeof candidate>>> = [],
   options: {
+    paused?: boolean;
     claimNullIds?: string[];
     claimErrorById?: Record<string, { message: string; code?: string }>;
     supersedeError?: { message: string; code?: string };
@@ -97,6 +98,16 @@ function createSupabaseStub(
 
   const client = {
     from: vi.fn((table: string) => {
+      if (table === 'qa_pipeline_control') {
+        return query({
+          data: {
+            paused: options.paused === true,
+            reason: options.paused ? 'Golden VM maintenance' : null,
+            updated_at: '2026-08-11T12:00:00.000Z',
+          },
+          error: null,
+        });
+      }
       if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
       return {
         select: vi.fn((columns: string) => {
@@ -193,6 +204,25 @@ afterEach(() => {
 });
 
 describe('GET /api/cron/qa-dispatch', () => {
+  it('does not reconcile or dispatch candidates while maintenance is paused', async () => {
+    const row = candidate('catalog-default');
+    const { client, claimedIds } = createSupabaseStub([row], [], { paused: true });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      dispatched: false,
+      reason: 'maintenance_paused',
+      maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
   it('supersedes an invalid row and dispatches the valid row behind it', async () => {
     const invalid = candidate('catalog-default');
     invalid.id = testUuid(10);

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { dispatchQaCandidate } from '@/lib/qa/dispatch';
 import { validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
+import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
@@ -43,6 +44,16 @@ export async function GET(request: Request) {
   }
 
   const supabase = createServerClient();
+  const control = await getQaPipelineControl(supabase);
+  if (control.paused) {
+    return NextResponse.json({
+      success: true,
+      dispatched: false,
+      reason: 'maintenance_paused',
+      maintenanceReason: control.reason,
+      pausedAt: control.updatedAt,
+    });
+  }
   const now = new Date();
   const { data: active, error: activeError } = await supabase
     .from('qa_candidates')

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -60,6 +60,7 @@ function query(result: QueryResult) {
 }
 
 function createSupabaseStub(options: {
+  paused?: boolean;
   coverage?: number;
   coverageError?: string;
   supportedApps?: Array<Record<string, unknown>>;
@@ -88,6 +89,16 @@ function createSupabaseStub(options: {
       });
     }),
     from: vi.fn((table: string) => {
+      if (table === 'qa_pipeline_control') {
+        return query({
+          data: {
+            paused: options.paused === true,
+            reason: options.paused ? 'Golden VM maintenance' : null,
+            updated_at: '2026-08-11T12:00:00.000Z',
+          },
+          error: null,
+        });
+      }
       if (table === 'qa_poll_runs') {
         return {
           insert: vi.fn((row: Record<string, unknown>) => {
@@ -295,6 +306,25 @@ afterEach(() => {
 });
 
 describe('GET /api/cron/qa-enqueue', () => {
+  it('does not poll or mutate the queue while maintenance is paused', async () => {
+    const { client, pollRunInserts, candidateInserts } = createSupabaseStub({ paused: true });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      paused: true,
+      reason: 'maintenance_paused',
+      maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(pollRunInserts).toHaveLength(0);
+    expect(candidateInserts).toHaveLength(0);
+    expect(detectWingetChangesMock).not.toHaveBeenCalled();
+  });
+
   it('persists a successful full-catalog poll and advances its cursor', async () => {
     const { client, pollRunInserts, pollRunUpdates, cursorUpdates, rpcCalls } =
       createSupabaseStub({});

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -27,6 +27,7 @@ import {
   shouldRetryTerminalToolchainCandidate,
   type QaToolchainBackfillCandidate,
 } from '@/lib/qa/toolchain-backfill';
+import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
@@ -313,6 +314,16 @@ export async function GET(request: Request) {
 
   try {
     supabase = createServerClient();
+    const control = await getQaPipelineControl(supabase);
+    if (control.paused) {
+      return NextResponse.json({
+        success: true,
+        paused: true,
+        reason: 'maintenance_paused',
+        maintenanceReason: control.reason,
+        pausedAt: control.updatedAt,
+      });
+    }
     const { data: pollRun, error: pollRunError } = await supabase
       .from('qa_poll_runs')
       .insert({ request_id: requestId, started_at: startedAt })

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -51,7 +51,7 @@ function createSupabaseMock(tables: Record<string, TableHandlers>) {
       const handlers = tables[table] || {};
       const builder: Record<string, unknown> = {};
       const chain = () => builder;
-      for (const method of ['select', 'eq', 'not', 'order', 'limit']) {
+      for (const method of ['select', 'eq', 'not', 'contains', 'order', 'limit']) {
         builder[method] = vi.fn(chain);
       }
       builder.error = handlers.terminalError || null;

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
+import {
+  buildQaPackageIdentityFromWorkflowInput,
+  canonicalQaJson,
+  qaSha256,
+} from '@/lib/qa/package-profile';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string; code?: string } | null;
+};
+
+function query(result: QueryResult) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'in', 'contains', 'order', 'limit']) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.maybeSingle = vi.fn(async () => result);
+  builder.then = (
+    onFulfilled?: (value: QueryResult) => unknown,
+    onRejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return builder;
+}
+
+function demandInput(): QaDemandInput {
+  return {
+    wingetId: 'Example.App',
+    displayName: 'Example',
+    publisher: 'Contoso',
+    version: '1.2.3',
+    architecture: 'x64',
+    installerUrl: 'https://example.test/setup.exe',
+    installerSha256: 'A'.repeat(64),
+    installerType: 'nullsoft',
+    silentSwitches: '/S',
+    uninstallCommand: 'REGISTRY_UNINSTALL:Example:/S',
+    installScope: 'machine',
+    psadtConfig: JSON.stringify(DEFAULT_PSADT_CONFIG),
+    detectionRules: '[]',
+    priority: 1_000,
+    demandSource: 'customer',
+  };
+}
+
+function priorCandidate(input: QaDemandInput, packagerCommit: string) {
+  const identity = buildQaPackageIdentityFromWorkflowInput(input);
+  const current = JSON.parse(identity.canonicalJson) as Record<string, unknown> & {
+    toolchain: Record<string, unknown>;
+  };
+  const canonical = canonicalQaJson({
+    ...current,
+    toolchain: { ...current.toolchain, packagerCommit },
+  });
+  return {
+    winget_id: input.wingetId,
+    version: input.version,
+    architecture: input.architecture,
+    installer_sha256: input.installerSha256,
+    package_profile_sha256: qaSha256(canonical),
+    test_config: {
+      profileKind: 'deployment-config',
+      packageProfileCanonicalJson: canonical,
+      packageProfileSha256: qaSha256(canonical),
+    },
+    finished_at: '2026-08-10T10:00:00.000Z',
+  };
+}
+
+describe('ensureQaDemand compatible evidence reuse', () => {
+  it('aliases a behavior-identical prior pass instead of queueing the app again', async () => {
+    const input = demandInput();
+    const prior = priorCandidate(
+      input,
+      '66448ea49841c2c9f3ebf56e455ce8797e2b2abb'
+    );
+    const aliasInserts: Array<Record<string, unknown>> = [];
+    let packageResultRead = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_candidates') {
+          return query({ data: [prior], error: null });
+        }
+        if (table === 'qa_package_results') {
+          return {
+            select: vi.fn(() => {
+              packageResultRead++;
+              if (packageResultRead === 1) return query({ data: null, error: null });
+              return query({
+                data: [{
+                  package_profile_sha256: prior.package_profile_sha256,
+                  winget_id: input.wingetId,
+                  tested_version: input.version,
+                  architecture: 'x64',
+                  installer_sha256: input.installerSha256,
+                  outcome: 'Passed',
+                  tested_at_utc: '2026-08-10T10:10:00.000Z',
+                  psadt_version: '4.1.8',
+                  psadt_template_sha256: 'B'.repeat(64),
+                  psadt_config_sha256: 'C'.repeat(64),
+                  detection_rules_sha256: 'D'.repeat(64),
+                  packager_commit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
+                  package_content_sha256: 'E'.repeat(64),
+                  github_run_id: '123',
+                  github_run_url: 'https://github.test/run/123',
+                }],
+                error: null,
+              });
+            }),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              aliasInserts.push(row);
+              return query({ data: null, error: null });
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result.state).toBe('passed');
+    expect(result.candidateId).toBeNull();
+    expect(aliasInserts).toEqual([
+      expect.objectContaining({
+        package_profile_sha256: result.identity.executionProfileSha256,
+        packager_commit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
+        github_run_id: '123',
+      }),
+    ]);
+  });
+
+  it('uses an exact current result without scanning historical candidates', async () => {
+    const input = demandInput();
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table !== 'qa_package_results') throw new Error(`Unexpected table: ${table}`);
+        return {
+          select: vi.fn(() => query({ data: { outcome: 'Passed' }, error: null })),
+        };
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result.state).toBe('passed');
+    expect(client.from).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { normalizeQaInstallerType, qaInstallerFileName } from '@/lib/qa/candidate';
 import {
   buildQaPackageIdentityFromWorkflowInput,
+  validateCompatiblePassedDeploymentQaProfile,
   type QaPackageIdentity,
   type QaWorkflowPackageInput,
 } from '@/lib/qa/package-profile';
@@ -21,6 +22,125 @@ export interface QaDemandResult {
   candidateId: string | null;
   state: QaDemandState;
   failureSummary?: string;
+}
+
+const PACKAGE_RESULT_COLUMNS = [
+  'package_profile_sha256',
+  'winget_id',
+  'tested_version',
+  'architecture',
+  'installer_sha256',
+  'outcome',
+  'tested_at_utc',
+  'psadt_version',
+  'psadt_template_sha256',
+  'psadt_config_sha256',
+  'detection_rules_sha256',
+  'packager_commit',
+  'package_content_sha256',
+  'github_run_id',
+  'github_run_url',
+].join(', ');
+
+interface CompatiblePackageResult {
+  package_profile_sha256: string;
+  winget_id: string;
+  tested_version: string;
+  architecture: string;
+  installer_sha256: string;
+  outcome: 'Passed';
+  tested_at_utc: string;
+  psadt_version: string;
+  psadt_template_sha256: string;
+  psadt_config_sha256: string;
+  detection_rules_sha256: string;
+  packager_commit: string;
+  package_content_sha256: string;
+  github_run_id: string | null;
+  github_run_url: string | null;
+}
+
+async function aliasCompatiblePassedDeploymentResult(
+  supabase: SupabaseClient,
+  input: QaDemandInput,
+  identity: QaPackageIdentity
+): Promise<boolean> {
+  const architecture = (input.architecture || 'x64').toLowerCase();
+  const installerSha256 = input.installerSha256.toUpperCase();
+  const { data: candidates, error: candidateError } = await supabase
+    .from('qa_candidates')
+    .select(
+      'winget_id, version, architecture, installer_sha256, package_profile_sha256, test_config, finished_at'
+    )
+    .eq('winget_id', input.wingetId)
+    .eq('version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('test_level', 'psadt-package')
+    .eq('status', 'passed')
+    .contains('test_config', { profileKind: 'deployment-config' })
+    .order('finished_at', { ascending: false })
+    .limit(100);
+  if (candidateError) {
+    throw new Error(`Could not read compatible package QA candidates: ${candidateError.message}`);
+  }
+
+  const compatibleHashes: string[] = [];
+  for (const candidate of candidates || []) {
+    if (!candidate.package_profile_sha256) continue;
+    const validation = validateCompatiblePassedDeploymentQaProfile({
+      prior: {
+        testConfig: candidate.test_config,
+        candidatePackageProfileSha256: candidate.package_profile_sha256,
+        candidateWingetId: candidate.winget_id,
+        candidateVersion: candidate.version,
+        candidateArchitecture: candidate.architecture,
+        candidateInstallerSha256: candidate.installer_sha256,
+      },
+      currentCanonicalJson: identity.canonicalJson,
+      currentPackageProfileSha256: identity.executionProfileSha256,
+    });
+    if (validation.valid) compatibleHashes.push(candidate.package_profile_sha256);
+  }
+  if (compatibleHashes.length === 0) return false;
+
+  const { data: compatibleResults, error: resultError } = await supabase
+    .from('qa_package_results')
+    .select(PACKAGE_RESULT_COLUMNS)
+    .in('package_profile_sha256', compatibleHashes)
+    .eq('outcome', 'Passed')
+    .order('tested_at_utc', { ascending: false })
+    .limit(1);
+  if (resultError) {
+    throw new Error(`Could not read compatible package QA results: ${resultError.message}`);
+  }
+  const source = (compatibleResults as unknown as CompatiblePackageResult[] | null)?.[0];
+  if (!source) return false;
+
+  const { error: aliasError } = await supabase
+    .from('qa_package_results')
+    .insert({
+      package_profile_sha256: identity.executionProfileSha256,
+      winget_id: source.winget_id,
+      tested_version: source.tested_version,
+      architecture: source.architecture,
+      installer_sha256: source.installer_sha256,
+      outcome: source.outcome,
+      tested_at_utc: source.tested_at_utc,
+      psadt_version: source.psadt_version,
+      psadt_template_sha256: source.psadt_template_sha256,
+      psadt_config_sha256: source.psadt_config_sha256,
+      detection_rules_sha256: source.detection_rules_sha256,
+      packager_commit: source.packager_commit,
+      package_content_sha256: source.package_content_sha256,
+      github_run_id: source.github_run_id,
+      github_run_url: source.github_run_url,
+      synced_at: new Date().toISOString(),
+    });
+  if (aliasError && aliasError.code !== '23505') {
+    throw new Error(`Could not preserve compatible package QA evidence: ${aliasError.message}`);
+  }
+  return true;
 }
 
 export async function ensureQaDemand(
@@ -46,6 +166,10 @@ export async function ensureQaDemand(
       state: 'failed',
       failureSummary: 'This app did not pass the isolated installation test.',
     };
+  }
+
+  if (await aliasCompatiblePassedDeploymentResult(supabase, input, identity)) {
+    return { identity, candidateId: null, state: 'passed' };
   }
 
   const architecture = (input.architecture || 'x64').toLowerCase();

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -252,4 +252,35 @@ describe('buildQaLiveResponse', () => {
       issue: 'github_rate_limit',
     });
   });
+
+  it('shows deliberate maintenance instead of reporting the scheduler as degraded', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-11T12:05:00.000Z'),
+      current: null,
+      queuedCount: 12,
+      queued: [],
+      poll: {
+        status: 'failed',
+        started_at: '2026-08-11T12:00:00.000Z',
+        finished_at: '2026-08-11T12:00:01.000Z',
+        errors: ['upstream failed'],
+      },
+      consecutivePollFailures: 3,
+      recent: [],
+      apps: [],
+      frame: null,
+      control: {
+        paused: true,
+        reason: 'Golden VM wallpaper maintenance',
+        updatedAt: '2026-08-11T12:04:00.000Z',
+      },
+    });
+
+    expect(response.scheduler).toMatchObject({
+      state: 'paused',
+      issue: 'maintenance',
+      maintenanceReason: 'Golden VM wallpaper maintenance',
+      pausedAt: '2026-08-11T12:04:00.000Z',
+    });
+  });
 });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { createServerClient } from '@/lib/supabase';
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
+import { getQaPipelineControl, type QaPipelineControl } from '@/lib/qa/pipeline-control';
 import type { Json } from '@/types/database';
 import type { QaArchitecture, QaLiveActivity, QaLiveLog, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome } from '@/types/qa';
 
@@ -71,6 +72,7 @@ export interface QaLiveSnapshotInput {
   recent: ResultRow[];
   apps: AppRow[];
   frame: FrameRow | null;
+  control?: QaPipelineControl;
 }
 
 const VALID_PHASES = new Set<QaLivePhase>([
@@ -269,6 +271,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
           ? 'healthy'
           : 'degraded';
   }
+  if (input.control?.paused) schedulerState = 'paused';
 
   const currentApp = input.current ? appById.get(input.current.winget_id) : null;
   const frameIsCurrent = Boolean(
@@ -295,8 +298,10 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       state: schedulerState,
       lastPollAt: input.poll?.finished_at || input.poll?.started_at || null,
       lastOutcome: input.poll?.status || null,
-      issue: schedulerIssue(input.poll, stalePoll),
+      issue: input.control?.paused ? 'maintenance' : schedulerIssue(input.poll, stalePoll),
       consecutiveFailures: input.consecutivePollFailures,
+      maintenanceReason: input.control?.paused ? input.control.reason : null,
+      pausedAt: input.control?.paused ? input.control.updatedAt : null,
     },
     current: input.current && currentStartedAt
       ? {
@@ -354,7 +359,7 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const candidateColumns =
     'id, winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, live_activity, activity_updated_at, live_log, log_updated_at, test_config';
 
-  const [activeResult, queueResult, countResult, pollResult, recentResult] = await Promise.all([
+  const [activeResult, queueResult, countResult, pollResult, recentResult, control] = await Promise.all([
     supabase
       .from('qa_candidates')
       .select(candidateColumns)
@@ -389,6 +394,7 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
       )
       .order('tested_at_utc', { ascending: false })
       .limit(10),
+    getQaPipelineControl(supabase),
   ]);
 
   for (const result of [activeResult, queueResult, countResult, pollResult, recentResult]) {
@@ -440,5 +446,6 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
     recent,
     apps,
     frame,
+    control,
   });
 }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -11,6 +11,7 @@ import {
   qaSha256,
   splitQaPsadtConfig,
   validateCompatiblePassedCatalogQaProfile,
+  validateCompatiblePassedDeploymentQaProfile,
   validateCurrentQaPackageProfile,
 } from './package-profile';
 
@@ -255,10 +256,8 @@ describe('current catalog QA package validation', () => {
     ).toMatchObject({ valid: true });
   });
 
-  it('does not reuse an older pass with configured process lifecycle behavior', () => {
-    const priorCommit = QA_COMPATIBLE_PASSED_PACKAGER_COMMITS.find(
-      (commit) => commit !== QA_PSADT_TOOLCHAIN.packagerCommit
-    )!;
+  it('does not reuse a process lifecycle pass from before the lifecycle release', () => {
+    const priorCommit = 'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028';
     const legacyIdentity = identityWithPackagerCommit(
       buildQaPackageIdentity({
         ...input,
@@ -273,6 +272,102 @@ describe('current catalog QA package validation', () => {
     expect(
       validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
     ).toEqual({ valid: false, reason: 'compatible-process-lifecycle-changed' });
+  });
+
+  it('reuses a process lifecycle pass through later unrelated releases', () => {
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        psadtConfig: {
+          ...DEFAULT_PSADT_CONFIG,
+          processesToClose: [{ name: 'Example', description: 'Example' }],
+        },
+      }),
+      '66448ea49841c2c9f3ebf56e455ce8797e2b2abb'
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toMatchObject({ valid: true });
+  });
+
+  it('retests only a profile that exercises the zero-day deferral branch', () => {
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        psadtConfig: {
+          ...DEFAULT_PSADT_CONFIG,
+          allowDefer: true,
+          deferDays: 0,
+        },
+      }),
+      '430f817da1120f6a14f421b7016b628a06854aba'
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toEqual({ valid: false, reason: 'compatible-zero-day-deferral-changed' });
+  });
+
+  it('reuses the same deployment execution profile across an unrelated packager release', () => {
+    const currentIdentity = buildQaPackageIdentity({
+      ...input,
+      profileKind: 'deployment-config',
+      psadtConfig: {
+        ...DEFAULT_PSADT_CONFIG,
+        processesToClose: [{ name: 'Example', description: 'Example' }],
+      },
+    });
+    const priorIdentity = identityWithPackagerCommit(
+      currentIdentity,
+      '66448ea49841c2c9f3ebf56e455ce8797e2b2abb'
+    );
+
+    expect(validateCompatiblePassedDeploymentQaProfile({
+      prior: {
+        testConfig: {
+          profileKind: 'deployment-config',
+          packageProfileCanonicalJson: priorIdentity.canonicalJson,
+          packageProfileSha256: priorIdentity.packageProfileSha256,
+        },
+        candidatePackageProfileSha256: priorIdentity.packageProfileSha256,
+        candidateWingetId: input.wingetId,
+        candidateVersion: input.version,
+        candidateArchitecture: input.architecture,
+        candidateInstallerSha256: input.installerSha256,
+      },
+      currentCanonicalJson: currentIdentity.canonicalJson,
+      currentPackageProfileSha256: currentIdentity.packageProfileSha256,
+    })).toMatchObject({ valid: true });
+  });
+
+  it('does not reuse a different deployment execution profile', () => {
+    const currentIdentity = buildQaPackageIdentity({
+      ...input,
+      profileKind: 'deployment-config',
+      psadtConfig: { ...DEFAULT_PSADT_CONFIG, deployMode: 'Auto' },
+    });
+    const priorIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({ ...input, profileKind: 'deployment-config' }),
+      '66448ea49841c2c9f3ebf56e455ce8797e2b2abb'
+    );
+
+    expect(validateCompatiblePassedDeploymentQaProfile({
+      prior: {
+        testConfig: {
+          profileKind: 'deployment-config',
+          packageProfileCanonicalJson: priorIdentity.canonicalJson,
+          packageProfileSha256: priorIdentity.packageProfileSha256,
+        },
+        candidatePackageProfileSha256: priorIdentity.packageProfileSha256,
+        candidateWingetId: input.wingetId,
+        candidateVersion: input.version,
+        candidateArchitecture: input.architecture,
+        candidateInstallerSha256: input.installerSha256,
+      },
+      currentCanonicalJson: currentIdentity.canonicalJson,
+      currentPackageProfileSha256: currentIdentity.packageProfileSha256,
+    })).toEqual({ valid: false, reason: 'compatible-execution-profile-changed' });
   });
 
   it('does not reuse an older pass when the current app adapter adds behavior', () => {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -20,20 +20,25 @@ export const QA_PSADT_TOOLCHAIN = {
  * background coverage. Only add a commit when every change after it is limited
  * to a failure path that a passing package could not have exercised.
  *
- * This compatibility is deliberately not used for customer deployment
- * profiles or queued-candidate dispatch: those continue to require the exact
- * current package profile.
+ * Queued-candidate dispatch still requires the exact current package profile.
+ * Customer demand can reuse an older pass only after its full execution
+ * profile matches with the commit removed and every intervening release is
+ * proven irrelevant to the behavior that profile exercises.
  */
-export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
-  QA_PSADT_TOOLCHAIN.packagerCommit,
-  '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
-  '430f817da1120f6a14f421b7016b628a06854aba',
-  '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
-  'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
-  '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
-  'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
+export const QA_PACKAGER_RELEASE_HISTORY = [
   'de49775e759b693b92db09bc99aa116f197c4850',
+  'c603eab9b8de23a6b5eb466f0fd8cdf2bfd04e33',
+  '99edd0a9f4b7e10d4cc4272f90d763f3bd681440',
+  'c1fe66c04b11f595bfaf4c9ca7cc1444186ea028',
+  '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
+  '430f817da1120f6a14f421b7016b628a06854aba',
+  '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
+  QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
+
+export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
+  ...QA_PACKAGER_RELEASE_HISTORY,
+].reverse();
 
 /**
  * Increment this whenever profile-building semantics change without a corresponding
@@ -198,6 +203,63 @@ function textValue(value: unknown): string {
 
 function lowerTextValue(value: unknown): string {
   return textValue(value).toLowerCase();
+}
+
+function passingProfileCompatibilityReason(
+  priorPackagerCommit: string,
+  profile: Record<string, unknown>
+): string | null {
+  const priorIndex = QA_PACKAGER_RELEASE_HISTORY.indexOf(
+    priorPackagerCommit as (typeof QA_PACKAGER_RELEASE_HISTORY)[number]
+  );
+  const currentIndex = QA_PACKAGER_RELEASE_HISTORY.indexOf(
+    QA_PSADT_TOOLCHAIN.packagerCommit
+  );
+  if (priorIndex < 0 || currentIndex < 0 || priorIndex > currentIndex) {
+    return 'compatible-packager-history-unknown';
+  }
+
+  const psadtConfig = record(profile.psadtConfig);
+  if (!psadtConfig) return 'compatible-profile-invalid';
+  const configuredProcesses = Array.isArray(psadtConfig.processesToClose)
+    ? psadtConfig.processesToClose
+    : [];
+
+  for (const release of QA_PACKAGER_RELEASE_HISTORY.slice(priorIndex + 1, currentIndex + 1)) {
+    // 42bf6e2 introduced the reviewed process-close lifecycle. A prior pass
+    // with no configured process list remains valid; one that expected this
+    // behavior must be exercised again. Later releases inherit the behavior
+    // and must not repeatedly invalidate the same profile.
+    if (
+      release === '42bf6e2af604a5e6bb44f2feff38e941ab2222c1' &&
+      configuredProcesses.length > 0
+    ) {
+      return 'compatible-process-lifecycle-changed';
+    }
+
+    // 66448ea corrected PSADT's zero-day deferral sentinel. Only profiles
+    // that actually contain that value can exercise the changed branch.
+    if (
+      release === '66448ea49841c2c9f3ebf56e455ce8797e2b2abb' &&
+      psadtConfig.deferDays === 0
+    ) {
+      return 'compatible-zero-day-deferral-changed';
+    }
+  }
+
+  return null;
+}
+
+function profileWithoutPackagerCommit(profile: Record<string, unknown>): Record<string, unknown> {
+  const toolchain = record(profile.toolchain);
+  return {
+    ...profile,
+    toolchain: toolchain
+      ? Object.fromEntries(
+          Object.entries(toolchain).filter(([field]) => field !== 'packagerCommit')
+        )
+      : toolchain,
+  };
 }
 
 function normalizeForJson(value: unknown): unknown {
@@ -372,23 +434,23 @@ export function validateCompatiblePassedCatalogQaProfile(
   );
   if (!validation.valid || !validation.canonicalJson) return validation;
 
-  // Older successful catalog profiles remain reusable only when this
-  // lifecycle change cannot affect their generated script. Customer and
-  // queued deployment profiles always require the exact current commit.
+  // A passed result remains reusable through a later release only when none
+  // of the intervening changes can alter the behavior that profile exercises.
+  // This is release-aware: a process-close profile tested after the lifecycle
+  // release is not invalidated again by every later unrelated packager fix.
   const profile = record(JSON.parse(validation.canonicalJson));
   const toolchain = record(profile?.toolchain);
-  if (textValue(toolchain?.packagerCommit) === QA_PSADT_TOOLCHAIN.packagerCommit) {
+  const priorPackagerCommit = textValue(toolchain?.packagerCommit);
+  if (priorPackagerCommit === QA_PSADT_TOOLCHAIN.packagerCommit) {
     return validation;
   }
 
-  const psadtConfig = record(profile?.psadtConfig);
-  const configuredProcesses = Array.isArray(psadtConfig?.processesToClose)
-    ? psadtConfig.processesToClose
-    : [];
-  if (configuredProcesses.length > 0) {
-    return { valid: false, reason: 'compatible-process-lifecycle-changed' };
-  }
+  const compatibilityReason = profile
+    ? passingProfileCompatibilityReason(priorPackagerCommit, profile)
+    : 'compatible-profile-invalid';
+  if (compatibilityReason) return { valid: false, reason: compatibilityReason };
 
+  const psadtConfig = record(profile?.psadtConfig);
   const app = record(profile?.app);
   const wingetId = textValue(app?.wingetId);
   if (!wingetId || !psadtConfig) {
@@ -401,6 +463,55 @@ export function validateCompatiblePassedCatalogQaProfile(
   }
 
   return validation;
+}
+
+export function validateCompatiblePassedDeploymentQaProfile(input: {
+  prior: QaPackageProfileValidationInput;
+  currentCanonicalJson: string;
+  currentPackageProfileSha256: string;
+}): QaPackageProfileValidation {
+  const priorValidation = validateQaPackageProfile(
+    input.prior,
+    QA_COMPATIBLE_PASSED_PACKAGER_COMMITS
+  );
+  if (!priorValidation.valid || !priorValidation.canonicalJson) return priorValidation;
+
+  let priorProfile: Record<string, unknown> | null = null;
+  let currentProfile: Record<string, unknown> | null = null;
+  try {
+    priorProfile = record(JSON.parse(priorValidation.canonicalJson));
+    currentProfile = record(JSON.parse(input.currentCanonicalJson));
+  } catch {
+    return { valid: false, reason: 'compatible-profile-invalid' };
+  }
+  if (!priorProfile || !currentProfile) {
+    return { valid: false, reason: 'compatible-profile-invalid' };
+  }
+  if (priorProfile.profileKind !== 'deployment-config' || currentProfile.profileKind !== 'deployment-config') {
+    return { valid: false, reason: 'compatible-profile-kind-mismatch' };
+  }
+  if (qaSha256(input.currentCanonicalJson) !== sha256(input.currentPackageProfileSha256)) {
+    return { valid: false, reason: 'compatible-current-profile-sha-mismatch' };
+  }
+  const currentToolchain = record(currentProfile.toolchain);
+  if (textValue(currentToolchain?.packagerCommit) !== QA_PSADT_TOOLCHAIN.packagerCommit) {
+    return { valid: false, reason: 'compatible-current-packager-mismatch' };
+  }
+
+  const priorComparable = canonicalQaJson(profileWithoutPackagerCommit(priorProfile));
+  const currentComparable = canonicalQaJson(profileWithoutPackagerCommit(currentProfile));
+  if (priorComparable !== currentComparable) {
+    return { valid: false, reason: 'compatible-execution-profile-changed' };
+  }
+
+  const priorToolchain = record(priorProfile.toolchain);
+  const compatibilityReason = passingProfileCompatibilityReason(
+    textValue(priorToolchain?.packagerCommit),
+    priorProfile
+  );
+  if (compatibilityReason) return { valid: false, reason: compatibilityReason };
+
+  return priorValidation;
 }
 
 export function normalizeQaPsadtConfig(

--- a/lib/qa/pipeline-control.ts
+++ b/lib/qa/pipeline-control.ts
@@ -1,0 +1,37 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface QaPipelineControl {
+  paused: boolean;
+  reason: string | null;
+  updatedAt: string;
+}
+
+/**
+ * Read the singleton maintenance control. Missing or unreadable state is an
+ * error rather than an implicit resume: the one-VM pipeline must fail closed
+ * when operators cannot prove that maintenance has ended.
+ */
+export async function getQaPipelineControl(
+  supabase: SupabaseClient
+): Promise<QaPipelineControl> {
+  const { data, error } = await supabase
+    .from('qa_pipeline_control')
+    .select('paused, reason, updated_at')
+    .eq('id', 'global')
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Could not read QA pipeline maintenance control: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error('QA pipeline maintenance control is missing.');
+  }
+
+  return {
+    paused: data.paused === true,
+    reason: typeof data.reason === 'string' && data.reason.trim()
+      ? data.reason.trim()
+      : null,
+    updatedAt: data.updated_at,
+  };
+}

--- a/supabase/migrations/20260811141939_qa_pipeline_maintenance_control.sql
+++ b/supabase/migrations/20260811141939_qa_pipeline_maintenance_control.sql
@@ -1,0 +1,24 @@
+-- A single, private control row gives operators a deliberate maintenance
+-- boundary for the one-VM QA pipeline. Both enqueue and dispatch fail closed
+-- while paused, so guest maintenance cannot race a newly scheduled test.
+create table if not exists public.qa_pipeline_control (
+  id text primary key check (id = 'global'),
+  paused boolean not null default false,
+  reason text,
+  updated_at timestamptz not null default now(),
+  updated_by text
+);
+
+insert into public.qa_pipeline_control (id, paused, reason, updated_by)
+values ('global', false, null, 'migration')
+on conflict (id) do nothing;
+
+alter table public.qa_pipeline_control enable row level security;
+
+revoke all on table public.qa_pipeline_control from public, anon, authenticated;
+grant select, update on table public.qa_pipeline_control to service_role;
+
+comment on table public.qa_pipeline_control is
+  'Private fail-safe maintenance control for the single-VM Intune QA pipeline.';
+comment on column public.qa_pipeline_control.paused is
+  'When true, scheduled enqueue and dispatch endpoints perform no queue mutation or workflow dispatch.';

--- a/supabase/migrations/20260811143327_qa_pipeline_control_restrict_privileges.sql
+++ b/supabase/migrations/20260811143327_qa_pipeline_control_restrict_privileges.sql
@@ -1,0 +1,4 @@
+-- Supabase's default table grants include broader service-role privileges.
+-- The application only needs to read and flip the singleton pause row.
+revoke all on table public.qa_pipeline_control from service_role;
+grant select, update on table public.qa_pipeline_control to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -249,6 +249,24 @@ export interface Database {
         Update: Partial<Database['public']['Tables']['qa_package_results']['Insert']>;
         Relationships: GenericRelationship[];
       };
+      qa_pipeline_control: {
+        Row: {
+          id: string;
+          paused: boolean;
+          reason: string | null;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          id: string;
+          paused?: boolean;
+          reason?: string | null;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['qa_pipeline_control']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
       qa_poll_runs: {
         Row: {
           id: string;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -124,11 +124,13 @@ export interface QaLiveResponse {
     heartbeatAt: string | null;
   };
   scheduler: {
-    state: 'healthy' | 'degraded' | 'unknown';
+    state: 'healthy' | 'degraded' | 'paused' | 'unknown';
     lastPollAt: string | null;
     lastOutcome: 'running' | 'succeeded' | 'partial' | 'failed' | null;
-    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | null;
+    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | 'maintenance' | null;
     consecutiveFailures: number;
+    maintenanceReason: string | null;
+    pausedAt: string | null;
   };
   current: {
     wingetId: string;


### PR DESCRIPTION
## What changed

- Reuses a prior successful deployment QA result only when the app version, architecture, installer hash, complete execution configuration, and all behavior-affecting packager releases are compatible.
- Keeps genuinely different PSADT execution profiles separate.
- Makes catalog pass compatibility release-aware so later unrelated packager fixes do not enqueue the same app again.
- Adds a private, fail-safe Supabase maintenance control respected by both scheduled enqueue and dispatch.
- Shows deliberate maintenance as **Paused** on `/qa` instead of a degraded polling incident.
- Adds focused compatibility, aliasing, pause, scheduler, and route tests.

## Why

The raw packager commit was part of the execution hash. Every packager release therefore invalidated every prior profile, which repeatedly queued Chrome and other unchanged apps. The new compatibility check removes only the commit field for comparison, then evaluates the exact intervening releases against the behavior used by that profile.

## Security and operations

The singleton maintenance row has RLS enabled, is unavailable to public/anon/authenticated roles, and grants the service role only `SELECT` and `UPDATE`. Enqueue and dispatch fail closed when that state cannot be read.

## Validation

- 76 targeted Vitest checks passed
- ESLint passed for all changed TypeScript/TSX files
- `npm run build:ci` passed
- Supabase RLS and effective grants verified in production