### PR TITLE
Pin OCS lifecycle packager release

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -489,14 +489,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Google.Chrome',
-        name: 'Google Chrome',
-        publisher: 'Google',
+        winget_id: 'OCSInventoryNG.WindowsAgent',
+        name: 'OCS Inventory NG Agent',
+        publisher: 'OCS Inventory NG',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Google.Chrome',
+          wingetId: 'OCSInventoryNG.WindowsAgent',
           packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
           status: 'failed',
         }),
@@ -518,7 +518,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Google.Chrome',
+      winget_id: 'OCSInventoryNG.WindowsAgent',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
+  packagerCommit: 'fc18fffd40f6d362be251e05e2bc784373dfc735',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -33,6 +33,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '42bf6e2af604a5e6bb44f2feff38e941ab2222c1',
   '430f817da1120f6a14f421b7016b628a06854aba',
   '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
+  'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,8 +3,8 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each(['Google.Chrome', 'Yealink.YealinkUSBConnect'])(
-    'retries the terminal %s failure for the current cumulative toolchain fixes',
+  it.each(['OCSInventoryNG.WindowsAgent'])(
+    'retries the terminal %s failure changed by the current toolchain release',
     (wingetId) => {
       expect(shouldRetryTerminalToolchainCandidate(
         QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'fc18fffd40f6d362be251e05e2bc784373dfc735': [
+    'OCSInventoryNG.WindowsAgent',
+  ],
   'ef75edee9fcabaf904bcf80e02ead9aa58490dc9': [
     'Google.Chrome',
     'Yealink.YealinkUSBConnect',


### PR DESCRIPTION
## Summary
- pin QA package identities to the merged OCS lifecycle adapter release
- keep the preceding release in ordered compatibility history so unaffected apps reuse valid passes
- target terminal replay to OCS Inventory only

## Validation
- `npx vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts app/api/cron/qa-enqueue/route.test.ts lib/qa/demand.test.ts` (63 passed)
- focused ESLint passed
- `git diff --check`