### PR TITLE
fix: pin localized QA profiles

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
+  packagerCommit: 'bbd8948f2bbefeaba9caf51f6e36ce5d26fdff35',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -42,6 +42,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
   '354756f01cb572cfd410f95dd6af5ab3a9cb8efb',
   '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
+  'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,7 @@ describe('QA toolchain targeted retries', () => {
     'Microsoft.VisualStudio.2022.Community',
     'Microsoft.VisualStudio.2022.Enterprise',
     'Microsoft.VisualStudio.2022.Professional',
+    'Mozilla.Firefox.de',
   ])(
     'retries the terminal %s failure changed by the current toolchain release',
     (wingetId) => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,7 +10,7 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
-  'ca37c9eadd7b64d4d926f60a158e3dafb4554788': [
+  'bbd8948f2bbefeaba9caf51f6e36ce5d26fdff35': [
     'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',
@@ -24,6 +24,7 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Microsoft.VisualStudio.2022.Community',
     'Microsoft.VisualStudio.2022.Enterprise',
     'Microsoft.VisualStudio.2022.Professional',
+    'Mozilla.Firefox.de',
   ],
   '1b130924ecc68909d6bb15f8cdf295944255a2f9': [
     'HandBrake.HandBrake',


### PR DESCRIPTION
Advances immutable QA candidate profiles to the localized ARP identity release, keeps earlier successful profiles compatible, and targets Firefox plus the pending SQL Server Management Studio and Visual Studio failures for current-profile retries. Validation: 83 scheduler/profile tests, focused ESLint, and diff checks passed.