### PR TITLE
Fix OCS Inventory process lifecycle packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -51,6 +51,38 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
+  it('closes the vendor-documented OCS Inventory processes before package lifecycle actions', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'OCSInventoryNG.WindowsAgent',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'OcsSystray', description: 'OCS Inventory system tray' },
+      { name: 'OcsService', description: 'OCS Inventory service' },
+      { name: 'OCSInventory', description: 'OCS Inventory agent' },
+      { name: 'download', description: 'OCS Inventory download helper' },
+    ]);
+  });
+
+  it('preserves customer OCS Inventory processes without adding duplicate executable names', () => {
+    const adapted = applyApplicationPackagingAdapter('OCSInventoryNG.WindowsAgent', {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: 'ocsservice.exe', description: 'Customer-managed OCS service' },
+        { name: 'OcsNotifyUser', description: 'Customer notification helper' },
+      ],
+    });
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'ocsservice', description: 'Customer-managed OCS service' },
+      { name: 'OcsNotifyUser', description: 'Customer notification helper' },
+      { name: 'OcsSystray', description: 'OCS Inventory system tray' },
+      { name: 'OCSInventory', description: 'OCS Inventory agent' },
+      { name: 'download', description: 'OCS Inventory download helper' },
+    ]);
+  });
+
   it('matches WinGet identities case-insensitively', () => {
     expect(
       applyApplicationPackagingAdapter('  elgato.streamdeck  ', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -34,6 +34,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ],
   },
+  {
+    wingetId: 'OCSInventoryNG.WindowsAgent',
+    requiredProcessesToClose: [
+      { name: 'OcsSystray', description: 'OCS Inventory system tray' },
+      { name: 'OcsService', description: 'OCS Inventory service' },
+      { name: 'OCSInventory', description: 'OCS Inventory agent' },
+      { name: 'download', description: 'OCS Inventory download helper' },
+    ],
+  },
 ];
 
 function normalizeProcessName(name: string): string {


### PR DESCRIPTION
## Summary
- add a declarative OCS Inventory packaging adapter for the four current-agent processes stopped by the vendor installer
- apply the same lifecycle behavior to customer packages and QA packages through the shared adapter path
- preserve customer process entries and avoid duplicate executable names

## Safety
- does not use the vendor's destructive `/CLEAN=ALL` option
- does not weaken QA uninstall verification

## Validation
- `npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/test-config.test.ts app/api/package/route.test.ts` (83 passed)
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`
- `npm run build:ci`
- `git diff --check`