### PR TITLE
Persist version-specific QA compatibility blocks

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -37,6 +37,7 @@ import {
   qaSha256,
 } from '@/lib/qa/package-profile';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { WingetDependencyCompatibilityError } from '@/lib/winget-dependencies';
 
 type QueryResult = {
   data: unknown;
@@ -84,6 +85,7 @@ function createSupabaseStub(options: {
   const pollRunUpdates: Array<Record<string, unknown>> = [];
   const cursorUpdates: Array<Record<string, unknown>> = [];
   const candidateInserts: Array<Record<string, unknown>> = [];
+  const compatibilityBlocks: Array<Record<string, unknown>> = [];
   const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
   let candidatePageIndex = 0;
 
@@ -168,6 +170,14 @@ function createSupabaseStub(options: {
       if (table === 'qa_package_results') {
         return query({ data: options.packageResults || [], error: null });
       }
+      if (table === 'qa_package_blocks') {
+        return {
+          upsert: vi.fn((row: Record<string, unknown>) => {
+            compatibilityBlocks.push(row);
+            return query({ data: null, error: null });
+          }),
+        };
+      }
       if (table === 'qa_candidates') {
         return {
           insert: vi.fn((row: Record<string, unknown>) => {
@@ -194,6 +204,7 @@ function createSupabaseStub(options: {
     pollRunUpdates,
     cursorUpdates,
     candidateInserts,
+    compatibilityBlocks,
     rpcCalls,
   };
 }
@@ -311,6 +322,7 @@ beforeEach(() => {
     etag: '"next"',
     rateLimitedUntil: null,
   });
+  resolveDependenciesMock.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -453,6 +465,55 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(pollRunUpdates[0]).toMatchObject({
       demand_backfill_requested_count: 1,
       demand_backfill_count: 1,
+    });
+  });
+
+  it('persists a user-scope dependency compatibility block without degrading polling', async () => {
+    const { client, candidateInserts, compatibilityBlocks, pollRunUpdates } =
+      createSupabaseStub({
+        demandBackfillApps: ['Blocked.App'],
+        supportedApps: [
+          {
+            winget_id: 'Blocked.App',
+            name: 'Blocked',
+            publisher: 'Contoso',
+            latest_version: '1.0.0',
+          },
+        ],
+      });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+    resolveDependenciesMock.mockRejectedValueOnce(
+      new WingetDependencyCompatibilityError(
+        'Blocked.App declares machine-wide package dependencies that cannot be installed safely in user scope.'
+      )
+    );
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      checked: 1,
+      queued: 0,
+      unavailable: 1,
+      errorCount: 0,
+    });
+    expect(candidateInserts).toHaveLength(0);
+    expect(compatibilityBlocks).toEqual([
+      expect.objectContaining({
+        winget_id: 'Blocked.App',
+        version: '1.0.0',
+        architecture: 'x64',
+        installer_sha256: 'A'.repeat(64),
+        block_code: 'user_scope_machine_dependencies',
+      }),
+    ]);
+    expect(pollRunUpdates[0]).toMatchObject({
+      status: 'succeeded',
+      unavailable_count: 1,
+      error_count: 0,
     });
   });
 

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -17,7 +17,10 @@ import {
 } from '@/lib/qa/candidate';
 import { buildQaCatalogTestConfig } from '@/lib/qa/test-config';
 import { evaluatePackagingContract } from '@/lib/packaging-contract';
-import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
+import {
+  isWingetDependencyCompatibilityError,
+  resolveWingetPackageDependencies,
+} from '@/lib/winget-dependencies';
 import {
   QA_PSADT_TOOLCHAIN,
   buildQaPackageIdentity,
@@ -577,13 +580,46 @@ export async function GET(request: Request) {
               manifest,
               installer: selectedForVm.installer as never,
             });
-            const packageDependencies = await resolveWingetPackageDependencies({
-              wingetId: app.winget_id,
-              version: resolution.version,
-              architecture,
-              installerSha256,
-              installScope: testConfig.scope,
-            });
+            let packageDependencies: Awaited<
+              ReturnType<typeof resolveWingetPackageDependencies>
+            >;
+            try {
+              packageDependencies = await resolveWingetPackageDependencies({
+                wingetId: app.winget_id,
+                version: resolution.version,
+                architecture,
+                installerSha256,
+                installScope: testConfig.scope,
+              });
+            } catch (error) {
+              if (!isWingetDependencyCompatibilityError(error)) throw error;
+              const { error: blockError } = await supabase!
+                .from('qa_package_blocks')
+                .upsert({
+                  winget_id: app.winget_id,
+                  version: resolution.version,
+                  architecture,
+                  installer_sha256: installerSha256,
+                  block_code: error.blockCode,
+                  detail: error.message,
+                  observed_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString(),
+                }, {
+                  onConflict: 'winget_id,version,architecture,installer_sha256',
+                });
+              if (blockError) {
+                throw new Error(`Could not persist the QA compatibility block: ${blockError.message}`);
+              }
+              summary.unavailable++;
+              structuredQaPollLog('info', 'qa_package_compatibility_blocked', {
+                runId,
+                wingetId: app.winget_id,
+                version: resolution.version,
+                architecture,
+                blockCode: error.blockCode,
+              });
+              return;
+            }
             if (packageDependencies.length > 0) {
               testConfig.packageDependencies = packageDependencies;
             }

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -179,3 +179,29 @@ describe('customer-deployed QA campaign migration contract', () => {
     expect(sql).not.toContain('union all');
   });
 });
+
+describe('QA package compatibility block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260812072500_qa_package_compatibility_blocks.sql'
+    ),
+    'utf8'
+  );
+
+  it('records an exact immutable installer tuple and keeps it private', () => {
+    expect(sql).toContain('primary key (winget_id, version, architecture, installer_sha256)');
+    expect(sql).toContain("block_code in ('user_scope_machine_dependencies')");
+    expect(sql).toContain('enable row level security');
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+  });
+
+  it('skips only the blocked version while preserving deployed-only demand', () => {
+    expect(sql).toContain('from public.qa_package_blocks as block');
+    expect(sql).toContain('block.version = app.latest_version');
+    expect(sql).toContain('from public.upload_history as history');
+    expect(sql).toContain('from deployed');
+    expect(sql).not.toContain('union all');
+  });
+});

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -43,6 +43,25 @@ const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
   },
 ];
 
+export class WingetDependencyCompatibilityError extends Error {
+  readonly blockCode: 'user_scope_machine_dependencies';
+
+  constructor(
+    message: string,
+    blockCode: 'user_scope_machine_dependencies' = 'user_scope_machine_dependencies'
+  ) {
+    super(message);
+    this.name = 'WingetDependencyCompatibilityError';
+    this.blockCode = blockCode;
+  }
+}
+
+export function isWingetDependencyCompatibilityError(
+  value: unknown
+): value is WingetDependencyCompatibilityError {
+  return value instanceof WingetDependencyCompatibilityError;
+}
+
 function reviewedDependencyPolicy(
   packageIdentifier: string
 ): ReviewedDependencyPolicy | null {
@@ -188,7 +207,7 @@ export async function resolveWingetPackageDependencies(
     input.installScope?.trim().toLowerCase() === 'user' &&
     (rootInstaller.packageDependencies || []).length > 0
   ) {
-    throw new Error(
+    throw new WingetDependencyCompatibilityError(
       `${input.wingetId} declares machine-wide package dependencies that cannot be installed safely in user scope.`
     );
   }

--- a/supabase/migrations/20260812072500_qa_package_compatibility_blocks.sql
+++ b/supabase/migrations/20260812072500_qa_package_compatibility_blocks.sql
@@ -1,0 +1,92 @@
+-- Persist exact package versions that cannot be tested or deployed safely
+-- under the current packaging contract. A new version remains eligible.
+
+create table public.qa_package_blocks (
+  winget_id text not null references public.curated_apps(winget_id) on update cascade,
+  version text not null,
+  architecture text not null check (architecture in ('x64', 'x86', 'arm64')),
+  installer_sha256 text not null check (installer_sha256 ~ '^[A-F0-9]{64}$'),
+  block_code text not null check (block_code in ('user_scope_machine_dependencies')),
+  detail text not null check (char_length(detail) between 1 and 1000),
+  observed_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (winget_id, version, architecture, installer_sha256)
+);
+
+comment on table public.qa_package_blocks is
+  'Service-only version-specific compatibility blocks discovered before isolated QA execution.';
+
+create index qa_package_blocks_app_version_idx
+  on public.qa_package_blocks(winget_id, version);
+
+alter table public.qa_package_blocks enable row level security;
+revoke all on table public.qa_package_blocks from public, anon, authenticated;
+grant select, insert, update, delete on table public.qa_package_blocks to service_role;
+
+create or replace function public.qa_missing_demand_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with deployed as (
+    select
+      history.winget_id,
+      max(history.deployed_at) as last_deployed_at
+    from public.upload_history as history
+    where nullif(btrim(history.winget_id), '') is not null
+    group by history.winget_id
+  ),
+  demand as (
+    select
+      deployed.winget_id,
+      exists (
+        select 1
+        from public.app_update_policies as policy
+        where policy.winget_id = deployed.winget_id
+          and policy.policy_type = 'auto_update'
+          and policy.is_enabled is true
+      ) as has_auto_update,
+      deployed.last_deployed_at as last_demanded_at
+    from deployed
+  )
+  select app.winget_id
+  from demand
+  join public.curated_apps as app on app.winget_id = demand.winget_id
+  where app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and candidate.version = app.latest_version
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+    and not exists (
+      select 1
+      from public.qa_package_blocks as block
+      where block.winget_id = app.winget_id
+        and block.version = app.latest_version
+    )
+  order by
+    demand.has_auto_update desc,
+    demand.last_demanded_at desc nulls last,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 100));
+$$;
+
+comment on function public.qa_missing_demand_backfill_ids(integer) is
+  'Returns customer-deployed Win32 apps missing current-version QA and not blocked by a reviewed compatibility boundary.';
+
+revoke all on function public.qa_missing_demand_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_missing_demand_backfill_ids(integer)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -249,6 +249,27 @@ export interface Database {
         Update: Partial<Database['public']['Tables']['qa_package_results']['Insert']>;
         Relationships: GenericRelationship[];
       };
+      qa_package_blocks: {
+        Row: {
+          winget_id: string;
+          version: string;
+          architecture: 'x64' | 'x86' | 'arm64';
+          installer_sha256: string;
+          block_code: 'user_scope_machine_dependencies';
+          detail: string;
+          observed_at: string;
+          updated_at: string;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['qa_package_blocks']['Row'],
+          'observed_at' | 'updated_at'
+        > & {
+          observed_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['qa_package_blocks']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
       qa_pipeline_control: {
         Row: {
           id: string;


### PR DESCRIPTION
## Summary
- classify per-user apps with machine-wide prerequisites as a typed compatibility boundary
- persist an exact version and installer block instead of degrading every WinGet poll
- keep customer-deployed backfill bounded and retry newer versions automatically
- keep unexpected dependency and upstream errors alerting as before

## Validation
- 50 focused tests
- ESLint
- production build
- git diff --check