### PR TITLE
Fix app scope overrides and public QA health

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -40,7 +40,6 @@ function healthTone(state: string): StatusTone {
 
 function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): string | null {
   if (issue === 'github_rate_limit') return 'GitHub temporarily limited WinGet checks; scanning will retry automatically';
-  if (issue === 'partial_failure') return 'Some package checks failed';
   if (issue === 'stalled') return 'Poll did not finish';
   if (issue === 'upstream_error') return 'Upstream polling error';
   return null;

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -345,6 +345,44 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock.mock.calls[0][0].relationships).toBeUndefined();
   });
 
+  it('uses a reviewed user scope consistently for QA, packaging, and Intune', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'VNGCorp.Zalo',
+          displayName: 'Zalo',
+          architecture: 'x86',
+          installerType: 'exe',
+          installScope: 'machine',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ install_scope: 'user' })
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ installScope: 'user' }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('uses the reviewed app adapter for both QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -37,7 +37,10 @@ import {
   InstallerPreflightError,
 } from '@/lib/installer-preflight';
 import { ensureQaDemand } from '@/lib/qa/demand';
-import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import {
+  applyApplicationPackagingAdapter,
+  resolveApplicationInstallScope,
+} from '@/lib/packaging-adapters';
 import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
@@ -172,6 +175,22 @@ export async function POST(request: NextRequest) {
       } else {
         // Treat missing appSource as win32 for backward compatibility
         win32Items.push(item as Win32CartItem);
+      }
+    }
+
+    // Apply reviewed behavior constraints before preflight, QA identity, job
+    // persistence, and Intune run-as selection so every packaging route uses
+    // the same effective scope. Custom packages remain fully user-controlled.
+    for (const item of win32Items) {
+      if (
+        item.sourceType !== 'custom' &&
+        typeof item.wingetId === 'string' &&
+        item.wingetId.trim()
+      ) {
+        item.installScope = resolveApplicationInstallScope(
+          item.wingetId,
+          item.installScope
+        );
       }
     }
 

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -307,6 +307,54 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     expect(storedConfig.psadtConfig?.processesToClose).toEqual([]);
   });
 
+  it('uses a reviewed user scope for both auto-update QA and the packaging job', async () => {
+    const supabase = createSupabaseMock({});
+    const trigger = makeTrigger(supabase);
+    const storedConfig: DeploymentConfig = {
+      displayName: 'Zalo',
+      publisher: 'VNGCorp',
+      architecture: 'x86',
+      installerType: 'exe',
+      installCommand: 'ZaloSetup.exe /S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Zalo',
+      installScope: 'machine',
+      detectionRules: [],
+      psadtConfig: DEFAULT_PSADT_CONFIG,
+    };
+    const policy = makePolicy(storedConfig);
+    policy.original_upload_history_id = 'prior-upload';
+    policy.consecutive_failures = 0;
+
+    vi.spyOn(trigger as never, 'verifyTenantConsent' as never).mockResolvedValue(true as never);
+    vi.spyOn(trigger as never, 'ensurePsadtConfig' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'ensureCurrentPackageDefaults' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'createHistoryRecord' as never)
+      .mockResolvedValue({ id: 'history-zalo' } as never);
+    const createPackagingJobSpy = vi.spyOn(trigger as never, 'createPackagingJob' as never)
+      .mockResolvedValue({ id: 'job-zalo' } as never);
+    vi.spyOn(trigger as never, 'updateHistoryRecord' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'updatePolicyTracking' as never).mockResolvedValue(undefined as never);
+
+    const result = await trigger.triggerAutoUpdate(policy, {
+      ...UPDATE_INFO,
+      wingetId: 'VNGCorp.Zalo',
+      displayName: 'Zalo',
+      installerType: 'exe',
+      installScope: 'machine',
+    }, { skipRateLimits: true });
+
+    expect(result).toMatchObject({ success: true, packagingJobId: 'job-zalo' });
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ installScope: 'user' })
+    );
+    const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
+    expect((effectivePolicy.deployment_config as DeploymentConfig).installScope).toBe('user');
+    const effectiveUpdate = createPackagingJobSpy.mock.calls[0][1] as { installScope?: string };
+    expect(effectiveUpdate.installScope).toBe('user');
+    expect(storedConfig.installScope).toBe('machine');
+  });
+
   describe('ensurePsadtConfig', () => {
     it('backfills psadtConfig from the most recent packaging job and persists it', async () => {
       const updateSpy = vi.fn();

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -24,7 +24,10 @@ import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { generateInstallCommand } from '@/lib/detection-rules';
 import { normalizeInstaller } from '@/lib/manifest-api';
 import { upgradeLegacyPackageDefaults } from '@/lib/update-policies/upgrade-legacy-package-defaults';
-import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import {
+  applyApplicationPackagingAdapter,
+  resolveApplicationInstallScope,
+} from '@/lib/packaging-adapters';
 import type { NormalizedInstaller, WingetInstaller, WingetScope } from '@/types/winget';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
@@ -207,10 +210,16 @@ export class AutoUpdateTrigger {
       await this.ensureCurrentPackageDefaults(policy, updateInfo);
 
       const storedDeploymentConfig = policy.deployment_config as DeploymentConfig;
+      const effectiveInstallScope = resolveApplicationInstallScope(
+        updateInfo.wingetId,
+        updateInfo.installScope || storedDeploymentConfig.installScope
+      );
+      updateInfo = { ...updateInfo, installScope: effectiveInstallScope };
       const deploymentConfig: DeploymentConfig = {
         ...storedDeploymentConfig,
+        installScope: effectiveInstallScope,
         psadtConfig: applyApplicationPackagingAdapter(
-        updateInfo.wingetId,
+          updateInfo.wingetId,
           storedDeploymentConfig.psadtConfig || DEFAULT_PSADT_CONFIG
         ),
       };

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
-import { applyApplicationPackagingAdapter } from './packaging-adapters';
+import {
+  applyApplicationPackagingAdapter,
+  resolveApplicationInstallScope,
+} from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('forces reviewed per-user installers out of the LocalSystem profile', () => {
+    expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
+    expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
+  });
+
   it('adds reviewed silent removal arguments for failing vendor lifecycles', () => {
     expect(
       applyApplicationPackagingAdapter('RARLab.WinRAR', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1,7 +1,9 @@
 import type { ProcessToClose, PSADTConfig } from '@/types/psadt';
+import type { WingetScope } from '@/types/winget';
 
 interface ApplicationPackagingAdapter {
   wingetId: string;
+  requiredInstallScope?: WingetScope;
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedUninstallArguments?: readonly string[];
 }
@@ -24,6 +26,13 @@ const VISUAL_STUDIO_WINGET_IDS = [
  * in the QA execution-profile hash.
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
+  {
+    // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
+    // currently omits Scope. Under LocalSystem it registers a disposable
+    // systemprofile path and leaves no usable vendor uninstaller.
+    wingetId: 'VNGCorp.Zalo',
+    requiredInstallScope: 'user',
+  },
   {
     wingetId: 'RARLab.WinRAR',
     reviewedUninstallArguments: ['/S'],
@@ -79,6 +88,23 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
 ];
 
+function applicationPackagingAdapter(
+  wingetId: string
+): ApplicationPackagingAdapter | undefined {
+  const normalizedWingetId = wingetId.trim().toLowerCase();
+  return APPLICATION_PACKAGING_ADAPTERS.find(
+    ({ wingetId: adapterWingetId }) => adapterWingetId.toLowerCase() === normalizedWingetId
+  );
+}
+
+export function resolveApplicationInstallScope(
+  wingetId: string,
+  requestedScope?: string | null
+): WingetScope {
+  const requested = requestedScope?.trim().toLowerCase() === 'user' ? 'user' : 'machine';
+  return applicationPackagingAdapter(wingetId)?.requiredInstallScope || requested;
+}
+
 function normalizeProcessName(name: string): string {
   return name.trim().replace(/\.exe$/i, '');
 }
@@ -95,10 +121,7 @@ export function applyApplicationPackagingAdapter(
   wingetId: string,
   config: PSADTConfig
 ): PSADTConfig {
-  const normalizedWingetId = wingetId.trim().toLowerCase();
-  const adapter = APPLICATION_PACKAGING_ADAPTERS.find(
-    ({ wingetId: adapterWingetId }) => adapterWingetId.toLowerCase() === normalizedWingetId
-  );
+  const adapter = applicationPackagingAdapter(wingetId);
   if (!adapter) return config;
 
   const processesToClose = (config.processesToClose || []).map((process) => {

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -270,6 +270,67 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     }));
   });
 
+  it('applies a required user scope before dependency resolution and QA identity', async () => {
+    const input = { ...demandInput(), wingetId: 'VNGCorp.Zalo' };
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
+        }
+        if (table === 'qa_candidates') {
+          return query({
+            data: { id: 'candidate-active', status: 'running', priority: 2_000 },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+    const profile = JSON.parse(result.identity.canonicalJson) as {
+      installer: { installScope: string };
+    };
+
+    expect(resolveWingetPackageDependenciesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(profile.installer.installScope).toBe('user');
+  });
+
+  it('only reuses a failed result for the current execution profile', async () => {
+    const input = demandInput();
+    let resultCall = 0;
+    const failedResultQuery = query({
+      data: { package_profile_sha256: 'A'.repeat(64) },
+      error: null,
+    });
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_results') {
+          return {
+            select: vi.fn(() => {
+              resultCall++;
+              return resultCall === 1
+                ? query({ data: null, error: null })
+                : failedResultQuery;
+            }),
+          };
+        }
+        if (table === 'qa_candidates') return query({ data: null, error: null });
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result.state).toBe('failed');
+    expect(failedResultQuery.eq).toHaveBeenCalledWith(
+      'package_profile_sha256',
+      result.identity.executionProfileSha256
+    );
+  });
+
   it('fails closed before creating QA state when dependency resolution fails', async () => {
     const client = { from: vi.fn() };
     resolveWingetPackageDependenciesMock.mockRejectedValue(

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -8,6 +8,7 @@ import {
 import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
 import type { Json } from '@/types/database';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
 export type QaDemandState = 'passed' | 'failed' | 'waiting';
@@ -29,6 +30,7 @@ export async function ensureQaDemand(
   supabase: SupabaseClient,
   input: QaDemandInput
 ): Promise<QaDemandResult> {
+  const installScope = resolveApplicationInstallScope(input.wingetId, input.installScope);
   // Resolve at the QA-demand boundary as well as at final packaging dispatch.
   // This keeps both gates bound to the same server-trusted dependency graph;
   // caller-supplied dependency metadata is never authoritative.
@@ -37,7 +39,7 @@ export async function ensureQaDemand(
     version: input.version,
     architecture: input.architecture,
     installerSha256: input.installerSha256,
-    installScope: input.installScope,
+    installScope,
   });
   // The VM validates the same PSADT packaging route used for customer uploads,
   // with one deterministic, non-blocking visual profile per immutable payload.
@@ -45,6 +47,7 @@ export async function ensureQaDemand(
   // must neither suppress QA evidence nor multiply app-version tests.
   const resolvedInput: QaDemandInput = {
     ...input,
+    installScope,
     psadtConfig: JSON.stringify({
       ...DEFAULT_PSADT_CONFIG,
       deployMode: 'Auto',
@@ -120,6 +123,7 @@ export async function ensureQaDemand(
     .eq('tested_version', input.version)
     .eq('architecture', architecture)
     .eq('installer_sha256', installerSha256)
+    .eq('package_profile_sha256', profileSha256)
     .eq('outcome', 'Failed')
     .order('tested_at_utc', { ascending: false })
     .limit(1)

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -276,6 +276,32 @@ describe('buildQaLiveResponse', () => {
     });
   });
 
+  it('keeps individual package-check failures out of public service health', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-10T07:11:00.000Z'),
+      current: null,
+      queuedCount: 3,
+      queued: [],
+      poll: {
+        status: 'partial',
+        started_at: '2026-08-10T07:10:47.000Z',
+        finished_at: '2026-08-10T07:10:49.000Z',
+        errors: ['Example.App: No compatible installer was found.'],
+      },
+      consecutivePollFailures: 0,
+      recent: [],
+      apps: [],
+      frame: null,
+    });
+
+    expect(response.scheduler).toMatchObject({
+      state: 'healthy',
+      lastOutcome: 'partial',
+      issue: null,
+      consecutiveFailures: 0,
+    });
+  });
+
   it('keeps operator maintenance details out of the public response', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-11T12:05:00.000Z'),

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -237,7 +237,16 @@ function schedulerIssue(
   ) {
     return 'github_rate_limit';
   }
-  if (poll.status === 'partial') return 'partial_failure';
+  // A partial scan means one or more individual packages could not be
+  // evaluated. The scheduler itself still completed and can keep processing
+  // the rest of the catalog, so this is operator diagnostic data rather than
+  // a customer-facing service incident. Only system-level partial failures
+  // degrade the public health projection.
+  if (poll.status === 'partial') {
+    return errors.some((error) => typeof error === 'string' && /^system:/i.test(error))
+      ? 'upstream_error'
+      : null;
+  }
   return 'upstream_error';
 }
 
@@ -260,16 +269,13 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
 
   let schedulerState: QaLiveResponse['scheduler']['state'] = 'unknown';
   let stalePoll = false;
+  let pollIssue: QaLiveResponse['scheduler']['issue'] = null;
   if (input.poll) {
     stalePoll =
       input.poll.status === 'running' &&
       input.now.getTime() - new Date(input.poll.started_at).getTime() > POLL_STALE_MS;
-    schedulerState =
-      input.poll.status === 'succeeded'
-        ? 'healthy'
-        : input.poll.status === 'running' && !stalePoll
-          ? 'healthy'
-          : 'degraded';
+    pollIssue = schedulerIssue(input.poll, stalePoll);
+    schedulerState = pollIssue ? 'degraded' : 'healthy';
   }
   // Pipeline maintenance is private operator state. Keep the public projection
   // neutral and never expose maintenance notes, commit hashes, or timestamps.
@@ -300,7 +306,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       state: schedulerState,
       lastPollAt: input.poll?.finished_at || input.poll?.started_at || null,
       lastOutcome: input.poll?.status || null,
-      issue: input.control?.paused ? null : schedulerIssue(input.poll, stalePoll),
+      issue: input.control?.paused ? null : pollIssue,
       consecutiveFailures: input.control?.paused ? 0 : input.consecutivePollFailures,
     },
     current: input.current && currentStartedAt

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -250,6 +250,33 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('normalizes reviewed per-user apps before hashing deployment QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'VNGCorp.Zalo',
+      displayName: 'Zalo',
+      publisher: 'VNGCorp',
+      version: '26.8.10',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{F0C47DE4-C117-54E4-97D9-EB3FD2985E6C}:Zalo',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\VNGCorp_Zalo',
+      }),
+    ]);
+  });
+
   it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -3,7 +3,10 @@ import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { assertPackagingContract } from '@/lib/packaging-contract';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
-import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import {
+  applyApplicationPackagingAdapter,
+  resolveApplicationInstallScope,
+} from '@/lib/packaging-adapters';
 import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
@@ -690,12 +693,16 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
   const parsedConfig = parseJsonObject<unknown>(input.psadtConfig, {});
   const rawConfig = (record(parsedConfig) || {}) as Partial<PSADTConfig>;
   const preliminaryConfig = normalizeQaPsadtConfig(rawConfig, parsedDetectionRules);
+  const installScope = resolveApplicationInstallScope(
+    input.wingetId,
+    input.installScope || 'machine'
+  );
   const detectionRules = normalizeCatalogDetectionRules({
     detectionRules: parsedDetectionRules,
     fallbackDetectionRules: rawConfig.detectionRules,
     wingetId: input.wingetId,
     version: input.version,
-    installScope: input.installScope || 'machine',
+    installScope,
     markerPath: preliminaryConfig.registryMarkerPath,
   });
   const psadtConfig = applyApplicationPackagingAdapter(
@@ -714,7 +721,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     silentArgs: input.silentSwitches,
     successCodes: input.installerSuccessCodes,
     uninstallCommand: input.uninstallCommand,
-    installScope: input.installScope || 'machine',
+    installScope,
     nestedInstallerType: input.nestedInstallerType || '',
     nestedInstallerFiles: input.nestedInstallerPath ? [input.nestedInstallerPath] : [],
     psadtConfig,

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -386,4 +386,31 @@ describe('buildQaCatalogTestConfig', () => {
       'CreativeCloudHelper',
     ]);
   });
+
+  it('tests a reviewed per-user bootstrapper in user context when WinGet omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'VNGCorp.Zalo',
+        name: 'Zalo',
+        publisher: 'VNGCorp',
+        version: '26.8.10',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        ProductCode: 'f0c47de4-c117-54e4-97d9-eb3fd2985e6c',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\VNGCorp_Zalo',
+      }),
+    ]);
+  });
 });

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -2,7 +2,10 @@ import { generateDetectionRules, generateUninstallCommand } from '@/lib/detectio
 import { normalizeInstaller } from '@/lib/manifest-api';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
-import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import {
+  applyApplicationPackagingAdapter,
+  resolveApplicationInstallScope,
+} from '@/lib/packaging-adapters';
 import { normalizeQaPsadtConfig } from './package-profile';
 import type {
   WingetInstaller,
@@ -119,7 +122,7 @@ export function buildQaCatalogTestConfig({
     ? (rawNestedInstallerType.toLowerCase() as WingetInstallerType)
     : undefined;
   const rawScope = text(installer.Scope) || text(manifest.Scope);
-  const scope: WingetScope = rawScope.toLowerCase() === 'user' ? 'user' : 'machine';
+  const scope: WingetScope = resolveApplicationInstallScope(app.wingetId, rawScope);
   const explicitInstallerProductCode = text(installer.ProductCode);
   const productCode = explicitInstallerProductCode
     ? msiProductCode(explicitInstallerProductCode)

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -127,7 +127,7 @@ export interface QaLiveResponse {
     state: 'healthy' | 'degraded' | 'unknown';
     lastPollAt: string | null;
     lastOutcome: 'running' | 'succeeded' | 'partial' | 'failed' | null;
-    issue: 'github_rate_limit' | 'upstream_error' | 'partial_failure' | 'stalled' | null;
+    issue: 'github_rate_limit' | 'upstream_error' | 'stalled' | null;
     consecutiveFailures: number;
   };
   current: {


### PR DESCRIPTION
## Summary
- enforce reviewed per-user scope for Zalo across QA, customer uploads, and auto-updates
- bind failed QA evidence to the exact corrected package profile so fixed profiles can retry
- keep individual package-check diagnostics from appearing as a public scheduler incident

## Verification
- 127 targeted tests passed
- focused ESLint passed
- production Next.js build passed