### PR TITLE
Retry Granola with corrected QA diagnostics

### DIFF
--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -55,6 +55,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('allows one current-toolchain Granola replay for corrected user-context diagnostics', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Granola.Granola', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f4bc37886e490ece525c701562869734a7e366d5',
+      { wingetId: 'Granola.Granola', status: 'failed' }
+    )).toBe(false);
+  });
+
   it.each([
     'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -11,6 +11,11 @@ export interface QaToolchainBackfillCandidate {
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
   '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc': [
+    // One bounded replay is required after the QA runner learned to collect
+    // PSADT logs from the active interactive-user profile. Granola's newer
+    // user-scoped release failed without those diagnostics, while its prior
+    // version passed through the same customer packaging path.
+    'Granola.Granola',
     'Microsoft.EdgeWebView2Runtime',
   ],
   'f4bc37886e490ece525c701562869734a7e366d5': [


### PR DESCRIPTION
## Summary
- allow one bounded Granola replay on the current protected packager toolchain
- collect the active-user PSADT evidence added in IntuneGet-Workflows PR 697
- keep all unrelated terminal failures excluded from toolchain backfill

Granola 7.469.2 passed, but 7.478.0 exited with 0xC0000005 and the old runner collected logs from a retired user profile. This replay is diagnostic, not a claim that the vendor failure is fixed.

## Validation
- 45 focused Vitest tests
- ESLint on changed and consuming files
- git diff --check