### PR TITLE
Accept valid preinstalled shared runtimes

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1905,6 +1905,44 @@ if ($useRegistryUninstall) {
         '            $configuredMatches = @($postInstallApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
         '            if ($configuredMatches.Count -eq 1) { $selectedApplications = $configuredMatches }'
         '        }'
+    )
+
+    # Shared Windows runtimes can already be installed at the requested (or a
+    # newer) version. Their vendor installer then succeeds without changing ARP.
+    # Accept that no-op only for a reviewed retention adapter, and only when one
+    # unchanged pre-install identity exactly matches and satisfies the requested
+    # version. Ordinary applications must still prove an observed install delta.
+    if ($preserveVendorInstallationOnUninstall) {
+        $lines += @(
+            '        if ($selectedApplications.Count -eq 0) {'
+            '            $sharedRuntimeMatches = @($postInstallApplications | Where-Object {'
+            '                $candidateApplication = $_'
+            '                $previousApplication = $preInstallApplications | Where-Object { $_.PSPath -eq $candidateApplication.PSPath } | Select-Object -First 1'
+            '                if (-not $previousApplication -or $previousApplication.DisplayVersion -ne $candidateApplication.DisplayVersion) { return $false }'
+            '                $identityMatches = if ($configuredUninstallProductCode) {'
+            '                    [string]$candidateApplication.PSChildName -eq $configuredUninstallProductCode'
+            '                } else {'
+            '                    [string]$candidateApplication.DisplayName -eq $configuredUninstallDisplayName'
+            '                }'
+            '                if (-not $identityMatches) { return $false }'
+            '                $installedVersionText = [string]$candidateApplication.DisplayVersion'
+            '                $requestedVersionText = [string]$adtSession.AppVersion'
+            '                if ($installedVersionText -eq $requestedVersionText) { return $true }'
+            '                $installedVersion = $null'
+            '                $requestedVersion = $null'
+            '                [version]::TryParse($installedVersionText, [ref]$installedVersion) -and'
+            '                    [version]::TryParse($requestedVersionText, [ref]$requestedVersion) -and'
+            '                    $installedVersion -ge $requestedVersion'
+            '            })'
+            '            if ($sharedRuntimeMatches.Count -eq 1) {'
+            '                $selectedApplications = $sharedRuntimeMatches'
+            '                Write-ADTLogEntry -Message "Reusing already-installed shared runtime identity [$($selectedApplications[0].DisplayName)] version [$($selectedApplications[0].DisplayVersion)]." -Source ''Install-ADTDeployment'''
+            '            }'
+            '        }'
+        )
+    }
+
+    $lines += @(
         '        if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1) {'
         '            $selectedApplications = @($changedApplications[0])'
         '        }'

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -78,7 +78,8 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the
     // Windows 11 registration can remain even after its vendor command exits.
-    // IntuneGet therefore removes only its own management marker on uninstall.
+    // IntuneGet accepts an exact preinstalled identity at the requested or a
+    // newer version, then removes only its own management marker on uninstall.
     wingetId: 'Microsoft.EdgeWebView2Runtime',
     preserveVendorInstallationOnUninstall: true,
   },

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -172,13 +172,46 @@ describe('PSADT vendor argument contract', () => {
         generated.indexOf('function Uninstall-ADTDeployment'),
         generated.indexOf('function Repair-ADTDeployment')
       );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
 
+      expect(installFunction).toContain(
+        '$sharedRuntimeMatches = @($postInstallApplications | Where-Object {'
+      );
+      expect(installFunction).toContain(
+        '$previousApplication.DisplayVersion -ne $candidateApplication.DisplayVersion'
+      );
+      expect(installFunction).toContain(
+        '[string]$candidateApplication.DisplayName -eq $configuredUninstallDisplayName'
+      );
+      expect(installFunction).toContain(
+        '[version]::TryParse($installedVersionText, [ref]$installedVersion)'
+      );
+      expect(installFunction).toContain('$installedVersion -ge $requestedVersion');
+      expect(installFunction).toContain(
+        'Reusing already-installed shared runtime identity'
+      );
       expect(uninstallFunction).toContain(
         'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
       );
       expect(uninstallFunction).toContain('IntuneGet detection marker removed from HKLM');
       expect(uninstallFunction).not.toContain('Waiting for vendor uninstall registration');
       expect(uninstallFunction).not.toContain('Start-ADTProcess @uninstallProcessParameters');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'does not reuse unchanged uninstall entries for ordinary applications',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Ordinary Application'
+      );
+
+      expect(generated).not.toContain('$sharedRuntimeMatches');
+      expect(generated).not.toContain('Reusing already-installed shared runtime identity');
     }
   );
 


### PR DESCRIPTION
## What changed
- allow a reviewed shared-runtime package to reuse one unchanged preinstalled ARP identity
- require an exact configured identity and an installed version equal to or newer than the requested version
- keep ordinary applications on the existing observed-install-delta requirement
- add generated PSADT contract coverage for both allowed and denied paths

## Root cause
Windows 11 already contained Microsoft Edge WebView2 Runtime at the requested version. The vendor installer correctly completed as a no-op, but the generated PSADT package rejected the unchanged uninstall registration and returned 60001.

## Impact
The shared generator is used by customer uploads and QA packaging, so the correction applies one-to-one. It is gated by the internal reviewed retention adapter and cannot be enabled by customer-controlled configuration.

## Validation
- `npm test -- lib/qa/psadt-packager-contract.test.ts lib/packaging-adapters.test.ts` (71 passed)
- focused ESLint passed
- generator and generated deployment scripts parsed successfully with PowerShell
- `git diff --check`