### PR TITLE
Pin publisher-aware QA profiles

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
+  packagerCommit: 'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -41,6 +41,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'fc18fffd40f6d362be251e05e2bc784373dfc735',
   'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
   '354756f01cb572cfd410f95dd6af5ab3a9cb8efb',
+  '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -4,6 +4,7 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
   it.each([
+    'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',
     'Microsoft.VisualStudio.Enterprise',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,7 +10,8 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
-  '267c8cbb3c520feaec04c2254de1a667b8fa90d4': [
+  'ca37c9eadd7b64d4d926f60a158e3dafb4554788': [
+    'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',
     'Microsoft.VisualStudio.Enterprise',


### PR DESCRIPTION
## What changed
- generate immutable QA candidate identities with packager `ca37c9eadd7b64d4d926f60a158e3dafb4554788`
- preserve compatibility with successful profiles generated by the preceding Visual Studio release
- target SQL Server Management Studio 22 and all affected Visual Studio families for retry under the current packager

## Why
Candidate identity, protected QA packaging, and customer packaging must use the same exact packager revision. SQL Server Management Studio also needs a fresh candidate because its previous install succeeded but registry identity capture rejected the WinGet/ARP publisher-prefix drift.

## Validation
- 82 affected scheduler/profile tests passed
- focused ESLint passed
- `npm run build:ci` passed
- `git diff --check` passed