### PR TITLE
Reconcile WinGet installer scope before packaging

### DIFF
--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -122,11 +122,12 @@ async function processAutoUpdates(
 
     try {
       // Get installer info for the new version
-      const installerInfo = await getLatestInstallerInfo(
-        supabase,
-        update.winget_id,
-        policy.deployment_config?.architecture
-      );
+        const installerInfo = await getLatestInstallerInfo(
+          supabase,
+          update.winget_id,
+          policy.deployment_config?.architecture,
+          policy.deployment_config?.installScope
+        );
 
       if (!installerInfo) {
         result.errors.push(

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -16,6 +16,7 @@ const {
   getAppConfigMock,
   getFeatureFlagsMock,
   enforceInstallerPreflightMock,
+  getLiveInstallersMock,
   ensureQaDemandMock,
 } = vi.hoisted(() => ({
   getDatabaseMock: vi.fn(),
@@ -31,7 +32,12 @@ const {
   getAppConfigMock: vi.fn(),
   getFeatureFlagsMock: vi.fn(),
   enforceInstallerPreflightMock: vi.fn(),
+  getLiveInstallersMock: vi.fn(),
   ensureQaDemandMock: vi.fn(),
+}));
+
+vi.mock('@/lib/manifest-api', () => ({
+  getLiveInstallers: getLiveInstallersMock,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -291,6 +297,46 @@ describe('POST /api/package (workflow dispatch)', () => {
       status: 'healthy',
       source: 'cache',
     });
+    getLiveInstallersMock.mockImplementation(async (wingetId: string) => {
+      if (wingetId === 'VNGCorp.Zalo') {
+        return [{
+          architecture: 'x86',
+          url: 'https://example.com/setup.exe',
+          sha256: 'A'.repeat(64),
+          type: 'exe',
+          scope: 'user',
+          silentArgs: '/S',
+        }];
+      }
+      if (wingetId === 'Opera.Opera') {
+        return [
+          {
+            architecture: 'x64',
+            url: 'https://example.com/opera.exe',
+            sha256: 'A'.repeat(64),
+            type: 'exe',
+            scope: 'user',
+            silentArgs: '/silent /allusers=0',
+          },
+          {
+            architecture: 'x64',
+            url: 'https://example.com/opera.exe',
+            sha256: 'A'.repeat(64),
+            type: 'exe',
+            scope: 'machine',
+            silentArgs: '/silent /allusers=1',
+          },
+        ];
+      }
+      return [{
+        architecture: 'x64',
+        url: 'https://example.com/setup.exe',
+        sha256: 'A'.repeat(64),
+        type: 'exe',
+        scope: 'machine',
+        silentArgs: '/S',
+      }];
+    });
     ensureQaDemandMock.mockResolvedValue({
       state: 'passed',
       candidateId: null,
@@ -367,7 +413,8 @@ describe('POST /api/package (workflow dispatch)', () => {
 
     expect(response.status).toBe(200);
     expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
-      expect.objectContaining({ installScope: 'user' })
+      expect.objectContaining({ installScope: 'user' }),
+      expect.any(Array)
     );
     expect(ensureQaDemandMock).toHaveBeenCalledWith(
       undefined,
@@ -378,6 +425,48 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
       expect.objectContaining({ installScope: 'user' }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
+  it('rebuilds machine-scope commands before both QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Opera.Opera',
+          displayName: 'Opera Browser',
+          installerUrl: 'https://example.com/opera.exe',
+          installScope: 'machine',
+          installCommand: '"opera.exe" /silent /allusers=0',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        installScope: 'machine',
+        silentSwitches: '/silent /allusers=1',
+      })
+    );
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      install_scope: 'machine',
+      install_command: '"opera.exe" /silent /allusers=1',
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installScope: 'machine',
+        silentSwitches: '/silent /allusers=1',
+      }),
       undefined,
       expect.any(Object)
     );

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -43,6 +43,8 @@ import {
 } from '@/lib/packaging-adapters';
 import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { reconcileCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
+import type { NormalizedInstaller } from '@/types/winget';
 
 export const maxDuration = 300;
 
@@ -227,21 +229,71 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Re-resolve catalog metadata from the live trusted manifest after the
+    // requested scope has been finalized. This prevents a stale cart command
+    // from combining a machine deployment with a per-user installer (or the
+    // reverse). Explicit PSADT command overrides remain authoritative.
+    const trustedInstallersByItem = new Map<Win32CartItem, NormalizedInstaller[]>();
+    for (let i = 0; i < win32Items.length; i += 2) {
+      const batch = win32Items.slice(i, i + 2);
+      const reconciliationResults = await Promise.allSettled(
+        batch.map(async (item) => {
+          if (
+            item.sourceType === 'custom' ||
+            typeof item.wingetId !== 'string' ||
+            !item.wingetId.trim()
+          ) return null;
+          const reconciled = await reconcileCatalogInstaller(item);
+          Object.assign(item, reconciled.item);
+          trustedInstallersByItem.set(item, reconciled.trustedInstallers);
+          return reconciled;
+        })
+      );
+
+      const failedIndex = reconciliationResults.findIndex(
+        (result) => result.status === 'rejected'
+      );
+      if (failedIndex !== -1) {
+        const failed = reconciliationResults[failedIndex] as PromiseRejectedResult;
+        const failedItem = batch[failedIndex];
+        const error = failed.reason;
+        if (error instanceof InstallerPreflightError) {
+          return NextResponse.json({
+            error: 'Installer validation blocked this deployment',
+            message: error.message,
+            code: error.code,
+            retryable: error.retryable,
+            package: {
+              wingetId: failedItem.wingetId,
+              displayName: failedItem.displayName || failedItem.wingetId,
+              version: failedItem.version,
+            },
+            expectedSha256: failedItem.installerSha256?.toUpperCase(),
+            actualSha256: error.actualSha256,
+          }, { status: error.retryable ? 503 : 409 });
+        }
+        throw error;
+      }
+    }
+
     // Enforce installer health before creating job rows. Work in pairs to
     // bound outbound bandwidth for a ten-app cart while keeping normal
     // batches responsive.
     for (let i = 0; i < win32Items.length; i += 2) {
       const preflightResults = await Promise.allSettled(
-        win32Items.slice(i, i + 2).map((item) => enforceInstallerPreflight({
-          wingetId: item.wingetId,
-          version: item.version,
-          architecture: item.architecture,
-          installerUrl: item.installerUrl,
-          installerSha256: item.installerSha256,
-          installerType: item.installerType,
-          installScope: item.installScope,
-          sourceType: item.sourceType,
-        })),
+        win32Items.slice(i, i + 2).map((item) => enforceInstallerPreflight(
+          {
+            wingetId: item.wingetId,
+            version: item.version,
+            architecture: item.architecture,
+            installerUrl: item.installerUrl,
+            installerSha256: item.installerSha256,
+            installerType: item.installerType,
+            installScope: item.installScope,
+            sourceType: item.sourceType,
+          },
+          trustedInstallersByItem.get(item),
+        )),
       );
 
       const failedIndex = preflightResults.findIndex((result) => result.status === 'rejected');

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -272,10 +272,12 @@ export async function POST(request: NextRequest) {
         }
 
         // Get installer info
+        const deploymentConfig = policy.deployment_config as unknown as DeploymentConfig | null;
         const installerInfo = await getLatestInstallerInfo(
           supabase,
           req.winget_id,
-          (policy.deployment_config as unknown as DeploymentConfig | null)?.architecture
+          deploymentConfig?.architecture,
+          deploymentConfig?.installScope
         );
 
         if (!installerInfo) {

--- a/app/api/winget/manifest/route.ts
+++ b/app/api/winget/manifest/route.ts
@@ -55,9 +55,11 @@ export async function GET(request: NextRequest) {
     const installers = await getInstallers(packageId, version || manifest.Version);
 
     // Get best installer for requested architecture
-    const bestInstaller = architecture
-      ? await getBestInstaller(packageId, version || manifest.Version, architecture)
-      : installers[0] || null;
+    const bestInstaller = await getBestInstaller(
+      packageId,
+      version || manifest.Version,
+      architecture || 'x64'
+    );
 
     // List of all available versions (Supabase-backed) so the catalog can offer
     // a version selector. Best-effort: an empty list just hides the selector.

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -275,8 +275,21 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
       ? versionManifest.installers
       : installers;
 
-  // Get selected installer (not relevant for store apps)
-  const selectedInstaller = effectiveInstallers.find((i) => i.architecture === selectedArch) || effectiveInstallers[0];
+  // Bind installer metadata to both architecture and scope. Some manifests
+  // publish separate user and machine entries with different vendor switches
+  // even when both entries download the same binary.
+  const architectureInstallers = effectiveInstallers.filter(
+    (installer) => installer.architecture === selectedArch
+  );
+  const selectedInstaller =
+    architectureInstallers.find((installer) => installer.scope === selectedScope) ||
+    architectureInstallers.find((installer) => !installer.scope) ||
+    architectureInstallers[0] ||
+    effectiveInstallers[0];
+  const scopeIsAvailable = (scope: WingetScope) =>
+    architectureInstallers.some(
+      (installer) => !installer.scope || installer.scope === scope
+    );
   const availableArchitectures = [...new Set(effectiveInstallers.map((i) => i.architecture))];
   const availableVersions = versions.length > 0 ? versions : (pkg.versions ?? []);
   const hasMultipleVersions = availableVersions.length > 1;
@@ -857,13 +870,16 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
                   const manifestScope = selectedInstaller?.scope;
                   const isRecommended = manifestScope ? scope === manifestScope : scope === 'machine';
                   const label = scope === 'machine' ? 'Per-Machine' : 'Per-User';
+                  const isAvailable = scopeIsAvailable(scope);
 
                   return (
                     <button
                       key={scope}
                       onClick={() => setSelectedScope(scope)}
+                      disabled={!isAvailable}
                       className={cn(
                         'flex-1 px-4 py-2.5 rounded-lg border text-sm font-medium transition-colors',
+                        !isAvailable && 'cursor-not-allowed opacity-45',
                         selectedScope === scope
                           ? 'bg-accent-cyan border-accent-cyan text-white'
                           : 'bg-bg-elevated border-overlay/15 text-text-primary hover:border-overlay/20'

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/installer-download', async (importOriginal) => {
 });
 
 import {
+  createInstallerHealthKey,
   enforceInstallerPreflight,
   InstallerPreflightError,
   resetInstallerPreflightStateForTests,
@@ -43,6 +44,7 @@ describe('installer dispatch preflight', () => {
     resetInstallerPreflightStateForTests();
     getLiveInstallersMock.mockResolvedValue([{
       architecture: 'x64',
+      url: request.installerUrl,
       sha256: expectedSha256,
       type: 'exe',
       scope: 'machine',
@@ -80,6 +82,26 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses an already-fetched trusted manifest during preflight', async () => {
+    await expect(enforceInstallerPreflight(request, [{
+      architecture: 'x64',
+      url: request.installerUrl,
+      sha256: expectedSha256,
+      type: 'exe',
+      scope: 'machine',
+    }])).resolves.toMatchObject({ status: 'healthy', source: 'live' });
+
+    expect(getLiveInstallersMock).not.toHaveBeenCalled();
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps user and machine health identities separate', () => {
+    expect(createInstallerHealthKey(request)).not.toBe(createInstallerHealthKey({
+      ...request,
+      installScope: 'user',
+    }));
+  });
+
   it('quarantines a hash mismatch and blocks later dispatch without another download', async () => {
     hashRemoteInstallerMock.mockResolvedValueOnce({
       sha256: actualSha256,
@@ -105,6 +127,7 @@ describe('installer dispatch preflight', () => {
   it('quarantines a stale tuple when the trusted manifest has changed', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',
+      url: request.installerUrl,
       sha256: actualSha256,
       type: 'exe',
       scope: 'machine',

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -183,6 +183,58 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     });
   });
 
+  it('selects the stored deployment scope when a release has user and machine variants', async () => {
+    getAppForInstallerMock.mockResolvedValue({
+      latest_version: '134.0.5954.46',
+      name: 'Opera Browser',
+    });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: 'https://example.com/opera.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      installers: [
+        {
+          Architecture: 'x64',
+          InstallerUrl: 'https://example.com/opera.exe',
+          InstallerSha256: 'A'.repeat(64),
+          InstallerType: 'exe',
+          Scope: 'user',
+          InstallerSwitches: { Silent: '/silent /allusers=0' },
+        },
+        {
+          Architecture: 'x64',
+          InstallerUrl: 'https://example.com/opera.exe',
+          InstallerSha256: 'A'.repeat(64),
+          InstallerType: 'exe',
+          Scope: 'machine',
+          InstallerSwitches: { Silent: '/silent /allusers=1' },
+        },
+      ],
+    });
+
+    const machine = await getLatestInstallerInfo(
+      {} as never,
+      'Opera.Opera',
+      'x64',
+      'machine'
+    );
+    const user = await getLatestInstallerInfo(
+      {} as never,
+      'Opera.Opera',
+      'x64',
+      'user'
+    );
+
+    expect(machine).toMatchObject({
+      installScope: 'machine',
+      silentSwitches: '/silent /allusers=1',
+    });
+    expect(user).toMatchObject({
+      installScope: 'user',
+      silentSwitches: '/silent /allusers=0',
+    });
+  });
+
   it('records a current QA failure as a safety skip before creating history or a job', async () => {
     const failedPackageResult = {
       winget_id: 'Test.App',

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -212,7 +212,7 @@ export class AutoUpdateTrigger {
       const storedDeploymentConfig = policy.deployment_config as DeploymentConfig;
       const effectiveInstallScope = resolveApplicationInstallScope(
         updateInfo.wingetId,
-        updateInfo.installScope || storedDeploymentConfig.installScope
+        storedDeploymentConfig.installScope || updateInfo.installScope
       );
       updateInfo = { ...updateInfo, installScope: effectiveInstallScope };
       const deploymentConfig: DeploymentConfig = {
@@ -842,7 +842,8 @@ export async function getLatestInstallerInfo(
   // Kept for call-site compatibility; the catalog source owns client creation.
   _supabase: SupabaseClient,
   wingetId: string,
-  architecture?: string
+  architecture?: string,
+  installScope?: string
 ): Promise<UpdateInfo | null> {
   const catalog = getCatalogSource();
 
@@ -873,7 +874,14 @@ export async function getLatestInstallerInfo(
 
   // The installers JSONB uses PascalCase from WinGet manifests.
   if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
-    const selectedInstaller = selectWingetInstaller(versionInfo.installers, architecture);
+    const requestedScope = installScope === undefined
+      ? undefined
+      : resolveApplicationInstallScope(wingetId, installScope);
+    const selectedInstaller = selectWingetInstaller(
+      versionInfo.installers,
+      architecture,
+      requestedScope
+    );
     if (!selectedInstaller) return null;
     installerUrl = selectedInstaller.InstallerUrl || installerUrl;
     installerSha256 = selectedInstaller.InstallerSha256 || installerSha256;

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getLiveInstallersMock } = vi.hoisted(() => ({
+  getLiveInstallersMock: vi.fn(),
+}));
+
+vi.mock('@/lib/manifest-api', () => ({
+  getLiveInstallers: getLiveInstallersMock,
+}));
+
+import {
+  reconcileCatalogInstaller,
+  selectTrustedCatalogInstaller,
+} from '@/lib/catalog-installer-reconciliation';
+import type { Win32CartItem } from '@/types/upload';
+import type { NormalizedInstaller } from '@/types/winget';
+
+const sha256 = 'A'.repeat(64);
+const operaInstallers: NormalizedInstaller[] = [
+  {
+    architecture: 'x64',
+    url: 'https://example.test/opera.exe',
+    sha256,
+    type: 'exe',
+    scope: 'user',
+    silentArgs: '/silent /allusers=0',
+  },
+  {
+    architecture: 'x64',
+    url: 'https://example.test/opera.exe',
+    sha256,
+    type: 'exe',
+    scope: 'machine',
+    silentArgs: '/silent /allusers=1',
+  },
+];
+
+function operaItem(overrides: Partial<Win32CartItem> = {}): Win32CartItem {
+  return {
+    appSource: 'win32',
+    wingetId: 'Opera.Opera',
+    displayName: 'Opera Browser',
+    publisher: 'Opera Software',
+    version: '134.0.5954.46',
+    architecture: 'x64',
+    installScope: 'machine',
+    installerType: 'exe',
+    installerUrl: 'https://example.test/opera.exe',
+    installerSha256: sha256,
+    installCommand: '"opera.exe" /silent /allusers=0',
+    uninstallCommand: 'REGISTRY_UNINSTALL:Opera Stable',
+    detectionRules: [],
+    psadtConfig: {} as Win32CartItem['psadtConfig'],
+    id: 'opera',
+    addedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('catalog installer reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLiveInstallersMock.mockResolvedValue(operaInstallers);
+  });
+
+  it('selects the requested scope even when user and machine entries share bytes', () => {
+    expect(selectTrustedCatalogInstaller(operaInstallers, {
+      wingetId: 'Opera.Opera',
+      version: '134.0.5954.46',
+      architecture: 'x64',
+      installScope: 'machine',
+      installerUrl: operaInstallers[0].url,
+      installerSha256: sha256,
+    })?.silentArgs).toBe('/silent /allusers=1');
+
+    expect(selectTrustedCatalogInstaller(operaInstallers, {
+      wingetId: 'Opera.Opera',
+      version: '134.0.5954.46',
+      architecture: 'x64',
+      installScope: 'user',
+    })?.silentArgs).toBe('/silent /allusers=0');
+  });
+
+  it('does not substitute an explicitly opposite installer scope', () => {
+    expect(selectTrustedCatalogInstaller([operaInstallers[0]], {
+      wingetId: 'Opera.Opera',
+      version: '134.0.5954.46',
+      architecture: 'x64',
+      installScope: 'machine',
+    })).toBeNull();
+  });
+
+  it('rebuilds a stale cart command from the trusted machine manifest entry', async () => {
+    const reconciled = await reconcileCatalogInstaller(operaItem());
+
+    expect(reconciled.item.installScope).toBe('machine');
+    expect(reconciled.item.installCommand).toBe('"opera.exe" /silent /allusers=1');
+    expect(reconciled.item.installCommand).not.toContain('/allusers=0');
+    expect(reconciled.trustedInstallers).toBe(operaInstallers);
+  });
+
+  it('preserves explicit PSADT command overrides', async () => {
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      psadtConfig: {
+        installCommand: 'custom-install.exe /tenant-approved',
+        uninstallCommand: 'custom-uninstall.exe /tenant-approved',
+      } as Win32CartItem['psadtConfig'],
+    }));
+
+    expect(reconciled.item.installCommand).toBe('custom-install.exe /tenant-approved');
+    expect(reconciled.item.uninstallCommand).toBe('custom-uninstall.exe /tenant-approved');
+  });
+});

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -1,0 +1,145 @@
+import {
+  generateInstallCommand,
+  generateUninstallCommand,
+} from '@/lib/detection-rules';
+import {
+  InstallerPreflightError,
+} from '@/lib/installer-preflight';
+import { getLiveInstallers } from '@/lib/manifest-api';
+import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
+import { hashesEqual } from '@/lib/installer-download';
+import type { Win32CartItem } from '@/types/upload';
+import type { NormalizedInstaller, WingetScope } from '@/types/winget';
+
+export interface TrustedCatalogInstallerRequest {
+  wingetId: string;
+  version: string;
+  architecture?: string;
+  installScope: WingetScope;
+  installerUrl?: string;
+  installerSha256?: string;
+  localeCode?: string;
+}
+
+export interface ReconciledCatalogInstaller {
+  item: Win32CartItem;
+  trustedInstallers: NormalizedInstaller[];
+}
+
+function normalized(value?: string | null): string {
+  return value?.trim().toLowerCase() || '';
+}
+
+function selectPreferredIdentity(
+  installers: NormalizedInstaller[],
+  input: TrustedCatalogInstallerRequest,
+): NormalizedInstaller | null {
+  if (installers.length === 0) return null;
+
+  const currentUrl = input.installerUrl?.trim();
+  const currentSha256 = input.installerSha256?.trim();
+  const currentIdentity = installers.find((installer) =>
+    Boolean(currentUrl) &&
+    installer.url?.trim() === currentUrl &&
+    Boolean(currentSha256) &&
+    hashesEqual(installer.sha256 || '', currentSha256 || '')
+  );
+  if (currentIdentity) return currentIdentity;
+
+  const locale = normalized(input.localeCode);
+  if (locale) {
+    const localized = installers.find(
+      (installer) => normalized(installer.installerLocale) === locale
+    );
+    if (localized) return localized;
+  }
+
+  return installers.find((installer) => !installer.installerLocale?.trim()) || installers[0];
+}
+
+/**
+ * Select the live WinGet installer that actually represents the requested
+ * architecture and deployment scope. An installer with no declared scope is
+ * compatible with either scope; an installer explicitly declaring the
+ * opposite scope is never substituted.
+ */
+export function selectTrustedCatalogInstaller(
+  installers: NormalizedInstaller[],
+  input: TrustedCatalogInstallerRequest,
+): NormalizedInstaller | null {
+  const requestedArchitecture = normalized(input.architecture) || 'x64';
+  const exactArchitecture = installers.filter(
+    (installer) => normalized(installer.architecture) === requestedArchitecture
+  );
+  const architectureCandidates = exactArchitecture.length > 0
+    ? exactArchitecture
+    : installers.filter((installer) => normalized(installer.architecture) === 'neutral');
+
+  const exactScope = architectureCandidates.filter(
+    (installer) => normalized(installer.scope) === input.installScope
+  );
+  if (exactScope.length > 0) {
+    return selectPreferredIdentity(exactScope, input);
+  }
+
+  const unspecifiedScope = architectureCandidates.filter(
+    (installer) => !installer.scope?.trim()
+  );
+  return selectPreferredIdentity(unspecifiedScope, input);
+}
+
+export async function reconcileCatalogInstaller(
+  item: Win32CartItem,
+): Promise<ReconciledCatalogInstaller> {
+  const installScope = resolveApplicationInstallScope(item.wingetId, item.installScope);
+  const trustedInstallers = await getLiveInstallers(item.wingetId, item.version);
+  if (trustedInstallers.length === 0) {
+    throw new InstallerPreflightError(
+      'MANIFEST_UNAVAILABLE',
+      `The trusted WinGet installer manifest for ${item.wingetId} ${item.version} is unavailable`,
+      true,
+    );
+  }
+
+  const installer = selectTrustedCatalogInstaller(trustedInstallers, {
+    wingetId: item.wingetId,
+    version: item.version,
+    architecture: item.architecture,
+    installScope,
+    installerUrl: item.installerUrl,
+    installerSha256: item.installerSha256,
+    localeCode: item.localeCode,
+  });
+  if (!installer) {
+    throw new InstallerPreflightError(
+      'INSTALL_SCOPE_UNAVAILABLE',
+      `WinGet does not publish a ${item.architecture || 'x64'} ${installScope}-scope installer for ${item.wingetId} ${item.version}`,
+    );
+  }
+  if (!installer.url?.trim() || !/^[A-Fa-f0-9]{64}$/.test(installer.sha256?.trim() || '')) {
+    throw new InstallerPreflightError(
+      'MANIFEST_CHANGED',
+      `The selected installer for ${item.wingetId} ${item.version} is missing its trusted URL or SHA256`,
+    );
+  }
+
+  const customInstallCommand = item.psadtConfig?.installCommand?.trim();
+  const customUninstallCommand = item.psadtConfig?.uninstallCommand?.trim();
+  return {
+    item: {
+      ...item,
+      installScope,
+      installerUrl: installer.url,
+      installerSha256: installer.sha256.toUpperCase(),
+      installerType: installer.type,
+      nestedInstallerType: installer.nestedInstallerType,
+      nestedInstallerPath: installer.nestedInstallerPath,
+      installerSuccessCodes: installer.installerSuccessCodes,
+      manifestDependencies: installer.packageDependencies,
+      installCommand: customInstallCommand || generateInstallCommand(installer, installScope),
+      uninstallCommand: customUninstallCommand ||
+        generateUninstallCommand(installer, item.displayName),
+    },
+    trustedInstallers,
+  };
+}

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -6,6 +6,7 @@ import {
   hashesEqual,
   isLikelyMutableInstallerUrl,
 } from '@/lib/installer-download';
+import type { NormalizedInstaller } from '@/types/winget';
 
 const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
 const HEALTHY_VERSIONED_TTL_MS = 6 * 60 * 60 * 1000;
@@ -99,6 +100,8 @@ export function createInstallerHealthKey(input: InstallerPreflightRequest): stri
       input.wingetId.trim().toLowerCase(),
       input.version.trim(),
       (input.architecture || 'x64').trim().toLowerCase(),
+      (input.installerType || '').trim().toLowerCase(),
+      (input.installScope || '').trim().toLowerCase(),
       input.installerUrl.trim(),
       input.installerSha256.trim().toUpperCase(),
     ].join('\0'))
@@ -219,15 +222,24 @@ function buildHealthRow(
   };
 }
 
-function installerExistsInManifest(input: InstallerPreflightRequest, installers: Awaited<ReturnType<typeof getLiveInstallers>>): boolean {
+function installerExistsInManifest(
+  input: InstallerPreflightRequest,
+  installers: NormalizedInstaller[],
+): boolean {
   const expectedHash = input.installerSha256.toUpperCase();
   const requestedArchitecture = (input.architecture || 'x64').toLowerCase();
   const requestedType = input.installerType?.toLowerCase();
   const requestedScope = input.installScope?.toLowerCase();
+  const requestedUrl = input.installerUrl.trim();
 
   return installers.some((installer) => {
     if (!hashesEqual(installer.sha256 || '', expectedHash)) return false;
-    if (installer.architecture && installer.architecture.toLowerCase() !== requestedArchitecture) return false;
+    if (installer.url?.trim() !== requestedUrl) return false;
+    if (
+      installer.architecture &&
+      installer.architecture.toLowerCase() !== requestedArchitecture &&
+      installer.architecture.toLowerCase() !== 'neutral'
+    ) return false;
     if (requestedType && installer.type && installer.type.toLowerCase() !== requestedType) return false;
     if (requestedScope && installer.scope && installer.scope.toLowerCase() !== requestedScope) return false;
     return true;
@@ -266,9 +278,11 @@ async function waitForSharedResult(cacheKey: string): Promise<InstallerPreflight
 async function performLivePreflight(
   cacheKey: string,
   input: InstallerPreflightRequest,
+  trustedInstallers?: NormalizedInstaller[],
 ): Promise<InstallerPreflightResult> {
   try {
-    const installers = await getLiveInstallers(input.wingetId, input.version);
+    const installers = trustedInstallers ||
+      await getLiveInstallers(input.wingetId, input.version);
     if (installers.length === 0) {
       throw new InstallerPreflightError(
         'MANIFEST_UNAVAILABLE',
@@ -340,7 +354,10 @@ async function performLivePreflight(
   }
 }
 
-async function enforceInternal(input: InstallerPreflightRequest): Promise<InstallerPreflightResult> {
+async function enforceInternal(
+  input: InstallerPreflightRequest,
+  trustedInstallers?: NormalizedInstaller[],
+): Promise<InstallerPreflightResult> {
   assertTrustedInput(input);
   const cacheKey = createInstallerHealthKey(input);
   const cached = await readHealth(cacheKey);
@@ -357,11 +374,12 @@ async function enforceInternal(input: InstallerPreflightRequest): Promise<Instal
 
   const claimed = await claimHealth(cacheKey, input);
   if (!claimed) return waitForSharedResult(cacheKey);
-  return performLivePreflight(cacheKey, input);
+  return performLivePreflight(cacheKey, input, trustedInstallers);
 }
 
 export async function enforceInstallerPreflight(
   input: InstallerPreflightRequest,
+  trustedInstallers?: NormalizedInstaller[],
 ): Promise<InstallerPreflightResult> {
   if (input.sourceType === 'custom' || input.wingetId.startsWith('Custom.')) {
     return { cacheKey: '', status: 'skipped', source: 'custom' };
@@ -378,7 +396,8 @@ export async function enforceInstallerPreflight(
   const existing = inFlight.get(cacheKey);
   if (existing) return existing;
 
-  const promise = enforceInternal(input).finally(() => inFlight.delete(cacheKey));
+  const promise = enforceInternal(input, trustedInstallers)
+    .finally(() => inFlight.delete(cacheKey));
   inFlight.set(cacheKey, promise);
   return promise;
 }

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -752,6 +752,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
 
   return {
     architecture: installer.Architecture,
+    installerLocale: installer.InstallerLocale,
     url: installer.InstallerUrl,
     sha256: installer.InstallerSha256,
     type: installer.InstallerType,
@@ -813,7 +814,8 @@ export async function getLiveInstallers(
 export async function getBestInstaller(
   wingetId: string,
   version?: string,
-  preferredArch: 'x64' | 'x86' | 'arm64' = 'x64'
+  preferredArch: 'x64' | 'x86' | 'arm64' = 'x64',
+  preferredScope?: 'machine' | 'user'
 ): Promise<NormalizedInstaller | null> {
   const installers = await getInstallers(wingetId, version);
 
@@ -830,13 +832,26 @@ export async function getBestInstaller(
   const priority = archPriority[preferredArch] || archPriority.x64;
 
   for (const arch of priority) {
-    const installer = installers.find((i) => i.architecture === arch);
+    const architectureInstallers = installers.filter((i) => i.architecture === arch);
+    const installer = preferredScope
+      ? architectureInstallers.find((i) => i.scope === preferredScope) ||
+        architectureInstallers.find((i) => !i.scope)
+      : architectureInstallers.find((i) => i.scope === 'machine') ||
+        architectureInstallers.find((i) => !i.scope) ||
+        architectureInstallers.find((i) => i.scope === 'user');
     if (installer) {
       return installer;
     }
   }
 
-  return installers[0];
+  return preferredScope
+    ? installers.find((i) => i.scope === preferredScope) ||
+      installers.find((i) => !i.scope) ||
+      null
+    : installers.find((i) => i.scope === 'machine') ||
+      installers.find((i) => !i.scope) ||
+      installers.find((i) => i.scope === 'user') ||
+      installers[0];
 }
 
 /**

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -58,6 +58,25 @@ describe('QA candidate normalization', () => {
     expect(selectQaVmInstaller([userInstaller])?.installer).toBe(userInstaller);
   });
 
+  it('honors an explicit deployment scope and never substitutes the opposite scope', () => {
+    const scopedInstallers = [
+      {
+        Architecture: 'x64',
+        Scope: 'user',
+        InstallerUrl: 'https://example.test/current-user.exe',
+      },
+      {
+        Architecture: 'x64',
+        Scope: 'machine',
+        InstallerUrl: 'https://example.test/all-users.exe',
+      },
+    ];
+
+    expect(selectWingetInstaller(scopedInstallers, 'x64', 'user')?.InstallerUrl)
+      .toContain('current-user');
+    expect(selectWingetInstaller([scopedInstallers[0]], 'x64', 'machine')).toBeNull();
+  });
+
   it('accepts and uppercases only complete SHA-256 values', () => {
     expect(normalizeInstallerSha256('a'.repeat(64))).toBe('A'.repeat(64));
     expect(normalizeInstallerSha256('abc')).toBe('');

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -8,7 +8,15 @@ export interface WingetInstallerCandidate {
   Scope?: string;
   ProductCode?: string;
   PackageFamilyName?: string;
-  InstallerSwitches?: Record<string, unknown>;
+  InstallerSwitches?: {
+    Silent?: string;
+    SilentWithProgress?: string;
+    Interactive?: string;
+    InstallLocation?: string;
+    Log?: string;
+    Upgrade?: string;
+    Custom?: string;
+  };
   AppsAndFeaturesEntries?: Array<{ ProductCode?: string }>;
 }
 
@@ -20,8 +28,19 @@ export interface QaInstallerSelection {
 const SUPPORTED_ARCHITECTURES = new Set(['x64', 'x86', 'arm64']);
 
 function preferredScopeInstaller(
-  installers: WingetInstallerCandidate[]
+  installers: WingetInstallerCandidate[],
+  requestedScope?: 'machine' | 'user'
 ): WingetInstallerCandidate | null {
+  if (requestedScope) {
+    return (
+      installers.find(
+        (installer) => installer.Scope?.trim().toLowerCase() === requestedScope
+      ) ||
+      installers.find((installer) => !installer.Scope?.trim()) ||
+      null
+    );
+  }
+
   return (
     installers.find((installer) => installer.Scope?.trim().toLowerCase() === 'machine') ||
     installers.find((installer) => !installer.Scope?.trim()) ||
@@ -41,18 +60,21 @@ export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 
 /** Select the exact architecture requested by a deployment or QA recipe. */
 export function selectWingetInstaller(
   installers: WingetInstallerCandidate[] | null | undefined,
-  architecture?: string | null
+  architecture?: string | null,
+  requestedScope?: 'machine' | 'user'
 ): WingetInstallerCandidate | null {
   if (!installers?.length) return null;
   const target = normalizeQaArchitecture(architecture);
   const exactArchitecture = installers.filter(
     (installer) => installer.Architecture?.toLowerCase() === target
   );
-  if (exactArchitecture.length) return preferredScopeInstaller(exactArchitecture);
+  if (exactArchitecture.length) {
+    return preferredScopeInstaller(exactArchitecture, requestedScope);
+  }
   const neutral = installers.filter(
     (installer) => installer.Architecture?.toLowerCase() === 'neutral'
   );
-  return preferredScopeInstaller(neutral);
+  return preferredScopeInstaller(neutral, requestedScope);
 }
 
 /**

--- a/lib/update-policies/build-deployment-config.ts
+++ b/lib/update-policies/build-deployment-config.ts
@@ -9,6 +9,8 @@
 
 import { createServerClient } from '@/lib/supabase';
 import { getCatalogSource } from '@/lib/catalog';
+import { normalizeInstaller } from '@/lib/manifest-api';
+import { selectWingetInstaller } from '@/lib/qa/candidate';
 import {
   generateDetectionRules,
   generateInstallCommand,
@@ -17,7 +19,7 @@ import {
 import type { DeploymentConfig } from '@/types/update-policies';
 import type { IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
 import type { AppRelationship, DetectionRule, RequirementRule } from '@/types/intune';
-import type { NormalizedInstaller } from '@/types/winget';
+import type { NormalizedInstaller, WingetInstaller } from '@/types/winget';
 
 export interface PackageConfigWithAssignments {
   assignments?: PackageAssignment[];
@@ -282,41 +284,37 @@ export async function buildDefaultDeploymentConfig(
     return null;
   }
 
-  // Resolve architecture-specific installer (prefer x64)
-  let installerUrl = versionInfo.installer_url;
-  let installerSha256 = versionInfo.installer_sha256 || '';
-  let installerType = versionInfo.installer_type || 'exe';
-  let architecture = 'x64';
+  // Resolve architecture and scope together. WinGet can publish separate x64
+  // user and machine entries whose URLs and hashes are identical but whose
+  // vendor switches differ.
+  const manifestInstallers = Array.isArray(versionInfo.installers)
+    ? versionInfo.installers as WingetInstaller[]
+    : [];
+  const selectedManifestInstaller = selectWingetInstaller(
+    manifestInstallers,
+    'x64'
+  ) as WingetInstaller | null;
+  const normalizedInstaller: NormalizedInstaller = selectedManifestInstaller
+    ? normalizeInstaller({
+        ...selectedManifestInstaller,
+        InstallerSwitches: {
+          ...(versionInfo.silent_args ? { Silent: versionInfo.silent_args } : {}),
+          ...(selectedManifestInstaller.InstallerSwitches || {}),
+        },
+      })
+    : {
+        architecture: 'x64',
+        url: versionInfo.installer_url,
+        sha256: versionInfo.installer_sha256 || '',
+        type: (versionInfo.installer_type || 'exe') as NormalizedInstaller['type'],
+        scope: versionInfo.installer_scope === 'user' ? 'user' : 'machine',
+        silentArgs: versionInfo.silent_args || undefined,
+      };
+  const architecture = normalizedInstaller.architecture;
+  const installerType = normalizedInstaller.type;
+  const installScope = normalizedInstaller.scope || 'machine';
 
-  if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
-    type InstallerEntry = { Architecture?: string; InstallerUrl?: string; InstallerSha256?: string; InstallerType?: string };
-    const installers = versionInfo.installers as InstallerEntry[];
-    const x64Installer = installers.find(
-      (i) => i.Architecture === 'x64'
-    );
-    if (x64Installer) {
-      installerUrl = x64Installer.InstallerUrl || installerUrl;
-      installerSha256 = x64Installer.InstallerSha256 || installerSha256;
-      installerType = x64Installer.InstallerType || installerType;
-    } else if (installers.length > 0) {
-      // Use first available installer's architecture
-      const first = installers[0];
-      if (first?.Architecture) {
-        architecture = first.Architecture.toLowerCase();
-      }
-    }
-  }
-
-  // Build a NormalizedInstaller for detection rule generation
-  const normalizedInstaller: NormalizedInstaller = {
-    architecture: architecture as NormalizedInstaller['architecture'],
-    url: installerUrl,
-    sha256: installerSha256,
-    type: installerType as NormalizedInstaller['type'],
-    scope: 'machine',
-  };
-
-  const installCommand = generateInstallCommand(normalizedInstaller, 'machine');
+  const installCommand = generateInstallCommand(normalizedInstaller, installScope);
   const uninstallCommand = generateUninstallCommand(normalizedInstaller, curatedApp.name);
   const detectionRules = generateDetectionRules(
     normalizedInstaller,
@@ -332,7 +330,7 @@ export async function buildDefaultDeploymentConfig(
     installerType,
     installCommand,
     uninstallCommand,
-    installScope: 'system',
+    installScope,
     detectionRules,
     assignments: [],
     categories: [],

--- a/lib/winget-api.ts
+++ b/lib/winget-api.ts
@@ -174,9 +174,10 @@ export async function getInstallers(
 export async function getBestInstaller(
   packageId: string,
   version?: string,
-  preferredArch: 'x64' | 'x86' | 'arm64' = 'x64'
+  preferredArch: 'x64' | 'x86' | 'arm64' = 'x64',
+  preferredScope?: 'machine' | 'user'
 ): Promise<NormalizedInstaller | null> {
-  return getManifestBestInstaller(packageId, version, preferredArch);
+  return getManifestBestInstaller(packageId, version, preferredArch, preferredScope);
 }
 
 /**

--- a/types/winget.ts
+++ b/types/winget.ts
@@ -165,6 +165,7 @@ export interface NormalizedPackage {
 // Normalized installer for internal use
 export interface NormalizedInstaller {
   architecture: WingetArchitecture;
+  installerLocale?: string;
   url: string;
   sha256: string;
   type: WingetInstallerType;


### PR DESCRIPTION
## Summary
- resolve installer URL, hash, switches, and commands from the live WinGet entry matching the requested architecture and scope
- apply the same selection to customer uploads, QA demand, automatic updates, catalog defaults, and the configuration UI
- keep explicit PSADT command overrides authoritative and reject unavailable scope combinations
- include scope and installer type in preflight identities and reuse the fetched manifest

## Verification
- 56 focused tests passed, including Opera user/machine regression coverage
- full suite: 970 tests passed; one unrelated translation timeout passed on immediate isolated rerun
- ESLint passed for all changed files
- production Next.js build passed