### PR TITLE
Pin preinstalled runtime packaging release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f4bc37886e490ece525c701562869734a7e366d5',
+  packagerCommit: '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -44,6 +44,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '267c8cbb3c520feaec04c2254de1a667b8fa90d4',
   'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
   '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
+  'f4bc37886e490ece525c701562869734a7e366d5',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -46,6 +46,10 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries WebView2 for the current shared-runtime lifecycle correction', () => {
     expect(shouldRetryTerminalToolchainCandidate(
+      'f4bc37886e490ece525c701562869734a7e366d5',
+      { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
     )).toBe(true);

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,9 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc': [
+    'Microsoft.EdgeWebView2Runtime',
+  ],
   'f4bc37886e490ece525c701562869734a7e366d5': [
     'Microsoft.EdgeWebView2Runtime',
   ],


### PR DESCRIPTION
## Summary
- pin QA profiles to shared packager commit `9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc`
- preserve the prior shared-runtime release in compatible pass history
- target only Microsoft Edge WebView2 Runtime for a bounded terminal retry on this release

## Validation
- package profile and toolchain backfill tests: 71 passed
- focused ESLint passed
- `git diff --check`