### PR TITLE
Preserve shared Windows runtimes during package removal

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -298,6 +298,10 @@ function Get-StrictPSADTBoolean {
     return [bool]$Config[$Name]
 }
 
+$preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
+    -Config $psadtConfig `
+    -Name 'preserveVendorInstallationOnUninstall'
+
 function ConvertTo-PSADTConfigValue {
     param(
         [AllowNull()][string]$Value,
@@ -2047,8 +2051,19 @@ if ($preUninstallPromptCalls) {
     $lines += $preUninstallPromptCalls
 }
 
-# Generate uninstall command - custom override takes precedence over registry lookup
-if (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
+# Generate uninstall command. A reviewed shared-runtime adapter takes
+# precedence because executing the vendor command could remove a prerequisite
+# used by Windows or unrelated applications. The ordinary marker cleanup below
+# still makes Intune's exact package detection transition to not installed.
+if ($preserveVendorInstallationOnUninstall) {
+    Write-Host 'Preserving the shared vendor installation during package removal'
+    $lines += @(
+        ''
+        '    # This reviewed package represents ownership of a shared Windows runtime.'
+        '    # Relinquish IntuneGet management without removing the shared vendor payload.'
+        '    Write-ADTLogEntry -Message "Retaining the shared vendor installation and removing only the IntuneGet management marker." -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
+    )
+} elseif (-not [string]::IsNullOrWhiteSpace($customUninstallCommand)) {
     Write-Host "Using custom uninstall command override from PSADT config"
     $lines += @(
         ''

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -58,6 +58,24 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('retains the shared WebView2 runtime while removing IntuneGet ownership', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.EdgeWebView2Runtime',
+        DEFAULT_PSADT_CONFIG
+      ).preserveVendorInstallationOnUninstall
+    ).toBe(true);
+  });
+
+  it('does not accept shared-runtime retention from customer-controlled config', () => {
+    const adapted = applyApplicationPackagingAdapter('Example.App', {
+      ...DEFAULT_PSADT_CONFIG,
+      preserveVendorInstallationOnUninstall: true,
+    });
+
+    expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
+  });
+
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {
     const adapted = applyApplicationPackagingAdapter('AnalogDevices.LTspice', {
       ...DEFAULT_PSADT_CONFIG,

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -8,6 +8,7 @@ interface ApplicationPackagingAdapter {
   reviewedInstallArguments?: readonly string[];
   reviewedUninstallArguments?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
+  preserveVendorInstallationOnUninstall?: boolean;
 }
 
 const VISUAL_STUDIO_WINGET_IDS = [
@@ -71,6 +72,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   {
     wingetId: 'PostgreSQL.PostgreSQL.18',
     reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
+  },
+  {
+    // The Evergreen WebView2 Runtime is shared by every WebView2 application,
+    // automatically serviced by Microsoft, and preinstalled on Windows 11.
+    // Removing the shared runtime can break unrelated applications, while the
+    // Windows 11 registration can remain even after its vendor command exits.
+    // IntuneGet therefore removes only its own management marker on uninstall.
+    wingetId: 'Microsoft.EdgeWebView2Runtime',
+    preserveVendorInstallationOnUninstall: true,
   },
   ...VISUAL_STUDIO_WINGET_IDS.map((wingetId) => ({
     wingetId,
@@ -164,7 +174,11 @@ export function applyApplicationPackagingAdapter(
   config: PSADTConfig
 ): PSADTConfig {
   const adapter = applicationPackagingAdapter(wingetId);
-  if (!adapter) return config;
+  if (!adapter) {
+    // This internal switch is never accepted from customer-controlled config.
+    if (!config.preserveVendorInstallationOnUninstall) return config;
+    return { ...config, preserveVendorInstallationOnUninstall: undefined };
+  }
 
   const processesToClose = (config.processesToClose || []).map((process) => {
     const name = normalizeProcessName(process.name);
@@ -221,5 +235,7 @@ export function applyApplicationPackagingAdapter(
     ...(adapter.uninstallCompletionTimeoutMinutes
       ? { uninstallCompletionTimeoutMinutes: adapter.uninstallCompletionTimeoutMinutes }
       : {}),
+    preserveVendorInstallationOnUninstall:
+      adapter.preserveVendorInstallationOnUninstall || undefined,
   };
 }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -277,6 +277,31 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds shared-runtime retention to both the normalized config and QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.EdgeWebView2Runtime',
+      displayName: 'Microsoft Edge WebView2 Runtime',
+      publisher: 'Microsoft',
+      version: '151.0.4129.78',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/silent /install',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Microsoft Edge WebView2 Runtime',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { preserveVendorInstallationOnUninstall?: boolean };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+    });
+    expect(profile.psadtConfig.preserveVendorInstallationOnUninstall).toBe(true);
+  });
+
   it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -157,6 +157,45 @@ describe('PSADT Inno packaging contract', () => {
 });
 
 describe('PSADT vendor argument contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'retains reviewed shared runtimes and removes only the IntuneGet marker',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Microsoft Edge WebView2 Runtime',
+        [],
+        { preserveVendorInstallationOnUninstall: true },
+        [],
+        'Microsoft.EdgeWebView2Runtime'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
+      );
+      expect(uninstallFunction).toContain('IntuneGet detection marker removed from HKLM');
+      expect(uninstallFunction).not.toContain('Waiting for vendor uninstall registration');
+      expect(uninstallFunction).not.toContain('Start-ADTProcess @uninstallProcessParameters');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects a non-boolean shared-runtime lifecycle flag',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'inno',
+          'Invalid Shared Runtime',
+          [],
+          { preserveVendorInstallationOnUninstall: 'true' }
+        )
+      ).toThrow('preserveVendorInstallationOnUninstall must be a JSON boolean');
+    }
+  );
+
   it('honors additional success exit codes declared by the WinGet manifest', () => {
     if (!canRunWindowsPowerShellPackager) return;
     const generated = generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -209,6 +209,11 @@ export interface PSADTConfig {
   // the exact registry identity remains the authoritative completion signal.
   uninstallCompletionTimeoutMinutes?: number;
 
+  // Internal lifecycle policy for shared Windows runtimes that must remain on
+  // the device when Intune relinquishes management. Application adapters are
+  // the only trusted source for this value; it is not customer-configurable.
+  preserveVendorInstallationOnUninstall?: boolean;
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.


### PR DESCRIPTION
## Summary
- add a reviewed shared-runtime lifecycle adapter for Microsoft Edge WebView2 Runtime
- keep the Microsoft-serviced runtime installed while removing IntuneGet's exact detection marker
- bind the behavior into QA identity and reject customer-controlled use on unrelated apps

## Verification
- 177 focused Vitest tests passed across QA enqueue, customer upload, auto-update, package identity, adapters, and generated PSADT contracts
- changed TypeScript files pass ESLint
- Create-PSADTPackage.ps1 and generated deployment fixture parse successfully in PowerShell
- git diff --check passes

## Root cause
WebView2 Evergreen is shared, automatically serviced, and preinstalled on Windows 11. Its vendor removal command does not remove the Windows 11 registration, so the prior package waited for five minutes and correctly failed with PSADT exit 60001. The reviewed adapter now relinquishes IntuneGet management without removing a shared Windows prerequisite.