### PR TITLE
fix: match localized uninstall identities

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -507,6 +507,11 @@ $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replac
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
 $sanitizedWingetId = $WingetId -replace '[\.\-]', '_'
+$registryUninstallLocaleHint = ''
+if ($WingetId -cmatch '\.([a-z]{2,3}(?:-[A-Z]{2})?)$') {
+    $registryUninstallLocaleHint = $Matches[1]
+}
+$registryUninstallLocaleHintEscaped = $registryUninstallLocaleHint -replace "'", "''"
 $installerFileName = $env:INSTALLER_FILENAME
 # Escaped variant for embedding in single-quoted strings in the generated script
 $installerFileNameSingleQuoteEscaped = $installerFileName -replace "'", "''"
@@ -1424,6 +1429,7 @@ if ($useRegistryUninstall) {
         '    $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
         "    `$configuredUninstallProductCode = '$registryUninstallProductCode'"
         "    `$configuredUninstallDisplayName = '$registryUninstallDisplayNameEscaped'"
+        "    `$configuredUninstallLocaleHint = '$registryUninstallLocaleHintEscaped'"
         '    $capturedUninstallKey = $null'
         '    $capturedUninstallName = $null'
         ''
@@ -1762,6 +1768,18 @@ if ($useRegistryUninstall) {
         '    $configuredUninstallPublisherAgnosticName = if ($configuredUninstallPublisherName) {'
         '        ($configuredUninstallComparableName -replace (''(?i)^'' + [regex]::Escape($configuredUninstallPublisherName) + ''(?:\s+|[._-]+)''), '''').Trim()'
         '    } else { $configuredUninstallComparableName }'
+        '    # Some language-specific WinGet manifests carry a default-locale ARP name even though'
+        '    # the selected installer registers its requested locale (for example en-US versus de).'
+        '    # Only enable locale-agnostic comparison when the package ID has a locale suffix and the'
+        '    # configured name has a strict locale qualifier. The observed install delta and one-match'
+        '    # requirement remain authoritative, so helper products and parallel editions stay excluded.'
+        '    $configuredLocaleSuffixPattern = ''\(\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\s+)?[a-z]{2,3}(?:-[A-Z]{2})?\s*\)$'''
+        '    $configuredUninstallLocaleAgnosticName = if ($configuredUninstallLocaleHint -and $configuredUninstallDisplayName -cmatch $configuredLocaleSuffixPattern) {'
+        '        ($configuredUninstallDisplayName -creplace $configuredLocaleSuffixPattern, '''').Trim()'
+        '    } else { $null }'
+        '    $candidateLocaleSuffixPattern = if ($configuredUninstallLocaleAgnosticName) {'
+        '        ''\(\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\s+)?'' + [regex]::Escape($configuredUninstallLocaleHint) + ''\s*\)$'''
+        '    } else { $null }'
         '    foreach ($verificationAttempt in 1..30) {'
         '        $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
         '        $changedApplications = @($postInstallApplications | Where-Object {'
@@ -1793,6 +1811,15 @@ if ($useRegistryUninstall) {
         '                $candidatePublisherAgnosticName -eq $configuredUninstallPublisherAgnosticName'
         '            })'
         '            if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }'
+        '        }'
+        '        if ($selectedApplications.Count -eq 0 -and $candidateLocaleSuffixPattern) {'
+        '            $localeAgnosticMatches = @($changedApplications | Where-Object {'
+        '                $candidateDisplayName = [string]$_.DisplayName'
+        '                if ($candidateDisplayName -cnotmatch $candidateLocaleSuffixPattern) { return $false }'
+        '                $candidateLocaleAgnosticName = ($candidateDisplayName -creplace $candidateLocaleSuffixPattern, '''').Trim()'
+        '                $candidateLocaleAgnosticName -eq $configuredUninstallLocaleAgnosticName'
+        '            })'
+        '            if ($localeAgnosticMatches.Count -eq 1) { $selectedApplications = $localeAgnosticMatches }'
         '        }'
         '        if ($selectedApplications.Count -eq 0) {'
         '            $bundleCandidates = @($changedApplications | Where-Object {'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -34,7 +34,9 @@ function generateRegistryUninstallPackage(
   displayName = 'Contract Test App',
   installerSuccessCodes: number[] = [],
   psadtConfig: unknown = {},
-  packageDependencies: Array<Record<string, unknown>> = []
+  packageDependencies: Array<Record<string, unknown>> = [],
+  wingetId = 'IntuneGet.ContractTest',
+  uninstallDisplayName = displayName
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -77,13 +79,13 @@ function generateRegistryUninstallPackage(
         INPUT_DISPLAY_NAME: displayName,
         INPUT_PUBLISHER: 'IntuneGet',
         INPUT_VERSION: '1.0.0',
-        INPUT_WINGET_ID: 'IntuneGet.ContractTest',
+        INPUT_WINGET_ID: wingetId,
         INPUT_INSTALLER_TYPE: installerType,
         INPUT_INSTALL_SCOPE: 'machine',
         INPUT_SILENT_SWITCHES: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
         INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
         INPUT_PACKAGE_DEPENDENCIES: JSON.stringify(packageDependencies),
-        INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${displayName}`,
+        INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${uninstallDisplayName}`,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
         ...(packageDependencies.length > 0
@@ -360,6 +362,36 @@ describe('PSADT registry uninstall identity contract', () => {
     );
   });
 
+  it('limits locale-aware ARP matching to one observed localized product entry', () => {
+    expect(packager).toContain('$configuredUninstallLocaleHint');
+    expect(packager).toContain('$configuredUninstallLocaleAgnosticName');
+    expect(packager).toContain('$localeAgnosticMatches = @($changedApplications');
+    expect(packager).toContain(
+      'if ($localeAgnosticMatches.Count -eq 1) { $selectedApplications = $localeAgnosticMatches }'
+    );
+    expect(packager.indexOf('$localeAgnosticMatches')).toBeLessThan(
+      packager.indexOf('$bundleCandidates')
+    );
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits the locale hint for a language-specific package and valid PowerShell',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Mozilla Firefox (Deutsch)',
+        [],
+        {},
+        [],
+        'Mozilla.Firefox.de',
+        'Mozilla Firefox (en-US)'
+      );
+
+      expect(generated).toContain("$configuredUninstallLocaleHint = 'de'");
+      expect(generated).toContain('$localeAgnosticMatches = @($changedApplications');
+    }
+  );
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'normalizes a manifest publisher prefix while preserving ambiguous matches',
     () => {
@@ -419,6 +451,37 @@ $ambiguous = @('SQL Server Management Studio 22', 'Microsoft SQL Server Manageme
       };
       expect(names.Product).toBe(names.Configured);
       expect(names.Helper).not.toBe(names.Configured);
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'matches a single requested locale while preserving ambiguity',
+    () => {
+      const result = spawnSync(
+        'pwsh',
+        [
+          '-NoProfile',
+          '-Command',
+          `$localeHint = 'de'
+$configuredName = 'Mozilla Firefox (en-US)'
+$configuredPattern = '\\(\\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\\s+)?[a-z]{2,3}(?:-[A-Z]{2})?\\s*\\)$'
+$configuredBase = if ($configuredName -cmatch $configuredPattern) { ($configuredName -creplace $configuredPattern, '').Trim() } else { $null }
+$candidatePattern = '\\(\\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\\s+)?' + [regex]::Escape($localeHint) + '\\s*\\)$'
+function Select-Localized([string[]]$Names) {
+  return @($Names | Where-Object {
+    if ($_ -cnotmatch $candidatePattern) { return $false }
+    (($_ -creplace $candidatePattern, '').Trim()) -eq $configuredBase
+  })
+}
+$oneMatch = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Maintenance Service', 'Microsoft Edge')
+$ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x86 de)', 'Mozilla Maintenance Service')
+[pscustomobject]@{ OneMatch = @($oneMatch).Count; Ambiguous = @($ambiguous).Count } | ConvertTo-Json -Compress`,
+        ],
+        { encoding: 'utf8' }
+      );
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout.trim())).toEqual({ OneMatch: 1, Ambiguous: 2 });
     }
   );
 

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1014,12 +1014,16 @@ ${steps}
       return '';
     }
 
+    const localeHint =
+      job.winget_id.match(/\.([a-z]{2,3}(?:-[A-Z]{2})?)$/)?.[1] || '';
+
     return `
     # Snapshot uninstall entries before install. Manifest identity is a preference,
     # while the observed registry delta remains authoritative when metadata is stale.
     $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)
     $configuredUninstallProductCode = '${identity.productCode}'
     $configuredUninstallDisplayName = '${identity.displayName || escapedAppName}'
+    $configuredUninstallLocaleHint = '${localeHint}'
     $capturedUninstallKey = $null
     $capturedUninstallName = $null
 `;
@@ -1044,6 +1048,17 @@ ${steps}
     $configuredUninstallPublisherAgnosticName = if ($configuredUninstallPublisherName) {
         ($configuredUninstallComparableName -replace ('(?i)^' + [regex]::Escape($configuredUninstallPublisherName) + '(?:\s+|[._-]+)'), '').Trim()
     } else { $configuredUninstallComparableName }
+    # Some language-specific WinGet manifests carry a default-locale ARP name even though
+    # the selected installer registers its requested locale (for example en-US versus de).
+    # Limit locale-agnostic comparison to locale-suffixed package IDs, the observed install
+    # delta, and exactly one result so helper products and parallel editions stay excluded.
+    $configuredLocaleSuffixPattern = '\\(\\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\\s+)?[a-z]{2,3}(?:-[A-Z]{2})?\\s*\\)$'
+    $configuredUninstallLocaleAgnosticName = if ($configuredUninstallLocaleHint -and $configuredUninstallDisplayName -cmatch $configuredLocaleSuffixPattern) {
+        ($configuredUninstallDisplayName -creplace $configuredLocaleSuffixPattern, '').Trim()
+    } else { $null }
+    $candidateLocaleSuffixPattern = if ($configuredUninstallLocaleAgnosticName) {
+        '\\(\\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\\s+)?' + [regex]::Escape($configuredUninstallLocaleHint) + '\\s*\\)$'
+    } else { $null }
     foreach ($verificationAttempt in 1..30) {
         $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)
         $changedApplications = @($postInstallApplications | Where-Object {
@@ -1075,6 +1090,15 @@ ${steps}
                 $candidatePublisherAgnosticName -eq $configuredUninstallPublisherAgnosticName
             })
             if ($publisherAgnosticMatches.Count -eq 1) { $selectedApplications = $publisherAgnosticMatches }
+        }
+        if ($selectedApplications.Count -eq 0 -and $candidateLocaleSuffixPattern) {
+            $localeAgnosticMatches = @($changedApplications | Where-Object {
+                $candidateDisplayName = [string]$_.DisplayName
+                if ($candidateDisplayName -cnotmatch $candidateLocaleSuffixPattern) { return $false }
+                $candidateLocaleAgnosticName = ($candidateDisplayName -creplace $candidateLocaleSuffixPattern, '').Trim()
+                $candidateLocaleAgnosticName -eq $configuredUninstallLocaleAgnosticName
+            })
+            if ($localeAgnosticMatches.Count -eq 1) { $selectedApplications = $localeAgnosticMatches }
         }
         if ($selectedApplications.Count -eq 0) {
             $bundleCandidates = @($changedApplications | Where-Object {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -482,6 +482,32 @@ describe('EXE product identity PSADT generation', () => {
     );
   });
 
+  it('matches one localized registry identity without accepting helper entries', () => {
+    const job = packagingJob({
+      winget_id: 'Mozilla.Firefox.de',
+      publisher: 'Mozilla',
+      display_name: 'Mozilla Firefox (Deutsch)',
+      installer_type: 'nullsoft',
+      uninstall_command: 'REGISTRY_UNINSTALL:Mozilla Firefox (en-US)',
+    });
+    const script = generator.generateDeployScript.call(generator, job, 'firefox.exe');
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'Mozilla Firefox (Deutsch)'
+    );
+
+    expect(script).toContain("$configuredUninstallLocaleHint = 'de'");
+    expect(verification).toContain('$configuredUninstallLocaleAgnosticName');
+    expect(verification).toContain('$localeAgnosticMatches = @($changedApplications');
+    expect(verification).toContain(
+      'if ($localeAgnosticMatches.Count -eq 1) { $selectedApplications = $localeAgnosticMatches }'
+    );
+    expect(verification.indexOf('$localeAgnosticMatches')).toBeLessThan(
+      verification.indexOf('$bundleCandidates')
+    );
+  });
+
   it('verifies and removes only the exact AppsAndFeatures product identity', () => {
     const job = packagingJob({
       winget_id: 'Adobe.Acrobat.Reader.64-bit',


### PR DESCRIPTION
## Summary
- match locale-qualified ARP entries only when the WinGet ID carries a locale hint
- keep selection scoped to the observed install delta and require exactly one match
- apply identical logic to hosted QA and the customer/self-hosted packager

## Root cause
Mozilla.Firefox.de installed successfully as `Mozilla Firefox (x64 de)`, while the prepared configuration carried `Mozilla Firefox (en-US)`. The prior identity matcher correctly excluded the maintenance service but had no safe localized-name reconciliation, so install verification failed closed.

## Verification
- 87 focused tests passed
- generated hosted package parsed successfully in PowerShell
- focused ESLint passed
- production Next.js build passed
- `git diff --check` passed