### PR TITLE
Persist dependency metadata on customer QA candidates

### DIFF
--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -70,6 +70,115 @@ function priorCandidate(input: QaDemandInput, packagerCommit: string) {
 }
 
 describe('ensureQaDemand compatible evidence reuse', () => {
+  it('persists dependency download metadata on a newly queued customer candidate', async () => {
+    const dependency = {
+      packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+      version: '14.51.36247.0',
+      architecture: 'x64' as const,
+      installerUrl: 'https://download.visualstudio.microsoft.com/vc_redist.x64.exe',
+      installerSha256: 'B'.repeat(64),
+      installerType: 'burn' as const,
+      silentArgs: '/quiet /norestart',
+      successCodes: [-2147023258, 0, 1638, 3010],
+      rebootCodes: [1641, 3010],
+      fileName: 'Microsoft.VCRedist.2015+.x64-VC_redist.x64.exe',
+      order: 1,
+      depth: 1,
+    };
+    const input = { ...demandInput(), packageDependencies: [dependency] };
+    const candidateInserts: Array<Record<string, unknown>> = [];
+    let candidateCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
+        }
+        if (table === 'qa_candidates') {
+          candidateCall++;
+          if (candidateCall === 1) return query({ data: [], error: null });
+          return {
+            insert: vi.fn((row: Record<string, unknown>) => {
+              candidateInserts.push(row);
+              return query({ data: { id: 'candidate-1', status: 'queued' }, error: null });
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result).toMatchObject({ state: 'waiting', candidateId: 'candidate-1' });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toEqual(expect.objectContaining({
+      test_config: expect.objectContaining({ packageDependencies: [dependency] }),
+    }));
+  });
+
+  it('refreshes dependency metadata when reactivating an exact candidate', async () => {
+    const dependency = {
+      packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
+      version: '14.51.36247.0',
+      architecture: 'x64' as const,
+      installerUrl: 'https://download.visualstudio.microsoft.com/vc_redist.x64.exe',
+      installerSha256: 'B'.repeat(64),
+      installerType: 'burn' as const,
+      silentArgs: '/quiet /norestart',
+      successCodes: [-2147023258, 0, 1638, 3010],
+      rebootCodes: [1641, 3010],
+      fileName: 'Microsoft.VCRedist.2015+.x64-VC_redist.x64.exe',
+      order: 1,
+      depth: 1,
+    };
+    const input = { ...demandInput(), packageDependencies: [dependency] };
+    const updates: Array<Record<string, unknown>> = [];
+    let candidateCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
+        }
+        if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
+        candidateCall++;
+        if (candidateCall === 1) return query({ data: [], error: null });
+        if (candidateCall === 2) {
+          return {
+            insert: vi.fn(() => query({
+              data: null,
+              error: { message: 'duplicate', code: '23505' },
+            })),
+          };
+        }
+        if (candidateCall === 3) {
+          return {
+            select: vi.fn(() => query({
+              data: { id: 'candidate-1', status: 'superseded', priority: 500 },
+              error: null,
+            })),
+          };
+        }
+        return {
+          update: vi.fn((values: Record<string, unknown>) => {
+            updates.push(values);
+            return query({ data: null, error: null });
+          }),
+        };
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result).toMatchObject({ state: 'waiting', candidateId: 'candidate-1' });
+    expect(updates).toEqual([
+      expect.objectContaining({
+        status: 'queued',
+        priority: 1_000,
+        test_config: expect.objectContaining({ packageDependencies: [dependency] }),
+      }),
+    ]);
+  });
+
   it('aliases a behavior-identical prior pass instead of queueing the app again', async () => {
     const input = demandInput();
     const prior = priorCandidate(

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -182,6 +182,9 @@ export async function ensureQaDemand(
   const testConfig = {
     mode: 'psadt-package',
     profileKind: 'deployment-config',
+    ...(input.packageDependencies?.length
+      ? { packageDependencies: input.packageDependencies as unknown as Json }
+      : {}),
     packageProfileCanonicalJson: identity.canonicalJson,
     packageProfileSha256: profileSha256,
     executionProfileSha256: profileSha256,
@@ -251,6 +254,7 @@ export async function ensureQaDemand(
         status: 'queued',
         priority: Math.max(existing.priority, input.priority),
         demand_source: input.demandSource,
+        test_config: testConfig as unknown as Json,
         attempts: 0,
         dispatched_at: null,
         started_at: null,
@@ -263,10 +267,15 @@ export async function ensureQaDemand(
       .eq('id', existing.id)
       .in('status', ['error', 'superseded']);
     if (reactivateError) throw new Error(`Could not reactivate exact QA: ${reactivateError.message}`);
-  } else if (existing.status === 'queued' && existing.priority < input.priority) {
+  } else if (existing.status === 'queued') {
     await supabase
       .from('qa_candidates')
-      .update({ priority: input.priority, demand_source: input.demandSource, updated_at: now })
+      .update({
+        priority: Math.max(existing.priority, input.priority),
+        demand_source: input.demandSource,
+        test_config: testConfig as unknown as Json,
+        updated_at: now,
+      })
       .eq('id', existing.id)
       .eq('status', 'queued');
   }


### PR DESCRIPTION
## What changed
- Persist verified dependency download metadata on customer/upload QA candidates.
- Refresh that metadata when an exact queued, errored, or superseded candidate is reused.
- Keep dependency-free candidate JSON unchanged.

## Why
The canonical package profile correctly bound the dependency identity, but the private QA host also needs the separately verified URL and SHA metadata to download the offline prerequisite bundle. Catalog candidates already carried this field; customer-demand candidates did not.

## Verification
- Focused QA demand and package-profile tests: 49 passed
- ESLint on both changed files
- `git diff --check`