### PR TITLE
Add bounded QA candidate recovery RPC

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -229,3 +229,40 @@ describe('QA package result duration migration contract', () => {
     expect(sql).toContain('to anon');
   });
 });
+
+describe('QA candidate operator recovery migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260812174000_qa_candidate_operator_recovery.sql'
+    ),
+    'utf8'
+  );
+
+  it('uses the bounded synchronization credential and only terminal infrastructure states', () => {
+    expect(sql).toContain("extensions.digest(coalesce(p_secret, ''), 'sha256')");
+    expect(sql).toContain("test_level = 'psadt-package'");
+    expect(sql).toContain("status in ('error', 'superseded')");
+    expect(sql).not.toContain("status in ('failed'");
+    expect(sql).not.toContain("status in ('dispatched', 'running')");
+  });
+
+  it('clears all prior attempt state and exposes only the narrow RPC', () => {
+    for (const column of [
+      'attempts = 0',
+      'dispatched_at = null',
+      'started_at = null',
+      'finished_at = null',
+      'github_run_id = null',
+      'github_run_url = null',
+      'phase = null',
+      'live_activity = null',
+      'live_log = null',
+      'failure_summary = null',
+    ]) {
+      expect(sql).toContain(column);
+    }
+    expect(sql).toContain('from public, authenticated, service_role');
+    expect(sql).toContain('to anon');
+  });
+});

--- a/supabase/migrations/20260812174000_qa_candidate_operator_recovery.sql
+++ b/supabase/migrations/20260812174000_qa_candidate_operator_recovery.sql
@@ -1,0 +1,47 @@
+-- Allow the protected GitHub operator workflow to re-queue a terminal QA
+-- infrastructure failure without exposing a broad database credential.
+create or replace function public.recover_qa_candidate(
+  p_secret text,
+  p_candidate_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  changed integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  update public.qa_candidates
+  set status = 'queued',
+      attempts = 0,
+      dispatched_at = null,
+      started_at = null,
+      finished_at = null,
+      github_run_id = null,
+      github_run_url = null,
+      phase = null,
+      phase_started_at = null,
+      phase_updated_at = null,
+      live_activity = null,
+      activity_updated_at = null,
+      live_log = null,
+      log_updated_at = null,
+      failure_summary = null,
+      updated_at = now()
+  where id = p_candidate_id
+    and test_level = 'psadt-package'
+    and status in ('error', 'superseded');
+  get diagnostics changed = row_count;
+  return changed = 1;
+end;
+$$;
+
+revoke all on function public.recover_qa_candidate(text, uuid)
+  from public, authenticated, service_role;
+grant execute on function public.recover_qa_candidate(text, uuid) to anon;


### PR DESCRIPTION
## What changed

- add a narrowly scoped `recover_qa_candidate` security-definer RPC
- authenticate with the existing bounded QA synchronization secret
- permit only terminal `error` or `superseded` PSADT candidates
- clear all prior-attempt execution and live telemetry state
- add migration contract coverage

## Why

Operator retries after an infrastructure fix must first return the terminal candidate to the protected queue. Direct table access requires a broad credential and the existing GitHub secret does not have that role. The RPC gives the protected workflow only the exact transition it needs.

## Validation

- migration applied successfully to the IntuneGet Supabase project
- verified `SECURITY DEFINER` and grants (`anon` execute only)
- `npx vitest run lib/qa/migration-contract.test.ts` — 27 passed
- `git diff --check`