### PR TITLE
Surface specific installer resolution errors for update triggers

### DIFF
--- a/app/(app)/dashboard/updates/page.tsx
+++ b/app/(app)/dashboard/updates/page.tsx
@@ -222,11 +222,20 @@ export default function UpdatesPage() {
   const executeTriggerUpdate = useCallback(async (update: AvailableUpdate) => {
     setUpdatingIds((prev) => new Set(prev).add(update.id));
     try {
-      await triggerUpdate({
+      const response = await triggerUpdate({
         winget_id: update.winget_id,
         tenant_id: update.tenant_id,
       });
-      router.push('/dashboard/uploads');
+      const result = response.results.find((r) => r.winget_id === update.winget_id)
+        ?? response.results[0];
+      if (result?.success) {
+        router.push('/dashboard/uploads');
+      } else {
+        toast.error(result?.error || 'The update could not be triggered.');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'The update could not be triggered.';
+      toast.error(message);
     } finally {
       setUpdatingIds((prev) => {
         const next = new Set(prev);

--- a/app/api/cron/check-updates/route.ts
+++ b/app/api/cron/check-updates/route.ts
@@ -122,20 +122,21 @@ async function processAutoUpdates(
 
     try {
       // Get installer info for the new version
-        const installerInfo = await getLatestInstallerInfo(
-          supabase,
-          update.winget_id,
-          policy.deployment_config?.architecture,
-          policy.deployment_config?.installScope
-        );
+      const installerResolution = await getLatestInstallerInfo(
+        supabase,
+        update.winget_id,
+        policy.deployment_config?.architecture,
+        policy.deployment_config?.installScope
+      );
 
-      if (!installerInfo) {
+      if (!installerResolution.ok) {
         result.errors.push(
-          `No installer info found for ${update.winget_id} v${update.latest_version}`
+          `${update.winget_id} v${update.latest_version}: ${installerResolution.failure.message}`
         );
         result.failed++;
         continue;
       }
+      const installerInfo = installerResolution.info;
 
       // Add current version to installer info.
       // Look up the most recent upload_history record to get the current

--- a/app/api/updates/trigger/route.test.ts
+++ b/app/api/updates/trigger/route.test.ts
@@ -195,7 +195,14 @@ describe('POST /api/updates/trigger', () => {
 
     const { supabase, policyUpdatePayloads } = createTriggerSupabaseMocks(policy);
     createServerClientMock.mockReturnValue(supabase);
-    getLatestInstallerInfoMock.mockResolvedValue(null);
+    const failureMessage = 'The catalog has not synced the installer manifest for Microsoft.Edge 2.0.0 yet. Try again after the next catalog sync.';
+    getLatestInstallerInfoMock.mockResolvedValue({
+      ok: false,
+      failure: {
+        reason: 'version_record_missing',
+        message: failureMessage,
+      },
+    });
 
     const request = new NextRequest('http://localhost:3000/api/updates/trigger', {
       method: 'POST',
@@ -215,6 +222,7 @@ describe('POST /api/updates/trigger', () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(false);
     expect(body.failed).toBe(1);
+    expect(body.results[0].error).toBe(failureMessage);
     expect(policyUpdatePayloads).toEqual([
       { policy_type: 'auto_update', is_enabled: true },
       { policy_type: 'notify', is_enabled: false },
@@ -242,7 +250,8 @@ describe('POST /api/updates/trigger', () => {
     const { supabase, policyUpdatePayloads } = createTriggerSupabaseMocks(policy);
     createServerClientMock.mockReturnValue(supabase);
     getLatestInstallerInfoMock.mockResolvedValue({
-      currentVersion: '',
+      ok: true,
+      info: { currentVersion: '' },
     });
     triggerAutoUpdateMock.mockRejectedValue(new Error('trigger crashed'));
 
@@ -292,9 +301,12 @@ describe('POST /api/updates/trigger', () => {
     const { supabase } = createTriggerSupabaseMocks(policy);
     createServerClientMock.mockReturnValue(supabase);
     getLatestInstallerInfoMock.mockResolvedValue({
-      wingetId: 'Microsoft.Edge',
-      currentVersion: '',
-      latestVersion: '2.0.0',
+      ok: true,
+      info: {
+        wingetId: 'Microsoft.Edge',
+        currentVersion: '',
+        latestVersion: '2.0.0',
+      },
     });
     triggerAutoUpdateMock.mockResolvedValue({
       success: false,
@@ -368,13 +380,16 @@ describe('POST /api/updates/trigger', () => {
     });
     createServerClientMock.mockReturnValue(supabase);
     getLatestInstallerInfoMock.mockResolvedValue({
-      wingetId: 'Microsoft.Edge',
-      currentVersion: '',
-      latestVersion: '2.0.0',
-      displayName: 'Microsoft Edge',
-      installerUrl: 'https://example.com/edge.exe',
-      installerSha256: 'abc123',
-      installerType: 'exe',
+      ok: true,
+      info: {
+        wingetId: 'Microsoft.Edge',
+        currentVersion: '',
+        latestVersion: '2.0.0',
+        displayName: 'Microsoft Edge',
+        installerUrl: 'https://example.com/edge.exe',
+        installerSha256: 'abc123',
+        installerType: 'exe',
+      },
     });
     triggerAutoUpdateMock.mockResolvedValue({
       success: true,
@@ -450,13 +465,16 @@ describe('POST /api/updates/trigger', () => {
     });
     createServerClientMock.mockReturnValue(supabase);
     getLatestInstallerInfoMock.mockResolvedValue({
-      wingetId: 'Microsoft.Edge',
-      currentVersion: '',
-      latestVersion: '2.0.0',
-      displayName: 'Microsoft Edge',
-      installerUrl: 'https://example.com/edge.exe',
-      installerSha256: 'abc123',
-      installerType: 'exe',
+      ok: true,
+      info: {
+        wingetId: 'Microsoft.Edge',
+        currentVersion: '',
+        latestVersion: '2.0.0',
+        displayName: 'Microsoft Edge',
+        installerUrl: 'https://example.com/edge.exe',
+        installerSha256: 'abc123',
+        installerType: 'exe',
+      },
     });
     triggerAutoUpdateMock.mockResolvedValue({
       success: true,

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -273,23 +273,24 @@ export async function POST(request: NextRequest) {
 
         // Get installer info
         const deploymentConfig = policy.deployment_config as unknown as DeploymentConfig | null;
-        const installerInfo = await getLatestInstallerInfo(
+        const installerResolution = await getLatestInstallerInfo(
           supabase,
           req.winget_id,
           deploymentConfig?.architecture,
           deploymentConfig?.installScope
         );
 
-        if (!installerInfo) {
+        if (!installerResolution.ok) {
           response.failed++;
           response.results.push({
             winget_id: req.winget_id,
             tenant_id: req.tenant_id,
             success: false,
-            error: 'Could not get installer information for latest version',
+            error: installerResolution.failure.message,
           });
           continue;
         }
+        const installerInfo = installerResolution.info;
 
         installerInfo.currentVersion = updateResult.current_version;
 

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -176,7 +176,9 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
 
     const result = await getLatestInstallerInfo({} as never, 'Vivaldi.Vivaldi', 'x64');
 
-    expect(result).toMatchObject({
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) throw new Error('Expected installer resolution to succeed');
+    expect(result.info).toMatchObject({
       installCommand: '"Vivaldi.8.1.4087.62.x64.exe" --vivaldi-silent --do-not-launch-chrome',
       silentSwitches: '--vivaldi-silent --do-not-launch-chrome',
       installScope: 'user',
@@ -225,14 +227,144 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       'user'
     );
 
-    expect(machine).toMatchObject({
+    expect(machine).toMatchObject({ ok: true });
+    if (!machine.ok) throw new Error('Expected machine installer resolution to succeed');
+    expect(machine.info).toMatchObject({
       installScope: 'machine',
       silentSwitches: '/silent /allusers=1',
     });
-    expect(user).toMatchObject({
+    expect(user).toMatchObject({ ok: true });
+    if (!user.ok) throw new Error('Expected user installer resolution to succeed');
+    expect(user.info).toMatchObject({
       installScope: 'user',
       silentSwitches: '/silent /allusers=0',
     });
+  });
+
+  it('reports when the app is not in the catalog', async () => {
+    getAppForInstallerMock.mockResolvedValue(null);
+
+    const result = await getLatestInstallerInfo({} as never, 'Missing.App');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'app_not_in_catalog' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Missing.App');
+  });
+
+  it('reports when the catalog has no latest version', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: null });
+
+    const result = await getLatestInstallerInfo({} as never, 'Test.App');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'version_record_missing' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
+  });
+
+  it('reports when the latest version manifest has not been synced', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: '2.0.0' });
+    getVersionInstallerInfoMock.mockResolvedValue(null);
+
+    const result = await getLatestInstallerInfo({} as never, 'Test.App');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'version_record_missing' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
+  });
+
+  it('reports missing per-architecture installer metadata', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: '2.0.0' });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: 'https://example.com/setup.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      installers: [],
+    });
+
+    const result = await getLatestInstallerInfo({} as never, 'Test.App', 'x64');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'installer_metadata_missing' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
+  });
+
+  it('reports when no installer matches architecture and scope', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: '2.0.0' });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: 'https://example.com/setup.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      installers: [{
+        Architecture: 'arm64',
+        Scope: 'user',
+        InstallerUrl: 'https://example.com/setup.exe',
+        InstallerSha256: 'A'.repeat(64),
+      }],
+    });
+
+    const result = await getLatestInstallerInfo(
+      {} as never,
+      'Test.App',
+      'x64',
+      'machine'
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'no_compatible_installer' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
+    expect(result.failure.message).toContain('x64');
+    expect(result.failure.message).toContain('machine install scope');
+  });
+
+  it('reports a missing installer URL', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: '2.0.0' });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: null,
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+    });
+
+    const result = await getLatestInstallerInfo({} as never, 'Test.App');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'installer_url_missing' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
+  });
+
+  it('reports a missing or invalid installer hash', async () => {
+    getAppForInstallerMock.mockResolvedValue({ name: 'Test App', latest_version: '2.0.0' });
+    getVersionInstallerInfoMock.mockResolvedValue({
+      installer_url: 'https://example.com/setup.exe',
+      installer_sha256: 'not-a-sha256',
+      installer_type: 'exe',
+    });
+
+    const result = await getLatestInstallerInfo({} as never, 'Test.App');
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: 'installer_hash_invalid' },
+    });
+    if (result.ok) throw new Error('Expected installer resolution to fail');
+    expect(result.failure.message).toContain('Test.App');
   });
 
   it('records a current QA failure as a safety skip before creating history or a job', async () => {

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -42,7 +42,7 @@ interface TriggerResult {
   code?: 'QA_FAILED_CURRENT_VERSION' | 'QA_NOT_PASSED_CURRENT_VERSION';
 }
 
-interface UpdateInfo {
+export interface UpdateInfo {
   wingetId: string;
   currentVersion: string;
   latestVersion: string;
@@ -58,6 +58,24 @@ interface UpdateInfo {
   nestedInstallerPath?: string;
   currentIntuneAppId?: string;
 }
+
+export type InstallerResolutionFailureReason =
+  | 'app_not_in_catalog'
+  | 'version_record_missing'
+  | 'installer_metadata_missing'
+  | 'no_compatible_installer'
+  | 'installer_url_missing'
+  | 'installer_hash_invalid';
+
+export interface InstallerResolutionFailure {
+  reason: InstallerResolutionFailureReason;
+  /** Human-readable, user-facing message with app/version/arch/scope context. */
+  message: string;
+}
+
+export type InstallerResolutionResult =
+  | { ok: true; info: UpdateInfo }
+  | { ok: false; failure: InstallerResolutionFailure };
 
 interface RateLimitCheck {
   allowed: boolean;
@@ -844,24 +862,48 @@ export async function getLatestInstallerInfo(
   wingetId: string,
   architecture?: string,
   installScope?: string
-): Promise<UpdateInfo | null> {
+): Promise<InstallerResolutionResult> {
   const catalog = getCatalogSource();
 
   // Get the curated app info
   const curatedApp = await catalog.getAppForInstaller(wingetId);
 
-  if (!curatedApp?.latest_version) {
-    return null;
+  if (!curatedApp) {
+    return {
+      ok: false,
+      failure: {
+        reason: 'app_not_in_catalog',
+        message: `${wingetId} is not in the app catalog, so an update cannot be packaged for it.`,
+      },
+    };
   }
+
+  if (!curatedApp.latest_version) {
+    return {
+      ok: false,
+      failure: {
+        reason: 'version_record_missing',
+        message: `The catalog has no latest version recorded for ${wingetId} yet. Try again after the next catalog sync.`,
+      },
+    };
+  }
+
+  const latestVersion = curatedApp.latest_version;
 
   // Get the version history for the latest version
   const versionInfo = await catalog.getVersionInstallerInfo(
     wingetId,
-    curatedApp.latest_version
+    latestVersion
   );
 
   if (!versionInfo) {
-    return null;
+    return {
+      ok: false,
+      failure: {
+        reason: 'version_record_missing',
+        message: `The catalog has not synced the installer manifest for ${wingetId} ${latestVersion} yet. Try again after the next catalog sync.`,
+      },
+    };
   }
 
   // Bind the selected installer to the deployment's requested architecture.
@@ -871,18 +913,26 @@ export async function getLatestInstallerInfo(
   let nestedInstallerType: string | undefined;
   let nestedInstallerPath: string | undefined;
   let selectedManifestInstaller: WingetInstaller | null = null;
+  const requestedScope = installScope === undefined
+    ? undefined
+    : resolveApplicationInstallScope(wingetId, installScope);
 
   // The installers JSONB uses PascalCase from WinGet manifests.
-  if (versionInfo.installers && Array.isArray(versionInfo.installers)) {
-    const requestedScope = installScope === undefined
-      ? undefined
-      : resolveApplicationInstallScope(wingetId, installScope);
+  if (Array.isArray(versionInfo.installers) && versionInfo.installers.length > 0) {
     const selectedInstaller = selectWingetInstaller(
       versionInfo.installers,
       architecture,
       requestedScope
     );
-    if (!selectedInstaller) return null;
+    if (!selectedInstaller) {
+      return {
+        ok: false,
+        failure: {
+          reason: 'no_compatible_installer',
+          message: `No installer for ${wingetId} ${latestVersion} matches architecture ${architecture || 'x64'}${requestedScope ? ` and ${requestedScope} install scope` : ''}.`,
+        },
+      };
+    }
     installerUrl = selectedInstaller.InstallerUrl || installerUrl;
     installerSha256 = selectedInstaller.InstallerSha256 || installerSha256;
     installerType = selectedInstaller.InstallerType || installerType;
@@ -892,12 +942,34 @@ export async function getLatestInstallerInfo(
       : undefined;
     selectedManifestInstaller = selectedInstaller as WingetInstaller;
   } else if (architecture) {
-    return null;
+    return {
+      ok: false,
+      failure: {
+        reason: 'installer_metadata_missing',
+        message: `The catalog entry for ${wingetId} ${latestVersion} is missing per-architecture installer metadata.`,
+      },
+    };
+  }
+
+  if (!installerUrl) {
+    return {
+      ok: false,
+      failure: {
+        reason: 'installer_url_missing',
+        message: `The installer manifest for ${wingetId} ${latestVersion} does not include a download URL.`,
+      },
+    };
   }
 
   const normalizedSha256 = normalizeInstallerSha256(installerSha256);
-  if (!installerUrl || !normalizedSha256) {
-    return null;
+  if (!normalizedSha256) {
+    return {
+      ok: false,
+      failure: {
+        reason: 'installer_hash_invalid',
+        message: `The installer manifest for ${wingetId} ${latestVersion} has a missing or invalid SHA-256 hash, so the download cannot be verified.`,
+      },
+    };
   }
 
   const manifestInstaller = {
@@ -921,18 +993,21 @@ export async function getLatestInstallerInfo(
   const normalizedInstaller = normalizeInstaller(manifestInstaller);
 
   return {
-    wingetId,
-    currentVersion: '', // Will be filled by caller
-    latestVersion: curatedApp.latest_version,
-    displayName: curatedApp.name,
-    installerUrl,
-    installerSha256: normalizedSha256,
-    installerType: installerType || 'exe',
-    installCommand: buildCurrentVersionInstallCommand(normalizedInstaller),
-    silentSwitches: normalizedInstaller.silentArgs,
-    installerSuccessCodes: normalizedInstaller.installerSuccessCodes,
-    installScope: normalizedInstaller.scope,
-    nestedInstallerType,
-    nestedInstallerPath,
+    ok: true,
+    info: {
+      wingetId,
+      currentVersion: '', // Will be filled by caller
+      latestVersion,
+      displayName: curatedApp.name,
+      installerUrl,
+      installerSha256: normalizedSha256,
+      installerType: installerType || 'exe',
+      installCommand: buildCurrentVersionInstallCommand(normalizedInstaller),
+      silentSwitches: normalizedInstaller.silentArgs,
+      installerSuccessCodes: normalizedInstaller.installerSuccessCodes,
+      installScope: normalizedInstaller.scope,
+      nestedInstallerType,
+      nestedInstallerPath,
+    },
   };
 }


### PR DESCRIPTION
Fixes #404

## Problem

Triggering an update from the Updates page could fail with a generic "Could not get installer information for latest version" while the UI still redirected to `/dashboard/uploads`, where no job appeared.

Two independent defects:

1. **Backend**: `getLatestInstallerInfo()` collapsed six distinct failure conditions into `null`, which the trigger route mapped to one generic message.
2. **Frontend**: `executeTriggerUpdate` on the Updates page always redirected after the API resolved. The API returns HTTP 200 even when `triggered: 0`, so failures redirected silently and `results[].error` was never shown.

## Changes

- `getLatestInstallerInfo()` now returns a typed `{ ok: true, info } | { ok: false, failure: { reason, message } }` result with a distinct, user-facing message per failure: app not in catalog, version record missing / manifest not synced, installer metadata missing, no compatible architecture/install scope, missing installer URL, missing/invalid SHA-256.
- `/api/updates/trigger` and the `check-updates` cron surface those messages per app.
- The Updates page only redirects to Uploads when the trigger succeeded; otherwise the specific error is shown as a toast (including network/timeout errors). Bulk update flow untouched.

## Testing

- 26 tests pass, including 7 new tests covering each failure reason and a route test asserting the specific message reaches the API response verbatim.
- Changed non-test files type-check cleanly; pre-commit secret scan and lint passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)