### PR TITLE
fix(packaging): apply reviewed vendor uninstall arguments

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -3,6 +3,36 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { applyApplicationPackagingAdapter } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('adds reviewed silent removal arguments for failing vendor lifecycles', () => {
+    expect(
+      applyApplicationPackagingAdapter('RARLab.WinRAR', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['/S']);
+    expect(
+      applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['/silent', 'forall']);
+    expect(
+      applyApplicationPackagingAdapter('PostgreSQL.PostgreSQL.18', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.VisualStudio.Professional',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['--quiet', '--norestart']);
+  });
+
+  it('preserves and deduplicates reviewed uninstall arguments case-insensitively', () => {
+    const adapted = applyApplicationPackagingAdapter('RARLab.WinRAR', {
+      ...DEFAULT_PSADT_CONFIG,
+      reviewedUninstallArguments: ['/s', '--custom'],
+    });
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/s', '--custom']);
+  });
+
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Adobe.CreativeCloud',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -3,7 +3,19 @@ import type { ProcessToClose, PSADTConfig } from '@/types/psadt';
 interface ApplicationPackagingAdapter {
   wingetId: string;
   requiredProcessesToClose?: readonly ProcessToClose[];
+  reviewedUninstallArguments?: readonly string[];
 }
+
+const VISUAL_STUDIO_WINGET_IDS = [
+  'Microsoft.VisualStudio.BuildTools',
+  'Microsoft.VisualStudio.Community',
+  'Microsoft.VisualStudio.Enterprise',
+  'Microsoft.VisualStudio.Professional',
+  'Microsoft.VisualStudio.2019.BuildTools',
+  'Microsoft.VisualStudio.2019.Community',
+  'Microsoft.VisualStudio.2019.Enterprise',
+  'Microsoft.VisualStudio.2019.Professional',
+] as const;
 
 /**
  * Reviewed application-specific behavior that cannot be derived safely from a
@@ -12,6 +24,22 @@ interface ApplicationPackagingAdapter {
  * in the QA execution-profile hash.
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
+  {
+    wingetId: 'RARLab.WinRAR',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
+    wingetId: 'SoftwareOK.Q-Dir',
+    reviewedUninstallArguments: ['/silent', 'forall'],
+  },
+  {
+    wingetId: 'PostgreSQL.PostgreSQL.18',
+    reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
+  },
+  ...VISUAL_STUDIO_WINGET_IDS.map((wingetId) => ({
+    wingetId,
+    reviewedUninstallArguments: ['--quiet', '--norestart'],
+  })),
   {
     wingetId: 'Adobe.CreativeCloud',
     requiredProcessesToClose: [
@@ -55,6 +83,14 @@ function normalizeProcessName(name: string): string {
   return name.trim().replace(/\.exe$/i, '');
 }
 
+function normalizeUninstallArgument(argument: string, wingetId: string): string {
+  const normalized = argument.trim();
+  if (!normalized || normalized.length > 256 || /[\x00-\x1f\x7f]/.test(normalized)) {
+    throw new Error(`Invalid reviewed uninstall argument for ${wingetId}`);
+  }
+  return normalized;
+}
+
 export function applyApplicationPackagingAdapter(
   wingetId: string,
   config: PSADTConfig
@@ -63,7 +99,7 @@ export function applyApplicationPackagingAdapter(
   const adapter = APPLICATION_PACKAGING_ADAPTERS.find(
     ({ wingetId: adapterWingetId }) => adapterWingetId.toLowerCase() === normalizedWingetId
   );
-  if (!adapter?.requiredProcessesToClose?.length) return config;
+  if (!adapter) return config;
 
   const processesToClose = (config.processesToClose || []).map((process) => {
     const name = normalizeProcessName(process.name);
@@ -76,7 +112,7 @@ export function applyApplicationPackagingAdapter(
     processesToClose.map(({ name }) => name.toLowerCase())
   );
 
-  for (const required of adapter.requiredProcessesToClose) {
+  for (const required of adapter.requiredProcessesToClose || []) {
     const normalizedName = normalizeProcessName(required.name);
     if (!configuredNames.has(normalizedName.toLowerCase())) {
       processesToClose.push({ ...required, name: normalizedName });
@@ -84,5 +120,19 @@ export function applyApplicationPackagingAdapter(
     }
   }
 
-  return { ...config, processesToClose };
+  const reviewedUninstallArguments = (config.reviewedUninstallArguments || []).map(
+    (argument) => normalizeUninstallArgument(argument, adapter.wingetId)
+  );
+  const configuredArguments = new Set(
+    reviewedUninstallArguments.map((argument) => argument.toLowerCase())
+  );
+  for (const required of adapter.reviewedUninstallArguments || []) {
+    const normalized = normalizeUninstallArgument(required, adapter.wingetId);
+    if (!configuredArguments.has(normalized.toLowerCase())) {
+      reviewedUninstallArguments.push(normalized);
+      configuredArguments.add(normalized.toLowerCase());
+    }
+  }
+
+  return { ...config, processesToClose, reviewedUninstallArguments };
 }

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -569,6 +569,7 @@ export function normalizeQaPsadtConfig(
     detectionRules,
     postInstallCommands: value?.postInstallCommands || [],
     postUninstallCommands: value?.postUninstallCommands || [],
+    reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
   };
 }
 

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -860,6 +860,36 @@ catch
   }
 
   /**
+   * Read the bounded, declarative arguments supplied by a reviewed application
+   * adapter. These are appended only to the exact captured vendor uninstaller.
+   */
+  private getReviewedUninstallArguments(job: PackagingJob): string[] {
+    const raw = this.getPsadtConfig(job)?.reviewedUninstallArguments;
+    if (raw === undefined || raw === null) return [];
+    if (!Array.isArray(raw) || raw.length > 20) {
+      throw new Error('PSADT reviewedUninstallArguments must be an array of at most 20 entries');
+    }
+
+    const result: string[] = [];
+    const seen = new Set<string>();
+    for (const value of raw) {
+      if (typeof value !== 'string') {
+        throw new Error('Each reviewed uninstall argument must be a string');
+      }
+      const argument = value.trim();
+      if (!argument || argument.length > 256 || /[\x00-\x1f\x7f]/.test(argument)) {
+        throw new Error('Each reviewed uninstall argument must be non-empty, bounded, and single-line');
+      }
+      const key = argument.toLowerCase();
+      if (!seen.has(key)) {
+        result.push(argument);
+        seen.add(key);
+      }
+    }
+    return result;
+  }
+
+  /**
    * Generate PowerShell for additional post-install / post-uninstall commands
    * (issue #118). Each entry runs as its own Start-ADTProcess (cmd.exe /c) step,
    * in order, mirroring the custom-override pattern. Returns '' when none.
@@ -1350,6 +1380,15 @@ ${steps}
       ).replace(/'/g, "''");
       const hiveLongName = job.install_scope === 'user' ? 'HKEY_CURRENT_USER' : 'HKEY_LOCAL_MACHINE';
       const markerProviderPath = `Registry::${hiveLongName}\\${this.getRegistryMarkerPath(job)}\\${this.sanitizeWingetId(job.winget_id)}`;
+      const reviewedUninstallArguments = this.getReviewedUninstallArguments(job)
+        .map((argument) => `'${argument.replace(/'/g, "''")}'`)
+        .join(', ');
+      const reviewedUninstallArgumentsBlock = `$reviewedUninstallArguments = @(${reviewedUninstallArguments})
+    foreach ($reviewedArgument in $reviewedUninstallArguments) {
+        if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {
+            $registeredUninstallArguments += $reviewedArgument
+        }
+    }`;
       const selectionBlock = `$configuredProductCode = '${registryIdentity.productCode}'
     $configuredDisplayName = '${registryIdentity.displayName}'
     $markerProviderPath = '${markerProviderPath}'
@@ -1384,6 +1423,7 @@ ${steps}
     if ($registeredUninstallArguments.Count -eq 0) {
         $registeredUninstallArguments = @('/uninstall', '/quiet', '/norestart')
     }
+    ${reviewedUninstallArgumentsBlock}
     $bundledUninstaller = Join-Path $adtSession.DirFiles '${fileNameEscaped}'
     if (-not (Test-Path -LiteralPath $bundledUninstaller -PathType Leaf)) {
         throw "The packaged Burn uninstaller was not found: $bundledUninstaller"
@@ -1490,6 +1530,7 @@ ${steps}
             # desktop-client command and never forward the install-only --mode=stub value.
             $registeredUninstallArguments = @('-u', '--silent')
         }
+        ${reviewedUninstallArgumentsBlock}
         $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile
         $isRegisteredMsiExec = $registeredUninstallLeaf -in @('msiexec', 'msiexec.exe')
         if ($isRegisteredMsiExec) {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -567,6 +567,44 @@ describe('EXE product identity PSADT generation', () => {
     expect(inno).toContain("$safeManifestUninstallArguments = @('/VERYSILENT /NORESTART' -split '\\s+'");
   });
 
+  it('appends only bounded reviewed arguments to the exact registered vendor uninstaller', () => {
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'exe',
+        uninstall_command: 'REGISTRY_UNINSTALL:WinRAR',
+        package_config: {
+          psadtConfig: {
+            reviewedUninstallArguments: ['/S', "vendor's-argument", '/S'],
+          },
+        },
+      }),
+      'winrar.exe'
+    );
+
+    expect(uninstall).toContain("$reviewedUninstallArguments = @('/S', 'vendor''s-argument')");
+    expect(uninstall).toContain(
+      "@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0"
+    );
+    expect(uninstall.indexOf('$reviewedUninstallArguments = @(')).toBeLessThan(
+      uninstall.indexOf('$uninstallHandle = Start-ADTProcess @uninstallProcessParameters')
+    );
+  });
+
+  it('rejects unsafe reviewed uninstall argument collections', () => {
+    expect(() => generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'exe',
+        uninstall_command: 'REGISTRY_UNINSTALL:Example',
+        package_config: {
+          psadtConfig: { reviewedUninstallArguments: ['--quiet\nRemove-Item C:\\'] },
+        },
+      }),
+      'example.exe'
+    )).toThrow('single-line');
+  });
+
   it('uses the Adobe Creative Cloud desktop client unattended removal contract', () => {
     const uninstall = generator.getUninstallCommand.call(
       generator,

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -194,6 +194,11 @@ export interface PSADTConfig {
   installCommand?: string;
   uninstallCommand?: string;
 
+  // Internal, reviewed vendor arguments appended to an exact registered
+  // uninstaller. Application adapters populate this field; it is intentionally
+  // not exposed as a customer-facing free-form command surface.
+  reviewedUninstallArguments?: string[];
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.
@@ -272,6 +277,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   // Commands will be auto-generated based on installer type
   installCommand: undefined,
   uninstallCommand: undefined,
+  reviewedUninstallArguments: [],
 };
 
 /**


### PR DESCRIPTION
## Summary
- add declarative reviewed uninstall arguments to the shared application adapter layer
- apply the same adapter to customer and QA PSADT packaging
- validate and append only bounded arguments to the exact captured vendor uninstaller

## Verification
- 132 focused Vitest tests passed
- touched-file ESLint passed
- production Next.js build passed