### PR TITLE
Fix Greenshot process lifecycle packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -51,6 +51,17 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
+  it('closes Greenshot before install and removal lifecycle actions', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Greenshot.Greenshot',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'Greenshot', description: 'Greenshot' },
+    ]);
+  });
+
   it('closes the vendor-documented OCS Inventory processes before package lifecycle actions', () => {
     const adapted = applyApplicationPackagingAdapter(
       'OCSInventoryNG.WindowsAgent',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -35,6 +35,12 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    wingetId: 'Greenshot.Greenshot',
+    requiredProcessesToClose: [
+      { name: 'Greenshot', description: 'Greenshot' },
+    ],
+  },
+  {
     wingetId: 'OCSInventoryNG.WindowsAgent',
     requiredProcessesToClose: [
       { name: 'OcsSystray', description: 'OCS Inventory system tray' },


### PR DESCRIPTION
## Summary
- close the reviewed Greenshot process before install and uninstall lifecycle actions
- apply the same adapter through shared customer and QA package generation
- preserve strict uninstall-registration and detection verification

## Root cause
The retained PSADT log showed that `Greenshot_is1` remained registered after the five-minute uninstall deadline. Greenshot's own installer documentation states that `Greenshot.exe` must be terminated for lifecycle operations.

## Validation
- `npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/test-config.test.ts app/api/package/route.test.ts lib/qa/psadt-packager-contract.test.ts` (123 passed)
- focused ESLint passed
- `git diff --check`