### PR TITLE
Reuse QA by immutable app payload

### DIFF
--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -275,6 +275,64 @@ describe('GET /api/cron/qa-resume', () => {
     expect(client.from).not.toHaveBeenCalledWith('qa_candidates');
   });
 
+  it('releases an unlinked upload immediately when the app payload already passed QA', async () => {
+    const job = {
+      id: 'job-already-passed',
+      qa_candidate_id: null,
+      execution_profile_sha256: 'A'.repeat(64),
+      status_message: 'Testing the app installation before upload',
+      created_at: '2026-08-09T12:00:00Z',
+      winget_id: 'Google.Chrome',
+      display_name: 'Google Chrome',
+      publisher: 'Google',
+      version: '151.0.7922.109',
+      architecture: 'x64',
+      installer_url: 'https://example.test/chrome.msi',
+      installer_sha256: 'C'.repeat(64),
+      installer_type: 'wix',
+      install_command: 'msiexec /i chrome.msi /qn',
+      uninstall_command: 'msiexec /x {11111111-1111-1111-1111-111111111111} /qn',
+      install_scope: 'machine',
+      package_config: { psadtConfig: { deployMode: 'Interactive' }, detectionRules: [] },
+      is_auto_update: false,
+    };
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'passed',
+      candidateId: null,
+      identity: {
+        executionProfileSha256: 'B'.repeat(64),
+        presentationProfileSha256: 'D'.repeat(64),
+      },
+    });
+    const relinkUpdate = chain({ data: null, error: null });
+    const claimUpdate = chain({ data: { id: job.id }, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table !== 'packaging_jobs') throw new Error(`Unexpected table ${table}`);
+        packagingCall++;
+        if (packagingCall === 1) return chain({ data: [job], error: null });
+        if (packagingCall === 2) return relinkUpdate;
+        return claimUpdate;
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 1, failed: 0, waiting: 0 });
+    expect(claimUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'queued',
+      qa_completed_at: expect.any(String),
+    }));
+    expect(client.from).not.toHaveBeenCalledWith('qa_candidates');
+    expect(client.from).not.toHaveBeenCalledWith('qa_package_results');
+  });
+
   it('finalizes auto-update tracking when packaging dispatch fails after QA passes', async () => {
     getFeatureFlagsMock.mockReturnValue({ localPackager: false });
     triggerPackagingWorkflowMock.mockRejectedValue(new Error('GitHub dispatch unavailable'));

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: Request) {
 
     let candidateStatus = candidate?.status;
     let candidateFailureSummary = candidate?.failure_summary;
-    let executionProfileSha256 = job.execution_profile_sha256;
+    let appVersionAlreadyPassed = false;
 
     if (!candidate || candidateStatus === 'superseded') {
       const item = job.package_config as unknown as Win32CartItem;
@@ -84,9 +84,9 @@ export async function GET(request: Request) {
         priority: 2000,
         demandSource: job.is_auto_update ? 'auto_update' : 'customer',
       });
-      executionProfileSha256 = demand.identity.executionProfileSha256;
       candidateStatus = demand.state === 'waiting' ? 'queued' : demand.state;
       candidateFailureSummary = demand.failureSummary || null;
+      appVersionAlreadyPassed = demand.state === 'passed';
 
       const { error: relinkError } = await supabase
         .from('packaging_jobs')
@@ -136,15 +136,19 @@ export async function GET(request: Request) {
       continue;
     }
 
-    const { data: result, error: resultError } = await supabase
-      .from('qa_package_results')
-      .select('outcome')
-      .eq('package_profile_sha256', executionProfileSha256!)
-      .maybeSingle();
-    if (resultError) throw resultError;
-    if (result?.outcome !== 'Passed') {
-      waiting++;
-      continue;
+    if (!appVersionAlreadyPassed) {
+      const { data: result, error: resultError } = candidate?.package_profile_sha256
+        ? await supabase
+            .from('qa_package_results')
+            .select('outcome')
+            .eq('package_profile_sha256', candidate.package_profile_sha256)
+            .maybeSingle()
+        : { data: null, error: null };
+      if (resultError) throw resultError;
+      if (result?.outcome !== 'Passed') {
+        waiting++;
+        continue;
+      }
     }
 
     const now = new Date().toISOString();

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -10,16 +10,14 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 const {
   getQaResultMock,
-  getPackageResultMock,
   getAppForInstallerMock,
   getVersionInstallerInfoMock,
-  resolveWingetPackageDependenciesMock,
+  ensureQaDemandMock,
 } = vi.hoisted(() => ({
   getQaResultMock: vi.fn(),
-  getPackageResultMock: vi.fn(),
   getAppForInstallerMock: vi.fn(),
   getVersionInstallerInfoMock: vi.fn(),
-  resolveWingetPackageDependenciesMock: vi.fn(),
+  ensureQaDemandMock: vi.fn(),
 }));
 vi.mock('@/lib/catalog', () => ({
   getCatalogSource: () => ({
@@ -28,17 +26,8 @@ vi.mock('@/lib/catalog', () => ({
     getVersionInstallerInfo: getVersionInstallerInfoMock,
   }),
 }));
-vi.mock('@/lib/supabase', () => ({
-  createServerClient: () => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({ maybeSingle: getPackageResultMock }),
-      }),
-    }),
-  }),
-}));
-vi.mock('@/lib/winget-dependencies', () => ({
-  resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
+vi.mock('@/lib/qa/demand', () => ({
+  ensureQaDemand: ensureQaDemandMock,
 }));
 
 interface TableHandlers {
@@ -150,10 +139,16 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getQaResultMock.mockResolvedValue(null);
-    getPackageResultMock.mockResolvedValue({ data: null, error: null });
     getAppForInstallerMock.mockReset();
     getVersionInstallerInfoMock.mockReset();
-    resolveWingetPackageDependenciesMock.mockResolvedValue([]);
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'waiting',
+      candidateId: 'candidate-1',
+      identity: {
+        executionProfileSha256: 'B'.repeat(64),
+        presentationProfileSha256: 'D'.repeat(64),
+      },
+    });
   });
 
   it('builds the current version command from normalized WinGet switches', async () => {
@@ -225,15 +220,17 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       package_content_sha256: 'F'.repeat(64),
     } satisfies QaResultRow;
     getQaResultMock.mockResolvedValue(failedPackageResult);
-    getPackageResultMock.mockResolvedValue({ data: failedPackageResult, error: null });
-
-    const candidateInsertSpy = vi.fn();
-    const supabase = createSupabaseMock({
-      qa_package_results: {
-        maybeSingleResult: { data: { outcome: 'Failed' }, error: null },
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'failed',
+      candidateId: null,
+      failureSummary: 'The isolated installation test failed.',
+      identity: {
+        executionProfileSha256: 'B'.repeat(64),
+        presentationProfileSha256: 'D'.repeat(64),
       },
-      qa_candidates: { insertSpy: candidateInsertSpy },
     });
+
+    const supabase = createSupabaseMock({});
     const trigger = makeTrigger(supabase);
     const policy = makePolicy({
       displayName: 'Test App',
@@ -252,25 +249,13 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       skipped: true,
       code: 'QA_FAILED_CURRENT_VERSION',
     });
-    expect(result.skipReason).toBe('This app did not pass the isolated installation test.');
+    expect(result.skipReason).toBe('The isolated installation test failed.');
     expect(createHistorySpy).not.toHaveBeenCalled();
-    expect(candidateInsertSpy).not.toHaveBeenCalled();
+    expect(ensureQaDemandMock).toHaveBeenCalledTimes(1);
   });
 
   it('applies the same app adapter to auto-update QA and customer packaging', async () => {
-    const candidateInsertSpy = vi.fn();
-    const supabase = createSupabaseMock({
-      qa_package_results: {
-        maybeSingleResult: { data: null, error: null },
-      },
-      qa_candidates: {
-        insertSpy: candidateInsertSpy,
-        maybeSingleResult: {
-          data: { id: 'candidate-elgato', status: 'queued', failure_summary: null },
-          error: null,
-        },
-      },
-    });
+    const supabase = createSupabaseMock({});
     const trigger = makeTrigger(supabase);
     const storedConfig: DeploymentConfig = {
       displayName: 'Elgato Stream Deck',
@@ -307,13 +292,11 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     }, { skipRateLimits: true });
 
     expect(result).toMatchObject({ success: true, packagingJobId: 'job-elgato' });
-    const candidateRow = candidateInsertSpy.mock.calls[0][0] as {
-      test_config: { psadtConfig: { processesToClose: unknown[] } };
+    const qaInput = ensureQaDemandMock.mock.calls[0][1] as {
+      psadtConfig: string;
     };
-    expect(candidateRow.test_config.psadtConfig.processesToClose).toEqual([
-      // Presentation-only descriptions are deliberately normalized in the QA
-      // execution profile; the process name and lifecycle behavior are exact.
-      { name: 'StreamDeck', description: 'StreamDeck' },
+    expect(JSON.parse(qaInput.psadtConfig).processesToClose).toEqual([
+      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ]);
     const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
     expect(
@@ -451,13 +434,8 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
 
     it('persists the corrected profile before looking up QA demand', async () => {
       const updateSpy = vi.fn();
-      const qaLookupSpy = vi.fn(async () => ({
-        data: { outcome: 'Failed' },
-        error: null,
-      }));
       const supabase = createSupabaseMock({
         app_update_policies: { updateSpy },
-        qa_package_results: { maybeSingleSpy: qaLookupSpy },
       });
       const trigger = makeTrigger(supabase);
       const legacyRule = {
@@ -497,10 +475,10 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
         installScope: 'machine',
       }, { skipRateLimits: true });
 
-      expect(updateSpy).toHaveBeenCalledTimes(1);
-      expect(qaLookupSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy).toHaveBeenCalled();
+      expect(ensureQaDemandMock).toHaveBeenCalledTimes(1);
       expect(updateSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        qaLookupSpy.mock.invocationCallOrder[0]
+        ensureQaDemandMock.mock.invocationCallOrder[0]
       );
     });
 

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -1,10 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
-import {
-  buildQaPackageIdentityFromWorkflowInput,
-  canonicalQaJson,
-  qaSha256,
-} from '@/lib/qa/package-profile';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 const { resolveWingetPackageDependenciesMock } = vi.hoisted(() => ({
@@ -22,7 +17,7 @@ type QueryResult = {
 
 function query(result: QueryResult) {
   const builder: Record<string, unknown> = {};
-  for (const method of ['select', 'eq', 'in', 'contains', 'order', 'limit']) {
+  for (const method of ['select', 'eq', 'in', 'contains', 'order', 'limit', 'update']) {
     builder[method] = vi.fn(() => builder);
   }
   builder.maybeSingle = vi.fn(async () => result);
@@ -53,31 +48,7 @@ function demandInput(): QaDemandInput {
   };
 }
 
-function priorCandidate(input: QaDemandInput, packagerCommit: string) {
-  const identity = buildQaPackageIdentityFromWorkflowInput(input);
-  const current = JSON.parse(identity.canonicalJson) as Record<string, unknown> & {
-    toolchain: Record<string, unknown>;
-  };
-  const canonical = canonicalQaJson({
-    ...current,
-    toolchain: { ...current.toolchain, packagerCommit },
-  });
-  return {
-    winget_id: input.wingetId,
-    version: input.version,
-    architecture: input.architecture,
-    installer_sha256: input.installerSha256,
-    package_profile_sha256: qaSha256(canonical),
-    test_config: {
-      profileKind: 'deployment-config',
-      packageProfileCanonicalJson: canonical,
-      packageProfileSha256: qaSha256(canonical),
-    },
-    finished_at: '2026-08-10T10:00:00.000Z',
-  };
-}
-
-describe('ensureQaDemand compatible evidence reuse', () => {
+describe('ensureQaDemand app-version evidence reuse', () => {
   beforeEach(() => {
     resolveWingetPackageDependenciesMock.mockReset();
     resolveWingetPackageDependenciesMock.mockResolvedValue([]);
@@ -109,7 +80,7 @@ describe('ensureQaDemand compatible evidence reuse', () => {
         }
         if (table === 'qa_candidates') {
           candidateCall++;
-          if (candidateCall === 1) return query({ data: [], error: null });
+          if (candidateCall === 1) return query({ data: null, error: null });
           return {
             insert: vi.fn((row: Record<string, unknown>) => {
               candidateInserts.push(row);
@@ -135,6 +106,14 @@ describe('ensureQaDemand compatible evidence reuse', () => {
     expect(candidateInserts[0]).toEqual(expect.objectContaining({
       test_config: expect.objectContaining({ packageDependencies: [dependency] }),
     }));
+    expect((candidateInserts[0].test_config as Record<string, unknown>).psadtConfig).toMatchObject({
+      deployMode: 'Auto',
+      progressDialog: {
+        enabled: true,
+        statusMessage: 'IntuneGet is validating this application package.',
+        windowLocation: 'BottomRight',
+      },
+    });
   });
 
   it('refreshes dependency metadata when reactivating an exact candidate', async () => {
@@ -163,7 +142,7 @@ describe('ensureQaDemand compatible evidence reuse', () => {
         }
         if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
         candidateCall++;
-        if (candidateCall === 1) return query({ data: [], error: null });
+        if (candidateCall === 1) return query({ data: null, error: null });
         if (candidateCall === 2) {
           return {
             insert: vi.fn(() => query({
@@ -172,7 +151,8 @@ describe('ensureQaDemand compatible evidence reuse', () => {
             })),
           };
         }
-        if (candidateCall === 3) {
+        if (candidateCall === 3) return query({ data: null, error: null });
+        if (candidateCall === 4) {
           return {
             select: vi.fn(() => query({
               data: { id: 'candidate-1', status: 'superseded', priority: 500 },
@@ -201,49 +181,52 @@ describe('ensureQaDemand compatible evidence reuse', () => {
     ]);
   });
 
-  it('aliases a behavior-identical prior pass instead of queueing the app again', async () => {
+  it('joins the active payload test when a concurrent insert wins the race', async () => {
     const input = demandInput();
-    const prior = priorCandidate(
-      input,
-      '66448ea49841c2c9f3ebf56e455ce8797e2b2abb'
-    );
-    const aliasInserts: Array<Record<string, unknown>> = [];
-    let packageResultRead = 0;
+    let candidateCall = 0;
     const client = {
       from: vi.fn((table: string) => {
-        if (table === 'qa_candidates') {
-          return query({ data: [prior], error: null });
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
         }
+        if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
+        candidateCall++;
+        if (candidateCall === 1) return query({ data: null, error: null });
+        if (candidateCall === 2) {
+          return {
+            insert: vi.fn(() => query({
+              data: null,
+              error: { message: 'duplicate active payload', code: '23505' },
+            })),
+          };
+        }
+        return {
+          select: vi.fn(() => query({
+            data: { id: 'candidate-concurrent', status: 'queued', priority: 2_000 },
+            error: null,
+          })),
+        };
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result).toMatchObject({
+      state: 'waiting',
+      candidateId: 'candidate-concurrent',
+    });
+  });
+
+  it('reuses a prior pass for the same app payload regardless of PSADT configuration', async () => {
+    const input = demandInput();
+    const client = {
+      from: vi.fn((table: string) => {
         if (table === 'qa_package_results') {
           return {
-            select: vi.fn(() => {
-              packageResultRead++;
-              if (packageResultRead === 1) return query({ data: null, error: null });
-              return query({
-                data: [{
-                  package_profile_sha256: prior.package_profile_sha256,
-                  winget_id: input.wingetId,
-                  tested_version: input.version,
-                  architecture: 'x64',
-                  installer_sha256: input.installerSha256,
-                  outcome: 'Passed',
-                  tested_at_utc: '2026-08-10T10:10:00.000Z',
-                  psadt_version: '4.1.8',
-                  psadt_template_sha256: 'B'.repeat(64),
-                  psadt_config_sha256: 'C'.repeat(64),
-                  detection_rules_sha256: 'D'.repeat(64),
-                  packager_commit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
-                  package_content_sha256: 'E'.repeat(64),
-                  github_run_id: '123',
-                  github_run_url: 'https://github.test/run/123',
-                }],
-                error: null,
-              });
-            }),
-            insert: vi.fn((row: Record<string, unknown>) => {
-              aliasInserts.push(row);
-              return query({ data: null, error: null });
-            }),
+            select: vi.fn(() => query({
+              data: { package_profile_sha256: 'B'.repeat(64) },
+              error: null,
+            })),
           };
         }
         throw new Error(`Unexpected table: ${table}`);
@@ -254,30 +237,37 @@ describe('ensureQaDemand compatible evidence reuse', () => {
 
     expect(result.state).toBe('passed');
     expect(result.candidateId).toBeNull();
-    expect(aliasInserts).toEqual([
-      expect.objectContaining({
-        package_profile_sha256: result.identity.executionProfileSha256,
-        packager_commit: '66448ea49841c2c9f3ebf56e455ce8797e2b2abb',
-        github_run_id: '123',
-      }),
-    ]);
+    expect(client.from).toHaveBeenCalledTimes(1);
   });
 
-  it('uses an exact current result without scanning historical candidates', async () => {
+  it('attaches another upload configuration to an active app-version test', async () => {
     const input = demandInput();
+    const priorityUpdate = query({ data: null, error: null });
+    let candidateCall = 0;
     const client = {
       from: vi.fn((table: string) => {
-        if (table !== 'qa_package_results') throw new Error(`Unexpected table: ${table}`);
-        return {
-          select: vi.fn(() => query({ data: { outcome: 'Passed' }, error: null })),
-        };
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
+        }
+        if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
+        candidateCall++;
+        if (candidateCall === 1) {
+          return query({
+            data: { id: 'candidate-active', status: 'queued', priority: 10 },
+            error: null,
+          });
+        }
+        return priorityUpdate;
       }),
     };
 
     const result = await ensureQaDemand(client as never, input);
 
-    expect(result.state).toBe('passed');
-    expect(client.from).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ state: 'waiting', candidateId: 'candidate-active' });
+    expect(priorityUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      priority: 1_000,
+      demand_source: 'customer',
+    }));
   });
 
   it('fails closed before creating QA state when dependency resolution fails', async () => {

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -1,13 +1,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { normalizeQaInstallerType, qaInstallerFileName } from '@/lib/qa/candidate';
 import {
-  buildQaPackageIdentityFromWorkflowInput,
-  validateCompatiblePassedDeploymentQaProfile,
+  normalizeQaWorkflowPackageInput,
   type QaPackageIdentity,
   type QaWorkflowPackageInput,
 } from '@/lib/qa/package-profile';
 import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
 import type { Json } from '@/types/database';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
 export type QaDemandState = 'passed' | 'failed' | 'waiting';
@@ -25,125 +25,6 @@ export interface QaDemandResult {
   failureSummary?: string;
 }
 
-const PACKAGE_RESULT_COLUMNS = [
-  'package_profile_sha256',
-  'winget_id',
-  'tested_version',
-  'architecture',
-  'installer_sha256',
-  'outcome',
-  'tested_at_utc',
-  'psadt_version',
-  'psadt_template_sha256',
-  'psadt_config_sha256',
-  'detection_rules_sha256',
-  'packager_commit',
-  'package_content_sha256',
-  'github_run_id',
-  'github_run_url',
-].join(', ');
-
-interface CompatiblePackageResult {
-  package_profile_sha256: string;
-  winget_id: string;
-  tested_version: string;
-  architecture: string;
-  installer_sha256: string;
-  outcome: 'Passed';
-  tested_at_utc: string;
-  psadt_version: string;
-  psadt_template_sha256: string;
-  psadt_config_sha256: string;
-  detection_rules_sha256: string;
-  packager_commit: string;
-  package_content_sha256: string;
-  github_run_id: string | null;
-  github_run_url: string | null;
-}
-
-async function aliasCompatiblePassedDeploymentResult(
-  supabase: SupabaseClient,
-  input: QaDemandInput,
-  identity: QaPackageIdentity
-): Promise<boolean> {
-  const architecture = (input.architecture || 'x64').toLowerCase();
-  const installerSha256 = input.installerSha256.toUpperCase();
-  const { data: candidates, error: candidateError } = await supabase
-    .from('qa_candidates')
-    .select(
-      'winget_id, version, architecture, installer_sha256, package_profile_sha256, test_config, finished_at'
-    )
-    .eq('winget_id', input.wingetId)
-    .eq('version', input.version)
-    .eq('architecture', architecture)
-    .eq('installer_sha256', installerSha256)
-    .eq('test_level', 'psadt-package')
-    .eq('status', 'passed')
-    .contains('test_config', { profileKind: 'deployment-config' })
-    .order('finished_at', { ascending: false })
-    .limit(100);
-  if (candidateError) {
-    throw new Error(`Could not read compatible package QA candidates: ${candidateError.message}`);
-  }
-
-  const compatibleHashes: string[] = [];
-  for (const candidate of candidates || []) {
-    if (!candidate.package_profile_sha256) continue;
-    const validation = validateCompatiblePassedDeploymentQaProfile({
-      prior: {
-        testConfig: candidate.test_config,
-        candidatePackageProfileSha256: candidate.package_profile_sha256,
-        candidateWingetId: candidate.winget_id,
-        candidateVersion: candidate.version,
-        candidateArchitecture: candidate.architecture,
-        candidateInstallerSha256: candidate.installer_sha256,
-      },
-      currentCanonicalJson: identity.canonicalJson,
-      currentPackageProfileSha256: identity.executionProfileSha256,
-    });
-    if (validation.valid) compatibleHashes.push(candidate.package_profile_sha256);
-  }
-  if (compatibleHashes.length === 0) return false;
-
-  const { data: compatibleResults, error: resultError } = await supabase
-    .from('qa_package_results')
-    .select(PACKAGE_RESULT_COLUMNS)
-    .in('package_profile_sha256', compatibleHashes)
-    .eq('outcome', 'Passed')
-    .order('tested_at_utc', { ascending: false })
-    .limit(1);
-  if (resultError) {
-    throw new Error(`Could not read compatible package QA results: ${resultError.message}`);
-  }
-  const source = (compatibleResults as unknown as CompatiblePackageResult[] | null)?.[0];
-  if (!source) return false;
-
-  const { error: aliasError } = await supabase
-    .from('qa_package_results')
-    .insert({
-      package_profile_sha256: identity.executionProfileSha256,
-      winget_id: source.winget_id,
-      tested_version: source.tested_version,
-      architecture: source.architecture,
-      installer_sha256: source.installer_sha256,
-      outcome: source.outcome,
-      tested_at_utc: source.tested_at_utc,
-      psadt_version: source.psadt_version,
-      psadt_template_sha256: source.psadt_template_sha256,
-      psadt_config_sha256: source.psadt_config_sha256,
-      detection_rules_sha256: source.detection_rules_sha256,
-      packager_commit: source.packager_commit,
-      package_content_sha256: source.package_content_sha256,
-      github_run_id: source.github_run_id,
-      github_run_url: source.github_run_url,
-      synced_at: new Date().toISOString(),
-    });
-  if (aliasError && aliasError.code !== '23505') {
-    throw new Error(`Could not preserve compatible package QA evidence: ${aliasError.message}`);
-  }
-  return true;
-}
-
 export async function ensureQaDemand(
   supabase: SupabaseClient,
   input: QaDemandInput
@@ -158,20 +39,93 @@ export async function ensureQaDemand(
     installerSha256: input.installerSha256,
     installScope: input.installScope,
   });
-  const resolvedInput: QaDemandInput = { ...input, packageDependencies };
-  const identity = buildQaPackageIdentityFromWorkflowInput(resolvedInput);
+  // The VM validates the same PSADT packaging route used for customer uploads,
+  // with one deterministic, non-blocking visual profile per immutable payload.
+  // Customer presentation choices are applied later by customer packaging and
+  // must neither suppress QA evidence nor multiply app-version tests.
+  const resolvedInput: QaDemandInput = {
+    ...input,
+    psadtConfig: JSON.stringify({
+      ...DEFAULT_PSADT_CONFIG,
+      deployMode: 'Auto',
+      progressDialog: {
+        enabled: true,
+        statusMessage: 'IntuneGet is validating this application package.',
+        windowLocation: 'BottomRight',
+      },
+    }),
+    packageDependencies,
+  };
+  const normalizedPackage = normalizeQaWorkflowPackageInput(resolvedInput);
+  const identity = normalizedPackage.identity;
   const profileSha256 = identity.executionProfileSha256;
+  const architecture = (input.architecture || 'x64').toLowerCase();
+  const installerSha256 = input.installerSha256.toUpperCase();
 
+  // QA qualifies the immutable application payload, not every possible PSADT
+  // presentation or policy combination. One successful test for this exact
+  // app/version/architecture/installer is sufficient for every customer upload.
   const { data: passedResult, error: resultError } = await supabase
     .from('qa_package_results')
-    .select('outcome')
-    .eq('package_profile_sha256', profileSha256)
+    .select('package_profile_sha256')
+    .eq('winget_id', input.wingetId)
+    .eq('tested_version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('outcome', 'Passed')
+    .order('tested_at_utc', { ascending: false })
+    .limit(1)
     .maybeSingle();
-  if (resultError) throw new Error(`Could not read exact package QA result: ${resultError.message}`);
-  if (passedResult?.outcome === 'Passed') {
+  if (resultError) throw new Error(`Could not read app-version QA result: ${resultError.message}`);
+  if (passedResult) {
     return { identity, candidateId: null, state: 'passed' };
   }
-  if (passedResult?.outcome === 'Failed') {
+
+  // If the same payload is already queued or running, attach this upload to
+  // that test instead of multiplying VM runs for different PSADT settings.
+  const { data: activeCandidate, error: activeError } = await supabase
+    .from('qa_candidates')
+    .select('id, status, priority')
+    .eq('winget_id', input.wingetId)
+    .eq('version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('test_level', 'psadt-package')
+    .in('status', ['queued', 'dispatched', 'running'])
+    .order('priority', { ascending: false })
+    .order('enqueued_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (activeError) throw new Error(`Could not read active app-version QA: ${activeError.message}`);
+  if (activeCandidate) {
+    if (activeCandidate.status === 'queued' && activeCandidate.priority < input.priority) {
+      const { error: priorityError } = await supabase
+        .from('qa_candidates')
+        .update({
+          priority: input.priority,
+          demand_source: input.demandSource,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', activeCandidate.id)
+        .eq('status', 'queued');
+      if (priorityError) throw new Error(`Could not prioritize app-version QA: ${priorityError.message}`);
+    }
+    return { identity, candidateId: activeCandidate.id, state: 'waiting' };
+  }
+
+  const { data: failedResult, error: failedError } = await supabase
+    .from('qa_package_results')
+    .select('package_profile_sha256')
+    .eq('winget_id', input.wingetId)
+    .eq('tested_version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('outcome', 'Failed')
+    .order('tested_at_utc', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (failedError) throw new Error(`Could not read failed app-version QA: ${failedError.message}`);
+  if (failedResult) {
     return {
       identity,
       candidateId: null,
@@ -179,18 +133,7 @@ export async function ensureQaDemand(
       failureSummary: 'This app did not pass the isolated installation test.',
     };
   }
-
-  if (await aliasCompatiblePassedDeploymentResult(supabase, resolvedInput, identity)) {
-    return { identity, candidateId: null, state: 'passed' };
-  }
-
-  const architecture = (input.architecture || 'x64').toLowerCase();
-  const installerSha256 = input.installerSha256.toUpperCase();
   const now = new Date().toISOString();
-  const profile = identity.profile as {
-    psadtConfig: unknown;
-    detectionRules: unknown;
-  };
   const testConfig = {
     mode: 'psadt-package',
     profileKind: 'deployment-config',
@@ -203,8 +146,10 @@ export async function ensureQaDemand(
     presentationProfileSha256: identity.presentationProfileSha256,
     psadtConfigSha256: identity.psadtConfigSha256,
     detectionRulesSha256: identity.detectionRulesSha256,
-    psadtConfig: profile.psadtConfig as Json,
-    detectionRules: profile.detectionRules as Json,
+    // Keep the real presentation values for the VM. The canonical execution
+    // identity intentionally strips those values only for hashing/deduplication.
+    psadtConfig: normalizedPackage.psadtConfig as unknown as Json,
+    detectionRules: normalizedPackage.detectionRules as unknown as Json,
   };
 
   const row = {
@@ -235,6 +180,29 @@ export async function ensureQaDemand(
   }
   if (insertError?.code !== '23505') {
     throw new Error(`Could not queue exact package QA: ${insertError?.message || 'unknown error'}`);
+  }
+
+  // A database-level active-payload constraint closes the small race between
+  // the lookup above and this insert. If another request won that race, join
+  // its test even when it carries a different PSADT presentation profile.
+  const { data: concurrentCandidate, error: concurrentError } = await supabase
+    .from('qa_candidates')
+    .select('id, status, priority')
+    .eq('winget_id', input.wingetId)
+    .eq('version', input.version)
+    .eq('architecture', architecture)
+    .eq('installer_sha256', installerSha256)
+    .eq('test_level', 'psadt-package')
+    .in('status', ['queued', 'dispatched', 'running'])
+    .order('priority', { ascending: false })
+    .order('enqueued_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (concurrentError) {
+    throw new Error(`Could not resolve concurrent app-version QA: ${concurrentError.message}`);
+  }
+  if (concurrentCandidate) {
+    return { identity, candidateId: concurrentCandidate.id, state: 'waiting' };
   }
 
   const { data: existing, error: existingError } = await supabase

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -1,20 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { QaResultRow } from '@/types/qa';
 
-const { getQaResultMock, getPackageResultMock } = vi.hoisted(() => ({
+const { getQaResultMock, getPackageResultMock, packageEqMock } = vi.hoisted(() => ({
   getQaResultMock: vi.fn(),
   getPackageResultMock: vi.fn(),
+  packageEqMock: vi.fn(),
 }));
 vi.mock('@/lib/catalog', () => ({
   getCatalogSource: () => ({ getQaResult: getQaResultMock }),
 }));
 vi.mock('@/lib/supabase', () => ({
   createServerClient: () => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({ maybeSingle: getPackageResultMock }),
-      }),
-    }),
+    from: () => {
+      const builder: Record<string, unknown> = {};
+      builder.select = vi.fn(() => builder);
+      builder.eq = vi.fn((...args: unknown[]) => {
+        packageEqMock(...args);
+        return builder;
+      });
+      builder.order = vi.fn(() => builder);
+      builder.limit = vi.fn(() => builder);
+      builder.maybeSingle = getPackageResultMock;
+      return builder;
+    },
   }),
 }));
 
@@ -63,6 +71,7 @@ describe('enforceQaGate', () => {
   beforeEach(() => {
     getQaResultMock.mockReset();
     getPackageResultMock.mockReset();
+    packageEqMock.mockReset();
   });
 
   it('blocks a failed exact version and architecture', async () => {
@@ -89,7 +98,7 @@ describe('enforceQaGate', () => {
     await expect(enforceQaGate({ wingetId: 'Unknown.App', version: '1.0' })).resolves.toBeUndefined();
   });
 
-  it('allows only an exact passed candidate when requirePassed is enabled', async () => {
+  it('reuses a passed app version regardless of the requested PSADT profile', async () => {
     getPackageResultMock.mockResolvedValue({
       data: { ...failedRow, outcome: 'Passed' },
       error: null,
@@ -100,26 +109,25 @@ describe('enforceQaGate', () => {
         version: '26.7.0',
         architecture: 'x64',
         installerSha256: installerSha256.toLowerCase(),
-        packageProfileSha256,
+        packageProfileSha256: 'C'.repeat(64),
         requirePassed: true,
       })
     ).resolves.toBeUndefined();
+    expect(packageEqMock).toHaveBeenCalledWith('winget_id', 'OpenJS.NodeJS');
+    expect(packageEqMock).toHaveBeenCalledWith('tested_version', '26.7.0');
+    expect(packageEqMock).toHaveBeenCalledWith('architecture', 'x64');
+    expect(packageEqMock).toHaveBeenCalledWith('installer_sha256', installerSha256);
+    expect(packageEqMock).toHaveBeenCalledWith('outcome', 'Passed');
   });
 
-  it.each([
-    ['missing', null, '26.7.0', 'x64', installerSha256],
-    ['failed', failedRow, '26.7.0', 'x64', installerSha256],
-    ['stale version', { ...failedRow, outcome: 'Passed' }, '26.8.0', 'x64', installerSha256],
-    ['wrong architecture', { ...failedRow, outcome: 'Passed' }, '26.7.0', 'arm64', installerSha256],
-    ['wrong SHA', { ...failedRow, outcome: 'Passed' }, '26.7.0', 'x64', 'B'.repeat(64)],
-  ])('blocks a %s candidate in strict mode', async (_label, row, version, architecture, sha) => {
-    getPackageResultMock.mockResolvedValue({ data: row, error: null });
+  it('blocks when the app payload has no successful QA result', async () => {
+    getPackageResultMock.mockResolvedValue({ data: null, error: null });
     await expect(
       enforceQaGate({
         wingetId: 'OpenJS.NodeJS',
-        version: String(version),
-        architecture: String(architecture),
-        installerSha256: String(sha),
+        version: '26.7.0',
+        architecture: 'x64',
+        installerSha256,
         packageProfileSha256,
         requirePassed: true,
       })

--- a/lib/qa/gate.ts
+++ b/lib/qa/gate.ts
@@ -79,42 +79,33 @@ export async function enforceQaGate(input: {
 }): Promise<void> {
   if (input.sourceType === 'custom' || (!input.requirePassed && input.qaOverride)) return;
 
-  if (input.requirePassed) {
-    const architecture = (input.architecture || 'x64').toLowerCase();
-    const installerSha256 = input.installerSha256?.trim().toUpperCase() || '';
-    const packageProfileSha256 = input.packageProfileSha256?.trim().toUpperCase() || '';
-    const { data: row, error } = packageProfileSha256
-      ? await createServerClient()
-          .from('qa_package_results')
-          .select(
-            'winget_id, tested_version, architecture, installer_sha256, package_profile_sha256, outcome'
-          )
-          .eq('package_profile_sha256', packageProfileSha256)
-          .maybeSingle()
-      : { data: null, error: null };
-    if (error) throw new Error(`Could not read package QA result: ${error.message}`);
-    const reason = !packageProfileSha256
-      ? 'package_profile'
-      : !row
-      ? 'missing'
-      : row.outcome !== 'Passed'
-        ? 'failed'
-        : row.tested_version !== input.version
-          ? 'version'
-          : row.architecture.toLowerCase() !== architecture
-            ? 'architecture'
-            : !installerSha256 || row.installer_sha256?.toUpperCase() !== installerSha256
-              ? 'installer_sha256'
-              : null;
+  const architecture = (input.architecture || 'x64').toLowerCase();
+  const installerSha256 = input.installerSha256?.trim().toUpperCase() || '';
+  const packageProfileSha256 = input.packageProfileSha256?.trim().toUpperCase() || '';
+  const { data: passedRow, error: passedError } = installerSha256
+    ? await createServerClient()
+        .from('qa_package_results')
+        .select('winget_id, tested_version, architecture, installer_sha256, outcome')
+        .eq('winget_id', input.wingetId)
+        .eq('tested_version', input.version)
+        .eq('architecture', architecture)
+        .eq('installer_sha256', installerSha256)
+        .eq('outcome', 'Passed')
+        .order('tested_at_utc', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+    : { data: null, error: null };
+  if (passedError) throw new Error(`Could not read app-version QA result: ${passedError.message}`);
+  if (passedRow) return;
 
-    if (!reason) return;
+  if (input.requirePassed) {
     throw new QaGateNotPassedError({
       wingetId: input.wingetId,
       version: input.version,
       architecture,
       installerSha256,
       packageProfileSha256,
-      reason,
+      reason: installerSha256 ? 'missing' : 'installer_sha256',
     });
   }
 
@@ -125,9 +116,7 @@ export async function enforceQaGate(input: {
     row.outcome !== 'Failed' ||
     row.tested_version !== input.version ||
     (input.architecture && row.architecture.toLowerCase() !== input.architecture.toLowerCase()) ||
-    row.test_level !== 'psadt-package' ||
-    (input.packageProfileSha256 &&
-      row.package_profile_sha256?.toUpperCase() !== input.packageProfileSha256.toUpperCase())
+    row.test_level !== 'psadt-package'
   ) {
     return;
   }

--- a/supabase/migrations/20260811200432_deduplicate_active_qa_payloads.sql
+++ b/supabase/migrations/20260811200432_deduplicate_active_qa_payloads.sql
@@ -1,0 +1,46 @@
+-- A QA pass belongs to an immutable installer payload. Keep only one queued
+-- or executing PSADT-package candidate for that payload, even when concurrent
+-- customer requests carry different presentation/configuration profiles.
+with ranked_active as (
+  select
+    id,
+    status,
+    row_number() over (
+      partition by
+        lower(winget_id),
+        version,
+        lower(architecture),
+        upper(installer_sha256)
+      order by
+        case status
+          when 'running' then 0
+          when 'dispatched' then 1
+          else 2
+        end,
+        priority desc,
+        enqueued_at asc,
+        id asc
+    ) as payload_rank
+  from public.qa_candidates
+  where test_level = 'psadt-package'
+    and status in ('queued', 'dispatched', 'running')
+)
+update public.qa_candidates as candidate
+set
+  status = 'superseded',
+  failure_summary = 'Superseded by another active test for the same app payload.',
+  updated_at = now()
+from ranked_active
+where candidate.id = ranked_active.id
+  and ranked_active.payload_rank > 1
+  and ranked_active.status = 'queued';
+
+create unique index if not exists qa_candidates_one_active_payload_idx
+  on public.qa_candidates (
+    lower(winget_id),
+    version,
+    lower(architecture),
+    upper(installer_sha256)
+  )
+  where test_level = 'psadt-package'
+    and status in ('queued', 'dispatched', 'running');


### PR DESCRIPTION
## Summary
- qualify QA by app ID, version, architecture, and installer SHA instead of every PSADT configuration
- use one deterministic Auto-mode PSADT QA package with visible bottom-right progress
- attach concurrent customer uploads to the same active VM test
- resume waiting uploads immediately when the exact payload already passed
- add a partial unique index to close concurrent queue races

## Verification
- 60 focused QA/upload tests passed
- ESLint passed
- production build passed
- full suite: 886/887 initially passed; the lone translation-provider timeout passed on immediate isolated rerun