### PR TITLE
Use runnable filenames for extensionless QA installers

### DIFF
--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -11,6 +11,7 @@ import {
 import {
   normalizeInstallerSha256,
   normalizeQaInstallerType,
+  qaInstallerFileName,
   selectQaVmInstaller,
   selectWingetInstaller,
 } from '@/lib/qa/candidate';
@@ -212,16 +213,6 @@ async function findToolchainBackfillIds(
     }
     cursor = { enqueuedAt: last.enqueued_at, id: last.id };
   }
-}
-
-function installerFileName(installerUrl: string, installerType: string): string {
-  try {
-    const decoded = decodeURIComponent(new URL(installerUrl).pathname.split('/').pop() || '');
-    if (decoded && !/[\\/:*?"<>|]/.test(decoded)) return decoded;
-  } catch {
-    // Validation below reports the malformed URL.
-  }
-  return `installer.${installerType || 'exe'}`;
 }
 
 function errorMessage(error: unknown): string {
@@ -642,7 +633,7 @@ export async function GET(request: Request) {
                 installer_url: installerUrl,
                 installer_sha256: installerSha256,
                 installer_type: installerType,
-                installer_file_name: installerFileName(installerUrl, installerType),
+                installer_file_name: qaInstallerFileName(installerUrl, installerType),
                 test_level: 'psadt-package',
                 package_profile_sha256: packageIdentity.packageProfileSha256,
                 test_config: testConfig as never,

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeInstallerSha256,
   normalizeQaArchitecture,
   normalizeQaInstallerType,
+  qaInstallerFileName,
   selectQaVmInstaller,
   selectWingetInstaller,
 } from './candidate';
@@ -67,5 +68,14 @@ describe('QA candidate normalization', () => {
     expect(normalizeQaInstallerType('nullsoft', 'exe')).toBe('exe');
     expect(normalizeQaInstallerType('wix', 'exe')).toBe('msi');
     expect(normalizeQaInstallerType('portable', 'exe')).toBe('exe');
+  });
+
+  it('gives extensionless executable URLs a runnable filename', () => {
+    expect(
+      qaInstallerFileName(
+        'https://dl.pstmn.io/download/version/12.23.1/windows_64',
+        'exe'
+      )
+    ).toBe('windows_64.exe');
   });
 });

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -99,11 +99,6 @@ export function normalizeQaInstallerType(
 }
 
 export function qaInstallerFileName(installerUrl: string, installerType: string): string {
-  try {
-    const decoded = decodeURIComponent(new URL(installerUrl).pathname.split('/').pop() || '');
-    if (decoded && !/[\\/:*?"<>|]/.test(decoded)) return decoded;
-  } catch {
-    // Use a deterministic safe fallback below.
-  }
-  return `installer.${normalizeQaInstallerType(installerType)}`;
+  return resolveInstallerFileName(installerUrl, normalizeQaInstallerType(installerType));
 }
+import { resolveInstallerFileName } from '@/lib/installer-filename';


### PR DESCRIPTION
## Summary
- route QA candidate filenames through the same shared resolver used by customer packaging
- append type-correct extensions for extensionless URLs such as Postman windows_64 -> windows_64.exe
- cover both scheduled and upload-triggered QA demand through qaInstallerFileName

## Verification
- 34 focused tests passed
- ESLint passed
- the preceding production build passed with the same route baseline