### PR TITLE
Clarify installation check upload step

### DIFF
--- a/components/ProgressStepper.tsx
+++ b/components/ProgressStepper.tsx
@@ -25,8 +25,8 @@ interface ProgressStepperProps {
 
 const QA_STAGE: ProgressStage = {
   id: 'qa',
-  label: 'Test',
-  description: 'Running an isolated installation test before deployment',
+  label: 'Installation check',
+  description: 'Checking for a successful installation test for this app version and configuration',
   minProgress: 0,
   maxProgress: 0,
 };
@@ -102,7 +102,7 @@ export function ProgressStepper({
                     <Check className="w-[18px] h-[18px] text-status-success" />
                   ) : isCurrent ? (
                     isQaStage ? (
-                      <ShieldCheck className="w-[18px] h-[18px] text-accent-violet animate-pulse" aria-label="Installation test in progress" />
+                      <ShieldCheck className="w-[18px] h-[18px] text-accent-violet animate-pulse" aria-label="Installation check in progress" />
                     ) : (
                       <Loader2 className="w-[18px] h-[18px] text-accent-cyan animate-spin" aria-label="Processing" />
                     )


### PR DESCRIPTION
## What changed

- Renamed the upload progress step from **Test** to **Installation check**.
- Clarified that this step checks for a successful installation test matching the app version and configuration.
- Updated the progress icon's accessibility label to use the same customer-facing wording.

## Why

The previous one-word label was hard-coded and did not explain to customers that IntuneGet verifies successful prior installation-testing coverage before continuing the upload.

## Impact

Customers get a clearer explanation of the pre-deployment validation step without needing to understand internal QA terminology. There is no behavior change.

## Validation

- Full repository ESLint completed successfully in the commit hook.
- Focused ESLint passed for `components/ProgressStepper.tsx`.
- `git diff --check` passed.