### PR TITLE
Handle Intune administrator approval requirements

### DIFF
--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -54,6 +54,9 @@ const categoryHints: Record<string, { message: string; showReVerify?: boolean }>
     message: 'This appears to be a permissions issue. Your Global Administrator may need to grant admin consent with Intune permissions.',
     showReVerify: true,
   },
+  approval: {
+    message: 'Your organization requires another Intune administrator to approve this app change. Approve the pending request in the Intune admin center, then retry the upload.',
+  },
   network: {
     message: 'This is a network-related error. The download server may be unavailable or rate-limiting requests. You can try again later or package a different version.',
   },
@@ -93,6 +96,7 @@ const errorCodeMessages: Record<string, string> = {
   AUTH_NO_CONSENT: 'Admin consent has not been granted for the required permissions',
   INTUNE_UNAUTHORIZED: 'Microsoft Graph rejected the service principal credentials (401)',
   INTUNE_FORBIDDEN: 'Access denied (403) - missing DeviceManagementApps.ReadWrite.All permission',
+  INTUNE_APPROVAL_REQUIRED: 'Your organization requires administrator approval before Intune can apply this app change.',
   INTUNE_SERVICE_TRANSIENT: 'Intune returned a temporary backend error. A safe retry is recommended.',
   INTUNE_BAD_REQUEST: 'Intune rejected the app or content request. Review the workflow log for the rejected field.',
   INTUNE_API_ERROR: 'The Intune API returned an unexpected error',

--- a/lib/package-callback.test.ts
+++ b/lib/package-callback.test.ts
@@ -33,6 +33,19 @@ describe('package callback contract', () => {
     expect(packageCallbackSchema.safeParse({ jobId, status: 'packaging', installerSha256: 'bad' }).success).toBe(false);
   });
 
+  it('accepts a distinct Intune administrator approval requirement', () => {
+    const result = packageCallbackSchema.safeParse({
+      jobId,
+      status: 'failed',
+      errorStage: 'upload',
+      errorCategory: 'approval',
+      errorCode: 'INTUNE_APPROVAL_REQUIRED',
+      message: 'Administrator approval is required before this upload can continue.',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('prevents regressions and terminal-state overwrites', () => {
     expect(shouldApplyCallback('uploading', 'packaging', '2026-07-09T10:00:00.000Z')).toBe(false);
     expect(shouldApplyCallback('cancelled', 'deployed', '2026-07-09T10:00:00.000Z')).toBe(false);

--- a/lib/package-callback.ts
+++ b/lib/package-callback.ts
@@ -45,7 +45,7 @@ export const packageCallbackSchema = z.object({
   runId: z.union([z.string(), z.number().int().nonnegative()]).optional(),
   runUrl: z.string().url().max(2_048).optional(),
   errorStage: z.enum(['download', 'package', 'upload', 'authenticate', 'finalize', 'unknown']).optional(),
-  errorCategory: z.enum(['network', 'validation', 'permission', 'installer', 'intune_api', 'system']).optional(),
+  errorCategory: z.enum(['network', 'validation', 'permission', 'approval', 'installer', 'intune_api', 'system']).optional(),
   errorCode: z.string().regex(/^[A-Z0-9_]{1,80}$/).optional(),
   errorDetails: z.record(z.string(), z.unknown()).optional(),
   retryable: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- accept the dedicated Intune approval-required callback category
- show customer-facing guidance for Multi Admin Approval instead of a permissions error
- cover the callback contract with a regression test

## Verification
- `npm run lint`
- `npm test` (72 files, 954 tests)
- `npm run build:ci`