### PR TITLE
Bundle reviewed WinGet dependencies into PSADT packages

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -50,6 +50,46 @@ $NestedInstallerType = $env:INPUT_NESTED_INSTALLER_TYPE
 $NestedInstallerPath = $env:INPUT_NESTED_INSTALLER_PATH
 $InstallScope = if ($env:INPUT_INSTALL_SCOPE) { $env:INPUT_INSTALL_SCOPE } else { 'machine' }
 $IsUserScope = $InstallScope -eq 'user'
+$PackageDependencies = @()
+if (-not [string]::IsNullOrWhiteSpace($env:INPUT_PACKAGE_DEPENDENCIES)) {
+    try {
+        $PackageDependencies = @($env:INPUT_PACKAGE_DEPENDENCIES | ConvertFrom-Json -ErrorAction Stop)
+    }
+    catch {
+        throw 'INPUT_PACKAGE_DEPENDENCIES must be a JSON array.'
+    }
+}
+if ($PackageDependencies.Count -gt 8) {
+    throw 'INPUT_PACKAGE_DEPENDENCIES cannot contain more than 8 packages.'
+}
+
+foreach ($dependency in $PackageDependencies) {
+    if ([string]::IsNullOrWhiteSpace([string]$dependency.packageIdentifier) -or
+        [string]::IsNullOrWhiteSpace([string]$dependency.version) -or
+        [string]::IsNullOrWhiteSpace([string]$dependency.fileName) -or
+        [string]::IsNullOrWhiteSpace([string]$dependency.installerSha256)) {
+        throw 'Every package dependency must include an identifier, version, filename, and SHA-256.'
+    }
+    if ([string]$dependency.packageIdentifier -notmatch '^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(x86|x64|arm64)$') {
+        throw "Package dependency is not in the reviewed redistribution allowlist: $($dependency.packageIdentifier)"
+    }
+    if ([string]$dependency.installerType -notin @('exe', 'burn')) {
+        throw "Package dependency uses an unreviewed installer type: $($dependency.installerType)"
+    }
+    if ([string]$dependency.fileName -match '[\\/:*?"<>|]' -or
+        [System.IO.Path]::GetFileName([string]$dependency.fileName) -ne [string]$dependency.fileName) {
+        throw "Package dependency filename is unsafe: $($dependency.fileName)"
+    }
+    if ([string]$dependency.installerSha256 -notmatch '^[A-Fa-f0-9]{64}$') {
+        throw "Package dependency SHA-256 is invalid: $($dependency.packageIdentifier)"
+    }
+    foreach ($exitCode in @($dependency.successCodes) + @($dependency.rebootCodes)) {
+        $parsedDependencyExitCode = 0
+        if (-not [int]::TryParse([string]$exitCode, [ref]$parsedDependencyExitCode)) {
+            throw "Package dependency exit code is invalid: $exitCode"
+        }
+    }
+}
 
 # Validate required inputs
 $requiredVars = @('INPUT_JOB_ID', 'INPUT_CALLBACK_URL', 'INPUT_DISPLAY_NAME', 'INPUT_PUBLISHER', 'INPUT_VERSION', 'INPUT_WINGET_ID', 'INPUT_INSTALLER_TYPE')
@@ -95,6 +135,26 @@ if (-not $env:INSTALLER_FILENAME) {
 }
 # Use -LiteralPath to handle filenames with special characters like brackets
 Copy-Item -LiteralPath $env:INSTALLER_PATH -Destination $filesDir
+
+if ($PackageDependencies.Count -gt 0) {
+    if ([string]::IsNullOrWhiteSpace($env:DEPENDENCIES_PATH) -or
+        -not (Test-Path -LiteralPath $env:DEPENDENCIES_PATH -PathType Container)) {
+        throw 'DEPENDENCIES_PATH must point to the verified dependency download directory.'
+    }
+    $dependencyFilesDir = Join-Path $filesDir 'Dependencies'
+    $null = New-Item -ItemType Directory -Path $dependencyFilesDir -Force
+    foreach ($dependency in $PackageDependencies) {
+        $dependencySource = Join-Path $env:DEPENDENCIES_PATH ([string]$dependency.fileName)
+        if (-not (Test-Path -LiteralPath $dependencySource -PathType Leaf)) {
+            throw "Verified package dependency file was not found: $($dependency.packageIdentifier)"
+        }
+        $dependencyHash = (Get-FileHash -LiteralPath $dependencySource -Algorithm SHA256).Hash
+        if ($dependencyHash -ne ([string]$dependency.installerSha256).ToUpperInvariant()) {
+            throw "Package dependency hash changed before packaging: $($dependency.packageIdentifier)"
+        }
+        Copy-Item -LiteralPath $dependencySource -Destination (Join-Path $dependencyFilesDir ([string]$dependency.fileName)) -Force
+    }
+}
 
 # Parse PSADT configuration
 $psadtConfig = @{}
@@ -1111,6 +1171,43 @@ if ($restartPromptConfig -and $restartPromptConfig.enabled) {
     ) -join "`r`n"
 }
 
+# Build a deterministic, offline prerequisite sequence. Dependency files were
+# hash-verified before being copied into Files\Dependencies above. They are
+# installed before the primary-app uninstall snapshot so their registry entries
+# cannot be mistaken for the application's vendor identity.
+$dependencyInstallLines = @()
+foreach ($dependency in @($PackageDependencies | Sort-Object order)) {
+    $dependencyIdEscaped = ([string]$dependency.packageIdentifier) -replace "'", "''"
+    $dependencyVersionEscaped = ([string]$dependency.version) -replace "'", "''"
+    $dependencyFileEscaped = ([string]$dependency.fileName) -replace "'", "''"
+    $dependencyArgumentsEscaped = ([string]$dependency.silentArgs) -replace "'", "''"
+    $dependencySuccessCodes = @(
+        0
+        @($dependency.successCodes) | ForEach-Object { [int]$_ }
+    ) | Sort-Object -Unique
+    $dependencyRebootCodes = @(
+        @($dependency.rebootCodes) | ForEach-Object { [int]$_ }
+    ) | Sort-Object -Unique
+    if ($dependencyRebootCodes.Count -eq 0) {
+        $dependencyRebootCodes = @(1641, 3010)
+    }
+    $dependencySuccessLiteral = $dependencySuccessCodes -join ', '
+    $dependencyRebootLiteral = $dependencyRebootCodes -join ', '
+    $dependencyInstallLines += @(
+        ''
+        "    # Install offline WinGet dependency: $dependencyIdEscaped $dependencyVersionEscaped"
+        "    `$dependencyPath = Join-Path `$adtSession.DirFiles 'Dependencies\$dependencyFileEscaped'"
+        '    if (-not (Test-Path -LiteralPath $dependencyPath -PathType Leaf)) {'
+        "        throw 'Bundled dependency file is missing: $dependencyIdEscaped'"
+        '    }'
+        "    Write-ADTLogEntry -Message 'Installing bundled dependency [$dependencyIdEscaped] version [$dependencyVersionEscaped].' -Severity 'Info' -Source 'Install-ADTDeployment'"
+        "    `$dependencyResult = Start-ADTProcess -FilePath `$dependencyPath -ArgumentList '$dependencyArgumentsEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 10) -TimeoutAction Stop -SuccessExitCodes @($dependencySuccessLiteral) -RebootExitCodes @($dependencyRebootLiteral) -PassThru"
+        "    if (`$dependencyResult.ExitCode -in @($dependencyRebootLiteral)) {"
+        '        $script:DependencyRebootExitCode = 3010'
+        '    }'
+    )
+}
+
 # Build Invoke-AppDeployToolkit.ps1 script content using PSADT v4 native syntax
 $lines = @(
     '<#'
@@ -1189,6 +1286,7 @@ $lines += @(
     '    }'
     ''
 )
+$lines += $dependencyInstallLines
 
 if ($useRegistryUninstall) {
     $lines += @(
@@ -2191,6 +2289,7 @@ $lines += @(
     '$ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop'
     '$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue'
     '$script:UninstallRebootExitCode = $null'
+    '$script:DependencyRebootExitCode = $null'
     'Set-StrictMode -Version 1'
     ''
     'try'
@@ -2235,8 +2334,8 @@ $lines += @(
     'try'
     '{'
     '    & "$($adtSession.DeploymentType)-ADTDeployment"'
-    '    if ($script:UninstallRebootExitCode) {'
-    '        Close-ADTSession -ExitCode $script:UninstallRebootExitCode'
+    '    if ($script:UninstallRebootExitCode -or $script:DependencyRebootExitCode) {'
+    '        Close-ADTSession -ExitCode 3010'
     '    } else {'
     '        Close-ADTSession'
     '    }'

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -498,15 +498,15 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Greenshot.Greenshot',
-        name: 'Greenshot',
-        publisher: 'Greenshot',
+        winget_id: 'Oracle.VirtualBox',
+        name: 'Oracle VirtualBox',
+        publisher: 'Oracle',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Greenshot.Greenshot',
-          packagerCommit: '430f817da1120f6a14f421b7016b628a06854aba',
+          wingetId: 'Oracle.VirtualBox',
+          packagerCommit: 'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
           status: 'failed',
         }),
       ],
@@ -527,7 +527,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Greenshot.Greenshot',
+      winget_id: 'Oracle.VirtualBox',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -5,11 +5,13 @@ const {
   createManifestClientMock,
   detectWingetChangesMock,
   resolveManifestMock,
+  resolveDependenciesMock,
 } = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
   createManifestClientMock: vi.fn(() => ({ kind: 'manifest-client' })),
   detectWingetChangesMock: vi.fn(),
   resolveManifestMock: vi.fn(),
+  resolveDependenciesMock: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
@@ -18,6 +20,13 @@ vi.mock('@/lib/winget-sync-resolution.mjs', () => ({
   createWingetManifestClient: createManifestClientMock,
   resolveWingetManifest: resolveManifestMock,
 }));
+vi.mock('@/lib/winget-dependencies', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/winget-dependencies')>();
+  return {
+    ...original,
+    resolveWingetPackageDependencies: resolveDependenciesMock,
+  };
+});
 
 import { GET } from './route';
 import { prioritizeToolchainBackfill } from '@/lib/qa/toolchain-backfill';

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
 import { evaluatePackagingContract } from '@/lib/packaging-contract';
+import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
 import {
   QA_PSADT_TOOLCHAIN,
   buildQaPackageIdentity,
@@ -558,10 +559,17 @@ export async function GET(request: Request) {
             }
 
             const architecture = selectedForVm.architecture;
+            const packageDependencies = await resolveWingetPackageDependencies({
+              wingetId: app.winget_id,
+              version: resolution.version,
+              architecture,
+              installerSha256,
+            });
             const testConfig = buildQaCatalogTestConfig({
               app: { ...app, wingetId: app.winget_id, version: resolution.version },
               manifest,
               installer: selectedForVm.installer as never,
+              packageDependencies,
             });
             const packageIdentity = buildQaPackageIdentity({
               profileKind: testConfig.profileKind,
@@ -580,6 +588,7 @@ export async function GET(request: Request) {
               nestedInstallerFiles: testConfig.nestedInstallerFiles,
               psadtConfig: testConfig.psadtConfig,
               detectionRules: testConfig.detectionRules,
+              packageDependencies,
             });
             const packagingContract = evaluatePackagingContract({
               wingetId: app.winget_id,

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -559,18 +559,21 @@ export async function GET(request: Request) {
             }
 
             const architecture = selectedForVm.architecture;
+            const testConfig = buildQaCatalogTestConfig({
+              app: { ...app, wingetId: app.winget_id, version: resolution.version },
+              manifest,
+              installer: selectedForVm.installer as never,
+            });
             const packageDependencies = await resolveWingetPackageDependencies({
               wingetId: app.winget_id,
               version: resolution.version,
               architecture,
               installerSha256,
+              installScope: testConfig.scope,
             });
-            const testConfig = buildQaCatalogTestConfig({
-              app: { ...app, wingetId: app.winget_id, version: resolution.version },
-              manifest,
-              installer: selectedForVm.installer as never,
-              packageDependencies,
-            });
+            if (packageDependencies.length > 0) {
+              testConfig.packageDependencies = packageDependencies;
+            }
             const packageIdentity = buildQaPackageIdentity({
               profileKind: testConfig.profileKind,
               wingetId: app.winget_id,

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -6,9 +6,10 @@ import {
 } from './github-actions';
 import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
 
-const { enforceInstallerPreflightMock, enforceQaGateMock } = vi.hoisted(() => ({
+const { enforceInstallerPreflightMock, enforceQaGateMock, resolveDependenciesMock } = vi.hoisted(() => ({
   enforceInstallerPreflightMock: vi.fn(),
   enforceQaGateMock: vi.fn(),
+  resolveDependenciesMock: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('./installer-preflight', async (importOriginal) => {
@@ -22,6 +23,14 @@ vi.mock('./installer-preflight', async (importOriginal) => {
 vi.mock('./qa/gate', async (importOriginal) => {
   const original = await importOriginal<typeof import('./qa/gate')>();
   return { ...original, enforceQaGate: enforceQaGateMock };
+});
+
+vi.mock('./winget-dependencies', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./winget-dependencies')>();
+  return {
+    ...original,
+    resolveWingetPackageDependencies: resolveDependenciesMock,
+  };
 });
 
 const config: GitHubActionsConfig = {
@@ -49,6 +58,7 @@ function workflowInputs(overrides: Partial<WorkflowInputs> = {}): WorkflowInputs
     uninstallCommand: 'uninstall.exe /S',
     callbackUrl: 'https://example.test/api/package/callback',
     hashValidationMode: 'calculate',
+    sourceType: 'custom',
     ...overrides,
   };
 }
@@ -96,6 +106,48 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     const request = fetchMock.mock.calls[0][1] as RequestInit;
     const payload = JSON.parse(String(request.body));
     expect(payload.client_payload.installer.hashValidationMode).toBe('strict');
+  });
+
+  it('dispatches only server-resolved dependency metadata and binds it to the QA profile', async () => {
+    const dependency = {
+      packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+      version: '14.51.36210.0',
+      architecture: 'x64' as const,
+      installerUrl: 'https://aka.ms/vc14/vc_redist.x64.exe',
+      installerSha256: 'B'.repeat(64),
+      installerType: 'exe' as const,
+      silentArgs: '/install /quiet /norestart',
+      successCodes: [-2147023258, 0, 1638],
+      rebootCodes: [1641, 3010],
+      fileName: 'Microsoft.VCRedist.2015+.x64-vc_redist.x64.exe',
+      order: 1,
+      depth: 1,
+    };
+    resolveDependenciesMock.mockResolvedValueOnce([dependency]);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Oracle.VirtualBox',
+      version: '7.2.14',
+      installerSha256: 'A'.repeat(64),
+      hashValidationMode: 'strict',
+      sourceType: 'winget',
+      packageDependencies: [],
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(JSON.parse(payload.client_payload.installer.packageDependencies)).toEqual([
+      dependency,
+    ]);
+    expect(resolveDependenciesMock).toHaveBeenCalledWith(expect.objectContaining({
+      wingetId: 'Oracle.VirtualBox',
+      installerSha256: 'A'.repeat(64),
+    }));
+    expect(enforceQaGateMock).toHaveBeenCalledWith(expect.objectContaining({
+      packageProfileSha256: expect.stringMatching(/^[A-F0-9]{64}$/),
+    }));
   });
 
   it('dispatches the same reconciled marker rules that are used for the QA gate', async () => {

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -124,6 +124,7 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
       depth: 1,
     };
     resolveDependenciesMock.mockResolvedValueOnce([dependency]);
+    vi.stubEnv('CALLBACK_SECRET', 'dependency-signing-secret');
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -141,6 +142,9 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(JSON.parse(payload.client_payload.installer.packageDependencies)).toEqual([
       dependency,
     ]);
+    expect(payload.client_payload.installer.dependencyBundleSignature).toMatch(
+      /^[a-f0-9]{64}$/
+    );
     expect(resolveDependenciesMock).toHaveBeenCalledWith(expect.objectContaining({
       wingetId: 'Oracle.VirtualBox',
       installerSha256: 'A'.repeat(64),

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -10,6 +10,10 @@ import { enforceQaGate } from './qa/gate';
 import {
   normalizeQaWorkflowPackageInput,
 } from './qa/package-profile';
+import {
+  resolveWingetPackageDependencies,
+  type PackagedWingetDependency,
+} from './winget-dependencies';
 
 export interface WorkflowInputs {
   jobId: string;
@@ -47,6 +51,7 @@ export interface WorkflowInputs {
   supersedenceType?: string; // Supersedence type for auto-supersede ('update' | 'replace')
   sourceType?: 'winget' | 'custom'; // Custom installers are outside winget-pkgs trust validation
   packageProfileSha256?: string; // Upstream QA identity; final dispatch recalculates from effective inputs
+  packageDependencies?: PackagedWingetDependency[]; // Server-resolved; caller values are never trusted
 }
 
 export interface GitHubActionsConfig {
@@ -119,9 +124,6 @@ export async function triggerPackagingWorkflow(
     inputs.architecture ?? '',
     inputs.installerUrl,
   );
-  const normalizedPackageInput =
-    inputs.sourceType === 'custom' ? null : normalizeQaWorkflowPackageInput(inputs);
-
   // This is the final dispatch boundary shared by manual, MSP, update-policy,
   // and auto-update paths. Never create a packaging run for a known-bad tuple.
   await enforceInstallerPreflight({
@@ -134,6 +136,17 @@ export async function triggerPackagingWorkflow(
     installScope: inputs.installScope,
     sourceType: inputs.sourceType,
   });
+  const packageDependencies = inputs.sourceType === 'custom'
+    ? []
+    : await resolveWingetPackageDependencies({
+        wingetId: inputs.wingetId,
+        version: inputs.version,
+        architecture: inputs.architecture,
+        installerSha256: inputs.installerSha256,
+      });
+  const normalizedPackageInput = inputs.sourceType === 'custom'
+    ? null
+    : normalizeQaWorkflowPackageInput({ ...inputs, packageDependencies });
   const calculatedPackageProfileSha256 = normalizedPackageInput?.identity.packageProfileSha256;
   const packageProfileSha256 = calculatedPackageProfileSha256;
   await enforceQaGate({
@@ -188,6 +201,7 @@ export async function triggerPackagingWorkflow(
           nestedInstallerPath: inputs.nestedInstallerPath || '',
           silentSwitches: inputs.silentSwitches,
           successCodes: JSON.stringify(inputs.installerSuccessCodes || []),
+          packageDependencies: JSON.stringify(packageDependencies),
           uninstallCommand: inputs.uninstallCommand,
         },
         config: {

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -4,6 +4,8 @@
  * Uses repository_dispatch to a private workflows repository
  */
 
+import { createHmac } from 'node:crypto';
+
 import { applyInstallerUrlOverride } from './installer-url-overrides';
 import { enforceInstallerPreflight } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
@@ -147,6 +149,18 @@ export async function triggerPackagingWorkflow(
   const normalizedPackageInput = inputs.sourceType === 'custom'
     ? null
     : normalizeQaWorkflowPackageInput({ ...inputs, packageDependencies });
+  const packageDependenciesJson = JSON.stringify(packageDependencies);
+  const dependencyBundleSignature = packageDependencies.length > 0
+    ? (() => {
+        const callbackSecret = process.env.CALLBACK_SECRET;
+        if (!callbackSecret) {
+          throw new Error('CALLBACK_SECRET is required to sign package dependencies.');
+        }
+        return createHmac('sha256', callbackSecret)
+          .update(packageDependenciesJson, 'utf8')
+          .digest('hex');
+      })()
+    : '';
   const calculatedPackageProfileSha256 = normalizedPackageInput?.identity.packageProfileSha256;
   const packageProfileSha256 = calculatedPackageProfileSha256;
   await enforceQaGate({
@@ -201,7 +215,8 @@ export async function triggerPackagingWorkflow(
           nestedInstallerPath: inputs.nestedInstallerPath || '',
           silentSwitches: inputs.silentSwitches,
           successCodes: JSON.stringify(inputs.installerSuccessCodes || []),
-          packageDependencies: JSON.stringify(packageDependencies),
+          packageDependencies: packageDependenciesJson,
+          dependencyBundleSignature,
           uninstallCommand: inputs.uninstallCommand,
         },
         config: {

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -145,6 +145,7 @@ export async function triggerPackagingWorkflow(
         version: inputs.version,
         architecture: inputs.architecture,
         installerSha256: inputs.installerSha256,
+        installScope: inputs.installScope,
       });
   const normalizedPackageInput = inputs.sourceType === 'custom'
     ? null

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -765,6 +765,9 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     productCode: normalizeProductCode(installer.ProductCode),
     packageFamilyName: installer.PackageFamilyName,
     packageDependencies: packageDependencies.length > 0 ? packageDependencies : undefined,
+    windowsFeatures: installer.Dependencies?.WindowsFeatures,
+    windowsLibraries: installer.Dependencies?.WindowsLibraries,
+    externalDependencies: installer.Dependencies?.ExternalDependencies,
   };
 }
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -135,6 +135,43 @@ describe('PSADT QA package identity', () => {
     expect(buildQaPackageIdentity({ ...input, successCodes: [] })).toEqual(baseline);
   });
 
+  it('binds offline dependency installers to the execution profile only when present', () => {
+    const baseline = buildQaPackageIdentity(input);
+    const dependency = {
+      packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+      version: '14.51.36210.0',
+      architecture: 'x64' as const,
+      installerUrl: 'https://aka.ms/vc14/vc_redist.x64.exe',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe' as const,
+      silentArgs: '/install /quiet /norestart',
+      successCodes: [-2147023258, 0, 1638],
+      rebootCodes: [1641, 3010],
+      fileName: 'Microsoft.VCRedist.2015+.x64-vc_redist.x64.exe',
+      order: 1,
+      depth: 1,
+    };
+    const withDependency = buildQaPackageIdentity({
+      ...input,
+      packageDependencies: [dependency],
+    });
+    const installer = withDependency.profile.installer as Record<string, unknown>;
+
+    expect(withDependency.packageProfileSha256).not.toBe(
+      baseline.packageProfileSha256
+    );
+    expect(installer.packageDependencies).toEqual([
+      expect.objectContaining({
+        packageIdentifier: dependency.packageIdentifier,
+        sha256: dependency.installerSha256.toUpperCase(),
+      }),
+    ]);
+    expect(installer.dependenciesSha256).toMatch(/^[A-F0-9]{64}$/);
+    expect((baseline.profile.installer as Record<string, unknown>).packageDependencies)
+      .toBeUndefined();
+    expect(buildQaPackageIdentity({ ...input, packageDependencies: [] })).toEqual(baseline);
+  });
+
   it('reconciles an IntuneGet marker with the current workflow scope and version', () => {
     const workflowInput = {
       wingetId: 'Asana.Asana',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -8,7 +8,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
+  packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -36,6 +36,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
   'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
   'fc18fffd40f6d362be251e05e2bc784373dfc735',
+  'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -4,6 +4,7 @@ import { assertPackagingContract } from '@/lib/packaging-contract';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
@@ -69,6 +70,7 @@ export interface QaPackageProfileInput {
   nestedInstallerFiles: readonly string[];
   psadtConfig: PSADTConfig;
   detectionRules: DetectionRule[];
+  packageDependencies?: readonly PackagedWingetDependency[];
 }
 
 export interface QaPackageIdentity {
@@ -177,6 +179,7 @@ export interface QaWorkflowPackageInput {
   installScope?: string;
   psadtConfig?: string;
   detectionRules?: string;
+  packageDependencies?: readonly PackagedWingetDependency[];
 }
 
 export type QaPackageProfileValidation =
@@ -415,6 +418,32 @@ function validateQaPackageProfile(
   if (canonicalInstallerSha256 !== candidateInstallerSha256) {
     return { valid: false, reason: 'candidate-installer-sha-mismatch' };
   }
+  if (installer.packageDependencies !== undefined) {
+    if (!Array.isArray(installer.packageDependencies) || installer.packageDependencies.length === 0) {
+      return { valid: false, reason: 'canonical-dependencies-invalid' };
+    }
+    const dependencySha256 = sha256(installer.dependenciesSha256);
+    if (!dependencySha256) {
+      return { valid: false, reason: 'canonical-dependencies-sha-invalid' };
+    }
+    if (
+      dependencySha256 !== qaSha256(canonicalQaJson(installer.packageDependencies))
+    ) {
+      return { valid: false, reason: 'canonical-dependencies-sha-mismatch' };
+    }
+    for (const dependencyValue of installer.packageDependencies) {
+      const dependency = record(dependencyValue);
+      if (
+        !dependency ||
+        !textValue(dependency.packageIdentifier) ||
+        !textValue(dependency.version) ||
+        !sha256(dependency.sha256) ||
+        !textValue(dependency.fileName)
+      ) {
+        return { valid: false, reason: 'canonical-dependency-entry-invalid' };
+      }
+    }
+  }
 
   return {
     valid: true,
@@ -552,6 +581,30 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
     psadt: presentation,
   }));
   const detectionRulesSha256 = qaSha256(canonicalQaJson(input.detectionRules));
+  const packageDependencies = (input.packageDependencies || []).map((dependency) => ({
+    packageIdentifier: dependency.packageIdentifier,
+    ...(dependency.minimumVersion
+      ? { minimumVersion: dependency.minimumVersion }
+      : {}),
+    version: dependency.version,
+    architecture: dependency.architecture,
+    sha256: dependency.installerSha256.toUpperCase(),
+    installerType: dependency.installerType,
+    ...(dependency.nestedInstallerType
+      ? { nestedInstallerType: dependency.nestedInstallerType }
+      : {}),
+    ...(dependency.nestedInstallerPath
+      ? { nestedInstallerPath: dependency.nestedInstallerPath }
+      : {}),
+    silentArgs: dependency.silentArgs,
+    successCodes: dependency.successCodes,
+    rebootCodes: dependency.rebootCodes,
+    fileName: dependency.fileName,
+    order: dependency.order,
+  }));
+  const dependenciesSha256 = packageDependencies.length > 0
+    ? qaSha256(canonicalQaJson(packageDependencies))
+    : '';
   const profile = {
     schemaVersion: QA_PACKAGE_PROFILE_SCHEMA_VERSION,
     testLevel: 'psadt-package',
@@ -575,6 +628,9 @@ export function buildQaPackageIdentity(input: QaPackageProfileInput): QaPackageI
       installScope: input.installScope || 'machine',
       nestedInstallerType: input.nestedInstallerType.toLowerCase(),
       nestedInstallerFiles: input.nestedInstallerFiles,
+      ...(packageDependencies.length > 0
+        ? { packageDependencies, dependenciesSha256 }
+        : {}),
     },
     psadtConfig: executionPsadtConfig,
     detectionRules: input.detectionRules,
@@ -660,6 +716,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     nestedInstallerFiles: input.nestedInstallerPath ? [input.nestedInstallerPath] : [],
     psadtConfig,
     detectionRules,
+    packageDependencies: input.packageDependencies,
   });
 
   return {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdirSync,
   mkdtempSync,
@@ -32,7 +33,8 @@ function generateRegistryUninstallPackage(
   installerType: 'inno' | 'burn',
   displayName = 'Contract Test App',
   installerSuccessCodes: number[] = [],
-  psadtConfig: unknown = {}
+  psadtConfig: unknown = {},
+  packageDependencies: Array<Record<string, unknown>> = []
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -53,6 +55,16 @@ function generateRegistryUninstallPackage(
       join(fixtureRoot, 'Send-Callback.ps1'),
       'function Send-Callback { param($Body, $CallbackUrl, $CallbackSecret) return $null }'
     );
+    const dependencyPath = join(fixtureRoot, 'dependencies');
+    if (packageDependencies.length > 0) {
+      mkdirSync(dependencyPath, { recursive: true });
+      for (const dependency of packageDependencies) {
+        writeFileSync(
+          join(dependencyPath, String(dependency.fileName)),
+          'dependency-fixture'
+        );
+      }
+    }
 
     const result = spawnSync('pwsh', ['-NoProfile', '-File', packagerPath], {
       cwd: fixtureRoot,
@@ -70,9 +82,13 @@ function generateRegistryUninstallPackage(
         INPUT_INSTALL_SCOPE: 'machine',
         INPUT_SILENT_SWITCHES: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
         INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
+        INPUT_PACKAGE_DEPENDENCIES: JSON.stringify(packageDependencies),
         INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${displayName}`,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
+        ...(packageDependencies.length > 0
+          ? { DEPENDENCIES_PATH: dependencyPath }
+          : {}),
         PSADT_CONFIG: JSON.stringify(psadtConfig),
       },
     });
@@ -155,6 +171,50 @@ describe('PSADT vendor argument contract', () => {
     expect(assignment).not.toContain("-replace '`'");
     expect(assignment).not.toContain("-replace '\\$'");
   });
+});
+
+describe('PSADT offline dependency contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'bundles and installs reviewed hash-pinned dependencies before the primary app',
+    () => {
+      const dependencySha256 = createHash('sha256')
+        .update('dependency-fixture')
+        .digest('hex')
+        .toUpperCase();
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Dependency Contract App',
+        [],
+        {},
+        [{
+          packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+          version: '14.51.36210.0',
+          fileName: 'Microsoft.VCRedist.2015+.x64-vc_redist.x64.exe',
+          installerSha256: dependencySha256,
+          installerType: 'exe',
+          silentArgs: '/install /quiet /norestart',
+          successCodes: [-2147023258, 0, 1638],
+          rebootCodes: [1641, 3010],
+          order: 1,
+        }]
+      );
+
+      expect(generated).toContain(
+        'Install offline WinGet dependency: Microsoft.VCRedist.2015+.x64 14.51.36210.0'
+      );
+      expect(generated).toContain(
+        "-SuccessExitCodes @(-2147023258, 0, 1638) -RebootExitCodes @(1641, 3010)"
+      );
+      expect(generated.indexOf('Install offline WinGet dependency')).toBeLessThan(
+        generated.indexOf('# Snapshot uninstall entries')
+      );
+      expect(generated).toContain('$script:DependencyRebootExitCode = 3010');
+      expect(generated).toContain(
+        'if ($script:UninstallRebootExitCode -or $script:DependencyRebootExitCode)'
+      );
+    },
+    30_000
+  );
 });
 
 describe.skipIf(!canRunWindowsPowerShellPackager)(
@@ -631,8 +691,9 @@ describe('PSADT registry uninstall identity contract', () => {
       '$script:UninstallRebootExitCode = 3010'
     );
     expect(packager).toContain(
-      'Close-ADTSession -ExitCode $script:UninstallRebootExitCode'
+      'if ($script:UninstallRebootExitCode -or $script:DependencyRebootExitCode)'
     );
+    expect(packager).toContain('Close-ADTSession -ExitCode 3010');
   });
 
   it('still fails closed when asynchronous registry removal never completes', () => {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -11,6 +11,7 @@ import type {
   WingetScope,
 } from '@/types/winget';
 import type { WingetInstallerCandidate } from './candidate';
+import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export interface QaCatalogTestConfig {
   mode: 'psadt-package';
@@ -26,6 +27,7 @@ export interface QaCatalogTestConfig {
   uninstallCommand: string;
   psadtConfig: PSADTConfig;
   detectionRules: DetectionRule[];
+  packageDependencies?: PackagedWingetDependency[];
   profileKind: 'catalog-default';
   packageProfileCanonicalJson?: string;
   packageProfileSha256?: string;
@@ -68,10 +70,12 @@ export function buildQaCatalogTestConfig({
   app,
   manifest,
   installer,
+  packageDependencies = [],
 }: {
   app: { wingetId: string; name: string; publisher: string; version: string };
   manifest: ManifestRecord;
   installer: WingetInstallerCandidate & ManifestRecord;
+  packageDependencies?: PackagedWingetDependency[];
 }): QaCatalogTestConfig {
   // WinGet installer defaults are inherited per switch field, not as one
   // replaceable object. Preserve root Silent when a selected installer only
@@ -181,6 +185,7 @@ export function buildQaCatalogTestConfig({
     uninstallCommand: generateUninstallCommand(normalizedInstaller, app.name),
     psadtConfig,
     detectionRules,
+    ...(packageDependencies.length > 0 ? { packageDependencies } : {}),
     profileKind: 'catalog-default',
   };
 }

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,7 +3,7 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each(['Greenshot.Greenshot'])(
+  it.each(['Oracle.VirtualBox'])(
     'retries the terminal %s failure changed by the current toolchain release',
     (wingetId) => {
       expect(shouldRetryTerminalToolchainCandidate(
@@ -12,6 +12,17 @@ describe('QA toolchain targeted retries', () => {
       )).toBe(true);
     }
   );
+
+  it('keeps the Greenshot retry scoped to its historical toolchain release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
+      { wingetId: 'Greenshot.Greenshot', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Greenshot.Greenshot', status: 'failed' }
+    )).toBe(false);
+  });
 
   it('keeps the OCS retry scoped to its historical toolchain release', () => {
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'bafea79a8dde42be074c385c35b4887fb5833aa0': [
+    'Oracle.VirtualBox',
+  ],
   'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99': [
     'Greenshot.Greenshot',
   ],

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import type { NormalizedInstaller } from '@/types/winget';
+import {
+  resolveWingetPackageDependencies,
+  type WingetDependencyResolverIo,
+} from './winget-dependencies';
+
+const ROOT_SHA = 'A'.repeat(64);
+const VC_SHA = 'B'.repeat(64);
+
+function installer(
+  overrides: Partial<NormalizedInstaller> = {}
+): NormalizedInstaller {
+  return {
+    architecture: 'x64',
+    url: 'https://example.invalid/setup.exe',
+    sha256: ROOT_SHA,
+    type: 'exe',
+    silentArgs: '/quiet',
+    ...overrides,
+  };
+}
+
+function fixtureIo(
+  installers: Record<string, NormalizedInstaller[]>,
+  versions: Record<string, string[]>
+): WingetDependencyResolverIo {
+  return {
+    getInstallers: async (packageIdentifier, version) =>
+      installers[`${packageIdentifier}@${version}`] || [],
+    getVersions: async (packageIdentifier) => versions[packageIdentifier] || [],
+  };
+}
+
+describe('resolveWingetPackageDependencies', () => {
+  it('returns no bundle metadata when the exact root installer has no dependencies', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer()] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io)).resolves.toEqual([]);
+  });
+
+  it('bundles the current VC++ runtime for VirtualBox with idempotent exit codes', async () => {
+    const io = fixtureIo(
+      {
+        'Oracle.VirtualBox@7.2.14': [installer({
+          packageDependencies: [{
+            packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+          }],
+        })],
+        'Microsoft.VCRedist.2015+.x64@14.51.36210.0': [installer({
+          url: 'https://aka.ms/vc14/vc_redist.x64.exe',
+          sha256: VC_SHA,
+          silentArgs: '/install /quiet /norestart',
+        })],
+      },
+      {
+        'Microsoft.VCRedist.2015+.x64': ['14.51.36210.0'],
+      }
+    );
+
+    const result = await resolveWingetPackageDependencies({
+      wingetId: 'Oracle.VirtualBox',
+      version: '7.2.14',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+        version: '14.51.36210.0',
+        installerSha256: VC_SHA,
+        order: 1,
+        successCodes: [-2147023258, 0, 1638],
+        rebootCodes: [1641, 3010],
+      }),
+    ]);
+    expect(result[0].fileName).toBe(
+      'Microsoft.VCRedist.2015+.x64-vc_redist.x64.exe'
+    );
+  });
+
+  it('selects the newest version satisfying the declared minimum', async () => {
+    const io = fixtureIo(
+      {
+        'Example.App@1.0.0': [installer({
+          packageDependencies: [{
+            packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+            minimumVersion: '14.40.0.0',
+          }],
+        })],
+        'Microsoft.VCRedist.2015+.x64@14.30.0.0': [installer({ sha256: VC_SHA })],
+        'Microsoft.VCRedist.2015+.x64@14.40.0.0': [installer({ sha256: VC_SHA })],
+        'Microsoft.VCRedist.2015+.x64@14.50.0.0': [installer({ sha256: VC_SHA })],
+      },
+      {
+        'Microsoft.VCRedist.2015+.x64': ['14.40.0.0', '14.30.0.0', '14.50.0.0'],
+      }
+    );
+
+    const [dependency] = await resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+    expect(dependency.version).toBe('14.50.0.0');
+    expect(dependency.minimumVersion).toBe('14.40.0.0');
+  });
+
+  it('fails closed for dependency families that have not been reviewed', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer({
+        packageDependencies: [{ packageIdentifier: 'Vendor.Runtime' }],
+      })] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io)).rejects.toThrow('not in the reviewed redistribution allowlist');
+  });
+
+  it('fails closed when WinGet declares an unsupported external dependency', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer({ externalDependencies: ['Vendor account'] })] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io)).rejects.toThrow('declares unsupported dependencies');
+  });
+
+  it('requires the exact trusted root installer hash', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer()] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: 'C'.repeat(64),
+    }, io)).rejects.toThrow('trusted WinGet installer tuple');
+  });
+});

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -146,6 +146,25 @@ describe('resolveWingetPackageDependencies', () => {
     }, io)).rejects.toThrow('declares unsupported dependencies');
   });
 
+  it('refuses machine-wide prerequisites in a user-scope package', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer({
+        packageDependencies: [{
+          packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+        }],
+      })] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+      installScope: 'user',
+    }, io)).rejects.toThrow('cannot be installed safely in user scope');
+  });
+
   it('requires the exact trusted root installer hash', async () => {
     const io = fixtureIo(
       { 'Example.App@1.0.0': [installer()] },

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -134,6 +134,7 @@ export async function resolveWingetPackageDependencies(
     version: string;
     architecture?: string;
     installerSha256: string;
+    installScope?: string;
   },
   io: WingetDependencyResolverIo = defaultIo
 ): Promise<PackagedWingetDependency[]> {
@@ -152,6 +153,14 @@ export async function resolveWingetPackageDependencies(
     );
   }
   ensureSupportedDependencyShape(input.wingetId, rootInstaller);
+  if (
+    input.installScope?.trim().toLowerCase() === 'user' &&
+    (rootInstaller.packageDependencies || []).length > 0
+  ) {
+    throw new Error(
+      `${input.wingetId} declares machine-wide package dependencies that cannot be installed safely in user scope.`
+    );
+  }
 
   const ordered: PackagedWingetDependency[] = [];
   const resolved = new Map<string, PackagedWingetDependency>();

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -1,0 +1,308 @@
+import { resolveInstallerFileName } from '@/lib/installer-filename';
+import {
+  fetchAvailableVersionsLive,
+  getLiveInstallers,
+} from '@/lib/manifest-api';
+import { assertPackagingContract } from '@/lib/packaging-contract';
+import { compareVersions } from '@/lib/version-compare';
+import type {
+  NormalizedInstaller,
+  WingetArchitecture,
+  WingetInstallerType,
+} from '@/types/winget';
+
+const MAX_DEPENDENCY_DEPTH = 3;
+const MAX_PACKAGE_DEPENDENCIES = 8;
+const SHA256_PATTERN = /^[A-F0-9]{64}$/;
+
+// Start with the Microsoft redistributable family that is safe to redistribute
+// and that WinGet packages commonly declare. Other package dependency families
+// fail closed until their redistribution and unattended-install contracts have
+// been reviewed explicitly.
+const REDISTRIBUTABLE_PACKAGE_PATTERN =
+  /^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(?:x86|x64|arm64)$/i;
+const REVIEWED_DEPENDENCY_INSTALLER_TYPES = new Set<WingetInstallerType>([
+  'exe',
+  'burn',
+]);
+
+export interface PackagedWingetDependency {
+  packageIdentifier: string;
+  minimumVersion?: string;
+  version: string;
+  architecture: WingetArchitecture;
+  installerUrl: string;
+  installerSha256: string;
+  installerType: WingetInstallerType;
+  nestedInstallerType?: WingetInstallerType;
+  nestedInstallerPath?: string;
+  silentArgs: string;
+  successCodes: number[];
+  rebootCodes: number[];
+  fileName: string;
+  order: number;
+  depth: number;
+}
+
+export interface WingetDependencyResolverIo {
+  getInstallers(packageIdentifier: string, version: string): Promise<NormalizedInstaller[]>;
+  getVersions(packageIdentifier: string): Promise<string[]>;
+}
+
+const defaultIo: WingetDependencyResolverIo = {
+  getInstallers: getLiveInstallers,
+  getVersions: fetchAvailableVersionsLive,
+};
+
+function normalizeSha256(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  return SHA256_PATTERN.test(normalized) ? normalized : '';
+}
+
+function normalizedArchitecture(value: string): 'x64' | 'x86' | 'arm64' {
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'x86' || normalized === 'arm64' ? normalized : 'x64';
+}
+
+function chooseInstaller(
+  installers: NormalizedInstaller[],
+  targetArchitecture: 'x64' | 'x86' | 'arm64'
+): NormalizedInstaller | null {
+  const exact = installers.find((installer) => installer.architecture === targetArchitecture);
+  if (exact) return exact;
+  const neutral = installers.find((installer) => installer.architecture === 'neutral');
+  if (neutral) return neutral;
+  // WinGet's dependency resolver permits an x86 prerequisite for an x64 app.
+  // Never make the inverse substitution and never use x86 for ARM64.
+  if (targetArchitecture === 'x64') {
+    return installers.find((installer) => installer.architecture === 'x86') || null;
+  }
+  return null;
+}
+
+function ensureSupportedDependencyShape(
+  packageIdentifier: string,
+  installer: NormalizedInstaller
+): void {
+  const unsupported = [
+    ...(installer.windowsFeatures || []).map((value) => `Windows feature ${value}`),
+    ...(installer.windowsLibraries || []).map((value) => `Windows library ${value}`),
+    ...(installer.externalDependencies || []).map((value) => `external dependency ${value}`),
+  ];
+  if (unsupported.length > 0) {
+    throw new Error(
+      `${packageIdentifier} declares unsupported dependencies: ${unsupported.join(', ')}`
+    );
+  }
+}
+
+function safeDependencyFileName(
+  packageIdentifier: string,
+  installerUrl: string,
+  installerType: WingetInstallerType
+): string {
+  const packagePrefix = packageIdentifier
+    .replace(/[^A-Za-z0-9._+-]/g, '_')
+    .slice(0, 80);
+  const installerName = resolveInstallerFileName(installerUrl, installerType)
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .slice(-140);
+  return `${packagePrefix}-${installerName}`;
+}
+
+function dependencySuccessCodes(packageIdentifier: string, installer: NormalizedInstaller): number[] {
+  const codes = new Set<number>([0, ...(installer.installerSuccessCodes || [])]);
+  if (REDISTRIBUTABLE_PACKAGE_PATTERN.test(packageIdentifier)) {
+    // VC++ redistributables return ERROR_PRODUCT_VERSION (1638), sometimes
+    // surfaced as signed HRESULT 0x80070666, when the same or a newer runtime
+    // is already installed. Both are successful idempotent outcomes.
+    codes.add(1638);
+    codes.add(-2147023258);
+  }
+  return Array.from(codes).sort((left, right) => left - right);
+}
+
+function highestMinimum(left?: string, right?: string): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return compareVersions(left, right) >= 0 ? left : right;
+}
+
+export async function resolveWingetPackageDependencies(
+  input: {
+    wingetId: string;
+    version: string;
+    architecture?: string;
+    installerSha256: string;
+  },
+  io: WingetDependencyResolverIo = defaultIo
+): Promise<PackagedWingetDependency[]> {
+  const targetArchitecture = normalizedArchitecture(input.architecture || 'x64');
+  const rootSha256 = normalizeSha256(input.installerSha256);
+  if (!rootSha256) throw new Error('Primary installer SHA-256 is invalid.');
+
+  const rootInstallers = await io.getInstallers(input.wingetId, input.version);
+  const rootCandidates = rootInstallers.filter(
+    (installer) => normalizeSha256(installer.sha256) === rootSha256
+  );
+  const rootInstaller = chooseInstaller(rootCandidates, targetArchitecture);
+  if (!rootInstaller) {
+    throw new Error(
+      `The trusted WinGet installer tuple for ${input.wingetId} ${input.version} could not be resolved.`
+    );
+  }
+  ensureSupportedDependencyShape(input.wingetId, rootInstaller);
+
+  const ordered: PackagedWingetDependency[] = [];
+  const resolved = new Map<string, PackagedWingetDependency>();
+  const minimums = new Map<string, string | undefined>();
+  const activePath: string[] = [];
+
+  const visit = async (
+    packageIdentifier: string,
+    minimumVersion: string | undefined,
+    depth: number
+  ): Promise<void> => {
+    if (depth > MAX_DEPENDENCY_DEPTH) {
+      throw new Error(
+        `WinGet dependency depth exceeds ${MAX_DEPENDENCY_DEPTH} at ${packageIdentifier}.`
+      );
+    }
+    if (!REDISTRIBUTABLE_PACKAGE_PATTERN.test(packageIdentifier)) {
+      throw new Error(
+        `WinGet dependency ${packageIdentifier} is not in the reviewed redistribution allowlist.`
+      );
+    }
+
+    const key = packageIdentifier.toLowerCase();
+    const cycleIndex = activePath.indexOf(key);
+    if (cycleIndex >= 0) {
+      throw new Error(
+        `WinGet dependency cycle detected: ${[
+          ...activePath.slice(cycleIndex),
+          key,
+        ].join(' -> ')}`
+      );
+    }
+    const effectiveMinimum = highestMinimum(minimums.get(key), minimumVersion);
+    minimums.set(key, effectiveMinimum);
+    const existing = resolved.get(key);
+    if (
+      existing &&
+      (!effectiveMinimum || compareVersions(existing.version, effectiveMinimum) >= 0)
+    ) {
+      return;
+    }
+    if (!existing && resolved.size >= MAX_PACKAGE_DEPENDENCIES) {
+      throw new Error(
+        `WinGet package dependency count exceeds ${MAX_PACKAGE_DEPENDENCIES}.`
+      );
+    }
+
+    activePath.push(key);
+    try {
+      const versions = (await io.getVersions(packageIdentifier))
+        .filter((version) => !effectiveMinimum || compareVersions(version, effectiveMinimum) >= 0)
+        .sort((left, right) => compareVersions(right, left));
+
+      let selectedVersion = '';
+      let selectedInstaller: NormalizedInstaller | null = null;
+      for (const version of versions) {
+        const installers = await io.getInstallers(packageIdentifier, version);
+        const candidate = chooseInstaller(installers, targetArchitecture);
+        if (candidate) {
+          selectedVersion = version;
+          selectedInstaller = candidate;
+          break;
+        }
+      }
+      if (!selectedInstaller || !selectedVersion) {
+        throw new Error(
+          `No compatible installer was found for WinGet dependency ${packageIdentifier}` +
+            (effectiveMinimum ? ` >= ${effectiveMinimum}.` : '.')
+        );
+      }
+      ensureSupportedDependencyShape(packageIdentifier, selectedInstaller);
+      if (!REVIEWED_DEPENDENCY_INSTALLER_TYPES.has(selectedInstaller.type)) {
+        throw new Error(
+          `WinGet dependency ${packageIdentifier} uses unreviewed installer type ${selectedInstaller.type}.`
+        );
+      }
+      const installerSha256 = normalizeSha256(selectedInstaller.sha256);
+      let protocol = '';
+      try {
+        protocol = new URL(selectedInstaller.url).protocol;
+      } catch {
+        // The actionable error below covers malformed URLs without exposing them.
+      }
+      if (protocol !== 'https:' || !installerSha256) {
+        throw new Error(
+          `WinGet dependency ${packageIdentifier} is missing a trusted HTTPS URL or SHA-256.`
+        );
+      }
+      assertPackagingContract({
+        wingetId: packageIdentifier,
+        installerType: selectedInstaller.type,
+        silentArgs: selectedInstaller.silentArgs || '',
+        nestedInstallerType: selectedInstaller.nestedInstallerType,
+        nestedInstallerFiles: selectedInstaller.nestedInstallerPath
+          ? [selectedInstaller.nestedInstallerPath]
+          : [],
+      });
+
+      for (const child of selectedInstaller.packageDependencies || []) {
+        await visit(child.packageIdentifier, child.minimumVersion, depth + 1);
+      }
+
+      const dependency: PackagedWingetDependency = {
+        packageIdentifier,
+        ...(effectiveMinimum ? { minimumVersion: effectiveMinimum } : {}),
+        version: selectedVersion,
+        architecture: selectedInstaller.architecture,
+        installerUrl: selectedInstaller.url,
+        installerSha256,
+        installerType: selectedInstaller.type,
+        ...(selectedInstaller.nestedInstallerType
+          ? { nestedInstallerType: selectedInstaller.nestedInstallerType }
+          : {}),
+        ...(selectedInstaller.nestedInstallerPath
+          ? { nestedInstallerPath: selectedInstaller.nestedInstallerPath }
+          : {}),
+        silentArgs: selectedInstaller.silentArgs || '',
+        successCodes: dependencySuccessCodes(packageIdentifier, selectedInstaller),
+        rebootCodes: [1641, 3010],
+        fileName: safeDependencyFileName(
+          packageIdentifier,
+          selectedInstaller.url,
+          selectedInstaller.type
+        ),
+        order: existing?.order || ordered.length + 1,
+        depth,
+      };
+
+      if (existing) {
+        const index = ordered.findIndex(
+          (item) => item.packageIdentifier.toLowerCase() === key
+        );
+        if (index >= 0) ordered[index] = dependency;
+      } else {
+        ordered.push(dependency);
+      }
+      resolved.set(key, dependency);
+    } finally {
+      activePath.pop();
+    }
+  };
+
+  for (const dependency of rootInstaller.packageDependencies || []) {
+    await visit(dependency.packageIdentifier, dependency.minimumVersion, 1);
+  }
+
+  return ordered.map((dependency, index) => ({ ...dependency, order: index + 1 }));
+}
+
+export function hasPackagedDependencies(
+  value: readonly PackagedWingetDependency[] | null | undefined
+): value is readonly PackagedWingetDependency[] {
+  return Array.isArray(value) && value.length > 0;
+}

--- a/types/winget.ts
+++ b/types/winget.ts
@@ -176,6 +176,9 @@ export interface NormalizedInstaller {
   productCode?: string;
   packageFamilyName?: string;
   packageDependencies?: Array<{ packageIdentifier: string; minimumVersion?: string }>;
+  windowsFeatures?: string[];
+  windowsLibraries?: string[];
+  externalDependencies?: string[];
 }
 
 // Microsoft Store manifest enrichment (fetched from public Store APIs)


### PR DESCRIPTION
## What changed
- Resolve supported WinGet package dependencies recursively on the server and bind them to the exact root installer tuple.
- Include dependency identity in QA profiles only when dependencies exist; dependency-free profile hashes remain compatible.
- Sign customer workflow dependency metadata with HMAC and ignore any client-supplied dependency values.
- Install verified prerequisites through PSADT before the primary app, including accepted already-installed and reboot exit codes.
- Reject user-context packages that require machine-wide prerequisites before packaging.

## Why
Oracle VirtualBox declares the Microsoft Visual C++ 2015+ x64 runtime as a WinGet dependency. The unchanged vendor command failed without it and passed under SYSTEM once the prerequisite was installed. The previous pipeline packaged only the root installer.

## Scope
The first reviewed redistribution adapter supports Microsoft Visual C++ Redistributables. Unsupported dependency families fail closed so packages cannot silently omit prerequisites.

## Verification
- Focused Vitest suites for resolver, workflow dispatch, QA profile identity, and PSADT generation
- ESLint on all changed TypeScript files
- Generated PowerShell package script parser check
- `git diff --check`
- Claude Code Opus review; HMAC binding, validation, host restrictions, and user-scope protections were added from review findings

The repository-wide TypeScript command still reports unrelated pre-existing test-global/type errors; the changed-file test and lint scope is green.