### PR TITLE
Block retired catalog applications permanently

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -18,6 +18,7 @@ const {
   enforceInstallerPreflightMock,
   getLiveInstallersMock,
   ensureQaDemandMock,
+  getPackageEligibilityBlocksMock,
 } = vi.hoisted(() => ({
   getDatabaseMock: vi.fn(),
   getByUserIdMock: vi.fn(),
@@ -34,6 +35,7 @@ const {
   enforceInstallerPreflightMock: vi.fn(),
   getLiveInstallersMock: vi.fn(),
   ensureQaDemandMock: vi.fn(),
+  getPackageEligibilityBlocksMock: vi.fn(),
 }));
 
 vi.mock('@/lib/manifest-api', () => ({
@@ -78,6 +80,14 @@ vi.mock('@/lib/installer-preflight', async (importOriginal) => {
 });
 
 vi.mock('@/lib/qa/demand', () => ({ ensureQaDemand: ensureQaDemandMock }));
+
+vi.mock('@/lib/package-eligibility', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/package-eligibility')>();
+  return {
+    ...original,
+    getPackageEligibilityBlocks: getPackageEligibilityBlocksMock,
+  };
+});
 
 vi.mock('@/lib/supabase', () => ({
   createServerClient: vi.fn(),
@@ -346,6 +356,64 @@ describe('POST /api/package (workflow dispatch)', () => {
         presentationProfileSha256: 'B'.repeat(64),
       },
     });
+    getPackageEligibilityBlocksMock.mockResolvedValue([]);
+  });
+
+  it('blocks a retired catalog app before QA or customer packaging begins', async () => {
+    getPackageEligibilityBlocksMock.mockResolvedValueOnce([
+      { wingetId: 'Autodesk.DesktopApp', code: 'vendor_retired' },
+    ]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Autodesk.DesktopApp',
+          displayName: 'Autodesk Desktop App',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body).toMatchObject({
+      error: 'App unavailable',
+      message: 'This app is no longer available for deployment.',
+      code: 'PACKAGE_UNAVAILABLE',
+      package: { wingetId: 'Autodesk.DesktopApp' },
+    });
+    expect(enforceInstallerPreflightMock).not.toHaveBeenCalled();
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it('does not apply catalog retirement policy to a custom package', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Autodesk.DesktopApp',
+          sourceType: 'custom',
+          installerSha256: '',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(getPackageEligibilityBlocksMock.mock.calls[0][1]).toEqual([]);
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
   });
 
   it('forwards item relationships into the workflow inputs', async () => {

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -45,6 +45,10 @@ import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { reconcileCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
 import type { NormalizedInstaller } from '@/types/winget';
+import {
+  getPackageEligibilityBlocks,
+  PACKAGE_UNAVAILABLE_MESSAGE,
+} from '@/lib/package-eligibility';
 
 export const maxDuration = 300;
 
@@ -178,6 +182,30 @@ export async function POST(request: NextRequest) {
         // Treat missing appSource as win32 for backward compatibility
         win32Items.push(item as Win32CartItem);
       }
+    }
+
+    const catalogWin32Items = win32Items.filter(
+      (item) => item.sourceType !== 'custom' && typeof item.wingetId === 'string'
+    );
+    const eligibilityBlocks = await getPackageEligibilityBlocks(
+      createServerClient(),
+      catalogWin32Items.map((item) => item.wingetId)
+    );
+    if (eligibilityBlocks.length > 0) {
+      const block = eligibilityBlocks[0];
+      const blockedItem = catalogWin32Items.find(
+        (item) => item.wingetId === block.wingetId
+      );
+      return NextResponse.json({
+        error: 'App unavailable',
+        message: PACKAGE_UNAVAILABLE_MESSAGE,
+        code: 'PACKAGE_UNAVAILABLE',
+        package: {
+          wingetId: block.wingetId,
+          displayName: blockedItem?.displayName || block.wingetId,
+          version: blockedItem?.version,
+        },
+      }, { status: 409 });
     }
 
     // Apply reviewed behavior constraints before preflight, QA identity, job

--- a/lib/package-eligibility.test.ts
+++ b/lib/package-eligibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPackageEligibilityBlocks } from '@/lib/package-eligibility';
+
+function query(result: { data: unknown; error: { message: string } | null }) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> & {
+    then?: Promise<unknown>['then'];
+  } = {
+    select: vi.fn(),
+    in: vi.fn(),
+  };
+  builder.select.mockReturnValue(builder);
+  builder.in.mockReturnValue(builder);
+  builder.then = (onFulfilled, onRejected) =>
+    Promise.resolve(result).then(onFulfilled, onRejected);
+  return builder;
+}
+
+describe('getPackageEligibilityBlocks', () => {
+  it('deduplicates requested IDs and returns only application-level blocks', async () => {
+    const builder = query({
+      data: [{ winget_id: 'Autodesk.DesktopApp', block_code: 'vendor_retired' }],
+      error: null,
+    });
+    const client = { from: vi.fn(() => builder) };
+
+    const result = await getPackageEligibilityBlocks(client as never, [
+      ' Autodesk.DesktopApp ',
+      'Autodesk.DesktopApp',
+      '',
+    ]);
+
+    expect(client.from).toHaveBeenCalledWith('package_eligibility_blocks');
+    expect(builder.select).toHaveBeenCalledWith('winget_id, block_code');
+    expect(builder.in).toHaveBeenCalledWith('winget_id', ['Autodesk.DesktopApp']);
+    expect(result).toEqual([
+      { wingetId: 'Autodesk.DesktopApp', code: 'vendor_retired' },
+    ]);
+  });
+
+  it('does not query Supabase when no catalog IDs are present', async () => {
+    const client = { from: vi.fn() };
+
+    await expect(getPackageEligibilityBlocks(client as never, [])).resolves.toEqual([]);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when package availability cannot be verified', async () => {
+    const client = {
+      from: vi.fn(() => query({ data: null, error: { message: 'database unavailable' } })),
+    };
+
+    await expect(
+      getPackageEligibilityBlocks(client as never, ['Example.App'])
+    ).rejects.toThrow('Could not verify package availability: database unavailable');
+  });
+});

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database';
+
+export type PackageEligibilityBlockCode = 'vendor_retired';
+
+export interface PackageEligibilityBlock {
+  wingetId: string;
+  code: PackageEligibilityBlockCode;
+}
+
+export const PACKAGE_UNAVAILABLE_MESSAGE =
+  'This app is no longer available for deployment.';
+
+export async function getPackageEligibilityBlocks(
+  supabase: SupabaseClient<Database>,
+  wingetIds: readonly string[]
+): Promise<PackageEligibilityBlock[]> {
+  const ids = Array.from(
+    new Set(wingetIds.map((id) => id.trim()).filter(Boolean))
+  );
+  if (ids.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from('package_eligibility_blocks')
+    .select('winget_id, block_code')
+    .in('winget_id', ids);
+  if (error) {
+    throw new Error(`Could not verify package availability: ${error.message}`);
+  }
+
+  return (data || []).map((row) => ({
+    wingetId: row.winget_id,
+    code: row.block_code,
+  }));
+}

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -2,13 +2,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
-const { resolveWingetPackageDependenciesMock } = vi.hoisted(() => ({
+const { resolveWingetPackageDependenciesMock, getPackageEligibilityBlocksMock } = vi.hoisted(() => ({
   resolveWingetPackageDependenciesMock: vi.fn(),
+  getPackageEligibilityBlocksMock: vi.fn(),
 }));
 
 vi.mock('@/lib/winget-dependencies', () => ({
   resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
 }));
+
+vi.mock('@/lib/package-eligibility', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/package-eligibility')>();
+  return {
+    ...original,
+    getPackageEligibilityBlocks: getPackageEligibilityBlocksMock,
+  };
+});
 
 type QueryResult = {
   data: unknown;
@@ -52,6 +61,25 @@ describe('ensureQaDemand app-version evidence reuse', () => {
   beforeEach(() => {
     resolveWingetPackageDependenciesMock.mockReset();
     resolveWingetPackageDependenciesMock.mockResolvedValue([]);
+    getPackageEligibilityBlocksMock.mockReset();
+    getPackageEligibilityBlocksMock.mockResolvedValue([]);
+  });
+
+  it('does not queue or resolve dependencies for a retired catalog app', async () => {
+    getPackageEligibilityBlocksMock.mockResolvedValue([
+      { wingetId: 'Example.App', code: 'vendor_retired' },
+    ]);
+    const client = { from: vi.fn() };
+
+    const result = await ensureQaDemand(client as never, demandInput());
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      candidateId: null,
+      failureSummary: 'This app is no longer available for deployment.',
+    });
+    expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalled();
   });
 
   it('persists dependency download metadata on a newly queued customer candidate', async () => {

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -9,6 +9,10 @@ import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
 import type { Json } from '@/types/database';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
+import {
+  getPackageEligibilityBlocks,
+  PACKAGE_UNAVAILABLE_MESSAGE,
+} from '@/lib/package-eligibility';
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
 export type QaDemandState = 'passed' | 'failed' | 'waiting';
@@ -31,6 +35,28 @@ export async function ensureQaDemand(
   input: QaDemandInput
 ): Promise<QaDemandResult> {
   const installScope = resolveApplicationInstallScope(input.wingetId, input.installScope);
+  const baseResolvedInput: QaDemandInput = {
+    ...input,
+    installScope,
+    psadtConfig: JSON.stringify({
+      ...DEFAULT_PSADT_CONFIG,
+      deployMode: 'Auto',
+      progressDialog: {
+        enabled: true,
+        statusMessage: 'IntuneGet is validating this application package.',
+        windowLocation: 'BottomRight',
+      },
+    }),
+  };
+  const eligibilityBlocks = await getPackageEligibilityBlocks(supabase, [input.wingetId]);
+  if (eligibilityBlocks.length > 0) {
+    return {
+      identity: normalizeQaWorkflowPackageInput(baseResolvedInput).identity,
+      candidateId: null,
+      state: 'failed',
+      failureSummary: PACKAGE_UNAVAILABLE_MESSAGE,
+    };
+  }
   // Resolve at the QA-demand boundary as well as at final packaging dispatch.
   // This keeps both gates bound to the same server-trusted dependency graph;
   // caller-supplied dependency metadata is never authoritative.
@@ -46,17 +72,7 @@ export async function ensureQaDemand(
   // Customer presentation choices are applied later by customer packaging and
   // must neither suppress QA evidence nor multiply app-version tests.
   const resolvedInput: QaDemandInput = {
-    ...input,
-    installScope,
-    psadtConfig: JSON.stringify({
-      ...DEFAULT_PSADT_CONFIG,
-      deployMode: 'Auto',
-      progressDialog: {
-        enabled: true,
-        statusMessage: 'IntuneGet is validating this application package.',
-        windowLocation: 'BottomRight',
-      },
-    }),
+    ...baseResolvedInput,
     packageDependencies,
   };
   const normalizedPackage = normalizeQaWorkflowPackageInput(resolvedInput);

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -235,6 +235,35 @@ describe('failed QA backfill priority migration contract', () => {
   });
 });
 
+describe('retired catalog app migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260812205027_block_retired_catalog_apps.sql'
+    ),
+    'utf8'
+  );
+
+  it('defines a private application-level block and keeps catalog verification false', () => {
+    expect(sql).toContain('create table public.package_eligibility_blocks');
+    expect(sql).toContain("block_code in ('vendor_retired')");
+    expect(sql).toContain('before insert or update on public.curated_apps');
+    expect(sql).toContain('new.is_verified := false');
+    expect(sql).toContain('enable row level security');
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+  });
+
+  it('blocks Autodesk Desktop App from retries and customer-deployed backfill', () => {
+    expect(sql).toContain("'Autodesk.DesktopApp'");
+    expect(sql).toContain("candidate.status = 'queued'");
+    expect(sql).toContain('from public.package_eligibility_blocks as eligibility_block');
+    expect(sql).toContain('from public.qa_package_blocks as block');
+    expect(sql).toContain('from public.upload_history as history');
+    expect(sql).toContain('failure.last_failed_at desc nulls last');
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260812205027_block_retired_catalog_apps.sql
+++ b/supabase/migrations/20260812205027_block_retired_catalog_apps.sql
@@ -1,0 +1,175 @@
+-- Some upstream package records remain available after the publisher has
+-- retired the product or the service it depends on. These are application-
+-- level eligibility decisions, not version-specific installer failures.
+
+create table public.package_eligibility_blocks (
+  winget_id text primary key
+    references public.curated_apps(winget_id) on update cascade on delete cascade,
+  block_code text not null check (block_code in ('vendor_retired')),
+  detail text not null check (char_length(detail) between 1 and 1000),
+  source_url text not null check (source_url ~ '^https://'),
+  blocked_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.package_eligibility_blocks is
+  'Service-only application-level blocks shared by catalog, customer packaging, auto-update, and QA.';
+
+alter table public.package_eligibility_blocks enable row level security;
+revoke all on table public.package_eligibility_blocks from public, anon, authenticated;
+grant select, insert, update, delete on table public.package_eligibility_blocks to service_role;
+
+create or replace function public.enforce_catalog_package_eligibility()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if exists (
+    select 1
+    from public.package_eligibility_blocks as block
+    where block.winget_id = new.winget_id
+  ) then
+    new.is_verified := false;
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_catalog_package_eligibility()
+  from public, anon, authenticated;
+grant execute on function public.enforce_catalog_package_eligibility()
+  to service_role;
+
+create trigger curated_apps_enforce_package_eligibility
+before insert or update on public.curated_apps
+for each row
+when (new.is_verified is true)
+execute function public.enforce_catalog_package_eligibility();
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Autodesk.DesktopApp',
+  'vendor_retired',
+  'Autodesk discontinued Desktop App and its backend content services. Autodesk Access is the supported successor.',
+  'https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Is-the-Autodesk-Desktop-App-now-called-Autodesk-Access.html'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps as app
+set is_verified = false
+where exists (
+  select 1
+  from public.package_eligibility_blocks as block
+  where block.winget_id = app.winget_id
+);
+
+update public.qa_candidates as candidate
+set status = 'superseded',
+    finished_at = coalesce(candidate.finished_at, now()),
+    failure_summary = 'QA superseded because this application is no longer available from its publisher.',
+    updated_at = now()
+where candidate.status = 'queued'
+  and exists (
+    select 1
+    from public.package_eligibility_blocks as block
+    where block.winget_id = candidate.winget_id
+  );
+
+create or replace function public.qa_missing_demand_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with deployed as (
+    select
+      history.winget_id,
+      max(history.deployed_at) as last_deployed_at
+    from public.upload_history as history
+    where nullif(btrim(history.winget_id), '') is not null
+    group by history.winget_id
+  ),
+  demand as (
+    select
+      deployed.winget_id,
+      exists (
+        select 1
+        from public.app_update_policies as policy
+        where policy.winget_id = deployed.winget_id
+          and policy.policy_type = 'auto_update'
+          and policy.is_enabled is true
+      ) as has_auto_update,
+      deployed.last_deployed_at as last_demanded_at
+    from deployed
+  ),
+  current_version_failures as (
+    select
+      candidate.winget_id,
+      max(candidate.finished_at) as last_failed_at
+    from public.qa_candidates as candidate
+    join public.curated_apps as current_app
+      on current_app.winget_id = candidate.winget_id
+     and current_app.latest_version = candidate.version
+    where candidate.test_level = 'psadt-package'
+      and candidate.status in ('failed', 'error')
+    group by candidate.winget_id
+  )
+  select app.winget_id
+  from demand
+  join public.curated_apps as app on app.winget_id = demand.winget_id
+  left join current_version_failures as failure
+    on failure.winget_id = app.winget_id
+  where app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.package_eligibility_blocks as eligibility_block
+      where eligibility_block.winget_id = app.winget_id
+    )
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and candidate.version = app.latest_version
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+    and not exists (
+      select 1
+      from public.qa_package_blocks as block
+      where block.winget_id = app.winget_id
+        and block.version = app.latest_version
+    )
+  order by
+    failure.last_failed_at desc nulls last,
+    demand.has_auto_update desc,
+    demand.last_demanded_at desc nulls last,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 100));
+$$;
+
+comment on function public.qa_missing_demand_backfill_ids(integer) is
+  'Returns customer-deployed Win32 apps missing current-version QA, excluding application- and version-level compatibility blocks.';
+
+revoke all on function public.qa_missing_demand_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_missing_demand_backfill_ids(integer)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -284,6 +284,27 @@ export interface Database {
         Update: Partial<Database['public']['Tables']['qa_package_blocks']['Insert']>;
         Relationships: GenericRelationship[];
       };
+      package_eligibility_blocks: {
+        Row: {
+          winget_id: string;
+          block_code: 'vendor_retired';
+          detail: string;
+          source_url: string;
+          blocked_at: string;
+          updated_at: string;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['package_eligibility_blocks']['Row'],
+          'blocked_at' | 'updated_at'
+        > & {
+          blocked_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<
+          Database['public']['Tables']['package_eligibility_blocks']['Insert']
+        >;
+        Relationships: GenericRelationship[];
+      };
       qa_pipeline_control: {
         Row: {
           id: string;


### PR DESCRIPTION
## Summary
- add a private application-level eligibility block shared by catalog sync, QA backfill, and customer packaging
- retire Autodesk Desktop App based on the publisher's discontinued service and keep it from being re-enabled
- fail customer requests cleanly before QA or workflow dispatch while leaving custom packages unaffected

## Verification
- 68 focused Vitest tests passed
- Next.js production build passed
- Supabase migration applied and verified: catalog trigger held is_verified=false, backfill excluded Autodesk, no active candidate remained, and anon/authenticated roles cannot read the block table
- post-migration advisors reported no performance finding; the only related security info is expected RLS-without-policy for the intentionally service-only table