### PR TITLE
fix(qa): redact operator maintenance state

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -33,7 +33,6 @@ import type { QaLivePhase, QaLiveResponse } from '@/types/qa';
 
 function healthTone(state: string): StatusTone {
   if (state === 'healthy' || state === 'testing') return 'success';
-  if (state === 'paused') return 'warning';
   if (state === 'degraded') return 'warning';
   if (state === 'stalled') return 'error';
   return 'neutral';
@@ -44,9 +43,6 @@ function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): strin
   if (issue === 'partial_failure') return 'Some package checks failed';
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
-  // Maintenance is an operator concern. Do not expose internal coordination
-  // details or implementation terminology on the public QA page.
-  if (issue === 'maintenance') return null;
   return null;
 }
 
@@ -98,8 +94,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
   const runnerAge = formatRelativeTime(data.runner.heartbeatAt, data.serverTime);
   const pollAge = formatRelativeTime(data.scheduler.lastPollAt, data.serverTime);
   const schedulerIssue = schedulerIssueLabel(data.scheduler.issue);
-  const publicSchedulerState = data.scheduler.state === 'paused' ? 'healthy' : data.scheduler.state;
-  const hasIncident = data.runner.state === 'stalled' || publicSchedulerState === 'degraded';
+  const hasIncident = data.runner.state === 'stalled' || data.scheduler.state === 'degraded';
   const passCount = data.recent.filter((item) => item.outcome === 'Passed').length;
 
   return (
@@ -109,7 +104,7 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
         'overflow-hidden rounded-2xl border bg-bg-elevated',
         data.runner.state === 'stalled'
           ? 'border-status-error/30 bg-status-error/[0.04]'
-          : publicSchedulerState === 'degraded'
+          : data.scheduler.state === 'degraded'
             ? 'border-status-warning/30 bg-status-warning/[0.04]'
             : 'border-overlay/10'
       )}
@@ -135,8 +130,8 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
           <div className="min-w-0">
             <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>WinGet polling</T></p>
             <div className="mt-1 flex flex-wrap items-center gap-2">
-              <StatusBadge tone={healthTone(publicSchedulerState)}>
-                <T>{publicSchedulerState === 'healthy' ? 'Healthy' : publicSchedulerState === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
+              <StatusBadge tone={healthTone(data.scheduler.state)}>
+                <T>{data.scheduler.state === 'healthy' ? 'Healthy' : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
               </StatusBadge>
               <span className="text-xs text-text-muted">
                 {pollAge ? <T>Last scan <Var>{pollAge}</Var></T> : <T>No scan recorded yet</T>}

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -276,7 +276,7 @@ describe('buildQaLiveResponse', () => {
     });
   });
 
-  it('shows deliberate maintenance instead of reporting the scheduler as degraded', () => {
+  it('keeps operator maintenance details out of the public response', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-11T12:05:00.000Z'),
       current: null,
@@ -299,11 +299,13 @@ describe('buildQaLiveResponse', () => {
       },
     });
 
-    expect(response.scheduler).toMatchObject({
-      state: 'paused',
-      issue: 'maintenance',
-      maintenanceReason: 'Golden VM wallpaper maintenance',
-      pausedAt: '2026-08-11T12:04:00.000Z',
+    expect(response.scheduler).toEqual({
+      state: 'healthy',
+      lastPollAt: '2026-08-11T12:00:01.000Z',
+      lastOutcome: 'failed',
+      issue: null,
+      consecutiveFailures: 0,
     });
+    expect(JSON.stringify(response)).not.toContain('Golden VM wallpaper maintenance');
   });
 });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -271,7 +271,9 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
           ? 'healthy'
           : 'degraded';
   }
-  if (input.control?.paused) schedulerState = 'paused';
+  // Pipeline maintenance is private operator state. Keep the public projection
+  // neutral and never expose maintenance notes, commit hashes, or timestamps.
+  if (input.control?.paused) schedulerState = 'healthy';
 
   const currentApp = input.current ? appById.get(input.current.winget_id) : null;
   const frameIsCurrent = Boolean(
@@ -298,10 +300,8 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       state: schedulerState,
       lastPollAt: input.poll?.finished_at || input.poll?.started_at || null,
       lastOutcome: input.poll?.status || null,
-      issue: input.control?.paused ? 'maintenance' : schedulerIssue(input.poll, stalePoll),
-      consecutiveFailures: input.consecutivePollFailures,
-      maintenanceReason: input.control?.paused ? input.control.reason : null,
-      pausedAt: input.control?.paused ? input.control.updatedAt : null,
+      issue: input.control?.paused ? null : schedulerIssue(input.poll, stalePoll),
+      consecutiveFailures: input.control?.paused ? 0 : input.consecutivePollFailures,
     },
     current: input.current && currentStartedAt
       ? {

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -124,13 +124,11 @@ export interface QaLiveResponse {
     heartbeatAt: string | null;
   };
   scheduler: {
-    state: 'healthy' | 'degraded' | 'paused' | 'unknown';
+    state: 'healthy' | 'degraded' | 'unknown';
     lastPollAt: string | null;
     lastOutcome: 'running' | 'succeeded' | 'partial' | 'failed' | null;
-    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | 'maintenance' | null;
+    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | null;
     consecutiveFailures: number;
-    maintenanceReason: string | null;
-    pausedAt: string | null;
   };
   current: {
     wingetId: string;


### PR DESCRIPTION
## What changed
- remove operator maintenance reasons, commit hashes, and pause timestamps from the public QA response
- present deliberate maintenance as a neutral healthy scheduler state
- keep internal maintenance control available only to server-side operator workflows

## Why
Internal coordination details are confusing for customers and should not be part of the public QA page or its API payload.

## Validation
- `npx vitest run lib/qa/live.test.ts`
- focused ESLint on changed files
- `npm run build:ci`
- `git diff --check`