### PR TITLE
Handle SSMS Visual Studio Installer removal lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -35,6 +35,28 @@ describe('application packaging adapters', () => {
       reviewedUninstallArguments: ['--quiet', '--norestart'],
       uninstallCompletionTimeoutMinutes: 15,
     });
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.SQLServerManagementStudio.22',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
+      uninstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
+  it.each([
+    'Microsoft.SQLServerManagementStudio.21',
+    'Microsoft.SQLServerManagementStudio.22',
+    'Microsoft.SQLServerManagementStudio.22.Preview',
+  ])('applies the Visual Studio Installer lifecycle to %s', (wingetId) => {
+    expect(
+      applyApplicationPackagingAdapter(wingetId.toLowerCase(), DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
+      uninstallCompletionTimeoutMinutes: 15,
+    });
   });
 
   it('preserves and deduplicates reviewed uninstall arguments case-insensitively', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -24,6 +24,12 @@ const VISUAL_STUDIO_WINGET_IDS = [
   'Microsoft.VisualStudio.2022.Professional',
 ] as const;
 
+const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
+  'Microsoft.SQLServerManagementStudio.21',
+  'Microsoft.SQLServerManagementStudio.22',
+  'Microsoft.SQLServerManagementStudio.22.Preview',
+] as const;
+
 /**
  * Reviewed application-specific behavior that cannot be derived safely from a
  * WinGet manifest. Keep this registry declarative: executable implementation
@@ -57,6 +63,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // installer engine has removed the exact product registration. Microsoft
     // documents --wait for the bootstrapper only, not setup.exe, so retain
     // registry-aware completion polling for this longer vendor lifecycle.
+    uninstallCompletionTimeoutMinutes: 15,
+  })),
+  ...SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS.map((wingetId) => ({
+    wingetId,
+    // SSMS 21+ is serviced by the Visual Studio Installer. Its setup.exe
+    // parent can return while the installer engine is still removing the
+    // product, so keep exact ARP polling active for the longer lifecycle.
+    // --noweb is part of Microsoft's documented SSMS removal command and
+    // prevents an unnecessary installer update check during unattended runs.
+    reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
     uninstallCompletionTimeoutMinutes: 15,
   })),
   {


### PR DESCRIPTION
## Summary
- apply the existing long-running Visual Studio Installer lifecycle to SSMS 21/22 packages
- add Microsoft's documented offline uninstall flag plus unattended arguments
- cover stable and preview SSMS package identities case-insensitively

## Verification
- 118 focused tests passed
- focused ESLint passed
- git diff --check passed

This shared adapter is consumed by both customer packaging and QA package-profile generation.