### PR TITLE
Add protected targeted QA enqueue

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -78,6 +78,7 @@ function createSupabaseStub(options: {
   candidates?: Array<Record<string, unknown>>;
   candidatePages?: Array<Array<Record<string, unknown>>>;
   demandBackfillApps?: string[];
+  deployedApps?: string[];
   pollState?: Record<string, unknown>;
   packageResults?: Array<Record<string, unknown>>;
 }) {
@@ -160,7 +161,8 @@ function createSupabaseStub(options: {
       }
       if (table === 'upload_history') {
         return query({
-          data: (options.supportedApps || []).map((app) => ({ winget_id: app.winget_id })),
+          data: (options.deployedApps || (options.supportedApps || []).map((app) => String(app.winget_id)))
+            .map((winget_id) => ({ winget_id })),
           error: null,
         });
       }
@@ -299,8 +301,8 @@ function resolvedManifest() {
   };
 }
 
-function cronRequest(): Request {
-  return new Request('https://intuneget.com/api/cron/qa-enqueue', {
+function cronRequest(query = ''): Request {
+  return new Request(`https://intuneget.com/api/cron/qa-enqueue${query}`, {
     headers: {
       authorization: 'Bearer test-cron-secret',
       'x-vercel-id': 'fra1::request-1',
@@ -466,6 +468,68 @@ describe('GET /api/cron/qa-enqueue', () => {
       demand_backfill_requested_count: 1,
       demand_backfill_count: 1,
     });
+  });
+
+  it('immediately rebuilds a targeted customer-deployed app through the catalog QA path', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [
+        {
+          winget_id: 'Opera.Opera',
+          name: 'Opera',
+          publisher: 'Opera Software',
+          latest_version: '1.0.0',
+        },
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest('?ids=Opera.Opera'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      targetedRequestedCount: 1,
+      targetedCount: 1,
+    });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({
+      winget_id: 'Opera.Opera',
+      status: 'queued',
+      priority: 1_000,
+      demand_source: 'operator',
+      test_config: { profileKind: 'catalog-default' },
+    });
+  });
+
+  it('does not let a targeted request expand QA beyond customer-deployed apps', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [
+        {
+          winget_id: 'Undeployed.App',
+          name: 'Undeployed',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+      deployedApps: [],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest('?id=Undeployed.App'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 0,
+      queued: 0,
+      targetedRequestedCount: 1,
+      targetedCount: 0,
+    });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
   it('persists a user-scope dependency compatibility block without degrading polling', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -47,6 +47,23 @@ const MAX_ERROR_LENGTH = 1_000;
 const TOOLCHAIN_BACKFILL_BATCH_SIZE = 3;
 const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
 const DEMAND_BACKFILL_BATCH_SIZE = 3;
+const MAX_TARGETED_PACKAGE_IDS = 20;
+const TARGETED_QA_PRIORITY = 1_000;
+
+function targetedPackageIds(request: Request): string[] {
+  const url = new URL(request.url);
+  const values = [
+    ...url.searchParams.getAll('id'),
+    ...url.searchParams.getAll('ids').flatMap((value) => value.split(',')),
+  ];
+  const ids = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+  if (ids.length > MAX_TARGETED_PACKAGE_IDS) {
+    throw new Error(`At most ${MAX_TARGETED_PACKAGE_IDS} targeted package IDs are allowed.`);
+  }
+  const invalid = ids.find((id) => !/^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(id));
+  if (invalid) throw new Error(`Invalid targeted WinGet package ID: ${invalid}`);
+  return ids;
+}
 
 interface QaCandidateProfileRow {
   id: string;
@@ -250,6 +267,12 @@ export async function GET(request: Request) {
   if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  let requestedPackageIds: string[];
+  try {
+    requestedPackageIds = targetedPackageIds(request);
+  } catch (error) {
+    return NextResponse.json({ error: errorMessage(error) }, { status: 400 });
+  }
 
   const startedAt = new Date().toISOString();
   const startedAtMs = Date.now();
@@ -270,6 +293,7 @@ export async function GET(request: Request) {
   let toolchainBackfillPagesScanned = 0;
   let demandBackfillRequestedCount = 0;
   let demandBackfillCount = 0;
+  let targetedCount = 0;
   let baseSha: string | null = null;
   let headSha: string | null = null;
   let runId: string | null = null;
@@ -399,8 +423,9 @@ export async function GET(request: Request) {
     const changedIds = new Set(changes.changedPackageIds);
     const backfillIds = new Set(backfill.ids);
     const demandBackfillIdSet = new Set(demandBackfillIds);
+    const targetedIdSet = new Set(requestedPackageIds);
     const targetPackageIds = Array.from(
-      new Set([...changedIds, ...backfillIds, ...demandBackfillIdSet])
+      new Set([...changedIds, ...backfillIds, ...demandBackfillIdSet, ...targetedIdSet])
     );
 
     structuredQaPollLog('info', 'qa_poll_started', {
@@ -414,6 +439,7 @@ export async function GET(request: Request) {
       toolchainBackfillRequestedCount: backfill.ids.length,
       toolchainBackfillPagesScanned,
       demandBackfillRequestedCount,
+      targetedRequestedCount: requestedPackageIds.length,
     });
 
     let supportedApps: Array<{
@@ -504,6 +530,15 @@ export async function GET(request: Request) {
       if (!priorities.has(deployed.winget_id)) priorities.set(deployed.winget_id, 1);
     }
     supportedApps = supportedApps.filter((app) => demandedIds.has(app.winget_id));
+    targetedCount = supportedApps.filter((app) => targetedIdSet.has(app.winget_id)).length;
+    for (const app of supportedApps) {
+      if (targetedIdSet.has(app.winget_id)) {
+        priorities.set(
+          app.winget_id,
+          Math.max(priorities.get(app.winget_id) || 0, TARGETED_QA_PRIORITY)
+        );
+      }
+    }
     supportedChangedCount = supportedApps.filter((app) => changedIds.has(app.winget_id)).length;
     toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
     demandBackfillCount = supportedApps.filter((app) =>
@@ -689,6 +724,8 @@ export async function GET(request: Request) {
                 priority: priorities.get(app.winget_id) || 0,
                 demand_source: policies.some((policy) => policy.winget_id === app.winget_id)
                   ? 'auto_update'
+                  : targetedIdSet.has(app.winget_id)
+                    ? 'operator'
                   : 'managed',
                 failure_summary: !packagingContract.valid
                   ? `Packaging preflight: ${packagingContract.message}`
@@ -834,6 +871,8 @@ export async function GET(request: Request) {
       toolchainBackfillPagesScanned,
       demandBackfillRequestedCount,
       demandBackfillCount,
+      targetedRequestedCount: requestedPackageIds.length,
+      targetedCount,
       ...summary,
     });
 
@@ -852,6 +891,8 @@ export async function GET(request: Request) {
         toolchainBackfillPagesScanned,
         demandBackfillRequestedCount,
         demandBackfillCount,
+        targetedRequestedCount: requestedPackageIds.length,
+        targetedCount,
         ...summary,
       },
       { status: status === 'succeeded' ? 200 : 207 }
@@ -892,6 +933,8 @@ export async function GET(request: Request) {
         toolchainBackfillPagesScanned,
         demandBackfillRequestedCount,
         demandBackfillCount,
+        targetedRequestedCount: requestedPackageIds.length,
+        targetedCount,
         ...summary,
       },
       { status: 500 }


### PR DESCRIPTION
## Summary
- add a CRON-secret-protected way to request immediate QA for specific WinGet IDs
- keep targeted runs restricted to verified applications with durable customer demand
- give operator verification priority below live customer uploads
- rebuild candidates through the normal catalog manifest, dependency, PSADT, and identity path

## Verification
- npm exec vitest run app/api/cron/qa-enqueue/route.test.ts
- npm exec eslint app/api/cron/qa-enqueue/route.ts app/api/cron/qa-enqueue/route.test.ts
- npm run build:ci