### PR TITLE
Synchronize QA packager profiles

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -608,14 +608,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'RARLab.WinRAR',
-        name: 'WinRAR',
-        publisher: 'RARLab',
+        winget_id: 'Microsoft.VisualStudio.2022.Professional',
+        name: 'Visual Studio Professional 2022',
+        publisher: 'Microsoft',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'RARLab.WinRAR',
+          wingetId: 'Microsoft.VisualStudio.2022.Professional',
           packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
           status: 'failed',
         }),
@@ -637,12 +637,16 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'RARLab.WinRAR',
+      winget_id: 'Microsoft.VisualStudio.2022.Professional',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
         profileKind: 'catalog-default',
         silentArgs: '/S',
+        psadtConfig: {
+          reviewedUninstallArguments: ['--quiet', '--norestart'],
+          uninstallCompletionTimeoutMinutes: 15,
+        },
       },
     });
     const canonical = JSON.parse(

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -28,7 +28,7 @@ describe('application packaging adapters', () => {
     ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
     expect(
       applyApplicationPackagingAdapter(
-        'Microsoft.VisualStudio.Professional',
+        'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -18,6 +18,10 @@ const VISUAL_STUDIO_WINGET_IDS = [
   'Microsoft.VisualStudio.2019.Community',
   'Microsoft.VisualStudio.2019.Enterprise',
   'Microsoft.VisualStudio.2019.Professional',
+  'Microsoft.VisualStudio.2022.BuildTools',
+  'Microsoft.VisualStudio.2022.Community',
+  'Microsoft.VisualStudio.2022.Enterprise',
+  'Microsoft.VisualStudio.2022.Professional',
 ] as const;
 
 /**

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '1b130924ecc68909d6bb15f8cdf295944255a2f9',
+  packagerCommit: '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -4,14 +4,18 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
   it.each([
-    'HandBrake.HandBrake',
-    'Microsoft.VisualStudio.2019.Enterprise',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
     'Microsoft.VisualStudio.Enterprise',
     'Microsoft.VisualStudio.Professional',
-    'Microsoft.WindowsApp',
-    'PostgreSQL.PostgreSQL.18',
-    'RARLab.WinRAR',
-    'SoftwareOK.Q-Dir',
+    'Microsoft.VisualStudio.2019.BuildTools',
+    'Microsoft.VisualStudio.2019.Community',
+    'Microsoft.VisualStudio.2019.Enterprise',
+    'Microsoft.VisualStudio.2019.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
   ])(
     'retries the terminal %s failure changed by the current toolchain release',
     (wingetId) => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,20 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '267c8cbb3c520feaec04c2254de1a667b8fa90d4': [
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2019.BuildTools',
+    'Microsoft.VisualStudio.2019.Community',
+    'Microsoft.VisualStudio.2019.Enterprise',
+    'Microsoft.VisualStudio.2019.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+  ],
   '1b130924ecc68909d6bb15f8cdf295944255a2f9': [
     'HandBrake.HandBrake',
     'Microsoft.VisualStudio.2019.Enterprise',


### PR DESCRIPTION
## What changed
- generate QA package profiles with the same protected packager commit already pinned by QA and customer workflows
- add the four missing Visual Studio 2022 WinGet IDs to the reviewed Visual Studio adapter
- target terminal retries for all reviewed Visual Studio families under the new packager release
- verify the exact Visual Studio 2022 profile contains the reviewed quiet arguments and 15-minute completion window

## Root cause
The workflows were pinned to the corrected packager, but the web scheduler still generated immutable candidate identities with the previous commit. The Visual Studio 2022 aliases were also absent from the adapter list, so the exact failing 2022 Professional package would not receive the new completion window.

## Validation
- 173 affected tests passed
- focused ESLint passed
- `npm run build:ci` passed
- `git diff --check` passed