### PR TITLE
Repair empty catalog detection profiles

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -419,7 +419,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
-  it('preserves configured PSADT rules when the top-level list is empty', async () => {
+  it('preserves configured PSADT rules when the top-level list is unusable', async () => {
     const fileRule = {
       type: 'file',
       path: '%ProgramFiles%\\Cursor',
@@ -434,7 +434,7 @@ describe('POST /api/package (workflow dispatch)', () => {
       },
       body: JSON.stringify({
         items: [makeWin32Item({
-          detectionRules: [],
+          detectionRules: [{}],
           psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [fileRule] },
         })],
       }),
@@ -486,6 +486,31 @@ describe('POST /api/package (workflow dispatch)', () => {
       sourceType: 'custom',
       detectionRules: [fileRule],
     });
+  });
+
+  it('fails closed before job creation when a catalog identity is missing', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({ wingetId: undefined })],
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: false,
+      errors: [{ error: 'Catalog package detection requires a non-empty Winget ID' }],
+    });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
   it('parks a customer deployment until its exact execution profile passes QA', async () => {

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -378,6 +378,47 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('repairs empty catalog detection rules for both QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Anysphere.Cursor',
+          displayName: 'Cursor',
+          version: '3.14.27',
+          detectionRules: [],
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [] },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedRule = expect.objectContaining({
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Anysphere_Cursor',
+      detectionValue: '3.14.27',
+    });
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].detectionRules)).toEqual([
+      expectedRule,
+    ]);
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].detectionRules)).toEqual([
+      expectedRule,
+    ]);
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject({
+      detectionRules: [expectedRule],
+    });
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      detectionRules: [expectedRule],
+      psadtConfig: { detectionRules: [expectedRule] },
+    });
+  });
+
   it('parks a customer deployment until its exact execution profile passes QA', async () => {
     ensureQaDemandMock.mockResolvedValueOnce({
       state: 'waiting',

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -419,6 +419,75 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('preserves configured PSADT rules when the top-level list is empty', async () => {
+    const fileRule = {
+      type: 'file',
+      path: '%ProgramFiles%\\Cursor',
+      fileOrFolderName: 'Cursor.exe',
+      detectionType: 'exists',
+    };
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          detectionRules: [],
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [fileRule] },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].detectionRules)).toEqual([fileRule]);
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].detectionRules)).toEqual([
+      fileRule,
+    ]);
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      detectionRules: [fileRule],
+      psadtConfig: { detectionRules: [fileRule] },
+    });
+  });
+
+  it('leaves custom-source detection rules untouched', async () => {
+    const fileRule = {
+      type: 'file',
+      path: '%LocalAppData%\\Custom App',
+      fileOrFolderName: 'Custom.exe',
+      detectionType: 'exists',
+    };
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          sourceType: 'custom',
+          installerSha256: '',
+          detectionRules: [fileRule],
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].detectionRules)).toEqual([
+      fileRule,
+    ]);
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      sourceType: 'custom',
+      detectionRules: [fileRule],
+    });
+  });
+
   it('parks a customer deployment until its exact execution profile passes QA', async () => {
     ensureQaDemandMock.mockResolvedValueOnce({
       state: 'waiting',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -38,6 +38,8 @@ import {
 } from '@/lib/installer-preflight';
 import { ensureQaDemand } from '@/lib/qa/demand';
 import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 export const maxDuration = 300;
 
@@ -397,9 +399,18 @@ export async function POST(request: NextRequest) {
         for (const item of win32Items) {
           try {
             if (item.sourceType !== 'custom') {
+              const requestedPsadtConfig = item.psadtConfig || DEFAULT_PSADT_CONFIG;
+              const detectionRules = normalizeCatalogDetectionRules({
+                detectionRules: item.detectionRules || requestedPsadtConfig.detectionRules,
+                wingetId: item.wingetId,
+                version: item.version,
+                installScope: item.installScope,
+                markerPath: requestedPsadtConfig.registryMarkerPath,
+              });
+              item.detectionRules = detectionRules;
               item.psadtConfig = applyApplicationPackagingAdapter(
                 item.wingetId,
-                item.psadtConfig
+                { ...requestedPsadtConfig, detectionRules }
               );
             }
             const jobId = crypto.randomUUID();

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -400,11 +400,9 @@ export async function POST(request: NextRequest) {
           try {
             if (item.sourceType !== 'custom') {
               const requestedPsadtConfig = item.psadtConfig || DEFAULT_PSADT_CONFIG;
-              const requestedDetectionRules = Array.isArray(item.detectionRules) && item.detectionRules.length > 0
-                ? item.detectionRules
-                : requestedPsadtConfig.detectionRules;
               const detectionRules = normalizeCatalogDetectionRules({
-                detectionRules: requestedDetectionRules,
+                detectionRules: item.detectionRules,
+                fallbackDetectionRules: requestedPsadtConfig.detectionRules,
                 wingetId: item.wingetId,
                 version: item.version,
                 installScope: item.installScope,

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -400,8 +400,11 @@ export async function POST(request: NextRequest) {
           try {
             if (item.sourceType !== 'custom') {
               const requestedPsadtConfig = item.psadtConfig || DEFAULT_PSADT_CONFIG;
+              const requestedDetectionRules = Array.isArray(item.detectionRules) && item.detectionRules.length > 0
+                ? item.detectionRules
+                : requestedPsadtConfig.detectionRules;
               const detectionRules = normalizeCatalogDetectionRules({
-                detectionRules: item.detectionRules || requestedPsadtConfig.detectionRules,
+                detectionRules: requestedDetectionRules,
                 wingetId: item.wingetId,
                 version: item.version,
                 installScope: item.installScope,

--- a/lib/catalog-detection.test.ts
+++ b/lib/catalog-detection.test.ts
@@ -66,6 +66,23 @@ describe('catalog detection normalization', () => {
     })]);
   });
 
+  it('uses valid fallback rules when the primary legacy list is malformed', () => {
+    const fileRule = {
+      type: 'file' as const,
+      path: '%ProgramFiles%\\Example',
+      fileOrFolderName: 'Example.exe',
+      detectionType: 'exists' as const,
+    };
+    const result = normalizeCatalogDetectionRules({
+      detectionRules: [null, {}],
+      fallbackDetectionRules: [fileRule],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+    });
+
+    expect(result).toEqual([fileRule]);
+  });
+
   it.each([
     { wingetId: '', version: '1.0.0', message: 'non-empty Winget ID' },
     { wingetId: 'Example.App', version: '   ', message: 'non-empty version' },

--- a/lib/catalog-detection.test.ts
+++ b/lib/catalog-detection.test.ts
@@ -83,6 +83,30 @@ describe('catalog detection normalization', () => {
     expect(result).toEqual([fileRule]);
   });
 
+  it('prefers valid primary rules when both sources are usable', () => {
+    const primaryRule = {
+      type: 'file' as const,
+      path: '%ProgramFiles%\\Primary',
+      fileOrFolderName: 'Primary.exe',
+      detectionType: 'exists' as const,
+    };
+    const fallbackRule = {
+      type: 'file' as const,
+      path: '%ProgramFiles%\\Fallback',
+      fileOrFolderName: 'Fallback.exe',
+      detectionType: 'exists' as const,
+    };
+    const result = normalizeCatalogDetectionRules({
+      detectionRules: [primaryRule],
+      fallbackDetectionRules: [fallbackRule],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+    });
+
+    expect(result).toEqual([primaryRule]);
+    expect(result[0]).toBe(primaryRule);
+  });
+
   it.each([
     { wingetId: '', version: '1.0.0', message: 'non-empty Winget ID' },
     { wingetId: 'Example.App', version: '   ', message: 'non-empty version' },

--- a/lib/catalog-detection.test.ts
+++ b/lib/catalog-detection.test.ts
@@ -51,4 +51,42 @@ describe('catalog detection normalization', () => {
     expect(result).toEqual([customRule]);
     expect(result[0]).toBe(customRule);
   });
+
+  it('drops malformed legacy entries and repairs the resulting empty rule list', () => {
+    const result = normalizeCatalogDetectionRules({
+      detectionRules: [null, {}, { type: 'registry', keyPath: '' }],
+      wingetId: 'Legacy.App',
+      version: '1.0.0',
+      installScope: 'machine',
+    });
+
+    expect(result).toEqual([expect.objectContaining({
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Legacy_App',
+      detectionValue: '1.0.0',
+    })]);
+  });
+
+  it.each([
+    { wingetId: '', version: '1.0.0', message: 'non-empty Winget ID' },
+    { wingetId: 'Example.App', version: '   ', message: 'non-empty version' },
+  ])('fails closed for a missing catalog identity', ({ wingetId, version, message }) => {
+    expect(() => normalizeCatalogDetectionRules({
+      detectionRules: [],
+      wingetId,
+      version,
+    })).toThrow(message);
+  });
+
+  it('matches packager scope semantics for whitespace-padded values', () => {
+    const result = normalizeCatalogDetectionRules({
+      detectionRules: [],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      installScope: ' user ',
+    });
+
+    expect(result[0]).toMatchObject({
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Example_App',
+    });
+  });
 });

--- a/lib/catalog-detection.test.ts
+++ b/lib/catalog-detection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCatalogDetectionRules } from './catalog-detection';
+
+describe('catalog detection normalization', () => {
+  it('repairs an empty legacy profile with a machine-scoped managed marker', () => {
+    expect(normalizeCatalogDetectionRules({
+      detectionRules: [],
+      wingetId: 'Anysphere.Cursor',
+      version: '3.14.27',
+      installScope: 'machine',
+    })).toEqual([{
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Anysphere_Cursor',
+      valueName: 'Version',
+      check32BitOn64System: false,
+      detectionType: 'version',
+      operator: 'greaterThanOrEqual',
+      detectionValue: '3.14.27',
+    }]);
+  });
+
+  it('uses the current user scope and marker root for a missing rule', () => {
+    expect(normalizeCatalogDetectionRules({
+      detectionRules: undefined,
+      wingetId: 'Example.App',
+      version: '2026.08-beta',
+      installScope: 'user',
+      markerPath: 'SOFTWARE\\Contoso\\Apps',
+    })).toEqual([expect.objectContaining({
+      keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\Contoso\\Apps\\Example_App',
+      detectionType: 'string',
+      operator: 'equal',
+      detectionValue: '2026.08-beta',
+    })]);
+  });
+
+  it('preserves a nonempty customer rule while reconciling managed markers', () => {
+    const customRule = {
+      type: 'file' as const,
+      path: '%ProgramFiles%\\Example',
+      fileOrFolderName: 'Example.exe',
+      detectionType: 'exists' as const,
+    };
+    const result = normalizeCatalogDetectionRules({
+      detectionRules: [customRule],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      installScope: 'machine',
+    });
+
+    expect(result).toEqual([customRule]);
+    expect(result[0]).toBe(customRule);
+  });
+});

--- a/lib/catalog-detection.ts
+++ b/lib/catalog-detection.ts
@@ -1,12 +1,16 @@
 import type { DetectionRule } from '@/types/intune';
 import type { WingetScope } from '@/types/winget';
-import { generateRegistryMarkerDetectionRules } from '@/lib/detection-rules';
+import {
+  generateRegistryMarkerDetectionRules,
+  validateDetectionRules,
+} from '@/lib/detection-rules';
 import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
 
 /**
  * Normalize trusted catalog-package detection at the server boundary. Saved
  * customer profiles can predate managed marker detection, so an empty rule
  * list must be repaired before either QA or customer packaging is dispatched.
+ * Callers must keep custom-source packages out of this catalog-only path.
  */
 export function normalizeCatalogDetectionRules({
   detectionRules,
@@ -15,17 +19,29 @@ export function normalizeCatalogDetectionRules({
   installScope,
   markerPath,
 }: {
-  detectionRules: DetectionRule[] | null | undefined;
+  detectionRules: readonly unknown[] | null | undefined;
   wingetId: string;
   version: string;
   installScope?: string;
   markerPath?: string | null;
 }): DetectionRule[] {
-  const scope: WingetScope = installScope?.trim().toLowerCase() === 'user'
+  if (!wingetId.trim()) {
+    throw new Error('Catalog package detection requires a non-empty Winget ID');
+  }
+  if (!version.trim()) {
+    throw new Error('Catalog package detection requires a non-empty version');
+  }
+
+  // Match the PowerShell packager's scope semantics. PowerShell string
+  // equality is case-insensitive but does not ignore surrounding whitespace.
+  const scope: WingetScope = installScope?.toLowerCase() === 'user'
     ? 'user'
     : 'machine';
+  const usableRules = Array.isArray(detectionRules)
+    ? detectionRules.filter(isUsableDetectionRule)
+    : [];
   const reconciled = reconcileManagedMarkerDetectionRules({
-    detectionRules: Array.isArray(detectionRules) ? detectionRules : [],
+    detectionRules: usableRules,
     wingetId,
     version,
     installScope: scope,
@@ -35,4 +51,11 @@ export function normalizeCatalogDetectionRules({
   return reconciled.length > 0
     ? reconciled
     : generateRegistryMarkerDetectionRules(wingetId, version, scope, markerPath || undefined);
+}
+
+function isUsableDetectionRule(value: unknown): value is DetectionRule {
+  if (!value || typeof value !== 'object') return false;
+  const type = (value as { type?: unknown }).type;
+  if (!['msi', 'file', 'registry', 'script'].includes(String(type))) return false;
+  return validateDetectionRules([value as DetectionRule]).valid;
 }

--- a/lib/catalog-detection.ts
+++ b/lib/catalog-detection.ts
@@ -14,21 +14,23 @@ import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
  */
 export function normalizeCatalogDetectionRules({
   detectionRules,
+  fallbackDetectionRules,
   wingetId,
   version,
   installScope,
   markerPath,
 }: {
   detectionRules: readonly unknown[] | null | undefined;
+  fallbackDetectionRules?: readonly unknown[] | null;
   wingetId: string;
   version: string;
   installScope?: string;
   markerPath?: string | null;
 }): DetectionRule[] {
-  if (!wingetId.trim()) {
+  if (typeof wingetId !== 'string' || !wingetId.trim()) {
     throw new Error('Catalog package detection requires a non-empty Winget ID');
   }
-  if (!version.trim()) {
+  if (typeof version !== 'string' || !version.trim()) {
     throw new Error('Catalog package detection requires a non-empty version');
   }
 
@@ -37,9 +39,10 @@ export function normalizeCatalogDetectionRules({
   const scope: WingetScope = installScope?.toLowerCase() === 'user'
     ? 'user'
     : 'machine';
-  const usableRules = Array.isArray(detectionRules)
-    ? detectionRules.filter(isUsableDetectionRule)
-    : [];
+  const primaryRules = usableDetectionRules(detectionRules);
+  const usableRules = primaryRules.length > 0
+    ? primaryRules
+    : usableDetectionRules(fallbackDetectionRules);
   const reconciled = reconcileManagedMarkerDetectionRules({
     detectionRules: usableRules,
     wingetId,
@@ -51,6 +54,10 @@ export function normalizeCatalogDetectionRules({
   return reconciled.length > 0
     ? reconciled
     : generateRegistryMarkerDetectionRules(wingetId, version, scope, markerPath || undefined);
+}
+
+function usableDetectionRules(values: readonly unknown[] | null | undefined): DetectionRule[] {
+  return Array.isArray(values) ? values.filter(isUsableDetectionRule) : [];
 }
 
 function isUsableDetectionRule(value: unknown): value is DetectionRule {

--- a/lib/catalog-detection.ts
+++ b/lib/catalog-detection.ts
@@ -36,7 +36,7 @@ export function normalizeCatalogDetectionRules({
 
   // Match the PowerShell packager's scope semantics. PowerShell string
   // equality is case-insensitive but does not ignore surrounding whitespace.
-  const scope: WingetScope = installScope?.toLowerCase() === 'user'
+  const scope: WingetScope = typeof installScope === 'string' && installScope.toLowerCase() === 'user'
     ? 'user'
     : 'machine';
   const primaryRules = usableDetectionRules(detectionRules);

--- a/lib/catalog-detection.ts
+++ b/lib/catalog-detection.ts
@@ -1,0 +1,38 @@
+import type { DetectionRule } from '@/types/intune';
+import type { WingetScope } from '@/types/winget';
+import { generateRegistryMarkerDetectionRules } from '@/lib/detection-rules';
+import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
+
+/**
+ * Normalize trusted catalog-package detection at the server boundary. Saved
+ * customer profiles can predate managed marker detection, so an empty rule
+ * list must be repaired before either QA or customer packaging is dispatched.
+ */
+export function normalizeCatalogDetectionRules({
+  detectionRules,
+  wingetId,
+  version,
+  installScope,
+  markerPath,
+}: {
+  detectionRules: DetectionRule[] | null | undefined;
+  wingetId: string;
+  version: string;
+  installScope?: string;
+  markerPath?: string | null;
+}): DetectionRule[] {
+  const scope: WingetScope = installScope?.trim().toLowerCase() === 'user'
+    ? 'user'
+    : 'machine';
+  const reconciled = reconcileManagedMarkerDetectionRules({
+    detectionRules: Array.isArray(detectionRules) ? detectionRules : [],
+    wingetId,
+    version,
+    installScope: scope,
+    markerPath,
+  });
+
+  return reconciled.length > 0
+    ? reconciled
+    : generateRegistryMarkerDetectionRules(wingetId, version, scope, markerPath || undefined);
+}

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -103,7 +103,7 @@ export function generateDetectionRules(
  * The SOFTWARE\IntuneGet\Apps root is customizable per package via
  * psadtConfig.registryMarkerPath (issue #106)
  */
-function generateRegistryMarkerDetectionRules(
+export function generateRegistryMarkerDetectionRules(
   wingetId: string,
   version: string,
   scope?: WingetScope,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -213,7 +213,7 @@ describe('PSADT QA package identity', () => {
     );
   });
 
-  it('preserves PSADT detection rules when the top-level workflow list is empty', () => {
+  it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,
       path: '%ProgramFiles%\\Cursor',
@@ -231,7 +231,7 @@ describe('PSADT QA package identity', () => {
       silentSwitches: '/VERYSILENT',
       uninstallCommand: 'REGISTRY_UNINSTALL:Cursor',
       installScope: 'machine',
-      detectionRules: '[]',
+      detectionRules: '[{}]',
       psadtConfig: JSON.stringify({ detectionRules: [fileRule] }),
     });
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -184,6 +184,34 @@ describe('PSADT QA package identity', () => {
       splitQaPsadtConfig(JSON.parse(normalized.psadtConfigJson)).execution
     ).toEqual(profile.psadtConfig);
   });
+
+  it('repairs a legacy deployment profile that has no detection rules', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Anysphere.Cursor',
+      displayName: 'Cursor',
+      publisher: 'Anysphere',
+      version: '3.14.27',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Cursor',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        type: 'registry',
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Anysphere_Cursor',
+        detectionValue: '3.14.27',
+      }),
+    ]);
+    expect(JSON.parse(normalized.psadtConfigJson).detectionRules).toEqual(
+      normalized.detectionRules
+    );
+  });
 });
 
 describe('current catalog QA package validation', () => {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -212,6 +212,32 @@ describe('PSADT QA package identity', () => {
       normalized.detectionRules
     );
   });
+
+  it('preserves PSADT detection rules when the top-level workflow list is empty', () => {
+    const fileRule = {
+      type: 'file' as const,
+      path: '%ProgramFiles%\\Cursor',
+      fileOrFolderName: 'Cursor.exe',
+      detectionType: 'exists' as const,
+    };
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Anysphere.Cursor',
+      displayName: 'Cursor',
+      publisher: 'Anysphere',
+      version: '3.14.27',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Cursor',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [fileRule] }),
+    });
+
+    expect(normalized.detectionRules).toEqual([fileRule]);
+    expect(JSON.parse(normalized.psadtConfigJson).detectionRules).toEqual([fileRule]);
+  });
 });
 
 describe('current catalog QA package validation', () => {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { reconcileManagedMarkerDetectionRules } from '@/lib/registry-marker';
+import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { assertPackagingContract } from '@/lib/packaging-contract';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
@@ -43,10 +43,12 @@ export const QA_COMPATIBLE_PASSED_PACKAGER_COMMITS = [
 ].reverse();
 
 /**
- * Increment this whenever profile-building semantics change without a corresponding
- * toolchain-pin change (for example, default PSADT settings or detection derivation),
- * and update the protected workflow verifier in the same rollout. Existing candidates
- * then fail closed and are rebuilt before they can be dispatched.
+ * Increment this whenever profile-building semantics can change without changing a
+ * canonical behavior field and there is no corresponding toolchain-pin change. A
+ * scoped normalization that adds or rewrites a canonical field (such as repairing an
+ * empty detection-rule list) invalidates only affected profiles through their hash and
+ * does not require a global schema bump. Update the protected workflow verifier with
+ * every schema bump so existing candidates fail closed before dispatch.
  */
 export const QA_PACKAGE_PROFILE_SCHEMA_VERSION = 4;
 
@@ -629,7 +631,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
   const parsedConfig = parseJsonObject<unknown>(input.psadtConfig, {});
   const rawConfig = (record(parsedConfig) || {}) as Partial<PSADTConfig>;
   const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, parsedDetectionRules);
-  const detectionRules = reconcileManagedMarkerDetectionRules({
+  const detectionRules = normalizeCatalogDetectionRules({
     detectionRules: parsedDetectionRules,
     wingetId: input.wingetId,
     version: input.version,

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -630,14 +630,10 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     : [];
   const parsedConfig = parseJsonObject<unknown>(input.psadtConfig, {});
   const rawConfig = (record(parsedConfig) || {}) as Partial<PSADTConfig>;
-  const requestedDetectionRules = parsedDetectionRules.length > 0
-    ? parsedDetectionRules
-    : Array.isArray(rawConfig.detectionRules)
-      ? rawConfig.detectionRules
-      : parsedDetectionRules;
-  const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, requestedDetectionRules);
+  const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, parsedDetectionRules);
   const detectionRules = normalizeCatalogDetectionRules({
-    detectionRules: requestedDetectionRules,
+    detectionRules: parsedDetectionRules,
+    fallbackDetectionRules: rawConfig.detectionRules,
     wingetId: input.wingetId,
     version: input.version,
     installScope: input.installScope || 'machine',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -630,9 +630,14 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     : [];
   const parsedConfig = parseJsonObject<unknown>(input.psadtConfig, {});
   const rawConfig = (record(parsedConfig) || {}) as Partial<PSADTConfig>;
-  const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, parsedDetectionRules);
+  const requestedDetectionRules = parsedDetectionRules.length > 0
+    ? parsedDetectionRules
+    : Array.isArray(rawConfig.detectionRules)
+      ? rawConfig.detectionRules
+      : parsedDetectionRules;
+  const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, requestedDetectionRules);
   const detectionRules = normalizeCatalogDetectionRules({
-    detectionRules: parsedDetectionRules,
+    detectionRules: requestedDetectionRules,
     wingetId: input.wingetId,
     version: input.version,
     installScope: input.installScope || 'machine',


### PR DESCRIPTION
## Root cause
Legacy customer deployment profiles can contain an empty detection-rule array. QA preparation correctly fails closed when no Intune detection rule exists, which caused Cursor and can affect any older catalog deployment profile.

## Fix
- normalize trusted catalog detection at the server boundary
- synthesize the owned IntuneGet registry marker only when a profile would otherwise have no rule
- use the same normalized rule for QA demand, persisted package configuration, and customer workflow dispatch
- repair stale QA deployment profiles during workflow-input normalization
- preserve non-empty customer rules and leave custom-source packages unchanged
- scope invalidation to affected profiles through their changed canonical detection output

## Validation
- 63 focused tests passed
- 167 tests passed in the wider focused suite before finalization
- focused ESLint passed
- full Next.js production build passed
- git diff check passed