### PR TITLE
fix(packaging): bundle reviewed Microsoft prerequisites

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -70,10 +70,16 @@ foreach ($dependency in $PackageDependencies) {
         [string]::IsNullOrWhiteSpace([string]$dependency.installerSha256)) {
         throw 'Every package dependency must include an identifier, version, filename, and SHA-256.'
     }
-    if ([string]$dependency.packageIdentifier -notmatch '^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(x86|x64|arm64)$') {
+    $dependencyIdentifier = [string]$dependency.packageIdentifier
+    $dependencyInstallerType = ([string]$dependency.installerType).ToLowerInvariant()
+    $isVCRedistributable = $dependencyIdentifier -match '^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(x86|x64|arm64)$'
+    $isDotNetDesktopRuntime = $dependencyIdentifier -match '^Microsoft\.DotNet\.DesktopRuntime\.\d+$'
+    $isPowerShell = $dependencyIdentifier -eq 'Microsoft.PowerShell'
+    if (-not ($isVCRedistributable -or $isDotNetDesktopRuntime -or $isPowerShell)) {
         throw "Package dependency is not in the reviewed redistribution allowlist: $($dependency.packageIdentifier)"
     }
-    if ([string]$dependency.installerType -notin @('exe', 'burn')) {
+    $reviewedInstallerTypes = if ($isPowerShell) { @('msi', 'wix') } else { @('exe', 'burn') }
+    if ($dependencyInstallerType -notin $reviewedInstallerTypes) {
         throw "Package dependency uses an unreviewed installer type: $($dependency.installerType)"
     }
     if ([string]$dependency.fileName -match '[\\/:*?"<>|]' -or
@@ -1181,6 +1187,7 @@ foreach ($dependency in @($PackageDependencies | Sort-Object order)) {
     $dependencyVersionEscaped = ([string]$dependency.version) -replace "'", "''"
     $dependencyFileEscaped = ([string]$dependency.fileName) -replace "'", "''"
     $dependencyArgumentsEscaped = ([string]$dependency.silentArgs) -replace "'", "''"
+    $dependencyInstallerType = ([string]$dependency.installerType).ToLowerInvariant()
     $dependencySuccessCodes = @(
         0
         @($dependency.successCodes) | ForEach-Object { [int]$_ }
@@ -1201,7 +1208,17 @@ foreach ($dependency in @($PackageDependencies | Sort-Object order)) {
         "        throw 'Bundled dependency file is missing: $dependencyIdEscaped'"
         '    }'
         "    Write-ADTLogEntry -Message 'Installing bundled dependency [$dependencyIdEscaped] version [$dependencyVersionEscaped].' -Severity 'Info' -Source 'Install-ADTDeployment'"
-        "    `$dependencyResult = Start-ADTProcess -FilePath `$dependencyPath -ArgumentList '$dependencyArgumentsEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 10) -TimeoutAction Stop -SuccessExitCodes @($dependencySuccessLiteral) -RebootExitCodes @($dependencyRebootLiteral) -PassThru"
+    )
+    if ($dependencyInstallerType -in @('msi', 'wix')) {
+        $dependencyInstallLines += @(
+            "    `$dependencyArgumentList = '/i `"{0}`" {1}' -f `$dependencyPath, '$dependencyArgumentsEscaped'"
+            "    `$dependencyResult = Start-ADTProcess -FilePath `"`$env:SystemRoot\System32\msiexec.exe`" -ArgumentList `$dependencyArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 10) -TimeoutAction Stop -SuccessExitCodes @($dependencySuccessLiteral) -RebootExitCodes @($dependencyRebootLiteral) -PassThru"
+        )
+    }
+    else {
+        $dependencyInstallLines += "    `$dependencyResult = Start-ADTProcess -FilePath `$dependencyPath -ArgumentList '$dependencyArgumentsEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 10) -TimeoutAction Stop -SuccessExitCodes @($dependencySuccessLiteral) -RebootExitCodes @($dependencyRebootLiteral) -PassThru"
+    }
+    $dependencyInstallLines += @(
         "    if (`$dependencyResult.ExitCode -in @($dependencyRebootLiteral)) {"
         '        $script:DependencyRebootExitCode = 3010'
         '    }'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -215,6 +215,41 @@ describe('PSADT offline dependency contract', () => {
     },
     30_000
   );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'installs a reviewed Wix dependency through explicit silent msiexec',
+    () => {
+      const dependencySha256 = createHash('sha256')
+        .update('dependency-fixture')
+        .digest('hex')
+        .toUpperCase();
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'PowerShell Dependency Contract App',
+        [],
+        {},
+        [{
+          packageIdentifier: 'Microsoft.PowerShell',
+          version: '7.6.4.0',
+          fileName: 'Microsoft.PowerShell-PowerShell-7.6.4-win-x64.msi',
+          installerSha256: dependencySha256,
+          installerType: 'wix',
+          silentArgs: '/qn /norestart',
+          successCodes: [0],
+          rebootCodes: [1641, 3010],
+          order: 1,
+        }]
+      );
+
+      expect(generated).toContain(
+        "Start-ADTProcess -FilePath \"$env:SystemRoot\\System32\\msiexec.exe\""
+      );
+      expect(generated).toContain(
+        "$dependencyArgumentList = '/i \"{0}\" {1}' -f $dependencyPath, '/qn /norestart'"
+      );
+    },
+    30_000
+  );
 });
 
 describe.skipIf(!canRunWindowsPowerShellPackager)(

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -116,6 +116,79 @@ describe('resolveWingetPackageDependencies', () => {
     expect(dependency.minimumVersion).toBe('14.40.0.0');
   });
 
+  it('bundles a reviewed .NET Desktop Runtime Burn prerequisite', async () => {
+    const io = fixtureIo(
+      {
+        'Example.App@1.0.0': [installer({
+          packageDependencies: [{
+            packageIdentifier: 'Microsoft.DotNet.DesktopRuntime.10',
+            minimumVersion: '10.0.10',
+          }],
+        })],
+        'Microsoft.DotNet.DesktopRuntime.10@10.0.11': [installer({
+          type: 'burn',
+          url: 'https://download.microsoft.com/windowsdesktop-runtime-10.0.11-win-x64.exe',
+          sha256: VC_SHA,
+          silentArgs: '/quiet /norestart',
+        })],
+      },
+      { 'Microsoft.DotNet.DesktopRuntime.10': ['10.0.11'] }
+    );
+
+    const [dependency] = await resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+
+    expect(dependency).toMatchObject({
+      packageIdentifier: 'Microsoft.DotNet.DesktopRuntime.10',
+      version: '10.0.11',
+      installerType: 'burn',
+      silentArgs: '/quiet /norestart',
+    });
+  });
+
+  it('selects the reviewed PowerShell Wix installer instead of its MSIX variant', async () => {
+    const io = fixtureIo(
+      {
+        'Example.App@1.0.0': [installer({
+          packageDependencies: [{ packageIdentifier: 'Microsoft.PowerShell' }],
+        })],
+        'Microsoft.PowerShell@7.6.4.0': [
+          installer({
+            type: 'msix',
+            url: 'https://github.com/PowerShell/PowerShell/releases/PowerShell-7.6.4.msixbundle',
+            sha256: 'C'.repeat(64),
+            silentArgs: '',
+          }),
+          installer({
+            type: 'wix',
+            url: 'https://github.com/PowerShell/PowerShell/releases/PowerShell-7.6.4-win-x64.msi',
+            sha256: VC_SHA,
+            silentArgs: '/qn /norestart',
+          }),
+        ],
+      },
+      { 'Microsoft.PowerShell': ['7.6.4.0'] }
+    );
+
+    const [dependency] = await resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+
+    expect(dependency).toMatchObject({
+      packageIdentifier: 'Microsoft.PowerShell',
+      installerType: 'wix',
+      silentArgs: '/qn /norestart',
+      installerSha256: VC_SHA,
+    });
+  });
+
   it('fails closed for dependency families that have not been reviewed', async () => {
     const io = fixtureIo(
       { 'Example.App@1.0.0': [installer({

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -15,16 +15,41 @@ const MAX_DEPENDENCY_DEPTH = 3;
 const MAX_PACKAGE_DEPENDENCIES = 8;
 const SHA256_PATTERN = /^[A-F0-9]{64}$/;
 
-// Start with the Microsoft redistributable family that is safe to redistribute
-// and that WinGet packages commonly declare. Other package dependency families
-// fail closed until their redistribution and unattended-install contracts have
-// been reviewed explicitly.
-const REDISTRIBUTABLE_PACKAGE_PATTERN =
+// Keep dependency redistribution explicit and fail closed. Each reviewed
+// family also constrains the installer formats we are prepared to invoke
+// offline inside the PSADT package.
+const VC_REDISTRIBUTABLE_PACKAGE_PATTERN =
   /^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(?:x86|x64|arm64)$/i;
-const REVIEWED_DEPENDENCY_INSTALLER_TYPES = new Set<WingetInstallerType>([
-  'exe',
-  'burn',
-]);
+const DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN =
+  /^Microsoft\.DotNet\.DesktopRuntime\.\d+$/i;
+
+interface ReviewedDependencyPolicy {
+  packagePattern: RegExp;
+  installerTypes: ReadonlySet<WingetInstallerType>;
+}
+
+const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
+  {
+    packagePattern: VC_REDISTRIBUTABLE_PACKAGE_PATTERN,
+    installerTypes: new Set<WingetInstallerType>(['exe', 'burn']),
+  },
+  {
+    packagePattern: DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN,
+    installerTypes: new Set<WingetInstallerType>(['exe', 'burn']),
+  },
+  {
+    packagePattern: /^Microsoft\.PowerShell$/i,
+    installerTypes: new Set<WingetInstallerType>(['msi', 'wix']),
+  },
+];
+
+function reviewedDependencyPolicy(
+  packageIdentifier: string
+): ReviewedDependencyPolicy | null {
+  return REVIEWED_DEPENDENCY_POLICIES.find((policy) =>
+    policy.packagePattern.test(packageIdentifier)
+  ) || null;
+}
 
 export interface PackagedWingetDependency {
   packageIdentifier: string;
@@ -66,16 +91,22 @@ function normalizedArchitecture(value: string): 'x64' | 'x86' | 'arm64' {
 
 function chooseInstaller(
   installers: NormalizedInstaller[],
-  targetArchitecture: 'x64' | 'x86' | 'arm64'
+  targetArchitecture: 'x64' | 'x86' | 'arm64',
+  allowedTypes?: ReadonlySet<WingetInstallerType>
 ): NormalizedInstaller | null {
-  const exact = installers.find((installer) => installer.architecture === targetArchitecture);
+  const reviewedInstallers = allowedTypes
+    ? installers.filter((installer) => allowedTypes.has(installer.type))
+    : installers;
+  const exact = reviewedInstallers.find(
+    (installer) => installer.architecture === targetArchitecture
+  );
   if (exact) return exact;
-  const neutral = installers.find((installer) => installer.architecture === 'neutral');
+  const neutral = reviewedInstallers.find((installer) => installer.architecture === 'neutral');
   if (neutral) return neutral;
   // WinGet's dependency resolver permits an x86 prerequisite for an x64 app.
   // Never make the inverse substitution and never use x86 for ARM64.
   if (targetArchitecture === 'x64') {
-    return installers.find((installer) => installer.architecture === 'x86') || null;
+    return reviewedInstallers.find((installer) => installer.architecture === 'x86') || null;
   }
   return null;
 }
@@ -112,7 +143,7 @@ function safeDependencyFileName(
 
 function dependencySuccessCodes(packageIdentifier: string, installer: NormalizedInstaller): number[] {
   const codes = new Set<number>([0, ...(installer.installerSuccessCodes || [])]);
-  if (REDISTRIBUTABLE_PACKAGE_PATTERN.test(packageIdentifier)) {
+  if (VC_REDISTRIBUTABLE_PACKAGE_PATTERN.test(packageIdentifier)) {
     // VC++ redistributables return ERROR_PRODUCT_VERSION (1638), sometimes
     // surfaced as signed HRESULT 0x80070666, when the same or a newer runtime
     // is already installed. Both are successful idempotent outcomes.
@@ -177,7 +208,8 @@ export async function resolveWingetPackageDependencies(
         `WinGet dependency depth exceeds ${MAX_DEPENDENCY_DEPTH} at ${packageIdentifier}.`
       );
     }
-    if (!REDISTRIBUTABLE_PACKAGE_PATTERN.test(packageIdentifier)) {
+    const dependencyPolicy = reviewedDependencyPolicy(packageIdentifier);
+    if (!dependencyPolicy) {
       throw new Error(
         `WinGet dependency ${packageIdentifier} is not in the reviewed redistribution allowlist.`
       );
@@ -218,7 +250,11 @@ export async function resolveWingetPackageDependencies(
       let selectedInstaller: NormalizedInstaller | null = null;
       for (const version of versions) {
         const installers = await io.getInstallers(packageIdentifier, version);
-        const candidate = chooseInstaller(installers, targetArchitecture);
+        const candidate = chooseInstaller(
+          installers,
+          targetArchitecture,
+          dependencyPolicy.installerTypes
+        );
         if (candidate) {
           selectedVersion = version;
           selectedInstaller = candidate;
@@ -232,7 +268,7 @@ export async function resolveWingetPackageDependencies(
         );
       }
       ensureSupportedDependencyShape(packageIdentifier, selectedInstaller);
-      if (!REVIEWED_DEPENDENCY_INSTALLER_TYPES.has(selectedInstaller.type)) {
+      if (!dependencyPolicy.installerTypes.has(selectedInstaller.type)) {
         throw new Error(
           `WinGet dependency ${packageIdentifier} uses unreviewed installer type ${selectedInstaller.type}.`
         );


### PR DESCRIPTION
## Summary
- review and allow Microsoft .NET Desktop Runtime and PowerShell package prerequisites
- choose only Burn/EXE for .NET and Wix/MSI for PowerShell, failing closed for all other families and formats
- install MSI prerequisites explicitly through silent msiexec in the shared customer/QA PSADT packager

## Verification
- 104 focused tests passed, including generated PowerShell parsing
- touched-file ESLint passed
- production Next.js build passed

## References
- https://learn.microsoft.com/dotnet/core/install/windows
- https://learn.microsoft.com/powershell/scripting/install/install-powershell-on-windows