### PR TITLE
Pin QA scheduler to xTool scope fix

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -608,14 +608,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Microsoft.SQLServerManagementStudio.22',
-        name: 'Microsoft SQL Server Management Studio 22',
-        publisher: 'Microsoft',
+        winget_id: 'Makeblock.xToolStudio',
+        name: 'xTool Studio',
+        publisher: 'Makeblock',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Microsoft.SQLServerManagementStudio.22',
+          wingetId: 'Makeblock.xToolStudio',
           packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
           status: 'failed',
         }),
@@ -637,15 +637,14 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Microsoft.SQLServerManagementStudio.22',
+      winget_id: 'Makeblock.xToolStudio',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
         profileKind: 'catalog-default',
         silentArgs: '/S',
         psadtConfig: {
-          reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
-          uninstallCompletionTimeoutMinutes: 15,
+          reviewedUninstallArguments: [],
         },
       },
     });

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '072dc26c5c25369bf01f265af5af17c47c0e50e5',
+  packagerCommit: 'b3b2729bab6959a554c0e6d41af0a841d6177386',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -7,10 +7,21 @@ describe('QA toolchain targeted retries', () => {
     'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.SQLServerManagementStudio.22.Preview',
-  ])('retries the SSMS Visual Studio Installer lifecycle for %s', (wingetId) => {
+  ])('keeps the SSMS retry scoped to its historical toolchain release for %s', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '072dc26c5c25369bf01f265af5af17c47c0e50e5',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries xTool Studio for the current user-scope correction', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b3b2729bab6959a554c0e6d41af0a841d6177386': [
+    'Makeblock.xToolStudio',
+  ],
   '072dc26c5c25369bf01f265af5af17c47c0e50e5': [
     'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',


### PR DESCRIPTION
## Summary
- pin QA package generation to the xTool user-scope correction
- retry only the affected terminal xTool failure
- preserve historical SSMS retry scoping

## Verification
- 86 focused tests passed
- ESLint passed
- git diff --check passed