### PR TITLE
Recover WinGet polling from truncated comparisons

### DIFF
--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -369,6 +369,16 @@ export async function GET(request: Request) {
     baseSha = changes.baseSha;
     headSha = changes.headSha;
     changedPackageCount = changes.changedPackageIds.length;
+    if (changes.comparisonTruncated) {
+      structuredQaPollLog('info', 'qa_winget_compare_reanchored', {
+        runId,
+        requestId,
+        baseSha,
+        headSha,
+        sampledChangedPackageCount: changedPackageCount,
+        recovery: 'demanded_app_reconciliation',
+      });
+    }
     if (changes.rateLimitedUntil) {
       const { error: rateLimitStateError } = await supabase
         .from('qa_winget_poll_state')

--- a/lib/qa/winget-changes.test.ts
+++ b/lib/qa/winget-changes.test.ts
@@ -76,7 +76,7 @@ describe('detectWingetChanges', () => {
     expect(changes.changedPackageIds).toEqual(['Mozilla.Firefox']);
   });
 
-  it('refuses to advance a truncated comparison', async () => {
+  it('re-anchors a truncated comparison and returns the bounded package sample', async () => {
     const files = Array.from({ length: 300 }, (_, index) => ({
       status: 'modified',
       filename: `manifests/e/Example/App/${index}/Example.App.yaml`,
@@ -88,9 +88,13 @@ describe('detectWingetChanges', () => {
         new Response(JSON.stringify({ status: 'ahead', total_commits: 10, files }), { status: 200 })
       );
 
-    await expect(detectWingetChanges({ baseSha: BASE, fetchImpl })).rejects.toThrow(
-      'compare limits'
-    );
+    await expect(detectWingetChanges({ baseSha: BASE, fetchImpl })).resolves.toMatchObject({
+      baseSha: BASE,
+      headSha: HEAD,
+      changedFiles: 300,
+      changedPackageIds: ['Example.App'],
+      comparisonTruncated: true,
+    });
   });
 
   it('persists the authenticated reset time without falling back to a shared public IP quota', async () => {

--- a/lib/qa/winget-changes.ts
+++ b/lib/qa/winget-changes.ts
@@ -26,6 +26,7 @@ export interface WingetChangeSet {
   initialized: boolean;
   etag: string | null;
   rateLimitedUntil: string | null;
+  comparisonTruncated?: boolean;
 }
 
 export interface DetectWingetChangesOptions {
@@ -127,7 +128,11 @@ async function compare(
   baseSha: string,
   headSha: string,
   token?: string
-): Promise<{ changedFiles: number; changedPackageIds: string[] }> {
+): Promise<{
+  changedFiles: number;
+  changedPackageIds: string[];
+  comparisonTruncated?: boolean;
+}> {
   if (baseSha === headSha) return { changedFiles: 0, changedPackageIds: [] };
   const response = await githubJson<GitHubComparison>(
     fetchImpl,
@@ -140,7 +145,16 @@ async function compare(
   }
   const files = result.files || [];
   if ((result.total_commits || 0) >= 250 || files.length >= 300) {
-    throw new Error('WinGet change window exceeded GitHub compare limits; cursor was not advanced');
+    // GitHub caps compare results at 250 commits / 300 files. Keeping the old
+    // cursor here creates a permanent failure loop as the repository moves
+    // farther ahead. Process the bounded file sample and re-anchor; the QA
+    // poller's demanded-app reconciliation independently queues every customer-
+    // deployed app whose current catalog version has no QA candidate.
+    return {
+      changedFiles: files.length,
+      changedPackageIds: changedPackageIds(files),
+      comparisonTruncated: true,
+    };
   }
   return { changedFiles: files.length, changedPackageIds: changedPackageIds(files) };
 }


### PR DESCRIPTION
## Summary
- re-anchor the WinGet cursor when GitHub truncates a large comparison instead of entering a permanent failure loop
- process the bounded changed-package sample returned by GitHub
- rely on the existing customer-deployed current-version reconciliation to cover packages omitted by truncation
- emit explicit recovery telemetry without marking the poll failed

## Verification
- 30 focused poll/live tests passed
- ESLint passed
- production build and TypeScript passed