### PR TITLE
Separate partial QA scans from failure streaks

### DIFF
--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -2,7 +2,30 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('server-only', () => ({}));
 
-import { buildQaLiveResponse } from './live';
+import { buildQaLiveResponse, countConsecutiveFailedPolls } from './live';
+
+describe('countConsecutiveFailedPolls', () => {
+  it('does not describe partial package checks as consecutive polling failures', () => {
+    expect(
+      countConsecutiveFailedPolls([
+        { status: 'partial' },
+        { status: 'failed' },
+        { status: 'failed' },
+      ])
+    ).toBe(0);
+  });
+
+  it('counts only the uninterrupted leading failed scan streak', () => {
+    expect(
+      countConsecutiveFailedPolls([
+        { status: 'failed' },
+        { status: 'failed' },
+        { status: 'succeeded' },
+        { status: 'failed' },
+      ])
+    ).toBe(2);
+  });
+});
 
 describe('buildQaLiveResponse', () => {
   it('returns a sanitized live projection and derives health', () => {

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -354,6 +354,17 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
   };
 }
 
+export function countConsecutiveFailedPolls(
+  polls: Array<{ status: string }>
+): number {
+  let failures = 0;
+  for (const poll of polls) {
+    if (poll.status !== 'failed') break;
+    failures += 1;
+  }
+  return failures;
+}
+
 export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const supabase = createServerClient();
   const candidateColumns =
@@ -405,11 +416,7 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
   const queued = (queueResult.data || []) as CandidateRow[];
   const recent = (recentResult.data || []) as ResultRow[];
   const polls = (pollResult.data || []) as PollRow[];
-  let consecutivePollFailures = 0;
-  for (const poll of polls) {
-    if (poll.status !== 'failed' && poll.status !== 'partial') break;
-    consecutivePollFailures += 1;
-  }
+  const consecutivePollFailures = countConsecutiveFailedPolls(polls);
   const ids = [
     ...(current ? [current.winget_id] : []),
     ...queued.map((row) => row.winget_id),


### PR DESCRIPTION
## Summary
- count only fully failed poll runs in the consecutive failure streak
- keep partial package-check outcomes visible as degraded without calling them a polling outage
- prevent isolated dependency-policy rejections from producing inflated consecutive-failure banners

## Verification
- live QA tests passed
- ESLint passed