### PR TITLE
Recover unlinked QA waiting jobs

### DIFF
--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -214,6 +214,67 @@ describe('GET /api/cron/qa-resume', () => {
     }));
   });
 
+  it('rebuilds a legacy waiting job that has no QA candidate link', async () => {
+    const job = {
+      id: 'job-unlinked',
+      qa_candidate_id: null,
+      execution_profile_sha256: 'A'.repeat(64),
+      status_message: 'Testing the app installation before upload',
+      created_at: '2026-08-09T12:00:00Z',
+      winget_id: 'Example.Legacy',
+      display_name: 'Example Legacy',
+      publisher: 'Example',
+      version: '2.0.0',
+      architecture: 'x64',
+      installer_url: 'https://example.test/installer.exe',
+      installer_sha256: 'C'.repeat(64),
+      installer_type: 'exe',
+      install_command: 'installer.exe /silent',
+      uninstall_command: 'installer.exe /uninstall',
+      install_scope: 'machine',
+      package_config: { psadtConfig: {}, detectionRules: [] },
+      is_auto_update: false,
+    };
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'waiting',
+      candidateId: 'candidate-recovered',
+      identity: {
+        executionProfileSha256: 'B'.repeat(64),
+        presentationProfileSha256: 'D'.repeat(64),
+      },
+    });
+    const relinkUpdate = chain({ data: null, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table !== 'packaging_jobs') throw new Error(`Unexpected table ${table}`);
+        packagingCall++;
+        if (packagingCall === 1) return chain({ data: [job], error: null });
+        return relinkUpdate;
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 0, failed: 0, waiting: 1 });
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(client, expect.objectContaining({
+      wingetId: 'Example.Legacy',
+      priority: 2000,
+      demandSource: 'customer',
+    }));
+    expect(relinkUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      qa_candidate_id: 'candidate-recovered',
+      execution_profile_sha256: 'B'.repeat(64),
+      presentation_profile_sha256: 'D'.repeat(64),
+    }));
+    expect(client.from).not.toHaveBeenCalledWith('qa_candidates');
+  });
+
   it('finalizes auto-update tracking when packaging dispatch fails after QA passes', async () => {
     getFeatureFlagsMock.mockReturnValue({ localPackager: false });
     triggerPackagingWorkflowMock.mockRejectedValue(new Error('GitHub dispatch unavailable'));

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -22,7 +22,6 @@ export async function GET(request: Request) {
     .from('packaging_jobs')
     .select('*')
     .eq('status', 'awaiting_qa')
-    .not('qa_candidate_id', 'is', null)
     .order('created_at', { ascending: true })
     .limit(RESUME_BATCH_SIZE);
   if (jobsError) throw new Error(`Could not read QA-waiting jobs: ${jobsError.message}`);
@@ -38,18 +37,27 @@ export async function GET(request: Request) {
   let waiting = 0;
 
   for (const job of jobs || []) {
-    const { data: candidate, error: candidateError } = await supabase
-      .from('qa_candidates')
-      .select('id, status, failure_summary, package_profile_sha256')
-      .eq('id', job.qa_candidate_id!)
-      .maybeSingle();
-    if (candidateError) throw candidateError;
+    let candidate: {
+      id: string;
+      status: string;
+      failure_summary: string | null;
+      package_profile_sha256: string | null;
+    } | null = null;
+    if (job.qa_candidate_id) {
+      const { data, error: candidateError } = await supabase
+        .from('qa_candidates')
+        .select('id, status, failure_summary, package_profile_sha256')
+        .eq('id', job.qa_candidate_id)
+        .maybeSingle();
+      if (candidateError) throw candidateError;
+      candidate = data;
+    }
 
     let candidateStatus = candidate?.status;
     let candidateFailureSummary = candidate?.failure_summary;
     let executionProfileSha256 = job.execution_profile_sha256;
 
-    if (candidateStatus === 'superseded') {
+    if (!candidate || candidateStatus === 'superseded') {
       const item = job.package_config as unknown as Win32CartItem;
       const installerType = job.installer_type || item.installerType;
       const demand = await ensureQaDemand(supabase, {


### PR DESCRIPTION
## Summary
- include legacy awaiting-QA jobs even when their candidate link is missing
- rebuild the current exact QA demand and relink the job safely
- preserve existing pass/fail/resume behavior

## Verification
- QA resume route tests: 5 passed
- targeted ESLint passed