### PR TITLE
Run xTool Studio in the user install scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -9,6 +9,8 @@ describe('application packaging adapters', () => {
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope('Makeblock.xToolStudio', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' makeblock.xtoolstudio ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -45,6 +45,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // xTool Studio's NSIS bootstrapper likewise installs below the invoking
+    // account's LocalAppData even when the WinGet manifest is selected as a
+    // machine package. LocalSystem therefore registers an uninstaller below
+    // systemprofile that is unavailable for the later Intune removal cycle.
+    wingetId: 'Makeblock.xToolStudio',
+    requiredInstallScope: 'user',
+  },
+  {
     wingetId: 'RARLab.WinRAR',
     reviewedUninstallArguments: ['/S'],
   },


### PR DESCRIPTION
## Summary
- classify xTool Studio's NSIS bootstrapper as a reviewed per-user installer
- prevent customer and QA packages from installing it into LocalSystem's disposable systemprofile
- cover case-insensitive scope resolution

## Verification
- 92 focused tests passed
- ESLint passed
- git diff --check passed