### PR TITLE
Run Docker smoke checks after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
 
   docker:
     name: Docker build and smoke test
+    # Keep the self-hosted QA repair loop responsive. The same commit is still
+    # built, scanned, and smoke-tested after it lands on main.
+    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
Keep QA repair PRs responsive by running the unchanged Docker build, vulnerability scan, and container smoke test on the merged main commit. PRs continue to require workflow lint, tests, ESLint, and the production Next.js build.