### PR TITLE
Carry superseded QA retries across toolchain release

### DIFF
--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,7 +18,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('keeps the xTool retry scoped to its historical toolchain release', () => {
+  it('carries the superseded xTool retry into the current toolchain release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'b3b2729bab6959a554c0e6d41af0a841d6177386',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
@@ -26,7 +26,7 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
-    )).toBe(false);
+    )).toBe(true);
   });
 
   it('retries LTspice for the current enterprise-mode correction', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -12,6 +12,9 @@ export interface QaToolchainBackfillCandidate {
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
   '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e': [
     'AnalogDevices.LTspice',
+    // The xTool retry was superseded while this release was deploying, so
+    // carry it forward until it receives one bounded run on the new toolchain.
+    'Makeblock.xToolStudio',
   ],
   'b3b2729bab6959a554c0e6d41af0a841d6177386': [
     'Makeblock.xToolStudio',


### PR DESCRIPTION
Carries the xTool retry into the current LTspice toolchain release after its prior queued run was superseded during deployment. The retry set remains bounded to the apps changed by this release.\n\nTests: npx vitest run lib/qa/toolchain-backfill.test.ts app/api/cron/qa-enqueue/route.test.ts