### PR TITLE
Pin QA scheduler to LTspice enterprise fix

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -608,14 +608,14 @@ describe('GET /api/cron/qa-enqueue', () => {
   it('queues a targeted terminal failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'Makeblock.xToolStudio',
-        name: 'xTool Studio',
-        publisher: 'Makeblock',
+        winget_id: 'AnalogDevices.LTspice',
+        name: 'LTspice',
+        publisher: 'Analog Devices',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'Makeblock.xToolStudio',
+          wingetId: 'AnalogDevices.LTspice',
           packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
           status: 'failed',
         }),
@@ -637,13 +637,14 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Makeblock.xToolStudio',
+      winget_id: 'AnalogDevices.LTspice',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
         profileKind: 'catalog-default',
         silentArgs: '/S',
         psadtConfig: {
+          reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
           reviewedUninstallArguments: [],
         },
       },

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b3b2729bab6959a554c0e6d41af0a841d6177386',
+  packagerCommit: '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,10 +18,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries xTool Studio for the current user-scope correction', () => {
+  it('keeps the xTool retry scoped to its historical toolchain release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b3b2729bab6959a554c0e6d41af0a841d6177386',
+      { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries LTspice for the current enterprise-mode correction', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e': [
+    'AnalogDevices.LTspice',
+  ],
   'b3b2729bab6959a554c0e6d41af0a841d6177386': [
     'Makeblock.xToolStudio',
   ],


### PR DESCRIPTION
## Summary
- pin QA profiles to the reviewed LTspice enterprise-mode packager
- retry only the affected terminal LTspice failure
- keep xTool and SSMS retries scoped to their historical releases

## Verification
- 105 focused tests passed
- ESLint passed
- git diff --check passed