### PR TITLE
Reuse compatible QA releases across packager fixes

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -675,7 +675,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(pollRunUpdates[0]).toMatchObject({ status: 'failed', error_count: 1 });
   });
 
-  it('queues a targeted shared-runtime failure when its fix is in the current packager', async () => {
+  it('does not replay a shared-runtime failure after its scoped release has passed', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{
         winget_id: 'Microsoft.EdgeWebView2Runtime',
@@ -700,30 +700,12 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(response.status).toBe(200);
     expect(body).toMatchObject({
       success: true,
-      checked: 1,
-      queued: 1,
-      toolchainBackfillCount: 1,
+      checked: 0,
+      queued: 0,
+      toolchainBackfillCount: 0,
       toolchainBackfillPagesScanned: 1,
     });
-    expect(candidateInserts).toHaveLength(1);
-    expect(candidateInserts[0]).toMatchObject({
-      winget_id: 'Microsoft.EdgeWebView2Runtime',
-      status: 'queued',
-      test_level: 'psadt-package',
-      test_config: {
-        profileKind: 'catalog-default',
-        silentArgs: '/S',
-        psadtConfig: {
-          preserveVendorInstallationOnUninstall: true,
-          reviewedInstallArguments: [],
-          reviewedUninstallArguments: [],
-        },
-      },
-    });
-    const canonical = JSON.parse(
-      String((candidateInserts[0].test_config as Record<string, unknown>).packageProfileCanonicalJson)
-    );
-    expect(canonical.toolchain.packagerCommit).toBe(CURRENT_PACKAGER_COMMIT);
+    expect(candidateInserts).toHaveLength(0);
   });
 
   it('preserves an unrelated terminal failure across a packager release', async () => {
@@ -749,14 +731,14 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
-  it('preserves a passing catalog result from an explicitly compatible packager', async () => {
+  it('reuses a passing release from the immediately preceding compatible packager', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       supportedApps: [{ winget_id: 'Example.App', name: 'Example', publisher: 'Contoso' }],
       candidates: [
         profileCandidate({
           id: 'compatible-passed-candidate',
           wingetId: 'Example.App',
-          packagerCommit: 'de49775e759b693b92db09bc99aa116f197c4850',
+          packagerCommit: '7d389dbd6e55b719e3d71772717cda0c8f724469',
           status: 'passed',
         }),
       ],

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -63,6 +63,51 @@ describe('buildQaLiveResponse', () => {
     });
   });
 
+  it('shows only the newest result for an app version and architecture', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-12T12:00:00.000Z'),
+      current: null,
+      queuedCount: 0,
+      queued: [],
+      poll: null,
+      consecutivePollFailures: 0,
+      recent: [
+        {
+          winget_id: 'Google.Chrome',
+          package_profile_sha256: 'B'.repeat(64),
+          tested_version: '151.0.0',
+          architecture: 'x64',
+          outcome: 'Passed',
+          tested_at_utc: '2026-08-12T11:59:00.000Z',
+          overall_duration_seconds: 82,
+        },
+        {
+          winget_id: 'google.chrome',
+          package_profile_sha256: 'A'.repeat(64),
+          tested_version: '151.0.0',
+          architecture: 'x64',
+          outcome: 'Failed',
+          tested_at_utc: '2026-08-12T11:30:00.000Z',
+          overall_duration_seconds: 300,
+        },
+      ],
+      apps: [{
+        winget_id: 'Google.Chrome',
+        name: 'Google Chrome',
+        publisher: 'Google',
+        latest_version: '151.0.0',
+      }],
+      frame: null,
+    });
+
+    expect(response.recent).toHaveLength(1);
+    expect(response.recent[0]).toMatchObject({
+      wingetId: 'Google.Chrome',
+      outcome: 'Passed',
+      packageProfileSha256: 'B'.repeat(64),
+    });
+  });
+
   it('returns a sanitized live projection and derives health', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-08T17:00:00.000Z'),

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -94,6 +94,23 @@ function architecture(value: string): QaArchitecture {
   return value === 'x86' || value === 'arm64' ? value : 'x64';
 }
 
+function latestRecentResultPerRelease(results: ResultRow[]): ResultRow[] {
+  const newestByRelease = new Map<string, ResultRow>();
+  for (const result of results) {
+    const key = [
+      result.winget_id.trim().toLowerCase(),
+      result.tested_version.trim(),
+      architecture(result.architecture),
+    ].join('|');
+    const existing = newestByRelease.get(key);
+    if (!existing || Date.parse(result.tested_at_utc) > Date.parse(existing.tested_at_utc)) {
+      newestByRelease.set(key, result);
+    }
+  }
+  return [...newestByRelease.values()]
+    .sort((left, right) => Date.parse(right.tested_at_utc) - Date.parse(left.tested_at_utc));
+}
+
 function phase(value: string | null): QaLivePhase {
   return value && VALID_PHASES.has(value as QaLivePhase)
     ? (value as QaLivePhase)
@@ -350,7 +367,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
         enqueuedAt: candidate.enqueued_at,
       })),
     },
-    recent: input.recent.map((result) => ({
+    recent: latestRecentResultPerRelease(input.recent).slice(0, 10).map((result) => ({
       wingetId: result.winget_id,
       packageProfileSha256: result.package_profile_sha256,
       displayName: result.display_name || appById.get(result.winget_id)?.name || result.winget_id,
@@ -412,7 +429,9 @@ export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
       .from('qa_package_results')
       .select(QA_LIVE_RECENT_RESULT_COLUMNS)
       .order('tested_at_utc', { ascending: false })
-      .limit(10),
+      // Fetch enough history to return ten distinct app/version/architecture
+      // releases even when a bounded failure retry produced another profile.
+      .limit(50),
     getQaPipelineControl(supabase),
   ]);
 

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7d389dbd6e55b719e3d71772717cda0c8f724469',
+  packagerCommit: '681b7510f7f30bec92c17581213c9ebc7f72765a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -46,6 +46,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
   'f4bc37886e490ece525c701562869734a7e366d5',
   '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
+  '7d389dbd6e55b719e3d71772717cda0c8f724469',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,7 +18,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('carries the queued xTool retry across the current pin', () => {
+  it('does not replay the already-resolved xTool failure on the current pin', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'b3b2729bab6959a554c0e6d41af0a841d6177386',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
@@ -28,23 +28,31 @@ describe('QA toolchain targeted retries', () => {
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '7d389dbd6e55b719e3d71772717cda0c8f724469',
       { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Makeblock.xToolStudio', status: 'failed' }
+    )).toBe(false);
   });
 
-  it('carries the queued LTspice retry across the current pin', () => {
+  it('does not replay the already-resolved LTspice failure on the current pin', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '93321ef6f7abd287f0fd6f37e37c5f4c199f3c4e',
       { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '7d389dbd6e55b719e3d71772717cda0c8f724469',
       { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'AnalogDevices.LTspice', status: 'failed' }
+    )).toBe(false);
   });
 
-  it('retries Opera once on the reviewed silent-uninstall release', () => {
+  it('retries Opera once on the reviewed immediate-uninstall release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Opera.Opera', status: 'failed' }
@@ -55,24 +63,32 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries WebView2 for the current shared-runtime lifecycle correction', () => {
+  it('keeps WebView2 replay scoped to its shared-runtime lifecycle releases', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'f4bc37886e490ece525c701562869734a7e366d5',
       { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '7d389dbd6e55b719e3d71772717cda0c8f724469',
       { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
     )).toBe(true);
-  });
-
-  it('allows one current-toolchain Granola replay for corrected user-context diagnostics', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Microsoft.EdgeWebView2Runtime', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('keeps the Granola diagnostics replay scoped to its historical releases', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '7d389dbd6e55b719e3d71772717cda0c8f724469',
       { wingetId: 'Granola.Granola', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       'f4bc37886e490ece525c701562869734a7e366d5',
+      { wingetId: 'Granola.Granola', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Granola.Granola', status: 'failed' }
     )).toBe(false);
   });
@@ -127,11 +143,11 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
-  it.each(['Autodesk.DesktopApp'])('carries the queued %s retry across the current pin', (wingetId) => {
+  it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
-    )).toBe(true);
+    )).toBe(false);
   });
 
   it('keeps the OCS retry scoped to its historical toolchain release', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,15 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '681b7510f7f30bec92c17581213c9ebc7f72765a': [
+    // Opera's former /silent adapter was removed by the vendor. This release
+    // switches both QA and customer packaging to --runimmediately.
+    'Opera.Opera',
+    // Greenshot never reached the VM because the pinned PSADT template download
+    // was interrupted. The protected runner now has a verified persistent tool
+    // cache, so carry that infrastructure error through one bounded replay.
+    'Greenshot.Greenshot',
+  ],
   '7d389dbd6e55b719e3d71772717cda0c8f724469': [
     // Opera's registered uninstaller is interactive unless /silent is added.
     // This release applies that reviewed lifecycle adapter to QA and customer


### PR DESCRIPTION
## Summary
- activate the reviewed Opera immediate-uninstall packager identity on the website
- reuse successful app/version/architecture results across unrelated packager releases
- allow one bounded replay only for Opera and Greenshot, the failures affected by this rollout
- collapse recent QA UI rows to the newest result per app/version/architecture so historical retries are not shown as duplicate current results
- keep newer versions and changed installer payloads eligible for QA

## Database audit
- 0 duplicate active payloads
- 0 repeated exact package profiles
- 0 duplicate GitHub run IDs
- existing unique indexes enforce exact-profile and active-payload deduplication

## Validation
- 202 focused tests passed
- full lint passed
- git diff --check passed