### PR TITLE
Use Opera immediate uninstall lifecycle

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -504,7 +504,7 @@ describe('GET /api/cron/qa-enqueue', () => {
         profileKind: 'catalog-default',
         psadtConfig: {
           processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-          reviewedUninstallArguments: ['/silent'],
+          reviewedUninstallArguments: ['--runimmediately'],
         },
       },
     });

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -573,7 +573,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
-  it('applies the reviewed Opera silent-uninstall contract to QA and customer packaging', async () => {
+  it('applies the reviewed Opera immediate-uninstall contract to QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',
       headers: {
@@ -594,7 +594,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     const expectedAdapter = {
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['/silent'],
+      reviewedUninstallArguments: ['--runimmediately'],
     };
     expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
       expectedAdapter

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -32,7 +32,7 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['/silent'],
+      reviewedUninstallArguments: ['--runimmediately'],
     });
     expect(
       applyApplicationPackagingAdapter(
@@ -116,19 +116,19 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual(['/s', '--custom']);
   });
 
-  it('preserves customer Opera lifecycle settings while adding the reviewed silent removal contract', () => {
+  it('preserves customer Opera lifecycle settings while adding the reviewed immediate removal contract', () => {
     const adapted = applyApplicationPackagingAdapter('opera.opera', {
       ...DEFAULT_PSADT_CONFIG,
       processesToClose: [
         { name: 'Opera.exe', description: 'Customer browser session' },
       ],
-      reviewedUninstallArguments: ['/SILENT', '--custom'],
+      reviewedUninstallArguments: ['--RUNIMMEDIATELY', '--custom'],
     });
 
     expect(adapted.processesToClose).toEqual([
       { name: 'Opera', description: 'Customer browser session' },
     ]);
-    expect(adapted.reviewedUninstallArguments).toEqual(['/SILENT', '--custom']);
+    expect(adapted.reviewedUninstallArguments).toEqual(['--RUNIMMEDIATELY', '--custom']);
   });
 
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -74,15 +74,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
   },
   {
-    // Opera registers `opera.exe /uninstall`, which presents a confirmation
-    // dialog and leaves the ARP entry intact under unattended SYSTEM removal.
-    // Its Chromium-derived uninstaller accepts /silent; close the browser
-    // first so both upgrades and removals can complete deterministically.
+    // Opera registers `opera.exe --uninstall`, which waits for confirmation
+    // unless --runimmediately is supplied. Opera removed support for its old
+    // silent switch, so use the vendor's current unattended-start argument
+    // without deleting user profiles. Close the browser first so both upgrades
+    // and removals can complete deterministically.
     wingetId: 'Opera.Opera',
     requiredProcessesToClose: [
       { name: 'opera', description: 'Opera browser' },
     ],
-    reviewedUninstallArguments: ['/silent'],
+    reviewedUninstallArguments: ['--runimmediately'],
   },
   {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,


### PR DESCRIPTION
## Summary
- replace Opera's removed silent-uninstall switch with the vendor's current --runimmediately lifecycle argument
- retain user profiles and close Opera before removal
- apply the same adapter to QA and customer packaging

## Evidence
- three identical QA failures installed and detected Opera successfully, then waited five minutes because the uninstall confirmation never advanced
- the current Opera forum guidance states that --silent was removed and --runimmediately starts removal without confirmation

## Verification
- 72 packaging adapter and generated PSADT contract tests passed
- diff check passed