### PR TITLE
Advance WinGet cursor past isolated package errors

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -452,7 +452,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
   });
 
-  it('records a changed supported app failure without advancing the cursor', async () => {
+  it('records a changed supported app failure and advances the completed comparison cursor', async () => {
     detectWingetChangesMock.mockResolvedValue({
       baseSha: 'a'.repeat(40),
       headSha: 'b'.repeat(40),
@@ -477,7 +477,12 @@ describe('GET /api/cron/qa-enqueue', () => {
       errorCount: 1,
       errors: ['Example.App: GitHub returned HTTP 503'],
     });
-    expect(cursorUpdates).toHaveLength(0);
+    expect(cursorUpdates).toEqual([
+      expect.objectContaining({
+        head_sha: 'b'.repeat(40),
+        github_rate_limited_until: null,
+      }),
+    ]);
     expect(pollRunUpdates[0]).toMatchObject({ status: 'partial', error_count: 1 });
   });
 

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -746,7 +746,13 @@ export async function GET(request: Request) {
       );
     }
 
-    if (summary.errorCount === 0) {
+    // The change-feed cursor represents a successful GitHub comparison, not
+    // the outcome of every package inspected from that comparison. Advancing
+    // it must not be blocked by an isolated manifest, policy, or packaging
+    // error; demanded apps that still lack QA are retried by the bounded
+    // reconciliation query on subsequent polls. A GitHub rate-limit deferral
+    // is different: no new comparison was performed, so preserve the cursor.
+    if (!changes.rateLimitedUntil) {
       const { error: cursorError } = await supabase
         .from('qa_winget_poll_state')
         .update({


### PR DESCRIPTION
## Summary
- advance the WinGet comparison cursor after a successful feed comparison even when individual package checks fail
- preserve the cursor during GitHub rate-limit deferrals
- keep bounded demand reconciliation responsible for retrying customer-deployed apps without QA

## Verification
- 30 focused tests passed
- ESLint passed
- production build passed