### PR TITLE
Fix Visual Studio uninstall completion handling

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -196,6 +196,59 @@ if ($env:PSADT_CONFIG -and $env:PSADT_CONFIG -ne '{}') {
     }
 }
 
+# Parse the bounded values supplied only by reviewed application adapters.
+# These are not a customer-facing free-form command surface.
+$reviewedUninstallArguments = @()
+if ($psadtConfig.Contains('reviewedUninstallArguments') -and
+    $null -ne $psadtConfig['reviewedUninstallArguments']) {
+    $rawReviewedArguments = $psadtConfig['reviewedUninstallArguments']
+    if ($rawReviewedArguments -is [string] -or
+        $rawReviewedArguments -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedUninstallArguments must be an array.'
+    }
+
+    $seenReviewedArguments = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($rawReviewedArgument in @($rawReviewedArguments)) {
+        if ($rawReviewedArgument -isnot [string]) {
+            throw 'Every PSADT reviewed uninstall argument must be a string.'
+        }
+        $reviewedArgument = $rawReviewedArgument.Trim()
+        if ([string]::IsNullOrWhiteSpace($reviewedArgument) -or
+            $reviewedArgument.Length -gt 256 -or
+            [regex]::IsMatch($reviewedArgument, '[\x00-\x1F\x7F]')) {
+            throw 'Every PSADT reviewed uninstall argument must be a non-empty, bounded, single-line string.'
+        }
+        if ($seenReviewedArguments.Add($reviewedArgument)) {
+            $reviewedUninstallArguments += $reviewedArgument
+        }
+    }
+    if ($reviewedUninstallArguments.Count -gt 20) {
+        throw 'PSADT reviewedUninstallArguments must contain at most 20 entries.'
+    }
+}
+$reviewedUninstallArgumentsLiteral = @(
+    $reviewedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
+) -join ', '
+
+$uninstallCompletionTimeoutMinutes = 5
+if ($psadtConfig.Contains('uninstallCompletionTimeoutMinutes') -and
+    $null -ne $psadtConfig['uninstallCompletionTimeoutMinutes']) {
+    $rawUninstallTimeout = $psadtConfig['uninstallCompletionTimeoutMinutes']
+    if ($rawUninstallTimeout -isnot [byte] -and
+        $rawUninstallTimeout -isnot [int16] -and
+        $rawUninstallTimeout -isnot [int32] -and
+        $rawUninstallTimeout -isnot [int64]) {
+        throw 'PSADT uninstallCompletionTimeoutMinutes must be an integer from 1 to 30.'
+    }
+    $uninstallCompletionTimeoutMinutes = [int]$rawUninstallTimeout
+    if ($uninstallCompletionTimeoutMinutes -lt 1 -or
+        $uninstallCompletionTimeoutMinutes -gt 30) {
+        throw 'PSADT uninstallCompletionTimeoutMinutes must be an integer from 1 to 30.'
+    }
+}
+
 function Get-StrictPSADTBoolean {
     param(
         [Parameter(Mandatory = $true)]
@@ -1981,13 +2034,19 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '    if ($registeredUninstallArguments.Count -eq 0) {'
             '        $registeredUninstallArguments = @(''/uninstall'', ''/quiet'', ''/norestart'')'
             '    }'
+            "    `$reviewedUninstallArguments = @($reviewedUninstallArgumentsLiteral)"
+            '    foreach ($reviewedArgument in $reviewedUninstallArguments) {'
+            '        if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {'
+            '            $registeredUninstallArguments += $reviewedArgument'
+            '        }'
+            '    }'
             "    `$bundledUninstaller = Join-Path `$adtSession.DirFiles '$installerFileNameSingleQuoteEscaped'"
             '    if (-not (Test-Path -LiteralPath $bundledUninstaller -PathType Leaf)) {'
             '        throw "The packaged Burn uninstaller was not found: $bundledUninstaller"'
             '    }'
             '    Write-ADTLogEntry -Message "Using packaged Burn bundle because the registered vendor cache may be disposable." -Source ''Uninstall-ADTDeployment'''
             '    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName'
-            '    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)'
+            "    `$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($uninstallCompletionTimeoutMinutes)"
             '    $uninstallHandle = Start-ADTProcess -FilePath $bundledUninstaller -ArgumentList $registeredUninstallArguments -WorkingDirectory $adtSession.DirFiles -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
             '    $uninstallProcessExitLogged = $false'
             '    $nextUninstallProgressLog = [DateTime]::UtcNow'
@@ -2104,6 +2163,12 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '            $registeredUninstallArguments = @(''-u'', ''--silent'')'
             '            Write-ADTLogEntry -Message "Executing the Adobe Creative Cloud desktop client silent uninstall command." -Source ''Uninstall-ADTDeployment'''
             '        }'
+            "        `$reviewedUninstallArguments = @($reviewedUninstallArgumentsLiteral)"
+            '        foreach ($reviewedArgument in $reviewedUninstallArguments) {'
+            '            if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {'
+            '                $registeredUninstallArguments += $reviewedArgument'
+            '            }'
+            '        }'
             '        $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile'
             '        $isRegisteredMsiExec = $registeredUninstallLeaf -in @(''msiexec'', ''msiexec.exe'')'
             '        if ($isRegisteredMsiExec) {'
@@ -2138,7 +2203,7 @@ if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
             '        if ($registeredUninstallArguments.Count -gt 0) {'
             '            $uninstallProcessParameters.ArgumentList = $registeredUninstallArguments'
             '        }'
-            '        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)'
+            "        `$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($uninstallCompletionTimeoutMinutes)"
             '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
             '        $uninstallProcessExitLogged = $false'
             '        $nextUninstallProgressLog = [DateTime]::UtcNow'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -30,8 +30,11 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.Professional',
         DEFAULT_PSADT_CONFIG
-      ).reviewedUninstallArguments
-    ).toEqual(['--quiet', '--norestart']);
+      )
+    ).toMatchObject({
+      reviewedUninstallArguments: ['--quiet', '--norestart'],
+      uninstallCompletionTimeoutMinutes: 15,
+    });
   });
 
   it('preserves and deduplicates reviewed uninstall arguments case-insensitively', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -6,6 +6,7 @@ interface ApplicationPackagingAdapter {
   requiredInstallScope?: WingetScope;
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedUninstallArguments?: readonly string[];
+  uninstallCompletionTimeoutMinutes?: number;
 }
 
 const VISUAL_STUDIO_WINGET_IDS = [
@@ -48,6 +49,11 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   ...VISUAL_STUDIO_WINGET_IDS.map((wingetId) => ({
     wingetId,
     reviewedUninstallArguments: ['--quiet', '--norestart'],
+    // Visual Studio's registered setup.exe command returns before its child
+    // installer engine has removed the exact product registration. Microsoft
+    // documents --wait for the bootstrapper only, not setup.exe, so retain
+    // registry-aware completion polling for this longer vendor lifecycle.
+    uninstallCompletionTimeoutMinutes: 15,
   })),
   {
     wingetId: 'Adobe.CreativeCloud',
@@ -157,5 +163,12 @@ export function applyApplicationPackagingAdapter(
     }
   }
 
-  return { ...config, processesToClose, reviewedUninstallArguments };
+  return {
+    ...config,
+    processesToClose,
+    reviewedUninstallArguments,
+    ...(adapter.uninstallCompletionTimeoutMinutes
+      ? { uninstallCompletionTimeoutMinutes: adapter.uninstallCompletionTimeoutMinutes }
+      : {}),
+  };
 }

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -320,7 +320,8 @@ describe('buildQaLiveResponse', () => {
       frame: null,
       control: {
         paused: true,
-        reason: 'Golden VM wallpaper maintenance',
+        reason:
+          'Testing is temporarily paused for maintenance · Coordinating protected QA and customer packager pins for commit 1b130924ecc68909d6bb15f8cdf295944255a2f9.',
         updatedAt: '2026-08-11T12:04:00.000Z',
       },
     });
@@ -332,6 +333,7 @@ describe('buildQaLiveResponse', () => {
       issue: null,
       consecutiveFailures: 0,
     });
-    expect(JSON.stringify(response)).not.toContain('Golden VM wallpaper maintenance');
+    expect(JSON.stringify(response)).not.toContain('Testing is temporarily paused');
+    expect(JSON.stringify(response)).not.toContain('1b130924ecc68909d6bb15f8cdf295944255a2f9');
   });
 });

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -701,7 +701,10 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain(
       'if ($registeredUninstallArguments.Count -gt 0) {'
     );
-    expect(packager).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)');
+    expect(packager).toContain('$uninstallCompletionTimeoutMinutes = 5');
+    expect(packager).toContain(
+      '$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($uninstallCompletionTimeoutMinutes)'
+    );
     expect(packager).toContain('Waiting for vendor uninstall registration');
     expect(packager).toContain('$uninstallHandle.Task.IsCompleted');
     expect(packager).toContain('$uninstallHandle.Task.GetAwaiter().GetResult().ExitCode');

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -890,6 +890,20 @@ catch
   }
 
   /**
+   * Bound the registry-aware vendor completion window. Most uninstallers use
+   * five minutes; reviewed adapters can extend it for asynchronous vendor
+   * engines without turning it into an unbounded customer-controlled wait.
+   */
+  private getUninstallCompletionTimeoutMinutes(job: PackagingJob): number {
+    const raw = this.getPsadtConfig(job)?.uninstallCompletionTimeoutMinutes;
+    if (raw === undefined || raw === null) return 5;
+    if (!Number.isInteger(raw) || raw < 1 || raw > 30) {
+      throw new Error('PSADT uninstallCompletionTimeoutMinutes must be an integer from 1 to 30');
+    }
+    return raw;
+  }
+
+  /**
    * Generate PowerShell for additional post-install / post-uninstall commands
    * (issue #118). Each entry runs as its own Start-ADTProcess (cmd.exe /c) step,
    * in order, mirroring the custom-override pattern. Returns '' when none.
@@ -1383,6 +1397,8 @@ ${steps}
       const reviewedUninstallArguments = this.getReviewedUninstallArguments(job)
         .map((argument) => `'${argument.replace(/'/g, "''")}'`)
         .join(', ');
+      const uninstallCompletionTimeoutMinutes =
+        this.getUninstallCompletionTimeoutMinutes(job);
       const reviewedUninstallArgumentsBlock = `$reviewedUninstallArguments = @(${reviewedUninstallArguments})
     foreach ($reviewedArgument in $reviewedUninstallArguments) {
         if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {
@@ -1438,7 +1454,7 @@ ${steps}
         NoWait = $true
         PassThru = $true
     }
-    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+    $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(${uninstallCompletionTimeoutMinutes})
     $uninstallHandle = Start-ADTProcess @uninstallProcessParameters
     $uninstallProcessExitLogged = $false
     $nextUninstallProgressLog = [DateTime]::UtcNow
@@ -1562,7 +1578,7 @@ ${steps}
         if ($registeredUninstallArguments.Count -gt 0) {
             $uninstallProcessParameters.ArgumentList = $registeredUninstallArguments
         }
-        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(5)
+        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes(${uninstallCompletionTimeoutMinutes})
         $uninstallHandle = Start-ADTProcess @uninstallProcessParameters
         $uninstallProcessExitLogged = $false
         $nextUninstallProgressLog = [DateTime]::UtcNow

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -319,6 +319,12 @@ describe('hosted PSADT portable generator', () => {
     );
     expect(script).toContain('$uninstallHandle.Task.IsCompleted');
     expect(script).toContain('$uninstallHandle.Task.GetAwaiter().GetResult().ExitCode');
+    expect(script).toContain("$psadtConfig.Contains('reviewedUninstallArguments')");
+    expect(script).toContain('$registeredUninstallArguments += $reviewedArgument');
+    expect(script).toContain("$psadtConfig.Contains('uninstallCompletionTimeoutMinutes')");
+    expect(script).toContain(
+      '$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($uninstallCompletionTimeoutMinutes)'
+    );
     expect(script).not.toContain('Start-ADTProcess -FilePath $wingetExe');
     expect(script).not.toContain('uninstall --id $wingetId');
   });
@@ -603,6 +609,45 @@ describe('EXE product identity PSADT generation', () => {
       }),
       'example.exe'
     )).toThrow('single-line');
+  });
+
+  it('extends registry-aware completion only for a reviewed vendor profile', () => {
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        winget_id: 'Microsoft.VisualStudio.Professional',
+        installer_type: 'exe',
+        uninstall_command: 'REGISTRY_UNINSTALL:Visual Studio Professional',
+        package_config: {
+          psadtConfig: {
+            reviewedUninstallArguments: ['--quiet', '--norestart'],
+            uninstallCompletionTimeoutMinutes: 15,
+          },
+        },
+      }),
+      'vs_Professional.exe'
+    );
+
+    expect(uninstall).toContain(
+      "$reviewedUninstallArguments = @('--quiet', '--norestart')"
+    );
+    expect(uninstall).toContain(
+      '$uninstallDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+    );
+  });
+
+  it('rejects unbounded vendor uninstall completion windows', () => {
+    expect(() => generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'exe',
+        uninstall_command: 'REGISTRY_UNINSTALL:Example',
+        package_config: {
+          psadtConfig: { uninstallCompletionTimeoutMinutes: 31 },
+        },
+      }),
+      'example.exe'
+    )).toThrow('integer from 1 to 30');
   });
 
   it('uses the Adobe Creative Cloud desktop client unattended removal contract', () => {

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -199,6 +199,11 @@ export interface PSADTConfig {
   // not exposed as a customer-facing free-form command surface.
   reviewedUninstallArguments?: string[];
 
+  // Internal completion window for vendor uninstallers that hand work to a
+  // child process. Application adapters may extend the five-minute default;
+  // the exact registry identity remains the authoritative completion signal.
+  uninstallCompletionTimeoutMinutes?: number;
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.


### PR DESCRIPTION
## What changed
- add a bounded 15-minute registry-aware completion window for reviewed Visual Studio adapters
- keep the five-minute default for every other application
- make the GitHub/QA PowerShell packager honor the same reviewed uninstall arguments and completion timeout as the customer/self-hosted packager
- add a regression test that prevents private maintenance notes and commit hashes from reaching the public QA response

## Root cause
Visual Studio's installed setup engine can return while its child installer engine is still removing the product. The existing five-minute deadline expired even though removal was continuing. The GitHub PowerShell packaging path also did not consume reviewed uninstall arguments, creating drift from the customer packager.

## Impact
QA and customer packages now use the same reviewed adapter behavior. Visual Studio removal remains validated by the exact registry identity and completes as soon as that registration disappears; the longer value is only a maximum window.

## Validation
- 156 focused tests passed
- public QA live projection test passed (9 tests)
- focused ESLint passed
- PowerShell parser validation passed
- `npm run build:ci` passed
- `git diff --check` passed