### PR TITLE
Use LTspice enterprise mode for SYSTEM deployment

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -198,6 +198,37 @@ if ($env:PSADT_CONFIG -and $env:PSADT_CONFIG -ne '{}') {
 
 # Parse the bounded values supplied only by reviewed application adapters.
 # These are not a customer-facing free-form command surface.
+$reviewedInstallArguments = @()
+if ($psadtConfig.Contains('reviewedInstallArguments') -and
+    $null -ne $psadtConfig['reviewedInstallArguments']) {
+    $rawReviewedInstallArguments = $psadtConfig['reviewedInstallArguments']
+    if ($rawReviewedInstallArguments -is [string] -or
+        $rawReviewedInstallArguments -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedInstallArguments must be an array.'
+    }
+
+    $seenReviewedInstallArguments = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($rawReviewedInstallArgument in @($rawReviewedInstallArguments)) {
+        if ($rawReviewedInstallArgument -isnot [string]) {
+            throw 'Every PSADT reviewed install argument must be a string.'
+        }
+        $reviewedInstallArgument = $rawReviewedInstallArgument.Trim()
+        if ([string]::IsNullOrWhiteSpace($reviewedInstallArgument) -or
+            $reviewedInstallArgument.Length -gt 256 -or
+            [regex]::IsMatch($reviewedInstallArgument, '[\x00-\x1F\x7F]')) {
+            throw 'Every PSADT reviewed install argument must be a non-empty, bounded, single-line string.'
+        }
+        if ($seenReviewedInstallArguments.Add($reviewedInstallArgument)) {
+            $reviewedInstallArguments += $reviewedInstallArgument
+        }
+    }
+    if ($reviewedInstallArguments.Count -gt 20) {
+        throw 'PSADT reviewedInstallArguments must contain at most 20 entries.'
+    }
+}
+
 $reviewedUninstallArguments = @()
 if ($psadtConfig.Contains('reviewedUninstallArguments') -and
     $null -ne $psadtConfig['reviewedUninstallArguments']) {
@@ -496,10 +527,21 @@ function Get-PSADTAssetFileName {
 }
 
 # Extract config values with defaults
+# Reviewed application adapters may append bounded vendor properties to the
+# manifest-derived command. Do this before quote encoding so MSI properties are
+# passed identically by QA and customer packages.
+$effectiveSilentSwitches = $SilentSwitches.Trim()
+foreach ($reviewedInstallArgument in $reviewedInstallArguments) {
+    $argumentPattern = '(?i)(^|\s)' + [regex]::Escape($reviewedInstallArgument) + '(\s|$)'
+    if ($effectiveSilentSwitches -notmatch $argumentPattern) {
+        $effectiveSilentSwitches = "$effectiveSilentSwitches $reviewedInstallArgument".Trim()
+    }
+}
+
 # This value is embedded in a single-quoted string in the generated script.
 # Only a single quote needs escaping; changing backticks or dollar signs would
 # silently change valid vendor arguments.
-$silentSwitchesEscaped = $SilentSwitches -replace "'", "''"
+$silentSwitchesEscaped = $effectiveSilentSwitches -replace "'", "''"
 $versionSingleQuoteEscaped = $Version -replace "'", "''"
 $uninstallCmd = [string]$UninstallCommand
 $uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
@@ -1466,7 +1508,7 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
 } else {
     $installerArgumentList = "'$silentSwitchesEscaped'"
     if ($installerTypeLower -eq 'inno') {
-        $innoSwitches = $SilentSwitches.Trim()
+        $innoSwitches = $effectiveSilentSwitches.Trim()
         if ($innoSwitches -notmatch '(?i)(^|\s)/SP-(\s|$)') { $innoSwitches = "$innoSwitches /SP-".Trim() }
         # Keep automatic observability out of the vendor command line. Some Inno
         # packages fail during initialization when an injected /LOG target cannot

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -48,6 +48,28 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('adds the vendor-supported LTspice enterprise install mode', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'AnalogDevices.LTspice',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArguments).toEqual(['MY_SPECIAL_MODE=2']);
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
+  it('preserves and deduplicates reviewed install arguments case-insensitively', () => {
+    const adapted = applyApplicationPackagingAdapter('AnalogDevices.LTspice', {
+      ...DEFAULT_PSADT_CONFIG,
+      reviewedInstallArguments: ['my_special_mode=2', 'EXAMPLE=1'],
+    });
+
+    expect(adapted.reviewedInstallArguments).toEqual([
+      'my_special_mode=2',
+      'EXAMPLE=1',
+    ]);
+  });
+
   it.each([
     'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -5,6 +5,7 @@ interface ApplicationPackagingAdapter {
   wingetId: string;
   requiredInstallScope?: WingetScope;
   requiredProcessesToClose?: readonly ProcessToClose[];
+  reviewedInstallArguments?: readonly string[];
   reviewedUninstallArguments?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
 }
@@ -51,6 +52,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // systemprofile that is unavailable for the later Intune removal cycle.
     wingetId: 'Makeblock.xToolStudio',
     requiredInstallScope: 'user',
+  },
+  {
+    // Analog Devices documents this enterprise/server mode for silent SYSTEM
+    // deployment. It prevents the MSI from extracting example data into the
+    // LocalSystem AppData profile, which otherwise rolls back with exit 1603.
+    wingetId: 'AnalogDevices.LTspice',
+    reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
     wingetId: 'RARLab.WinRAR',
@@ -143,7 +151,7 @@ function normalizeProcessName(name: string): string {
   return name.trim().replace(/\.exe$/i, '');
 }
 
-function normalizeUninstallArgument(argument: string, wingetId: string): string {
+function normalizeReviewedArgument(argument: string, wingetId: string): string {
   const normalized = argument.trim();
   if (!normalized || normalized.length > 256 || /[\x00-\x1f\x7f]/.test(normalized)) {
     throw new Error(`Invalid reviewed uninstall argument for ${wingetId}`);
@@ -177,14 +185,28 @@ export function applyApplicationPackagingAdapter(
     }
   }
 
+  const reviewedInstallArguments = (config.reviewedInstallArguments || []).map(
+    (argument) => normalizeReviewedArgument(argument, adapter.wingetId)
+  );
+  const configuredInstallArguments = new Set(
+    reviewedInstallArguments.map((argument) => argument.toLowerCase())
+  );
+  for (const required of adapter.reviewedInstallArguments || []) {
+    const normalized = normalizeReviewedArgument(required, adapter.wingetId);
+    if (!configuredInstallArguments.has(normalized.toLowerCase())) {
+      reviewedInstallArguments.push(normalized);
+      configuredInstallArguments.add(normalized.toLowerCase());
+    }
+  }
+
   const reviewedUninstallArguments = (config.reviewedUninstallArguments || []).map(
-    (argument) => normalizeUninstallArgument(argument, adapter.wingetId)
+    (argument) => normalizeReviewedArgument(argument, adapter.wingetId)
   );
   const configuredArguments = new Set(
     reviewedUninstallArguments.map((argument) => argument.toLowerCase())
   );
   for (const required of adapter.reviewedUninstallArguments || []) {
-    const normalized = normalizeUninstallArgument(required, adapter.wingetId);
+    const normalized = normalizeReviewedArgument(required, adapter.wingetId);
     if (!configuredArguments.has(normalized.toLowerCase())) {
       reviewedUninstallArguments.push(normalized);
       configuredArguments.add(normalized.toLowerCase());
@@ -194,6 +216,7 @@ export function applyApplicationPackagingAdapter(
   return {
     ...config,
     processesToClose,
+    reviewedInstallArguments,
     reviewedUninstallArguments,
     ...(adapter.uninstallCompletionTimeoutMinutes
       ? { uninstallCompletionTimeoutMinutes: adapter.uninstallCompletionTimeoutMinutes }

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -575,6 +575,7 @@ export function normalizeQaPsadtConfig(
     detectionRules,
     postInstallCommands: value?.postInstallCommands || [],
     postUninstallCommands: value?.postUninstallCommands || [],
+    reviewedInstallArguments: value?.reviewedInstallArguments || [],
     reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
   };
 }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -168,11 +168,39 @@ describe('PSADT vendor argument contract', () => {
   });
 
   it('does not rewrite dollar signs or backticks in generic silent switches', () => {
-    expect(packager).toContain('$silentSwitchesEscaped = $SilentSwitches -replace "\'", "\'\'"');
+    expect(packager).toContain('$silentSwitchesEscaped = $effectiveSilentSwitches -replace "\'", "\'\'"');
     const assignment = packager.match(/^\$silentSwitchesEscaped\s*=.*$/m)?.[0] ?? '';
     expect(assignment).not.toContain("-replace '`'");
     expect(assignment).not.toContain("-replace '\\$'");
   });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'appends bounded reviewed install arguments to the synthesized vendor command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Reviewed Install Contract App',
+        [],
+        { reviewedInstallArguments: ['MY_SPECIAL_MODE=2'] }
+      );
+
+      expect(generated).toContain(
+        "-ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- MY_SPECIAL_MODE=2'"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects an unbounded reviewed install argument surface',
+    () => {
+      expect(() => generateRegistryUninstallPackage(
+        'inno',
+        'Unsafe Install Contract App',
+        [],
+        { reviewedInstallArguments: ['x'.repeat(257)] }
+      )).toThrow('reviewed install argument must be a non-empty, bounded');
+    }
+  );
 });
 
 describe('PSADT offline dependency contract', () => {

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -194,6 +194,11 @@ export interface PSADTConfig {
   installCommand?: string;
   uninstallCommand?: string;
 
+  // Internal, reviewed vendor arguments appended to the manifest-derived
+  // install command. Application adapters populate this field; it is not a
+  // customer-facing free-form command surface.
+  reviewedInstallArguments?: string[];
+
   // Internal, reviewed vendor arguments appended to an exact registered
   // uninstaller. Application adapters populate this field; it is intentionally
   // not exposed as a customer-facing free-form command surface.
@@ -282,6 +287,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   // Commands will be auto-generated based on installer type
   installCommand: undefined,
   uninstallCommand: undefined,
+  reviewedInstallArguments: [],
   reviewedUninstallArguments: [],
 };
 


### PR DESCRIPTION
## Summary
- add a bounded reviewed-install-argument adapter surface shared by QA and customer packaging
- apply Analog Devices' documented MY_SPECIAL_MODE=2 enterprise mode to LTspice
- prevent the MSI from extracting examples into LocalSystem AppData and rolling back with 1603
- preserve the effective adapter in QA execution-profile hashing

## Evidence
- QA MSI log: vendor custom action rolled back while targeting systemprofile AppData
- Analog Devices deployment guidance recommends MY_SPECIAL_MODE=2 for silent distributed installs

## Verification
- 148 focused tests passed
- ESLint passed
- generated PSADT scripts parse successfully
- git diff --check passed