### PR TITLE
Pin QA scheduler to SSMS lifecycle fix

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -608,14 +608,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Microsoft.VisualStudio.2022.Professional',
-        name: 'Visual Studio Professional 2022',
+        winget_id: 'Microsoft.SQLServerManagementStudio.22',
+        name: 'Microsoft SQL Server Management Studio 22',
         publisher: 'Microsoft',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Microsoft.VisualStudio.2022.Professional',
+          wingetId: 'Microsoft.SQLServerManagementStudio.22',
           packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
           status: 'failed',
         }),
@@ -637,14 +637,14 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Microsoft.VisualStudio.2022.Professional',
+      winget_id: 'Microsoft.SQLServerManagementStudio.22',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
         profileKind: 'catalog-default',
         silentArgs: '/S',
         psadtConfig: {
-          reviewedUninstallArguments: ['--quiet', '--norestart'],
+          reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
           uninstallCompletionTimeoutMinutes: 15,
         },
       },

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'bbd8948f2bbefeaba9caf51f6e36ce5d26fdff35',
+  packagerCommit: '072dc26c5c25369bf01f265af5af17c47c0e50e5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -4,7 +4,17 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
   it.each([
+    'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',
+    'Microsoft.SQLServerManagementStudio.22.Preview',
+  ])('retries the SSMS Visual Studio Installer lifecycle for %s', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+  });
+
+  it.each([
     'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',
     'Microsoft.VisualStudio.Enterprise',
@@ -19,12 +29,16 @@ describe('QA toolchain targeted retries', () => {
     'Microsoft.VisualStudio.2022.Professional',
     'Mozilla.Firefox.de',
   ])(
-    'retries the terminal %s failure changed by the current toolchain release',
+    'keeps the terminal %s retry scoped to its historical toolchain release',
     (wingetId) => {
+      expect(shouldRetryTerminalToolchainCandidate(
+        'bbd8948f2bbefeaba9caf51f6e36ce5d26fdff35',
+        { wingetId, status: 'failed' }
+      )).toBe(true);
       expect(shouldRetryTerminalToolchainCandidate(
         QA_PSADT_TOOLCHAIN.packagerCommit,
         { wingetId, status: 'failed' }
-      )).toBe(true);
+      )).toBe(false);
     }
   );
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,11 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '072dc26c5c25369bf01f265af5af17c47c0e50e5': [
+    'Microsoft.SQLServerManagementStudio.21',
+    'Microsoft.SQLServerManagementStudio.22',
+    'Microsoft.SQLServerManagementStudio.22.Preview',
+  ],
   'bbd8948f2bbefeaba9caf51f6e36ce5d26fdff35': [
     'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.VisualStudio.BuildTools',


### PR DESCRIPTION
## Summary
- pin catalog QA profiles to the merged SSMS packager lifecycle
- retry only affected SSMS terminal profiles
- keep earlier Visual Studio and Firefox retries scoped to their historical release

## Verification
- 85 focused tests passed
- focused ESLint passed
- git diff --check passed