### PR TITLE
Prioritize recent QA failures in demand backfill

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -206,6 +206,35 @@ describe('QA package compatibility block migration contract', () => {
   });
 });
 
+describe('failed QA backfill priority migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260812184500_prioritize_failed_qa_backfill.sql'
+    ),
+    'utf8'
+  );
+
+  it('prioritizes only failures for the current catalog version', () => {
+    expect(sql).toContain('current_app.latest_version = candidate.version');
+    expect(sql).toContain("candidate.status in ('failed', 'error')");
+    expect(sql).toContain('failure.last_failed_at desc nulls last');
+    expect(sql.indexOf('failure.last_failed_at desc nulls last')).toBeLessThan(
+      sql.indexOf('demand.has_auto_update desc')
+    );
+  });
+
+  it('preserves the customer-demand, compatibility, and service-only boundaries', () => {
+    expect(sql).toContain('from public.upload_history as history');
+    expect(sql).toContain('from public.qa_package_blocks as block');
+    expect(sql).toContain("candidate.test_config @> '{\"profileKind\":\"catalog-default\"}'::jsonb");
+    expect(sql).toContain('limit greatest(1, least(coalesce(p_limit, 3), 100))');
+    expect(sql).toContain("set search_path = ''");
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260812184500_prioritize_failed_qa_backfill.sql
+++ b/supabase/migrations/20260812184500_prioritize_failed_qa_backfill.sql
@@ -1,0 +1,87 @@
+-- Once a packaging fix is deployed, recently failed current-version apps need
+-- a fresh catalog-default candidate before ordinary historical demand. Keep
+-- the campaign bounded to customer-deployed apps and preserve auto-update as
+-- the next priority signal.
+
+create or replace function public.qa_missing_demand_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with deployed as (
+    select
+      history.winget_id,
+      max(history.deployed_at) as last_deployed_at
+    from public.upload_history as history
+    where nullif(btrim(history.winget_id), '') is not null
+    group by history.winget_id
+  ),
+  demand as (
+    select
+      deployed.winget_id,
+      exists (
+        select 1
+        from public.app_update_policies as policy
+        where policy.winget_id = deployed.winget_id
+          and policy.policy_type = 'auto_update'
+          and policy.is_enabled is true
+      ) as has_auto_update,
+      deployed.last_deployed_at as last_demanded_at
+    from deployed
+  ),
+  current_version_failures as (
+    select
+      candidate.winget_id,
+      max(candidate.finished_at) as last_failed_at
+    from public.qa_candidates as candidate
+    join public.curated_apps as current_app
+      on current_app.winget_id = candidate.winget_id
+     and current_app.latest_version = candidate.version
+    where candidate.test_level = 'psadt-package'
+      and candidate.status in ('failed', 'error')
+    group by candidate.winget_id
+  )
+  select app.winget_id
+  from demand
+  join public.curated_apps as app on app.winget_id = demand.winget_id
+  left join current_version_failures as failure
+    on failure.winget_id = app.winget_id
+  where app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and candidate.version = app.latest_version
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+    and not exists (
+      select 1
+      from public.qa_package_blocks as block
+      where block.winget_id = app.winget_id
+        and block.version = app.latest_version
+    )
+  order by
+    failure.last_failed_at desc nulls last,
+    demand.has_auto_update desc,
+    demand.last_demanded_at desc nulls last,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 100));
+$$;
+
+comment on function public.qa_missing_demand_backfill_ids(integer) is
+  'Returns customer-deployed Win32 apps missing current-version QA, prioritizing recent current-version failures after packaging fixes.';
+
+revoke all on function public.qa_missing_demand_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_missing_demand_backfill_ids(integer)
+  to service_role;


### PR DESCRIPTION
## Summary
- prioritize recent current-version QA failures in the customer-demand backfill
- preserve deployed-app, compatibility-block, and service-role boundaries
- keep automatic-update demand as the next ordering signal

## Why
After a shared packaging fix, the corrected catalog profile should be tested promptly instead of waiting behind historical demand.

## Verification
- npm exec vitest run lib/qa/migration-contract.test.ts
- npm exec eslint lib/qa/migration-contract.test.ts
- read-only production query confirms Opera.Opera becomes the first eligible target