### PR TITLE
Pin shared-runtime QA toolchain

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -605,17 +605,17 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(pollRunUpdates[0]).toMatchObject({ status: 'failed', error_count: 1 });
   });
 
-  it('queues a targeted terminal failure when its fix is in the current packager', async () => {
+  it('queues a targeted shared-runtime failure when its fix is in the current packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
-        winget_id: 'AnalogDevices.LTspice',
-        name: 'LTspice',
-        publisher: 'Analog Devices',
+        winget_id: 'Microsoft.EdgeWebView2Runtime',
+        name: 'Microsoft Edge WebView2 Runtime',
+        publisher: 'Microsoft',
       }],
       candidates: [
         profileCandidate({
           id: 'old-candidate',
-          wingetId: 'AnalogDevices.LTspice',
+          wingetId: 'Microsoft.EdgeWebView2Runtime',
           packagerCommit: 'bafea79a8dde42be074c385c35b4887fb5833aa0',
           status: 'failed',
         }),
@@ -637,14 +637,15 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(candidateInserts).toHaveLength(1);
     expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'AnalogDevices.LTspice',
+      winget_id: 'Microsoft.EdgeWebView2Runtime',
       status: 'queued',
       test_level: 'psadt-package',
       test_config: {
         profileKind: 'catalog-default',
         silentArgs: '/S',
         psadtConfig: {
-          reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
+          preserveVendorInstallationOnUninstall: true,
+          reviewedInstallArguments: [],
           reviewedUninstallArguments: [],
         },
       },

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
+  packagerCommit: 'f4bc37886e490ece525c701562869734a7e366d5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -43,6 +43,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '354756f01cb572cfd410f95dd6af5ab3a9cb8efb',
   '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
   'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
+  '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,21 +18,36 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('carries the superseded xTool retry into the current toolchain release', () => {
+  it('keeps the carried xTool retry scoped to its historical releases', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'b3b2729bab6959a554c0e6d41af0a841d6177386',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
+    )).toBe(false);
   });
 
-  it('retries LTspice for the current enterprise-mode correction', () => {
+  it('keeps the LTspice retry scoped to its enterprise-mode release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
+      { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries WebView2 for the current shared-runtime lifecycle correction', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f4bc37886e490ece525c701562869734a7e366d5': [
+    'Microsoft.EdgeWebView2Runtime',
+  ],
   '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e': [
     'AnalogDevices.LTspice',
     // The xTool retry was superseded while this release was deploying, so


### PR DESCRIPTION
## Summary
- pin QA identity to the merged shared-runtime packager commit
- preserve the prior packager in compatibility history so unrelated successful apps are not retested
- retry only Microsoft Edge WebView2 Runtime on this release and retire historical LTspice/xTool retry targets

## Verification
- 97 focused QA identity, demand, enqueue, and toolchain-backfill tests passed
- changed TypeScript files pass ESLint
- git diff --check passes