### PR TITLE
Apply Opera silent uninstall lifecycle

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -500,7 +500,13 @@ describe('GET /api/cron/qa-enqueue', () => {
       status: 'queued',
       priority: 1_000,
       demand_source: 'operator',
-      test_config: { profileKind: 'catalog-default' },
+      test_config: {
+        profileKind: 'catalog-default',
+        psadtConfig: {
+          processesToClose: [{ name: 'opera', description: 'Opera browser' }],
+          reviewedUninstallArguments: ['/silent'],
+        },
+      },
     });
   });
 

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -505,6 +505,40 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('applies the reviewed Opera silent-uninstall contract to QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Opera.Opera',
+          displayName: 'Opera Browser',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedAdapter = {
+      processesToClose: [{ name: 'opera', description: 'Opera browser' }],
+      reviewedUninstallArguments: ['/silent'],
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedAdapter,
+    });
+  });
+
   it('repairs empty catalog detection rules for both QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -29,6 +29,12 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
     expect(
+      applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      processesToClose: [{ name: 'opera', description: 'Opera browser' }],
+      reviewedUninstallArguments: ['/silent'],
+    });
+    expect(
       applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG
@@ -108,6 +114,21 @@ describe('application packaging adapters', () => {
     });
 
     expect(adapted.reviewedUninstallArguments).toEqual(['/s', '--custom']);
+  });
+
+  it('preserves customer Opera lifecycle settings while adding the reviewed silent removal contract', () => {
+    const adapted = applyApplicationPackagingAdapter('opera.opera', {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: 'Opera.exe', description: 'Customer browser session' },
+      ],
+      reviewedUninstallArguments: ['/SILENT', '--custom'],
+    });
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'Opera', description: 'Customer browser session' },
+    ]);
+    expect(adapted.reviewedUninstallArguments).toEqual(['/SILENT', '--custom']);
   });
 
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -74,6 +74,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
   },
   {
+    // Opera registers `opera.exe /uninstall`, which presents a confirmation
+    // dialog and leaves the ARP entry intact under unattended SYSTEM removal.
+    // Its Chromium-derived uninstaller accepts /silent; close the browser
+    // first so both upgrades and removals can complete deterministically.
+    wingetId: 'Opera.Opera',
+    requiredProcessesToClose: [
+      { name: 'opera', description: 'Opera browser' },
+    ],
+    reviewedUninstallArguments: ['/silent'],
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the


### PR DESCRIPTION
## Summary
- add Opera's reviewed /silent removal switch to the shared packaging adapter
- close the Opera browser before upgrade or removal
- prove the same effective adapter reaches background QA and customer Intune packaging

Opera 134 installed and detected successfully, but its registered opera.exe /uninstall command remained interactive and retained the exact ARP entry for the full five-minute deadline. The adapter adds only the missing unattended argument for Opera.Opera.

## Validation
- 110 focused Vitest tests
- ESLint on changed files
- git diff --check