### PR TITLE
Resolve dependencies before creating QA demand

### DIFF
--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -13,11 +13,13 @@ const {
   getPackageResultMock,
   getAppForInstallerMock,
   getVersionInstallerInfoMock,
+  resolveWingetPackageDependenciesMock,
 } = vi.hoisted(() => ({
   getQaResultMock: vi.fn(),
   getPackageResultMock: vi.fn(),
   getAppForInstallerMock: vi.fn(),
   getVersionInstallerInfoMock: vi.fn(),
+  resolveWingetPackageDependenciesMock: vi.fn(),
 }));
 vi.mock('@/lib/catalog', () => ({
   getCatalogSource: () => ({
@@ -34,6 +36,9 @@ vi.mock('@/lib/supabase', () => ({
       }),
     }),
   }),
+}));
+vi.mock('@/lib/winget-dependencies', () => ({
+  resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
 }));
 
 interface TableHandlers {
@@ -148,6 +153,7 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     getPackageResultMock.mockResolvedValue({ data: null, error: null });
     getAppForInstallerMock.mockReset();
     getVersionInstallerInfoMock.mockReset();
+    resolveWingetPackageDependenciesMock.mockResolvedValue([]);
   });
 
   it('builds the current version command from normalized WinGet switches', async () => {

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
 import {
   buildQaPackageIdentityFromWorkflowInput,
@@ -6,6 +6,14 @@ import {
   qaSha256,
 } from '@/lib/qa/package-profile';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+
+const { resolveWingetPackageDependenciesMock } = vi.hoisted(() => ({
+  resolveWingetPackageDependenciesMock: vi.fn(),
+}));
+
+vi.mock('@/lib/winget-dependencies', () => ({
+  resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
+}));
 
 type QueryResult = {
   data: unknown;
@@ -70,6 +78,11 @@ function priorCandidate(input: QaDemandInput, packagerCommit: string) {
 }
 
 describe('ensureQaDemand compatible evidence reuse', () => {
+  beforeEach(() => {
+    resolveWingetPackageDependenciesMock.mockReset();
+    resolveWingetPackageDependenciesMock.mockResolvedValue([]);
+  });
+
   it('persists dependency download metadata on a newly queued customer candidate', async () => {
     const dependency = {
       packageIdentifier: 'Microsoft.VCRedist.2015+.x64',
@@ -85,7 +98,8 @@ describe('ensureQaDemand compatible evidence reuse', () => {
       order: 1,
       depth: 1,
     };
-    const input = { ...demandInput(), packageDependencies: [dependency] };
+    const input = demandInput();
+    resolveWingetPackageDependenciesMock.mockResolvedValue([dependency]);
     const candidateInserts: Array<Record<string, unknown>> = [];
     let candidateCall = 0;
     const client = {
@@ -110,6 +124,13 @@ describe('ensureQaDemand compatible evidence reuse', () => {
     const result = await ensureQaDemand(client as never, input);
 
     expect(result).toMatchObject({ state: 'waiting', candidateId: 'candidate-1' });
+    expect(resolveWingetPackageDependenciesMock).toHaveBeenCalledWith({
+      wingetId: input.wingetId,
+      version: input.version,
+      architecture: input.architecture,
+      installerSha256: input.installerSha256,
+      installScope: input.installScope,
+    });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toEqual(expect.objectContaining({
       test_config: expect.objectContaining({ packageDependencies: [dependency] }),
@@ -131,7 +152,8 @@ describe('ensureQaDemand compatible evidence reuse', () => {
       order: 1,
       depth: 1,
     };
-    const input = { ...demandInput(), packageDependencies: [dependency] };
+    const input = demandInput();
+    resolveWingetPackageDependenciesMock.mockResolvedValue([dependency]);
     const updates: Array<Record<string, unknown>> = [];
     let candidateCall = 0;
     const client = {
@@ -256,5 +278,17 @@ describe('ensureQaDemand compatible evidence reuse', () => {
 
     expect(result.state).toBe('passed');
     expect(client.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed before creating QA state when dependency resolution fails', async () => {
+    const client = { from: vi.fn() };
+    resolveWingetPackageDependenciesMock.mockRejectedValue(
+      new Error('Unreviewed package dependency')
+    );
+
+    await expect(ensureQaDemand(client as never, demandInput())).rejects.toThrow(
+      'Unreviewed package dependency'
+    );
+    expect(client.from).not.toHaveBeenCalled();
   });
 });

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -6,6 +6,7 @@ import {
   type QaPackageIdentity,
   type QaWorkflowPackageInput,
 } from '@/lib/qa/package-profile';
+import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
 import type { Json } from '@/types/database';
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
@@ -147,7 +148,18 @@ export async function ensureQaDemand(
   supabase: SupabaseClient,
   input: QaDemandInput
 ): Promise<QaDemandResult> {
-  const identity = buildQaPackageIdentityFromWorkflowInput(input);
+  // Resolve at the QA-demand boundary as well as at final packaging dispatch.
+  // This keeps both gates bound to the same server-trusted dependency graph;
+  // caller-supplied dependency metadata is never authoritative.
+  const packageDependencies = await resolveWingetPackageDependencies({
+    wingetId: input.wingetId,
+    version: input.version,
+    architecture: input.architecture,
+    installerSha256: input.installerSha256,
+    installScope: input.installScope,
+  });
+  const resolvedInput: QaDemandInput = { ...input, packageDependencies };
+  const identity = buildQaPackageIdentityFromWorkflowInput(resolvedInput);
   const profileSha256 = identity.executionProfileSha256;
 
   const { data: passedResult, error: resultError } = await supabase
@@ -168,7 +180,7 @@ export async function ensureQaDemand(
     };
   }
 
-  if (await aliasCompatiblePassedDeploymentResult(supabase, input, identity)) {
+  if (await aliasCompatiblePassedDeploymentResult(supabase, resolvedInput, identity)) {
     return { identity, candidateId: null, state: 'passed' };
   }
 
@@ -182,8 +194,8 @@ export async function ensureQaDemand(
   const testConfig = {
     mode: 'psadt-package',
     profileKind: 'deployment-config',
-    ...(input.packageDependencies?.length
-      ? { packageDependencies: input.packageDependencies as unknown as Json }
+    ...(packageDependencies.length
+      ? { packageDependencies: packageDependencies as unknown as Json }
       : {}),
     packageProfileCanonicalJson: identity.canonicalJson,
     packageProfileSha256: profileSha256,


### PR DESCRIPTION
## Summary
- resolve WinGet package dependencies at the shared QA-demand boundary
- bind customer uploads, auto-updates, and resumed jobs to the same dependency-aware profile as final packaging
- fail closed before creating QA state when dependency resolution is unsafe or unsupported

## Verification
- 48 focused tests passed
- targeted ESLint passed
- Next.js production build passed