### PR TITLE
Reuse successful QA across baseline profile changes

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -78,6 +78,7 @@ function createSupabaseStub(options: {
   candidatePages?: Array<Array<Record<string, unknown>>>;
   demandBackfillApps?: string[];
   pollState?: Record<string, unknown>;
+  packageResults?: Array<Record<string, unknown>>;
 }) {
   const pollRunInserts: Array<Record<string, unknown>> = [];
   const pollRunUpdates: Array<Record<string, unknown>> = [];
@@ -161,8 +162,11 @@ function createSupabaseStub(options: {
           error: null,
         });
       }
-      if (table === 'app_update_policies' || table === 'qa_results') {
+      if (table === 'app_update_policies') {
         return query({ data: [], error: null });
+      }
+      if (table === 'qa_package_results') {
+        return query({ data: options.packageResults || [], error: null });
       }
       if (table === 'qa_candidates') {
         return {
@@ -450,6 +454,46 @@ describe('GET /api/cron/qa-enqueue', () => {
       demand_backfill_requested_count: 1,
       demand_backfill_count: 1,
     });
+  });
+
+  it('does not queue an app payload that already passed under another PSADT profile', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      demandBackfillApps: ['Covered.App'],
+      supportedApps: [
+        {
+          winget_id: 'Covered.App',
+          name: 'Covered',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+      packageResults: [
+        {
+          winget_id: 'Covered.App',
+          tested_version: '1.0.0',
+          architecture: 'x64',
+          installer_sha256: 'A'.repeat(64),
+          outcome: 'Passed',
+          tested_at_utc: '2026-08-10T12:00:00.000Z',
+          package_profile_sha256: 'B'.repeat(64),
+        },
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, alreadyKnown: 1 });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({
+      winget_id: 'Covered.App',
+      version: '1.0.0',
+      status: 'passed',
+    });
+    expect(candidateInserts[0].package_profile_sha256).not.toBe('B'.repeat(64));
   });
 
   it('records a changed supported app failure and advances the completed comparison cursor', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -447,7 +447,6 @@ export async function GET(request: Request) {
       installer_sha256: string | null;
       outcome: string;
       tested_at_utc: string;
-      test_level: string;
       package_profile_sha256: string | null;
     }> = [];
     if (supportedIds.length > 0) {
@@ -468,9 +467,9 @@ export async function GET(request: Request) {
           .select('winget_id')
           .in('winget_id', supportedIds),
         supabase
-          .from('qa_results')
+          .from('qa_package_results')
           .select(
-            'winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc, test_level, package_profile_sha256'
+            'winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc, package_profile_sha256'
           )
           .in('winget_id', supportedIds),
       ]);
@@ -508,7 +507,20 @@ export async function GET(request: Request) {
       demandBackfillIdSet.has(app.winget_id)
     ).length;
     const recipeById = new Map(recipes.map((row) => [row.winget_id, row]));
-    const resultById = new Map(results.map((row) => [row.winget_id, row]));
+    const passedResultByPayload = new Map<string, (typeof results)[number]>();
+    for (const result of results) {
+      if (result.outcome !== 'Passed' || !result.installer_sha256) continue;
+      const key = [
+        result.winget_id.toLowerCase(),
+        result.tested_version,
+        result.architecture.toLowerCase(),
+        result.installer_sha256.toUpperCase(),
+      ].join('|');
+      const existing = passedResultByPayload.get(key);
+      if (!existing || result.tested_at_utc > existing.tested_at_utc) {
+        passedResultByPayload.set(key, result);
+      }
+    }
     const client = createWingetManifestClient({ token: process.env.GITHUB_PAT, maxRetries: 2 });
 
     for (let index = 0; index < supportedApps.length; index += BATCH_SIZE) {
@@ -605,23 +617,22 @@ export async function GET(request: Request) {
             testConfig.packageProfileSha256 = packageIdentity.packageProfileSha256;
             testConfig.psadtConfigSha256 = packageIdentity.psadtConfigSha256;
             testConfig.detectionRulesSha256 = packageIdentity.detectionRulesSha256;
-            const previous = resultById.get(app.winget_id);
-            const previousMatches = Boolean(
-              previous &&
-                previous.test_level === 'psadt-package' &&
-                previous.tested_version === resolution.version &&
-                previous.architecture.toLowerCase() === architecture.toLowerCase() &&
-                previous.installer_sha256?.toUpperCase() === installerSha256 &&
-                previous.package_profile_sha256?.toUpperCase() ===
-                  packageIdentity.packageProfileSha256
-            );
+            const payloadKey = [
+              app.winget_id.toLowerCase(),
+              resolution.version,
+              architecture.toLowerCase(),
+              installerSha256,
+            ].join('|');
+            const previous = passedResultByPayload.get(payloadKey);
+            // A successful QA run qualifies the immutable installer payload.
+            // Presentation-only PSADT profile changes must not schedule the same
+            // app version repeatedly.
+            const previousMatches = Boolean(previous);
             const now = new Date().toISOString();
             const initialStatus = !packagingContract.valid
               ? 'failed'
               : previousMatches
-                ? previous?.outcome === 'Passed'
-                  ? 'passed'
-                  : 'failed'
+                ? 'passed'
                 : 'queued';
             const { data: inserted, error: insertError } = await supabase!
               .from('qa_candidates')


### PR DESCRIPTION
Stops the scheduled demand backfill from re-queuing an immutable app/version/architecture/installer payload solely because its generated PSADT profile hash changed. Historical successful package results now qualify the payload consistently with customer-demand QA. Includes a focused regression test.\n\nVerified: npx vitest run app/api/cron/qa-enqueue/route.test.ts (17/17).