### PR TITLE
Pin Greenshot lifecycle packager release

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -489,14 +489,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'OCSInventoryNG.WindowsAgent',
-        name: 'OCS Inventory NG Agent',
-        publisher: 'OCS Inventory NG',
+        winget_id: 'Greenshot.Greenshot',
+        name: 'Greenshot',
+        publisher: 'Greenshot',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'OCSInventoryNG.WindowsAgent',
+          wingetId: 'Greenshot.Greenshot',
           packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
           status: 'failed',
         }),
@@ -518,7 +518,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'OCSInventoryNG.WindowsAgent',
+      winget_id: 'Greenshot.Greenshot',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -7,7 +7,7 @@ import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'fc18fffd40f6d362be251e05e2bc784373dfc735',
+  packagerCommit: 'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -34,6 +34,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '430f817da1120f6a14f421b7016b628a06854aba',
   '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
   'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
+  'fc18fffd40f6d362be251e05e2bc784373dfc735',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,7 +3,7 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each(['OCSInventoryNG.WindowsAgent'])(
+  it.each(['Greenshot.Greenshot'])(
     'retries the terminal %s failure changed by the current toolchain release',
     (wingetId) => {
       expect(shouldRetryTerminalToolchainCandidate(
@@ -12,6 +12,17 @@ describe('QA toolchain targeted retries', () => {
       )).toBe(true);
     }
   );
+
+  it('keeps the OCS retry scoped to its historical toolchain release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      'fc18fffd40f6d362be251e05e2bc784373dfc735',
+      { wingetId: 'OCSInventoryNG.WindowsAgent', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'OCSInventoryNG.WindowsAgent', status: 'failed' }
+    )).toBe(false);
+  });
 
   it('does not replay an unrelated terminal failure', () => {
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99': [
+    'Greenshot.Greenshot',
+  ],
   'fc18fffd40f6d362be251e05e2bc784373dfc735': [
     'OCSInventoryNG.WindowsAgent',
   ],


### PR DESCRIPTION
## Summary
- advance the QA packager pin to the merged Greenshot lifecycle adapter release
- retain prior passing evidence through release history
- retry only the terminal Greenshot failure for this release
- keep the earlier OCS retry scoped to its own release

## Validation
- 46 focused tests passed
- focused ESLint passed
- git diff check passed