### PR TITLE
fix(qa): hide operator maintenance details and pin packager

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -44,7 +44,9 @@ function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): strin
   if (issue === 'partial_failure') return 'Some package checks failed';
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
-  if (issue === 'maintenance') return 'Testing is temporarily paused for maintenance';
+  // Maintenance is an operator concern. Do not expose internal coordination
+  // details or implementation terminology on the public QA page.
+  if (issue === 'maintenance') return null;
   return null;
 }
 
@@ -96,7 +98,8 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
   const runnerAge = formatRelativeTime(data.runner.heartbeatAt, data.serverTime);
   const pollAge = formatRelativeTime(data.scheduler.lastPollAt, data.serverTime);
   const schedulerIssue = schedulerIssueLabel(data.scheduler.issue);
-  const hasIncident = data.runner.state === 'stalled' || data.scheduler.state === 'degraded' || data.scheduler.state === 'paused';
+  const publicSchedulerState = data.scheduler.state === 'paused' ? 'healthy' : data.scheduler.state;
+  const hasIncident = data.runner.state === 'stalled' || publicSchedulerState === 'degraded';
   const passCount = data.recent.filter((item) => item.outcome === 'Passed').length;
 
   return (
@@ -106,7 +109,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
         'overflow-hidden rounded-2xl border bg-bg-elevated',
         data.runner.state === 'stalled'
           ? 'border-status-error/30 bg-status-error/[0.04]'
-          : data.scheduler.state === 'degraded' || data.scheduler.state === 'paused'
+          : publicSchedulerState === 'degraded'
             ? 'border-status-warning/30 bg-status-warning/[0.04]'
             : 'border-overlay/10'
       )}
@@ -132,8 +135,8 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
           <div className="min-w-0">
             <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>WinGet polling</T></p>
             <div className="mt-1 flex flex-wrap items-center gap-2">
-              <StatusBadge tone={healthTone(data.scheduler.state)}>
-                <T>{data.scheduler.state === 'healthy' ? 'Healthy' : data.scheduler.state === 'paused' ? 'Paused' : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
+              <StatusBadge tone={healthTone(publicSchedulerState)}>
+                <T>{publicSchedulerState === 'healthy' ? 'Healthy' : publicSchedulerState === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
               </StatusBadge>
               <span className="text-xs text-text-muted">
                 {pollAge ? <T>Last scan <Var>{pollAge}</Var></T> : <T>No scan recorded yet</T>}
@@ -169,9 +172,6 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
         <div className="border-t border-status-warning/20 px-4 py-2 text-xs text-status-warning" role="status">
           <AlertTriangle className="mr-1.5 inline h-3.5 w-3.5" aria-hidden="true" />
           <T>{schedulerIssue}</T>
-          {data.scheduler.issue === 'maintenance' && data.scheduler.maintenanceReason
-            ? <> · <T>{data.scheduler.maintenanceReason}</T></>
-            : null}
           {data.scheduler.consecutiveFailures > 1
             ? data.scheduler.issue === 'github_rate_limit'
               ? <> · <T><Var>{data.scheduler.consecutiveFailures}</Var> affected scans</T></>

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -8,7 +8,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '354756f01cb572cfd410f95dd6af5ab3a9cb8efb',
+  packagerCommit: '1b130924ecc68909d6bb15f8cdf295944255a2f9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -37,6 +37,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'ef75edee9fcabaf904bcf80e02ead9aa58490dc9',
   'fc18fffd40f6d362be251e05e2bc784373dfc735',
   'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
+  '354756f01cb572cfd410f95dd6af5ab3a9cb8efb',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -4,9 +4,11 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
   it.each([
+    'HandBrake.HandBrake',
     'Microsoft.VisualStudio.2019.Enterprise',
     'Microsoft.VisualStudio.Enterprise',
     'Microsoft.VisualStudio.Professional',
+    'Microsoft.WindowsApp',
     'PostgreSQL.PostgreSQL.18',
     'RARLab.WinRAR',
     'SoftwareOK.Q-Dir',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,16 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '1b130924ecc68909d6bb15f8cdf295944255a2f9': [
+    'HandBrake.HandBrake',
+    'Microsoft.VisualStudio.2019.Enterprise',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.WindowsApp',
+    'PostgreSQL.PostgreSQL.18',
+    'RARLab.WinRAR',
+    'SoftwareOK.Q-Dir',
+  ],
   '354756f01cb572cfd410f95dd6af5ab3a9cb8efb': [
     'Microsoft.VisualStudio.2019.Enterprise',
     'Microsoft.VisualStudio.Enterprise',


### PR DESCRIPTION
## Summary
- keep operator-only maintenance details off the public QA page
- advance the canonical QA/customer PSADT packager pin to `1b130924`
- retry only the application paths fixed by this release, while carrying forward unresolved targeted retries

## Verification
- 86 focused Vitest tests passed
- ESLint passed for all touched files
- `git diff --check` passed