### PR TITLE
Pin Opera lifecycle packaging release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
+  packagerCommit: '7d389dbd6e55b719e3d71772717cda0c8f724469',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -45,6 +45,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'ca37c9eadd7b64d4d926f60a158e3dafb4554788',
   '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
   'f4bc37886e490ece525c701562869734a7e366d5',
+  '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,7 +18,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('keeps the carried xTool retry scoped to its historical releases', () => {
+  it('carries the queued xTool retry across the current pin', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'b3b2729bab6959a554c0e6d41af0a841d6177386',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
@@ -30,10 +30,10 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
-    )).toBe(false);
+    )).toBe(true);
   });
 
-  it('keeps the LTspice retry scoped to its enterprise-mode release', () => {
+  it('carries the queued LTspice retry across the current pin', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
       { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
@@ -41,6 +41,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries Opera once on the reviewed silent-uninstall release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Opera.Opera', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
+      { wingetId: 'Opera.Opera', status: 'failed' }
     )).toBe(false);
   });
 
@@ -105,7 +116,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('keeps the Greenshot retry scoped to its historical toolchain release', () => {
+  it('carries the queued Greenshot retry across the current pin', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
       { wingetId: 'Greenshot.Greenshot', status: 'failed' }
@@ -113,7 +124,14 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Greenshot.Greenshot', status: 'failed' }
-    )).toBe(false);
+    )).toBe(true);
+  });
+
+  it.each(['Autodesk.DesktopApp'])('carries the queued %s retry across the current pin', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
   });
 
   it('keeps the OCS retry scoped to its historical toolchain release', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,21 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '7d389dbd6e55b719e3d71772717cda0c8f724469': [
+    // Opera's registered uninstaller is interactive unless /silent is added.
+    // This release applies that reviewed lifecycle adapter to QA and customer
+    // packages, so the exact failing version receives one bounded replay.
+    'Opera.Opera',
+    // These bounded retries were queued on the preceding release when this
+    // pin superseded it. Carry them once so a toolchain rollout cannot discard
+    // already-selected customer coverage work.
+    'AnalogDevices.LTspice',
+    'Autodesk.DesktopApp',
+    'Granola.Granola',
+    'Greenshot.Greenshot',
+    'Makeblock.xToolStudio',
+    'Microsoft.EdgeWebView2Runtime',
+  ],
   '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc': [
     // One bounded replay is required after the QA runner learned to collect
     // PSADT logs from the active interactive-user profile. Granola's newer


### PR DESCRIPTION
## Summary
- pin the canonical QA package profile to the merged Opera lifecycle packager
- preserve the preceding release in compatibility history
- carry only already-selected terminal retries across the rollout

## Why
Opera 134 installed correctly but its registered uninstaller remained interactive. The merged adapter adds the reviewed `/silent` argument for both QA and customer packages. Pinning the exact merge commit makes the queued retest authoritative without globally invalidating unrelated successful profiles.

## Verification
- 114 focused Vitest tests passed
- ESLint passed on changed files
- git diff --check passed