### PR TITLE
Improve exact QA result details

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -418,7 +418,11 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
 
 function DashboardContent() {
   const { data, isLoading, isError, refetch } = useQaLive();
-  const [selected, setSelected] = useState<{ wingetId: string; catalogVersion: string } | null>(null);
+  const [selected, setSelected] = useState<{
+    wingetId: string;
+    catalogVersion: string;
+    packageProfileSha256: string;
+  } | null>(null);
   const [showFullQueue, setShowFullQueue] = useState(false);
 
   if (isLoading) {
@@ -489,9 +493,13 @@ function DashboardContent() {
               <div className="divide-y divide-overlay/10 sm:hidden">
                 {data.recent.map((item) => (
                   <button
-                    key={`${item.wingetId}-${item.testedVersion}-${item.architecture}`}
+                    key={item.packageProfileSha256}
                     type="button"
-                    onClick={() => setSelected({ wingetId: item.wingetId, catalogVersion: item.catalogVersion })}
+                    onClick={() => setSelected({
+                      wingetId: item.wingetId,
+                      catalogVersion: item.catalogVersion,
+                      packageProfileSha256: item.packageProfileSha256,
+                    })}
                     className={cn(
                       'flex min-h-20 w-full items-center gap-3 border-l-2 px-5 py-3 text-left transition-colors hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan',
                       resultEdgeClass(item.outcome)
@@ -525,14 +533,22 @@ function DashboardContent() {
                   <tbody className="divide-y divide-overlay/10">
                     {data.recent.map((item) => (
                       <tr
-                        key={`${item.wingetId}-${item.testedVersion}-${item.architecture}`}
-                        onClick={() => setSelected({ wingetId: item.wingetId, catalogVersion: item.catalogVersion })}
+                        key={item.packageProfileSha256}
+                        onClick={() => setSelected({
+                          wingetId: item.wingetId,
+                          catalogVersion: item.catalogVersion,
+                          packageProfileSha256: item.packageProfileSha256,
+                        })}
                         className="cursor-pointer transition-colors hover:bg-overlay/5"
                       >
                         <td className={cn('border-l-2 px-6 py-3', resultEdgeClass(item.outcome))}>
                           <button
                             type="button"
-                            onClick={() => setSelected({ wingetId: item.wingetId, catalogVersion: item.catalogVersion })}
+                            onClick={() => setSelected({
+                              wingetId: item.wingetId,
+                              catalogVersion: item.catalogVersion,
+                              packageProfileSha256: item.packageProfileSha256,
+                            })}
                             className="flex min-w-0 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
                           >
                             <AppIcon packageId={item.wingetId} packageName={item.displayName} size="sm" />
@@ -565,6 +581,7 @@ function DashboardContent() {
         <QaDetailsDialog
           wingetId={selected.wingetId}
           catalogVersion={selected.catalogVersion}
+          packageProfileSha256={selected.packageProfileSha256}
           open={Boolean(selected)}
           onOpenChange={(open) => { if (!open) setSelected(null); }}
         />

--- a/app/api/apps/[id]/qa/route.test.ts
+++ b/app/api/apps/[id]/qa/route.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/lib/catalog', () => ({
 vi.mock('@/lib/rate-limit', () => ({
   applyRateLimit: applyRateLimitMock,
   getIpKey: () => 'ip:test',
-  PUBLIC_RATE_LIMIT: { limit: 30, windowMs: 60_000 },
+  QA_DETAILS_RATE_LIMIT: { limit: 90, windowMs: 60_000 },
 }));
 
 import { GET } from './route';
@@ -75,6 +75,22 @@ describe('GET /api/apps/[id]/qa', () => {
     expect(JSON.stringify(body)).not.toMatch(/runUrl|runId|runAttempt|testId|computerName|executedAs/);
     expect(JSON.stringify(body)).not.toMatch(/processName|promptMessage|brandingPath/);
     expect(body.classification).toBeNull();
+    expect(applyRateLimitMock).toHaveBeenCalledWith(
+      'qa-details:ip:test',
+      { limit: 90, windowMs: 60_000 }
+    );
+  });
+
+  it('loads the exact package profile selected in recent results', async () => {
+    getQaResultMock.mockResolvedValue(row);
+    const profile = 'a'.repeat(64);
+    const response = await GET(
+      new NextRequest(`http://localhost/api/apps/OpenJS.NodeJS/qa?profile=${profile}`),
+      { params: Promise.resolve({ id: 'OpenJS.NodeJS' }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(getQaResultMock).toHaveBeenCalledWith('OpenJS.NodeJS', 'A'.repeat(64));
   });
 
   it('returns 404 for an untested app', async () => {
@@ -91,5 +107,24 @@ describe('GET /api/apps/[id]/qa', () => {
     });
     expect(response.status).toBe(400);
     expect(getQaResultMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid package profile without querying QA data', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost/api/apps/OpenJS.NodeJS/qa?profile=not-a-hash'),
+      { params: Promise.resolve({ id: 'OpenJS.NodeJS' }) }
+    );
+    expect(response.status).toBe(400);
+    expect(getQaResultMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a retryable service response when the evidence store fails', async () => {
+    getQaResultMock.mockRejectedValue(new Error('temporary database failure'));
+    const response = await GET(new NextRequest('http://localhost/api/apps/OpenJS.NodeJS/qa'), {
+      params: Promise.resolve({ id: 'OpenJS.NodeJS' }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('2');
   });
 });

--- a/app/api/apps/[id]/qa/route.ts
+++ b/app/api/apps/[id]/qa/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCatalogSource } from '@/lib/catalog';
 import { classifyQaFailure } from '@/lib/qa/classify';
-import { applyRateLimit, getIpKey, PUBLIC_RATE_LIMIT } from '@/lib/rate-limit';
+import { applyRateLimit, getIpKey, QA_DETAILS_RATE_LIMIT } from '@/lib/rate-limit';
 import type { QaDetailsResponse } from '@/types/qa';
 
 interface RouteParams {
@@ -9,9 +9,13 @@ interface RouteParams {
 }
 
 const APP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]*\.[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+const PACKAGE_PROFILE_PATTERN = /^[A-Fa-f0-9]{64}$/;
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
-  const rateLimitResponse = await applyRateLimit(getIpKey(request), PUBLIC_RATE_LIMIT);
+  const rateLimitResponse = await applyRateLimit(
+    `qa-details:${getIpKey(request)}`,
+    QA_DETAILS_RATE_LIMIT
+  );
   if (rateLimitResponse) return rateLimitResponse;
 
   const { id } = await params;
@@ -24,11 +28,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (!APP_ID_PATTERN.test(wingetId)) {
     return NextResponse.json({ error: 'Invalid WinGet package ID' }, { status: 400 });
   }
+  const requestedProfile = request.nextUrl.searchParams.get('profile');
+  if (requestedProfile && !PACKAGE_PROFILE_PATTERN.test(requestedProfile)) {
+    return NextResponse.json({ error: 'Invalid QA package profile' }, { status: 400 });
+  }
+  const packageProfileSha256 = requestedProfile?.toUpperCase();
 
   try {
-    const row = await getCatalogSource().getQaResult(wingetId);
+    const row = await getCatalogSource().getQaResult(wingetId, packageProfileSha256);
     if (!row) {
-      return NextResponse.json({ error: 'No QA result is available for this app' }, { status: 404 });
+      return NextResponse.json(
+        {
+          error: packageProfileSha256
+            ? 'This exact QA result is still being published'
+            : 'No QA result is available for this app',
+        },
+        { status: 404, headers: { 'Cache-Control': 'no-store', 'Retry-After': '2' } }
+      );
     }
 
     const response: QaDetailsResponse = {
@@ -67,6 +83,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error) {
     console.error('Failed to load QA details:', error);
-    return NextResponse.json({ error: 'Failed to load QA details' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'QA evidence is temporarily unavailable' },
+      { status: 503, headers: { 'Cache-Control': 'no-store', 'Retry-After': '2' } }
+    );
   }
 }

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -1,8 +1,22 @@
 'use client';
 
 import { Fragment, type ReactNode } from 'react';
-import { AlertTriangle, CheckCircle2, Clock3, Loader2, XCircle } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  FileClock,
+  Gauge,
+  Loader2,
+  PackageCheck,
+  RefreshCw,
+  Settings2,
+  ShieldCheck,
+  TerminalSquare,
+  XCircle,
+} from 'lucide-react';
 import { T, Var } from 'gt-next';
+import { AppIcon } from '@/components/AppIcon';
 import {
   Dialog,
   DialogContent,
@@ -10,10 +24,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { StatusBadge } from '@/components/ui/status-badge';
-import { useQaDetails } from '@/hooks/use-qa';
+import { QaDetailsRequestError, useQaDetails } from '@/hooks/use-qa';
 import { formatQaDuration } from '@/lib/qa/presentation';
 import { qaVersionMismatchKind } from '@/lib/qa/version-mismatch';
+import { cn } from '@/lib/utils';
 import {
   QA_CHANGE_CATEGORIES,
   type QaChangeSet,
@@ -24,6 +38,7 @@ import {
 interface QaDetailsDialogProps {
   wingetId: string;
   catalogVersion: string;
+  packageProfileSha256?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -103,27 +118,27 @@ function QaVersionMismatchNotice({ testedVersion, catalogVersion }: { testedVers
 
 function ChangeTable({ title, changes }: { title: string; changes: QaChangeSet }) {
   return (
-    <details className="rounded-xl border border-overlay/10 bg-bg-elevated/50" open={title === 'Changes after installation'}>
-      <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan">
+    <details className="group overflow-hidden rounded-2xl border border-overlay/10 bg-bg-elevated/40" open={title === 'Changes after installation'}>
+      <summary className="cursor-pointer px-4 py-3.5 text-sm font-medium text-text-primary transition-colors hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan">
         <T>{title}</T>
       </summary>
       <div className="overflow-x-auto border-t border-overlay/10">
         <table className="w-full text-left text-xs">
-          <thead className="text-text-muted">
+          <thead className="bg-bg-deepest/30 text-text-muted">
             <tr>
-              <th className="px-4 py-2 font-medium"><T>Area</T></th>
-              <th className="px-3 py-2 text-right font-medium"><T>Added</T></th>
-              <th className="px-3 py-2 text-right font-medium"><T>Updated</T></th>
-              <th className="px-4 py-2 text-right font-medium"><T>Removed</T></th>
+              <th className="px-4 py-2.5 font-medium"><T>Area</T></th>
+              <th className="px-3 py-2.5 text-right font-medium"><T>Added</T></th>
+              <th className="px-3 py-2.5 text-right font-medium"><T>Updated</T></th>
+              <th className="px-4 py-2.5 text-right font-medium"><T>Removed</T></th>
             </tr>
           </thead>
           <tbody>
             {QA_CHANGE_CATEGORIES.map((category) => (
               <tr key={category} className="border-t border-overlay/5 text-text-secondary">
-                <td className="px-4 py-2"><T>{CATEGORY_LABELS[category]}</T></td>
-                <td className="px-3 py-2 text-right font-mono">{changes[category].added}</td>
-                <td className="px-3 py-2 text-right font-mono">{changes[category].changed}</td>
-                <td className="px-4 py-2 text-right font-mono">{changes[category].removed}</td>
+                <td className="px-4 py-2.5"><T>{CATEGORY_LABELS[category]}</T></td>
+                <td className="px-3 py-2.5 text-right font-mono">{changes[category].added}</td>
+                <td className="px-3 py-2.5 text-right font-mono">{changes[category].changed}</td>
+                <td className="px-4 py-2.5 text-right font-mono">{changes[category].removed}</td>
               </tr>
             ))}
           </tbody>
@@ -133,149 +148,276 @@ function ChangeTable({ title, changes }: { title: string; changes: QaChangeSet }
   );
 }
 
-export function QaDetailsDialog({ wingetId, catalogVersion, open, onOpenChange }: QaDetailsDialogProps) {
-  const { data, isLoading, isError } = useQaDetails(wingetId, open);
+function SummaryItem({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: typeof Clock3;
+  label: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 gap-3 rounded-2xl border border-overlay/10 bg-bg-elevated/45 p-4">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-accent-cyan/10 text-accent-cyan">
+        <Icon className="h-4.5 w-4.5" aria-hidden="true" />
+      </span>
+      <span className="min-w-0">
+        <span className="block text-xs text-text-muted">{label}</span>
+        <span className="mt-1 block truncate text-sm font-medium text-text-primary">{children}</span>
+      </span>
+    </div>
+  );
+}
+
+function LifecycleCard({ name, result }: { name: string; result: QaPhaseResult | null }) {
+  const status = phaseStatus(name, result);
+  const Icon = status.passed === true ? CheckCircle2 : status.passed === false ? XCircle : Clock3;
+
+  return (
+    <div className={cn(
+      'rounded-2xl border border-overlay/10 bg-bg-elevated/40 p-4',
+      status.passed === true && 'border-t-2 border-t-status-success/70',
+      status.passed === false && 'border-t-2 border-t-status-error/70'
+    )}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs text-text-muted"><T>{name}</T></p>
+          <p className={cn(
+            'mt-1 text-sm font-medium',
+            status.passed === true ? 'text-status-success' : status.passed === false ? 'text-status-error' : 'text-text-muted'
+          )}><T>{status.label}</T></p>
+        </div>
+        <Icon className={cn(
+          'h-5 w-5 shrink-0',
+          status.passed === true ? 'text-status-success' : status.passed === false ? 'text-status-error' : 'text-text-muted'
+        )} aria-hidden="true" />
+      </div>
+      <div className="mt-4 flex justify-between gap-3 border-t border-overlay/10 pt-3 text-xs text-text-muted">
+        <span><T>Exit</T> <code className="text-text-secondary">{result?.exitCode ?? '—'}</code></span>
+        <span className="font-mono text-text-secondary">{formatQaDuration(result?.durationSeconds)}</span>
+      </div>
+    </div>
+  );
+}
+
+function DetailsSkeleton({ wingetId }: { wingetId: string }) {
+  return (
+    <div className="space-y-6" aria-label="Loading QA result">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div key={index} className="h-20 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
+        ))}
+      </div>
+      <div className="space-y-3">
+        <div className="h-4 w-36 animate-pulse rounded bg-overlay/10 motion-reduce:animate-none" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <div key={index} className="h-32 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
+          ))}
+        </div>
+      </div>
+      <div className="h-52 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
+      <p className="sr-only"><T>Loading the exact QA result for <Var>{wingetId}</Var>.</T></p>
+    </div>
+  );
+}
+
+export function QaDetailsDialog({
+  wingetId,
+  catalogVersion,
+  packageProfileSha256,
+  open,
+  onOpenChange,
+}: QaDetailsDialogProps) {
+  const { data, error, isLoading, isFetching, refetch } = useQaDetails(
+    wingetId,
+    packageProfileSha256,
+    open
+  );
+  const requestError = error instanceof QaDetailsRequestError ? error : null;
+  const isPublishing = requestError?.status === 404;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] max-w-3xl flex-col">
-        <DialogHeader className="shrink-0">
-          <DialogTitle><T>Installation test details</T></DialogTitle>
-          <DialogDescription><T>Latest isolated test of the package IntuneGet deploys through Intune.</T></DialogDescription>
+      <DialogContent className="flex max-h-[92vh] max-w-5xl flex-col bg-bg-surface shadow-[0_28px_90px_rgba(0,0,0,0.35)]">
+        <DialogHeader className="shrink-0 border-b border-overlay/10 bg-gradient-to-br from-bg-elevated/80 via-bg-surface to-accent-cyan/5 px-6 py-5 pr-14 sm:px-8 sm:py-6 sm:pr-16">
+          <div className="flex items-center gap-4">
+            <AppIcon
+              packageId={wingetId}
+              packageName={data?.displayName || wingetId}
+              size="xl"
+              className="shadow-sm"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="mb-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span className="text-xs font-medium uppercase tracking-[0.16em] text-accent-cyan"><T>Application QA</T></span>
+                {data ? (
+                  <span className={cn(
+                    'inline-flex items-center gap-1.5 text-xs font-medium',
+                    data.outcome === 'Passed' ? 'text-status-success' : 'text-status-error'
+                  )}>
+                    {data.outcome === 'Passed'
+                      ? <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      : <XCircle className="h-3.5 w-3.5" aria-hidden="true" />}
+                    <T>{data.outcome}</T>
+                  </span>
+                ) : null}
+              </div>
+              <DialogTitle className="truncate text-xl sm:text-2xl">
+                {data?.displayName || <T>Installation test details</T>}
+              </DialogTitle>
+              <DialogDescription className="mt-1 truncate">
+                {data
+                  ? <>{wingetId} · <T>Version <Var>{data.testedVersion}</Var></T> · {data.architecture}</>
+                  : <T>Loading the exact isolated test run and its evidence.</T>}
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-6">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6 sm:px-8 sm:py-7">
           {isLoading ? (
-            <div className="flex min-h-48 items-center justify-center gap-2 text-sm text-text-secondary">
-              <Loader2 className="h-5 w-5 animate-spin motion-reduce:animate-none" aria-hidden="true" /> <T>Loading QA result…</T>
-            </div>
-          ) : isError || !data ? (
-            <div className="rounded-xl border border-status-error/20 bg-status-error/10 p-4 text-sm text-status-error">
-              <T>The QA result could not be loaded. Please try again.</T>
+            <DetailsSkeleton wingetId={wingetId} />
+          ) : !data ? (
+            <div className="mx-auto flex min-h-80 max-w-xl flex-col items-center justify-center text-center" role="alert">
+              <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-status-warning/10 text-status-warning">
+                {isPublishing
+                  ? <FileClock className="h-6 w-6" aria-hidden="true" />
+                  : <AlertTriangle className="h-6 w-6" aria-hidden="true" />}
+              </span>
+              <h3 className="mt-5 text-lg font-semibold text-text-primary">
+                {isPublishing ? <T>This test result is still being prepared</T> : <T>We could not load this test result</T>}
+              </h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-text-secondary">
+                {isPublishing
+                  ? <T>The run is complete, but its evidence is still being published. Retry in a moment.</T>
+                  : <T>The evidence service may be temporarily unavailable. The QA result itself has not been lost.</T>}
+              </p>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                disabled={isFetching}
+                className="mt-6 inline-flex min-h-11 items-center gap-2 rounded-xl bg-accent-cyan px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-cyan-bright disabled:cursor-wait disabled:opacity-70"
+              >
+                {isFetching
+                  ? <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                  : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+                <T>Try again</T>
+              </button>
             </div>
           ) : (
-            <>
-              <section className="space-y-3">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <h3 className="text-lg font-semibold text-text-primary">{data.displayName}</h3>
-                    <p className="text-sm text-text-secondary">
-                      <T>Version <Var>{data.testedVersion}</Var></T> · {data.architecture} · {data.publisher}
-                    </p>
-                  </div>
-                  <StatusBadge
-                    tone={data.outcome === 'Passed' ? 'success' : 'error'}
-                    icon={data.outcome === 'Passed' ? CheckCircle2 : XCircle}
-                  >
-                    <T>QA <Var>{data.outcome}</Var></T>
-                  </StatusBadge>
-                </div>
-                <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-text-muted">
-                  <span>{new Date(data.testedAtUtc).toLocaleString()}</span>
-                  <span className="inline-flex items-center gap-1"><Clock3 className="h-3.5 w-3.5" aria-hidden="true" /> {formatQaDuration(data.overallDurationSeconds)}</span>
-                  <span>{data.installerType?.toUpperCase() || <T>Installer type unknown</T>}</span>
-                  <span>PSADT {data.package?.psadtVersion || <T>version unknown</T>}</span>
+            <div className="space-y-7">
+              <section aria-labelledby="qa-summary-heading">
+                <h3 id="qa-summary-heading" className="sr-only"><T>Test summary</T></h3>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <SummaryItem icon={ShieldCheck} label={<T>Result</T>}>
+                    <span className={data.outcome === 'Passed' ? 'text-status-success' : 'text-status-error'}><T>{data.outcome}</T></span>
+                  </SummaryItem>
+                  <SummaryItem icon={Clock3} label={<T>Total duration</T>}>
+                    {formatQaDuration(data.overallDurationSeconds)}
+                  </SummaryItem>
+                  <SummaryItem icon={PackageCheck} label={<T>Installer</T>}>
+                    {data.installerType?.toUpperCase() || <T>Type unknown</T>}
+                  </SummaryItem>
+                  <SummaryItem icon={Gauge} label={<T>Tested</T>}>
+                    {new Date(data.testedAtUtc).toLocaleString()}
+                  </SummaryItem>
                 </div>
               </section>
 
               {data.testedVersion !== catalogVersion ? (
-                <div className="flex gap-2 rounded-xl border border-status-warning/20 bg-status-warning/10 p-3 text-sm text-status-warning">
+                <div className="flex gap-3 rounded-2xl border border-status-warning/20 bg-status-warning/10 p-4 text-sm leading-6 text-status-warning">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
                   <p><QaVersionMismatchNotice testedVersion={data.testedVersion} catalogVersion={catalogVersion} /></p>
                 </div>
               ) : null}
 
+              <section className="space-y-3" aria-labelledby="qa-lifecycle-heading">
+                <div>
+                  <h3 id="qa-lifecycle-heading" className="text-base font-semibold text-text-primary"><T>Installation lifecycle</T></h3>
+                  <p className="mt-1 text-sm text-text-muted"><T>The package was installed, detected, removed, and checked again inside a clean Windows VM.</T></p>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <LifecycleCard name="Install" result={data.phases.install} />
+                  <LifecycleCard name="Detection after install" result={data.phases.detectionAfterInstall} />
+                  <LifecycleCard name="Uninstall" result={data.phases.uninstall} />
+                  <LifecycleCard name="Detection after uninstall" result={data.phases.detectionAfterUninstall} />
+                </div>
+              </section>
+
               {data.effectiveConfiguration ? (
-                <section className="space-y-3">
-                  <div>
-                    <h4 className="text-sm font-semibold text-text-primary"><T>Effective PSADT configuration</T></h4>
-                    <p className="mt-1 text-xs text-text-muted"><T>Safe, compact settings from the exact package profile used for this test.</T></p>
-                  </div>
-                  <div className="grid gap-3 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 text-xs text-text-secondary sm:grid-cols-2 lg:grid-cols-4">
-                    <div><span className="block text-text-muted"><T>Deploy mode</T></span><code>{data.effectiveConfiguration.deployMode}</code></div>
-                    <div><span className="block text-text-muted"><T>Restart behavior</T></span><code>{data.effectiveConfiguration.restartBehavior}</code></div>
-                    <div><span className="block text-text-muted"><T>Processes to close</T></span>{data.effectiveConfiguration.processCloseCount}</div>
-                    <div><span className="block text-text-muted"><T>UI evidence expected</T></span><T>{data.effectiveConfiguration.uiEvidenceExpected ? 'Yes' : 'No'}</T></div>
-                    <div className="sm:col-span-2 lg:col-span-4">
-                      <span className="block text-text-muted"><T>Prompt configuration</T></span>
-                      <PromptConfigurationSummary configuration={data.effectiveConfiguration.promptConfiguration} />
+                <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-configuration-heading">
+                  <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
+                    <Settings2 className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
+                    <div>
+                      <h3 id="qa-configuration-heading" className="text-sm font-semibold text-text-primary"><T>Test configuration</T></h3>
+                      <p className="mt-0.5 text-xs text-text-muted"><T>The effective PSADT settings used for this exact run.</T></p>
                     </div>
                   </div>
-                  <div>
-                    <p className="mb-1 text-xs text-text-muted"><T>Vendor silent arguments</T></p>
-                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-overlay/10 bg-bg-deepest p-3 text-xs text-text-secondary">
-                      {data.effectiveConfiguration.vendorSilentArguments === null
-                        ? <T>Custom deployment arguments withheld</T>
-                        : data.effectiveConfiguration.vendorSilentArguments || <T>No arguments required</T>}
-                    </pre>
+                  <div className="grid gap-x-6 gap-y-5 p-5 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                    <div><span className="block text-xs text-text-muted"><T>Deploy mode</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.deployMode}</code></div>
+                    <div><span className="block text-xs text-text-muted"><T>Restart behavior</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.restartBehavior}</code></div>
+                    <div><span className="block text-xs text-text-muted"><T>Processes to close</T></span><span className="mt-1 block font-medium text-text-primary">{data.effectiveConfiguration.processCloseCount}</span></div>
+                    <div><span className="block text-xs text-text-muted"><T>UI evidence expected</T></span><span className="mt-1 block font-medium text-text-primary"><T>{data.effectiveConfiguration.uiEvidenceExpected ? 'Yes' : 'No'}</T></span></div>
+                    <div className="sm:col-span-2 lg:col-span-4"><span className="block text-xs text-text-muted"><T>Prompt configuration</T></span><span className="mt-1 block text-text-primary"><PromptConfigurationSummary configuration={data.effectiveConfiguration.promptConfiguration} /></span></div>
+                    <div className="sm:col-span-2 lg:col-span-4">
+                      <span className="block text-xs text-text-muted"><T>Vendor silent arguments</T></span>
+                      <code className="mt-1.5 block overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 px-3 py-2.5 text-xs text-text-secondary">
+                        {data.effectiveConfiguration.vendorSilentArguments === null
+                          ? <T>Custom deployment arguments withheld</T>
+                          : data.effectiveConfiguration.vendorSilentArguments || <T>No arguments required</T>}
+                      </code>
+                    </div>
                   </div>
                 </section>
               ) : null}
 
-              <section className="space-y-3">
-                <h4 className="text-sm font-semibold text-text-primary"><T>Silent installation method</T></h4>
-                <div>
-                  <p className="mb-1 text-xs text-text-muted"><T>Install command</T></p>
-                  <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-overlay/10 bg-bg-deepest p-3 text-xs text-text-secondary">{data.commands.install}</pre>
+              <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-method-heading">
+                <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
+                  <TerminalSquare className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
+                  <div>
+                    <h3 id="qa-method-heading" className="text-sm font-semibold text-text-primary"><T>Installation method</T></h3>
+                    <p className="mt-0.5 text-xs text-text-muted"><T>Commands and detection logic used by the package.</T></p>
+                  </div>
                 </div>
-                <div>
-                  <p className="mb-1 text-xs text-text-muted"><T>Uninstall command</T></p>
-                  <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-overlay/10 bg-bg-deepest p-3 text-xs text-text-secondary">{data.commands.uninstall}</pre>
-                </div>
-                <p className="text-xs text-text-secondary">
-                  {data.detection.type === 'fileVersion' ? (
-                    <T>Detection: file version at <Var><code className="rounded bg-bg-deepest px-1 py-0.5">{data.detection.path}</code></Var> must be at least <Var>{data.detection.minimumVersion}</Var>.</T>
-                  ) : (
-                    <T>Detection: <Var>{data.detection.description}</Var>.</T>
-                  )}
-                </p>
-              </section>
-
-              <section className="space-y-3">
-                <h4 className="text-sm font-semibold text-text-primary"><T>Command results</T></h4>
-                <div className="overflow-x-auto rounded-xl border border-overlay/10">
-                  <table className="w-full text-left text-xs">
-                    <thead className="text-text-muted">
-                      <tr><th className="px-4 py-2 font-medium"><T>Phase</T></th><th className="px-3 py-2 font-medium"><T>Result</T></th><th className="px-3 py-2 text-right font-medium"><T>Exit</T></th><th className="px-4 py-2 text-right font-medium"><T>Duration</T></th></tr>
-                    </thead>
-                    <tbody>
-                      {([
-                        ['Install', data.phases.install],
-                        ['Detection after install', data.phases.detectionAfterInstall],
-                        ['Uninstall', data.phases.uninstall],
-                        ['Detection after uninstall', data.phases.detectionAfterUninstall],
-                      ] as const).map(([name, result]) => {
-                        const status = phaseStatus(name, result);
-                        return (
-                          <tr key={name} className="border-t border-overlay/5 text-text-secondary">
-                            <td className="px-4 py-2"><T>{name}</T></td>
-                            <td className={status.passed === true ? 'px-3 py-2 text-status-success' : status.passed === false ? 'px-3 py-2 text-status-error' : 'px-3 py-2 text-text-muted'}><T>{status.label}</T></td>
-                            <td className="px-3 py-2 text-right font-mono">{result?.exitCode ?? '—'}</td>
-                            <td className="px-4 py-2 text-right font-mono">{formatQaDuration(result?.durationSeconds)}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
+                <div className="space-y-5 p-5">
+                  <div>
+                    <p className="mb-1.5 text-xs text-text-muted"><T>Install command</T></p>
+                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.install}</pre>
+                  </div>
+                  <div>
+                    <p className="mb-1.5 text-xs text-text-muted"><T>Uninstall command</T></p>
+                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.uninstall}</pre>
+                  </div>
+                  <p className="text-xs leading-5 text-text-secondary">
+                    {data.detection.type === 'fileVersion' ? (
+                      <T>Detection: file version at <Var><code className="rounded bg-bg-deepest px-1 py-0.5">{data.detection.path}</code></Var> must be at least <Var>{data.detection.minimumVersion}</Var>.</T>
+                    ) : (
+                      <T>Detection: <Var>{data.detection.description}</Var>.</T>
+                    )}
+                  </p>
                 </div>
               </section>
 
               {data.changes ? (
-                <section className="space-y-3">
-                  <h4 className="text-sm font-semibold text-text-primary"><T>Observed system changes</T></h4>
+                <section className="space-y-3" aria-labelledby="qa-changes-heading">
+                  <div>
+                    <h3 id="qa-changes-heading" className="text-base font-semibold text-text-primary"><T>Observed system changes</T></h3>
+                    <p className="mt-1 text-sm text-text-muted"><T>Compact counts captured before and after the installation lifecycle.</T></p>
+                  </div>
                   <ChangeTable title="Changes after installation" changes={data.changes.afterInstall} />
                   <ChangeTable title="Residual changes after uninstall" changes={data.changes.residualAfterUninstall} />
                   <p className="text-xs leading-relaxed text-text-muted"><T>Counts are correlated with the test window, not attributed to the app; background Windows activity is included. A nonzero residual does not mean the uninstall was dirty.</T></p>
                 </section>
               ) : null}
 
-              <section className="grid gap-3 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 text-xs text-text-secondary sm:grid-cols-2">
-                <div><span className="block text-text-muted"><T>Execution context</T></span><code>{data.environment?.executionContext || <T>Not recorded</T>}</code></div>
-                <div><span className="block text-text-muted"><T>Relevant Windows events</T></span>{data.relevantEventCount ?? <T>Not recorded</T>}</div>
-                <div><span className="block text-text-muted"><T>Tested configuration</T></span><code>{data.package?.profileSha256?.slice(0, 12) || <T>Not recorded</T>}</code></div>
-                <div><span className="block text-text-muted"><T>Packager commit</T></span><code>{data.package?.packagerCommit?.slice(0, 12) || <T>Not recorded</T>}</code></div>
+              <section className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-overlay/10 pt-5 text-xs text-text-muted">
+                <span><T>Publisher</T>: <span className="text-text-secondary">{data.publisher || <T>Not recorded</T>}</span></span>
+                <span>PSADT <span className="text-text-secondary">{data.package?.psadtVersion || <T>version unknown</T>}</span></span>
+                <span><T>Windows events</T>: <span className="text-text-secondary">{data.relevantEventCount ?? <T>Not recorded</T>}</span></span>
               </section>
-            </>
+            </div>
           )}
         </div>
       </DialogContent>

--- a/hooks/use-qa.test.ts
+++ b/hooks/use-qa.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { QaDetailsRequestError, shouldRetryQaDetails } from './use-qa';
+
+describe('shouldRetryQaDetails', () => {
+  it('retries a just-published exact result once', () => {
+    const error = new QaDetailsRequestError('still publishing', 404, 2);
+    expect(shouldRetryQaDetails(0, error)).toBe(true);
+    expect(shouldRetryQaDetails(1, error)).toBe(false);
+  });
+
+  it('retries transient service errors without retrying rate limits', () => {
+    expect(shouldRetryQaDetails(1, new QaDetailsRequestError('unavailable', 503, 2))).toBe(true);
+    expect(shouldRetryQaDetails(2, new QaDetailsRequestError('unavailable', 503, 2))).toBe(false);
+    expect(shouldRetryQaDetails(0, new QaDetailsRequestError('limited', 429, 30))).toBe(false);
+  });
+});

--- a/hooks/use-qa.ts
+++ b/hooks/use-qa.ts
@@ -32,16 +32,61 @@ export function useQaStatuses(ids: string[]) {
   });
 }
 
-export function useQaDetails(wingetId: string, enabled: boolean) {
+export class QaDetailsRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryAfterSeconds: number | null
+  ) {
+    super(message);
+    this.name = 'QaDetailsRequestError';
+  }
+}
+
+function parseRetryAfter(response: Response): number | null {
+  const seconds = Number(response.headers.get('retry-after'));
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}
+
+export function shouldRetryQaDetails(failureCount: number, error: Error): boolean {
+  if (!(error instanceof QaDetailsRequestError)) return failureCount < 1;
+  if (error.status === 404) return failureCount < 1;
+  if (error.status >= 500) return failureCount < 2;
+  return false;
+}
+
+export function useQaDetails(
+  wingetId: string,
+  packageProfileSha256: string | undefined,
+  enabled: boolean
+) {
   return useQuery<QaDetailsResponse>({
-    queryKey: ['qa', 'details', wingetId],
+    queryKey: ['qa', 'details', wingetId, packageProfileSha256 || 'latest'],
     queryFn: async () => {
-      const response = await fetch(`/api/apps/${encodeURIComponent(wingetId)}/qa`);
-      if (!response.ok) throw new Error('Failed to load QA details');
+      const params = new URLSearchParams();
+      if (packageProfileSha256) params.set('profile', packageProfileSha256);
+      const suffix = params.size ? `?${params.toString()}` : '';
+      const response = await fetch(`/api/apps/${encodeURIComponent(wingetId)}/qa${suffix}`);
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null) as { error?: string } | null;
+        throw new QaDetailsRequestError(
+          payload?.error || 'Failed to load QA details',
+          response.status,
+          parseRetryAfter(response)
+        );
+      }
       return response.json();
     },
     enabled: Boolean(wingetId) && enabled,
     staleTime: 5 * 60 * 1000,
+    retry: shouldRetryQaDetails,
+    retryDelay: (attempt, error) => {
+      if (error instanceof QaDetailsRequestError && error.retryAfterSeconds) {
+        return error.retryAfterSeconds * 1000;
+      }
+      return Math.min(500 * 2 ** attempt, 2_000);
+    },
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -271,6 +271,8 @@ describe('SnapshotCatalogSource', () => {
     expect(result?.detection.minimumVersion).toBe('120.0');
     expect(result?.phase_results.detectionAfterUninstall?.exitCode).toBe(1);
     expect(result?.effective_configuration?.deployMode).toBe('Silent');
+    expect(await source.getQaResult('Google.Chrome', 'B'.repeat(64))).not.toBeNull();
+    expect(await source.getQaResult('Google.Chrome', 'A'.repeat(64))).toBeNull();
     expect(await source.getQaResult('Mozilla.Firefox')).toBeNull();
   });
 

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -566,15 +566,19 @@ export class SnapshotCatalogSource implements CatalogSource {
     );
   }
 
-  async getQaResult(wingetId: string): Promise<QaResultRow | null> {
+  async getQaResult(
+    wingetId: string,
+    packageProfileSha256?: string
+  ): Promise<QaResultRow | null> {
     return withDb(
       (db) => {
         if (!hasCompatibleQaResultsTable(db)) return null;
+        const sql = packageProfileSha256
+          ? "SELECT * FROM qa_results WHERE winget_id = ? AND test_level = 'psadt-package' AND package_profile_sha256 = ? LIMIT 1"
+          : "SELECT * FROM qa_results WHERE winget_id = ? AND test_level = 'psadt-package' LIMIT 1";
         const row = db
-          .prepare(
-            "SELECT * FROM qa_results WHERE winget_id = ? AND test_level = 'psadt-package' LIMIT 1"
-          )
-          .get(wingetId) as
+          .prepare(sql)
+          .get(...(packageProfileSha256 ? [wingetId, packageProfileSha256.toUpperCase()] : [wingetId])) as
           | (Omit<QaResultRow, 'detection' | 'phase_results' | 'changes' | 'environment' | 'effective_configuration'> & {
               detection: string;
               phase_results: string;

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -380,7 +380,36 @@ export class SupabaseCatalogSource implements CatalogSource {
     return (data || []) as QaStatusRow[];
   }
 
-  async getQaResult(wingetId: string): Promise<QaResultRow | null> {
+  async getQaResult(
+    wingetId: string,
+    packageProfileSha256?: string
+  ): Promise<QaResultRow | null> {
+    if (packageProfileSha256) {
+      const supabase = createServerClient();
+      const { data, error } = await supabase
+        .from('qa_package_results')
+        .select(
+          'package_profile_sha256, winget_id, display_name, publisher, tested_version, architecture, installer_sha256, outcome, tested_at_utc, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256'
+        )
+        .eq('winget_id', wingetId)
+        .eq('package_profile_sha256', packageProfileSha256.toUpperCase())
+        .maybeSingle();
+
+      if (error) {
+        throw new Error(`Failed to read exact QA package result: ${error.message}`);
+      }
+      if (!data?.detection || !data.phase_results || !data.install_command || !data.uninstall_command) {
+        return null;
+      }
+
+      return {
+        ...data,
+        display_name: data.display_name || wingetId,
+        publisher: data.publisher || '',
+        test_level: 'psadt-package',
+      } as unknown as QaResultRow;
+    }
+
     const supabase = serviceOrAnonClient();
     if (!supabase) return null;
 
@@ -394,8 +423,7 @@ export class SupabaseCatalogSource implements CatalogSource {
       .maybeSingle();
 
     if (error) {
-      console.error('Failed to read QA result:', error.message);
-      return null;
+      throw new Error(`Failed to read QA result: ${error.message}`);
     }
 
     return (data as QaResultRow | null) || null;

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -218,8 +218,8 @@ export interface CatalogSource {
   /** Latest active queued/running candidate for each requested app. */
   getQaCandidateStatuses(ids: string[]): Promise<QaCandidateStatusRow[]>;
 
-  /** Latest compact QA result for one catalog app. */
-  getQaResult(wingetId: string): Promise<QaResultRow | null>;
+  /** Exact package-profile QA result, or the latest catalog result when omitted. */
+  getQaResult(wingetId: string, packageProfileSha256?: string): Promise<QaResultRow | null>;
 
   // --- update detection ---
 

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -44,6 +44,7 @@ describe('buildQaLiveResponse', () => {
       consecutivePollFailures: 0,
       recent: [{
         winget_id: 'Example.App',
+        package_profile_sha256: 'A'.repeat(64),
         display_name: 'Example',
         tested_version: '2.0.0',
         architecture: 'x64',
@@ -57,6 +58,7 @@ describe('buildQaLiveResponse', () => {
 
     expect(response.recent[0]).toMatchObject({
       displayName: 'Example',
+      packageProfileSha256: 'A'.repeat(64),
       durationSeconds: 94.25,
     });
   });

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -9,7 +9,7 @@ import type { QaArchitecture, QaLiveActivity, QaLiveLog, QaLivePhase, QaLiveResp
 const RUNNER_STALE_MS = 10 * 60 * 1000;
 const POLL_STALE_MS = 5 * 60 * 1000;
 export const QA_LIVE_RECENT_RESULT_COLUMNS =
-  'winget_id, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds';
+  'winget_id, package_profile_sha256, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds';
 
 interface CandidateRow {
   id: string;
@@ -49,6 +49,7 @@ interface PollRow {
 
 interface ResultRow {
   winget_id: string;
+  package_profile_sha256: string;
   display_name?: string | null;
   tested_version: string;
   architecture: string;
@@ -351,6 +352,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
     },
     recent: input.recent.map((result) => ({
       wingetId: result.winget_id,
+      packageProfileSha256: result.package_profile_sha256,
       displayName: result.display_name || appById.get(result.winget_id)?.name || result.winget_id,
       testedVersion: result.tested_version,
       catalogVersion: appById.get(result.winget_id)?.latest_version || result.tested_version,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -90,6 +90,12 @@ export const PUBLIC_RATE_LIMIT: RateLimitConfig = {
   windowMs: 60 * 1000,
 };
 
+/** QA details: independent allowance for opening exact recent-run evidence. */
+export const QA_DETAILS_RATE_LIMIT: RateLimitConfig = {
+  limit: 90,
+  windowMs: 60 * 1000,
+};
+
 /** Live QA status: two-second foreground polling with room for shared egress. */
 export const QA_LIVE_RATE_LIMIT: RateLimitConfig = {
   limit: 180,

--- a/supabase/migrations/20260812163353_qa_exact_package_result_details.sql
+++ b/supabase/migrations/20260812163353_qa_exact_package_result_details.sql
@@ -1,0 +1,130 @@
+-- Keep the full sanitized evidence for every exact PSADT package profile.
+-- qa_results remains the one-row-per-app catalog projection, while this
+-- private table powers exact recent-run details without exposing provenance.
+alter table public.qa_package_results
+  add column if not exists display_name text,
+  add column if not exists publisher text,
+  add column if not exists installer_type text,
+  add column if not exists install_command text,
+  add column if not exists uninstall_command text,
+  add column if not exists detection jsonb,
+  add column if not exists phase_results jsonb,
+  add column if not exists changes jsonb,
+  add column if not exists relevant_event_count integer,
+  add column if not exists environment jsonb,
+  add column if not exists effective_configuration jsonb,
+  add column if not exists qa_schema_version integer,
+  add column if not exists profile_kind text not null default 'catalog-default';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'qa_package_results_profile_kind_check'
+      and conrelid = 'public.qa_package_results'::regclass
+  ) then
+    alter table public.qa_package_results
+      add constraint qa_package_results_profile_kind_check
+      check (profile_kind in ('catalog-default', 'deployment-config'));
+  end if;
+end
+$$;
+
+-- Canonical package rows can be populated immediately from qa_results. The
+-- workflow reconciliation fills configuration-specific historical rows.
+update public.qa_package_results as package_result
+set display_name = result.display_name,
+    publisher = result.publisher,
+    installer_type = result.installer_type,
+    install_command = result.install_command,
+    uninstall_command = result.uninstall_command,
+    detection = result.detection,
+    phase_results = result.phase_results,
+    changes = result.changes,
+    relevant_event_count = result.relevant_event_count,
+    environment = result.environment,
+    effective_configuration = result.effective_configuration,
+    qa_schema_version = result.qa_schema_version,
+    profile_kind = 'catalog-default'
+from public.qa_results as result
+where result.package_profile_sha256 = package_result.package_profile_sha256;
+
+-- Preserve the existing synchronization behavior behind a private helper,
+-- then enrich every exact package row from the same already-sanitized payload.
+alter function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  rename to sync_qa_results_v2_metadata_only;
+
+revoke all on function public.sync_qa_results_v2_metadata_only(text, jsonb, jsonb, boolean)
+  from public, anon, authenticated, service_role;
+grant execute on function public.sync_qa_results_v2_metadata_only(text, jsonb, jsonb, boolean)
+  to service_role;
+
+create function public.sync_qa_results_v2(
+  p_secret text,
+  p_rows jsonb,
+  p_recipes jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  sync_result jsonb;
+begin
+  sync_result := public.sync_qa_results_v2_metadata_only(
+    p_secret,
+    p_rows,
+    p_recipes,
+    p_allow_large_delete
+  );
+
+  update public.qa_package_results as package_result
+  set display_name = row_data.display_name,
+      publisher = row_data.publisher,
+      installer_type = row_data.installer_type,
+      install_command = row_data.install_command,
+      uninstall_command = row_data.uninstall_command,
+      detection = row_data.detection,
+      phase_results = row_data.phase_results,
+      changes = row_data.changes,
+      relevant_event_count = row_data.relevant_event_count,
+      environment = row_data.environment,
+      effective_configuration = row_data.effective_configuration,
+      qa_schema_version = row_data.qa_schema_version,
+      profile_kind = coalesce(nullif(row_data.profile_kind, ''), 'catalog-default')
+  from pg_catalog.jsonb_to_recordset(p_rows) as row_data(
+    package_profile_sha256 text,
+    tested_at_utc timestamptz,
+    test_level text,
+    display_name text,
+    publisher text,
+    installer_type text,
+    install_command text,
+    uninstall_command text,
+    detection jsonb,
+    phase_results jsonb,
+    changes jsonb,
+    relevant_event_count integer,
+    environment jsonb,
+    effective_configuration jsonb,
+    qa_schema_version integer,
+    profile_kind text
+  )
+  where row_data.test_level = 'psadt-package'
+    and upper(row_data.package_profile_sha256) = package_result.package_profile_sha256
+    and row_data.tested_at_utc >= package_result.tested_at_utc;
+
+  return sync_result;
+end;
+$$;
+
+revoke all on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  from public, authenticated, service_role;
+grant execute on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  to anon;
+
+comment on column public.qa_package_results.profile_kind is
+  'Sanitized package profile category used to distinguish catalog QA from customer configuration QA.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -228,12 +228,25 @@ export interface Database {
         Row: {
           package_profile_sha256: string;
           winget_id: string;
+          display_name: string | null;
+          publisher: string | null;
           tested_version: string;
           architecture: string;
           installer_sha256: string;
           outcome: 'Passed' | 'Failed';
           tested_at_utc: string;
           overall_duration_seconds: number | null;
+          installer_type: string | null;
+          install_command: string | null;
+          uninstall_command: string | null;
+          detection: Json | null;
+          phase_results: Json | null;
+          changes: Json | null;
+          relevant_event_count: number | null;
+          environment: Json | null;
+          effective_configuration: Json | null;
+          qa_schema_version: number | null;
+          profile_kind: 'catalog-default' | 'deployment-config';
           psadt_version: string;
           psadt_template_sha256: string;
           psadt_config_sha256: string;

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -168,6 +168,7 @@ export interface QaLiveResponse {
   };
   recent: Array<{
     wingetId: string;
+    packageProfileSha256: string;
     displayName: string;
     testedVersion: string;
     catalogVersion: string;


### PR DESCRIPTION
## What changed

- redesigned the recent-run details dialog with app identity, a compact summary, lifecycle cards, structured configuration and command sections, responsive evidence tables, and a matching skeleton state
- added a clear retryable error state instead of the previous generic dead end
- made recent rows open their exact package-profile result rather than the one-row-per-app catalog result
- gave QA details an independent, namespaced rate-limit budget
- persisted sanitized compact evidence for every exact PSADT package profile while keeping the underlying table private
- backfilled exact historical evidence through the existing QA result reconciliation workflow

## Root cause

The recent-results table reads `qa_package_results`, but the dialog endpoint previously read only `qa_results`. Configuration-specific runs could therefore appear in the list without a matching details row. Transient Supabase failures were also converted to a misleading 404, and details shared the generic public request budget.

## Impact

Clicking a recent result now loads the precise run that was selected, including failed and configuration-specific profiles. Temporary publication or service errors resolve quickly and expose an in-place retry without leaving the modal stuck.

## Validation

- `npm run lint`
- `npm test` — 953 tests passed
- `npm run build:ci`
- Supabase migration applied successfully
- QA result reconciliation completed successfully
- verified all current ten recent rows have exact detail evidence