### PR TITLE
Bundle reviewed VCLibs dependency and reduce GitHub API use

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -75,12 +75,33 @@ foreach ($dependency in $PackageDependencies) {
     $isVCRedistributable = $dependencyIdentifier -match '^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(x86|x64|arm64)$'
     $isDotNetDesktopRuntime = $dependencyIdentifier -match '^Microsoft\.DotNet\.DesktopRuntime\.\d+$'
     $isPowerShell = $dependencyIdentifier -eq 'Microsoft.PowerShell'
-    if (-not ($isVCRedistributable -or $isDotNetDesktopRuntime -or $isPowerShell)) {
+    $isVCLibsDesktop = $dependencyIdentifier -eq 'Microsoft.VCLibs.Desktop.14'
+    if (-not ($isVCRedistributable -or $isDotNetDesktopRuntime -or $isPowerShell -or $isVCLibsDesktop)) {
         throw "Package dependency is not in the reviewed redistribution allowlist: $($dependency.packageIdentifier)"
     }
-    $reviewedInstallerTypes = if ($isPowerShell) { @('msi', 'wix') } else { @('exe', 'burn') }
+    $reviewedInstallerTypes = if ($isPowerShell) {
+        @('msi', 'wix')
+    }
+    elseif ($isVCLibsDesktop) {
+        @('zip')
+    }
+    else {
+        @('exe', 'burn')
+    }
     if ($dependencyInstallerType -notin $reviewedInstallerTypes) {
         throw "Package dependency uses an unreviewed installer type: $($dependency.installerType)"
+    }
+    if ($isVCLibsDesktop) {
+        $dependencyNestedType = ([string]$dependency.nestedInstallerType).ToLowerInvariant()
+        $dependencyNestedPath = ([string]$dependency.nestedInstallerPath).Replace('/', '\')
+        $dependencyPackageFamilyName = [string]$dependency.packageFamilyName
+        if ($dependencyNestedType -ne 'appx' -or
+            [string]::IsNullOrWhiteSpace($dependencyNestedPath) -or
+            [string]::IsNullOrWhiteSpace($dependencyPackageFamilyName) -or
+            [System.IO.Path]::IsPathRooted($dependencyNestedPath) -or
+            @($dependencyNestedPath.Split('\')) -contains '..') {
+            throw 'Microsoft.VCLibs.Desktop.14 must use the reviewed relative APPX payload from its ZIP package.'
+        }
     }
     if ([string]$dependency.fileName -match '[\\/:*?"<>|]' -or
         [System.IO.Path]::GetFileName([string]$dependency.fileName) -ne [string]$dependency.fileName) {
@@ -1188,6 +1209,8 @@ foreach ($dependency in @($PackageDependencies | Sort-Object order)) {
     $dependencyFileEscaped = ([string]$dependency.fileName) -replace "'", "''"
     $dependencyArgumentsEscaped = ([string]$dependency.silentArgs) -replace "'", "''"
     $dependencyInstallerType = ([string]$dependency.installerType).ToLowerInvariant()
+    $dependencyNestedPathEscaped = ([string]$dependency.nestedInstallerPath) -replace "'", "''"
+    $dependencyPackageNameEscaped = (([string]$dependency.packageFamilyName -split '_')[0]) -replace "'", "''"
     $dependencySuccessCodes = @(
         0
         @($dependency.successCodes) | ForEach-Object { [int]$_ }
@@ -1213,6 +1236,42 @@ foreach ($dependency in @($PackageDependencies | Sort-Object order)) {
         $dependencyInstallLines += @(
             "    `$dependencyArgumentList = '/i `"{0}`" {1}' -f `$dependencyPath, '$dependencyArgumentsEscaped'"
             "    `$dependencyResult = Start-ADTProcess -FilePath `"`$env:SystemRoot\System32\msiexec.exe`" -ArgumentList `$dependencyArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 10) -TimeoutAction Stop -SuccessExitCodes @($dependencySuccessLiteral) -RebootExitCodes @($dependencyRebootLiteral) -PassThru"
+        )
+    }
+    elseif ($dependencyInstallerType -eq 'zip') {
+        $dependencyInstallLines += @(
+            "    `$dependencyExtractRoot = Join-Path `$env:TEMP 'IntuneGet-Dependency-$([int]$dependency.order)'"
+            '    if (Test-Path -LiteralPath $dependencyExtractRoot) {'
+            '        Remove-Item -LiteralPath $dependencyExtractRoot -Recurse -Force'
+            '    }'
+            '    $null = New-Item -ItemType Directory -Path $dependencyExtractRoot -Force'
+            '    try {'
+            '        Expand-Archive -LiteralPath $dependencyPath -DestinationPath $dependencyExtractRoot -Force'
+            "        `$dependencyNestedPath = [System.IO.Path]::GetFullPath((Join-Path `$dependencyExtractRoot '$dependencyNestedPathEscaped'))"
+            '        $dependencyRootPrefix = [System.IO.Path]::GetFullPath($dependencyExtractRoot).TrimEnd(''\'') + ''\'''
+            '        if (-not $dependencyNestedPath.StartsWith($dependencyRootPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or'
+            '            -not (Test-Path -LiteralPath $dependencyNestedPath -PathType Leaf)) {'
+            "            throw 'Reviewed dependency APPX payload is missing or escaped its extraction root: $dependencyIdEscaped'"
+            '        }'
+            "        `$existingDependency = Get-AppxProvisionedPackage -Online | Where-Object { `$_.DisplayName -eq '$dependencyPackageNameEscaped' } | Sort-Object Version -Descending | Select-Object -First 1"
+            '        $dependencyNeedsInstall = $true'
+            '        if ($existingDependency) {'
+            "            try { `$dependencyNeedsInstall = [version]`$existingDependency.Version -lt [version]'$dependencyVersionEscaped' } catch { `$dependencyNeedsInstall = `$true }"
+            '        }'
+            '        if ($dependencyNeedsInstall) {'
+            '            Add-AppxProvisionedPackage -Online -PackagePath $dependencyNestedPath -SkipLicense -ErrorAction Stop | Out-Null'
+            "            Write-ADTLogEntry -Message 'Provisioned bundled APPX dependency [$dependencyIdEscaped].' -Severity 'Success' -Source 'Install-ADTDeployment'"
+            '        }'
+            '        else {'
+            "            Write-ADTLogEntry -Message 'Bundled APPX dependency [$dependencyIdEscaped] is already satisfied.' -Severity 'Success' -Source 'Install-ADTDeployment'"
+            '        }'
+            '        $dependencyResult = [pscustomobject]@{ ExitCode = 0 }'
+            '    }'
+            '    finally {'
+            '        if (Test-Path -LiteralPath $dependencyExtractRoot) {'
+            '            Remove-Item -LiteralPath $dependencyExtractRoot -Recurse -Force -ErrorAction SilentlyContinue'
+            '        }'
+            '    }'
         )
     }
     else {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -250,6 +250,45 @@ describe('PSADT offline dependency contract', () => {
     },
     30_000
   );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'extracts and provisions the reviewed Microsoft VCLibs APPX dependency',
+    () => {
+      const dependencySha256 = createHash('sha256')
+        .update('dependency-fixture')
+        .digest('hex')
+        .toUpperCase();
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'VCLibs Dependency Contract App',
+        [],
+        {},
+        [{
+          packageIdentifier: 'Microsoft.VCLibs.Desktop.14',
+          version: '14.0.33728.0',
+          fileName: 'Microsoft.VCLibs.Desktop.14-DesktopAppInstaller_Dependencies.zip',
+          installerSha256: dependencySha256,
+          installerType: 'zip',
+          nestedInstallerType: 'appx',
+          nestedInstallerPath: 'x64/Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx',
+          packageFamilyName: 'Microsoft.VCLibs.140.00.UWPDesktop_8wekyb3d8bbwe',
+          silentArgs: '',
+          successCodes: [0],
+          rebootCodes: [1641, 3010],
+          order: 1,
+        }]
+      );
+
+      expect(generated).toContain('Expand-Archive -LiteralPath $dependencyPath');
+      expect(generated).toContain(
+        'Add-AppxProvisionedPackage -Online -PackagePath $dependencyNestedPath -SkipLicense'
+      );
+      expect(generated).toContain(
+        "Where-Object { $_.DisplayName -eq 'Microsoft.VCLibs.140.00.UWPDesktop' }"
+      );
+    },
+    30_000
+  );
 });
 
 describe.skipIf(!canRunWindowsPowerShellPackager)(

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -189,6 +189,42 @@ describe('resolveWingetPackageDependencies', () => {
     });
   });
 
+  it('bundles the reviewed Microsoft VCLibs APPX payload for MSIX packages', async () => {
+    const io = fixtureIo(
+      {
+        'Microsoft.WindowsApp@2.0.1314.0': [installer({
+          type: 'msix',
+          packageDependencies: [{ packageIdentifier: 'Microsoft.VCLibs.Desktop.14' }],
+        })],
+        'Microsoft.VCLibs.Desktop.14@14.0.33728.0': [installer({
+          type: 'zip',
+          nestedInstallerType: 'appx',
+          nestedInstallerPath: 'x64/Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx',
+          packageFamilyName: 'Microsoft.VCLibs.140.00.UWPDesktop_8wekyb3d8bbwe',
+          url: 'https://github.com/microsoft/winget-cli/releases/download/v1.9.25180/DesktopAppInstaller_Dependencies.zip',
+          sha256: VC_SHA,
+          silentArgs: '',
+        })],
+      },
+      { 'Microsoft.VCLibs.Desktop.14': ['14.0.33728.0'] }
+    );
+
+    const [dependency] = await resolveWingetPackageDependencies({
+      wingetId: 'Microsoft.WindowsApp',
+      version: '2.0.1314.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+
+    expect(dependency).toMatchObject({
+      packageIdentifier: 'Microsoft.VCLibs.Desktop.14',
+      installerType: 'zip',
+      nestedInstallerType: 'appx',
+      nestedInstallerPath: 'x64/Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx',
+      packageFamilyName: 'Microsoft.VCLibs.140.00.UWPDesktop_8wekyb3d8bbwe',
+    });
+  });
+
   it('fails closed for dependency families that have not been reviewed', async () => {
     const io = fixtureIo(
       { 'Example.App@1.0.0': [installer({

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -1,6 +1,6 @@
 import { resolveInstallerFileName } from '@/lib/installer-filename';
 import {
-  fetchAvailableVersionsLive,
+  fetchAvailableVersions,
   getLiveInstallers,
 } from '@/lib/manifest-api';
 import { assertPackagingContract } from '@/lib/packaging-contract';
@@ -22,6 +22,7 @@ const VC_REDISTRIBUTABLE_PACKAGE_PATTERN =
   /^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(?:x86|x64|arm64)$/i;
 const DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN =
   /^Microsoft\.DotNet\.DesktopRuntime\.\d+$/i;
+const VCLIBS_DESKTOP_PACKAGE_PATTERN = /^Microsoft\.VCLibs\.Desktop\.14$/i;
 
 interface ReviewedDependencyPolicy {
   packagePattern: RegExp;
@@ -40,6 +41,10 @@ const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
   {
     packagePattern: /^Microsoft\.PowerShell$/i,
     installerTypes: new Set<WingetInstallerType>(['msi', 'wix']),
+  },
+  {
+    packagePattern: VCLIBS_DESKTOP_PACKAGE_PATTERN,
+    installerTypes: new Set<WingetInstallerType>(['zip']),
   },
 ];
 
@@ -80,6 +85,7 @@ export interface PackagedWingetDependency {
   installerType: WingetInstallerType;
   nestedInstallerType?: WingetInstallerType;
   nestedInstallerPath?: string;
+  packageFamilyName?: string;
   silentArgs: string;
   successCodes: number[];
   rebootCodes: number[];
@@ -95,7 +101,10 @@ export interface WingetDependencyResolverIo {
 
 const defaultIo: WingetDependencyResolverIo = {
   getInstallers: getLiveInstallers,
-  getVersions: fetchAvailableVersionsLive,
+  // Version history is already synchronized into the catalog. Using it first
+  // avoids spending GitHub API quota on one directory listing per dependency;
+  // exact installer metadata still comes from the raw signed manifest below.
+  getVersions: fetchAvailableVersions,
 };
 
 function normalizeSha256(value: string): string {
@@ -331,6 +340,9 @@ export async function resolveWingetPackageDependencies(
           : {}),
         ...(selectedInstaller.nestedInstallerPath
           ? { nestedInstallerPath: selectedInstaller.nestedInstallerPath }
+          : {}),
+        ...(selectedInstaller.packageFamilyName
+          ? { packageFamilyName: selectedInstaller.packageFamilyName }
           : {}),
         silentArgs: selectedInstaller.silentArgs || '',
         successCodes: dependencySuccessCodes(packageIdentifier, selectedInstaller),


### PR DESCRIPTION
## Summary
- resolve dependency version lists from the synchronized catalog before GitHub fallback
- preserve raw manifest verification for exact dependency installers
- support the exact Microsoft.VCLibs.Desktop.14 ZIP/APPX prerequisite shape
- provision the hash-pinned APPX before machine-scoped MSIX apps in both customer and QA PSADT packages

## Validation
- 52 focused resolver and generated-PSADT tests
- generated PowerShell syntax validation
- ESLint
- production build
- git diff --check