### PR TITLE
Match publisher-decorated uninstall identities

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -505,6 +505,7 @@ $uninstallCmd = [string]$UninstallCommand
 $uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
+$publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
 $sanitizedWingetId = $WingetId -replace '[\.\-]', '_'
 $installerFileName = $env:INSTALLER_FILENAME
 # Escaped variant for embedding in single-quoted strings in the generated script
@@ -1757,6 +1758,10 @@ if ($useRegistryUninstall) {
         '    $selectedApplications = @()'
         '    $changedApplications = @()'
         '    $configuredUninstallComparableName = (($configuredUninstallDisplayName -replace ''(?i)(?<![A-Za-z0-9])(x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)(?![A-Za-z0-9])'', '''' -replace ''\(\s*\)'', '''' -replace ''\(\s+'', ''('' -replace ''\s+\)'', '')'' -replace ''\s{2,}'', '' '')).Trim()'
+        "    `$configuredUninstallPublisherName = '$publisherSingleQuoteEscaped'"
+        '    $configuredUninstallPublisherAgnosticName = if ($configuredUninstallPublisherName) {'
+        '        ($configuredUninstallComparableName -replace (''(?i)^'' + [regex]::Escape($configuredUninstallPublisherName) + ''(?:\s+|[._-]+)''), '''').Trim()'
+        '    } else { $configuredUninstallComparableName }'
         '    foreach ($verificationAttempt in 1..30) {'
         '        $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
         '        $changedApplications = @($postInstallApplications | Where-Object {'
@@ -1778,6 +1783,16 @@ if ($useRegistryUninstall) {
         '                $candidateComparableName -eq $configuredUninstallComparableName'
         '            })'
         '            if ($architectureAgnosticMatches.Count -eq 1) { $selectedApplications = $architectureAgnosticMatches }'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0 -and $configuredUninstallPublisherAgnosticName) {'
+        '            $publisherAgnosticMatches = @($changedApplications | Where-Object {'
+        '                $candidateComparableName = (([string]$_.DisplayName -replace ''(?i)(?<![A-Za-z0-9])(x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)(?![A-Za-z0-9])'', '''' -replace ''\(\s*\)'', '''' -replace ''\(\s+'', ''('' -replace ''\s+\)'', '')'' -replace ''\s{2,}'', '' '')).Trim()'
+        '                $candidatePublisherAgnosticName = if ($configuredUninstallPublisherName) {'
+        '                    ($candidateComparableName -replace (''(?i)^'' + [regex]::Escape($configuredUninstallPublisherName) + ''(?:\s+|[._-]+)''), '''').Trim()'
+        '                } else { $candidateComparableName }'
+        '                $candidatePublisherAgnosticName -eq $configuredUninstallPublisherAgnosticName'
+        '            })'
+        '            if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }'
         '        }'
         '        if ($selectedApplications.Count -eq 0) {'
         '            $bundleCandidates = @($changedApplications | Where-Object {'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -349,6 +349,48 @@ describe('PSADT registry uninstall identity contract', () => {
     );
   });
 
+  it('accepts one ARP entry after removing only the configured publisher prefix', () => {
+    expect(packager).toContain('$configuredUninstallPublisherAgnosticName = if (');
+    expect(packager).toContain('$publisherAgnosticMatches = @($changedApplications');
+    expect(packager).toContain(
+      'if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }'
+    );
+    expect(packager.indexOf('$publisherAgnosticMatches')).toBeLessThan(
+      packager.indexOf('$bundleCandidates')
+    );
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'normalizes a manifest publisher prefix while preserving ambiguous matches',
+    () => {
+      const result = spawnSync(
+        'pwsh',
+        [
+          '-NoProfile',
+          '-Command',
+          `function ConvertTo-ComparableName([string]$Name) {
+  return (($Name -replace '(?i)(?<![A-Za-z0-9])(x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)(?![A-Za-z0-9])', '' -replace '\\(\\s*\\)', '' -replace '\\(\\s+', '(' -replace '\\s+\\)', ')' -replace '\\s{2,}', ' ')).Trim()
+}
+function Remove-PublisherPrefix([string]$Name, [string]$Publisher) {
+  return ($Name -replace ('(?i)^' + [regex]::Escape($Publisher) + '(?:\\s+|[._-]+)'), '').Trim()
+}
+$configured = Remove-PublisherPrefix (ConvertTo-ComparableName 'Microsoft SQL Server Management Studio 22') 'Microsoft'
+$oneMatch = @('SQL Server Management Studio 22', 'Microsoft Visual Studio Installer') | Where-Object {
+  (Remove-PublisherPrefix (ConvertTo-ComparableName $_) 'Microsoft') -eq $configured
+}
+$ambiguous = @('SQL Server Management Studio 22', 'Microsoft SQL Server Management Studio 22') | Where-Object {
+  (Remove-PublisherPrefix (ConvertTo-ComparableName $_) 'Microsoft') -eq $configured
+}
+[pscustomobject]@{ OneMatch = @($oneMatch).Count; Ambiguous = @($ambiguous).Count } | ConvertTo-Json -Compress`,
+        ],
+        { encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout.trim())).toEqual({ OneMatch: 1, Ambiguous: 2 });
+    }
+  );
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'normalizes Firefox architecture metadata while leaving helper entries distinct',
     () => {

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1034,11 +1034,16 @@ ${steps}
   private getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string {
     const identity = this.getRegistryUninstallIdentity(job);
     if (identity) {
+      const escapedPublisher = job.publisher.replace(/'/g, "''");
       return `
     ## Capture and verify the exact uninstall identity observed for this installation.
     $selectedApplications = @()
     $changedApplications = @()
     $configuredUninstallComparableName = (($configuredUninstallDisplayName -replace '(?i)(?<![A-Za-z0-9])(x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)(?![A-Za-z0-9])', '' -replace '\(\s*\)', '' -replace '\(\s+', '(' -replace '\s+\)', ')' -replace '\s{2,}', ' ')).Trim()
+    $configuredUninstallPublisherName = '${escapedPublisher}'
+    $configuredUninstallPublisherAgnosticName = if ($configuredUninstallPublisherName) {
+        ($configuredUninstallComparableName -replace ('(?i)^' + [regex]::Escape($configuredUninstallPublisherName) + '(?:\s+|[._-]+)'), '').Trim()
+    } else { $configuredUninstallComparableName }
     foreach ($verificationAttempt in 1..30) {
         $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)
         $changedApplications = @($postInstallApplications | Where-Object {
@@ -1060,6 +1065,16 @@ ${steps}
                 $candidateComparableName -eq $configuredUninstallComparableName
             })
             if ($architectureAgnosticMatches.Count -eq 1) { $selectedApplications = $architectureAgnosticMatches }
+        }
+        if ($selectedApplications.Count -eq 0 -and $configuredUninstallPublisherAgnosticName) {
+            $publisherAgnosticMatches = @($changedApplications | Where-Object {
+                $candidateComparableName = (([string]$_.DisplayName -replace '(?i)(?<![A-Za-z0-9])(x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)(?![A-Za-z0-9])', '' -replace '\(\s*\)', '' -replace '\(\s+', '(' -replace '\s+\)', ')' -replace '\s{2,}', ' ')).Trim()
+                $candidatePublisherAgnosticName = if ($configuredUninstallPublisherName) {
+                    ($candidateComparableName -replace ('(?i)^' + [regex]::Escape($configuredUninstallPublisherName) + '(?:\s+|[._-]+)'), '').Trim()
+                } else { $candidateComparableName }
+                $candidatePublisherAgnosticName -eq $configuredUninstallPublisherAgnosticName
+            })
+            if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }
         }
         if ($selectedApplications.Count -eq 0) {
             $bundleCandidates = @($changedApplications | Where-Object {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -460,6 +460,28 @@ describe('EXE product identity PSADT generation', () => {
     );
   });
 
+  it('matches one publisher-decorated registry identity without widening the delta', () => {
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      packagingJob({
+        publisher: 'Microsoft',
+        display_name: 'Microsoft SQL Server Management Studio 22',
+        installer_type: 'exe',
+        uninstall_command: 'REGISTRY_UNINSTALL:Microsoft SQL Server Management Studio 22',
+      }),
+      'Microsoft SQL Server Management Studio 22'
+    );
+
+    expect(verification).toContain("$configuredUninstallPublisherName = 'Microsoft'");
+    expect(verification).toContain('$publisherAgnosticMatches = @($changedApplications');
+    expect(verification).toContain(
+      'if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }'
+    );
+    expect(verification.indexOf('$publisherAgnosticMatches')).toBeLessThan(
+      verification.indexOf('$bundleCandidates')
+    );
+  });
+
   it('verifies and removes only the exact AppsAndFeatures product identity', () => {
     const job = packagingJob({
       winget_id: 'Adobe.Acrobat.Reader.64-bit',


### PR DESCRIPTION
## What changed
- compare ARP identities after removing only the exact configured publisher prefix
- require exactly one match from the observed install-time registry delta
- retain exact product code, exact name, and architecture-normalized matching ahead of this fallback
- implement the same behavior in the GitHub/QA PowerShell packager and customer/self-hosted Node packager

## Root cause
SQL Server Management Studio 22 is named `Microsoft SQL Server Management Studio 22` in the WinGet catalog but registers `SQL Server Management Studio 22` in Windows. Installation succeeded and created the correct ARP entry, but the packager rejected all 28 changed entries because none exactly matched the catalog label.

## Safety
This does not use broad substring matching. The publisher is regex-escaped, removed only at the start of the name, and the observed registry delta must still contain exactly one matching entry; ambiguous results fail closed.

## Validation
- 83 focused packaging contract tests passed, including executable publisher-prefix and ambiguity cases
- focused ESLint passed
- PowerShell parser validation passed
- `npm run build:ci` passed
- `git diff --check` passed