### PR TITLE
Bundle Qfinder runtime dependency

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -190,6 +190,17 @@ describe('application packaging adapters', () => {
     ]);
   });
 
+  it('closes Qfinder Pro before its NSIS removal lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'QNAP.QfinderPro',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'QfinderPro', description: 'QNAP Qfinder Pro' },
+    ]);
+  });
+
   it('closes the vendor-documented OCS Inventory processes before package lifecycle actions', () => {
     const adapted = applyApplicationPackagingAdapter(
       'OCSInventoryNG.WindowsAgent',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -143,6 +143,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Qfinder Pro starts its desktop process after a silent install. Close it
+    // before removal so the NSIS uninstaller can delete the product instead
+    // of waiting behind the running application or its startup-error dialog.
+    wingetId: 'QNAP.QfinderPro',
+    requiredProcessesToClose: [
+      { name: 'QfinderPro', description: 'QNAP Qfinder Pro' },
+    ],
+  },
+  {
     wingetId: 'OCSInventoryNG.WindowsAgent',
     requiredProcessesToClose: [
       { name: 'OcsSystray', description: 'OCS Inventory system tray' },

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -88,6 +88,45 @@ describe('resolveWingetPackageDependencies', () => {
     );
   });
 
+  it('adds the reviewed x86 VC++ runtime omitted by the Qfinder Pro manifest', async () => {
+    const io = fixtureIo(
+      {
+        'QNAP.QfinderPro@7.14.0.0626': [installer({
+          architecture: 'x86',
+          type: 'nullsoft',
+          sha256: ROOT_SHA,
+        })],
+        'Microsoft.VCRedist.2015+.x86@14.51.36210.0': [installer({
+          architecture: 'x86',
+          url: 'https://aka.ms/vc14/vc_redist.x86.exe',
+          sha256: VC_SHA,
+          silentArgs: '/install /quiet /norestart',
+        })],
+      },
+      {
+        'Microsoft.VCRedist.2015+.x86': ['14.51.36210.0'],
+      }
+    );
+
+    const result = await resolveWingetPackageDependencies({
+      wingetId: 'QNAP.QfinderPro',
+      version: '7.14.0.0626',
+      architecture: 'x86',
+      installerSha256: ROOT_SHA,
+      installScope: 'machine',
+    }, io);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        packageIdentifier: 'Microsoft.VCRedist.2015+.x86',
+        architecture: 'x86',
+        version: '14.51.36210.0',
+        installerSha256: VC_SHA,
+        successCodes: [-2147023258, 0, 1638],
+      }),
+    ]);
+  });
+
   it('selects the newest version satisfying the declared minimum', async () => {
     const io = fixtureIo(
       {

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -24,6 +24,24 @@ const DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN =
   /^Microsoft\.DotNet\.DesktopRuntime\.\d+$/i;
 const VCLIBS_DESKTOP_PACKAGE_PATTERN = /^Microsoft\.VCLibs\.Desktop\.14$/i;
 
+interface PackageDependencyReference {
+  packageIdentifier: string;
+  minimumVersion?: string;
+}
+
+// Some vendors omit redistributable prerequisites from their WinGet
+// manifests even though the installed executable imports them. Keep these
+// corrections explicit and reviewed so QA and customer packages use the same
+// offline dependency bundle. Qfinder Pro fails to start on a clean Windows VM
+// without MSVCP140_1.dll; its current vendor manifest declares no dependency.
+const REVIEWED_ROOT_DEPENDENCY_OVERRIDES: Readonly<
+  Record<string, readonly PackageDependencyReference[]>
+> = {
+  'qnap.qfinderpro': [
+    { packageIdentifier: 'Microsoft.VCRedist.2015+.x86' },
+  ],
+};
+
 interface ReviewedDependencyPolicy {
   packagePattern: RegExp;
   installerTypes: ReadonlySet<WingetInstallerType>;
@@ -187,6 +205,32 @@ function highestMinimum(left?: string, right?: string): string | undefined {
   return compareVersions(left, right) >= 0 ? left : right;
 }
 
+function rootPackageDependencies(
+  wingetId: string,
+  declared: readonly PackageDependencyReference[] | undefined
+): PackageDependencyReference[] {
+  const merged = new Map<string, PackageDependencyReference>();
+  for (const dependency of [
+    ...(declared || []),
+    ...(REVIEWED_ROOT_DEPENDENCY_OVERRIDES[wingetId.toLowerCase()] || []),
+  ]) {
+    const key = dependency.packageIdentifier.toLowerCase();
+    const existing = merged.get(key);
+    merged.set(key, {
+      packageIdentifier: existing?.packageIdentifier || dependency.packageIdentifier,
+      ...(highestMinimum(existing?.minimumVersion, dependency.minimumVersion)
+        ? {
+            minimumVersion: highestMinimum(
+              existing?.minimumVersion,
+              dependency.minimumVersion
+            ),
+          }
+        : {}),
+    });
+  }
+  return Array.from(merged.values());
+}
+
 export async function resolveWingetPackageDependencies(
   input: {
     wingetId: string;
@@ -212,9 +256,13 @@ export async function resolveWingetPackageDependencies(
     );
   }
   ensureSupportedDependencyShape(input.wingetId, rootInstaller);
+  const rootDependencies = rootPackageDependencies(
+    input.wingetId,
+    rootInstaller.packageDependencies
+  );
   if (
     input.installScope?.trim().toLowerCase() === 'user' &&
-    (rootInstaller.packageDependencies || []).length > 0
+    rootDependencies.length > 0
   ) {
     throw new WingetDependencyCompatibilityError(
       `${input.wingetId} declares machine-wide package dependencies that cannot be installed safely in user scope.`
@@ -370,7 +418,7 @@ export async function resolveWingetPackageDependencies(
     }
   };
 
-  for (const dependency of rootInstaller.packageDependencies || []) {
+  for (const dependency of rootDependencies) {
     await visit(dependency.packageIdentifier, dependency.minimumVersion, 1);
   }
 


### PR DESCRIPTION
## Summary
- bundle the reviewed x86 Visual C++ runtime that Qfinder Pro requires but does not declare in its WinGet manifest
- close QfinderPro before the NSIS removal lifecycle so silent uninstall is not blocked by the running app or startup-error dialog
- use the same dependency resolver and lifecycle adapter for QA and customer packages

## Evidence
- clean VM showed MSVCP140_1.dll missing after install
- current PSADT uninstall waited five minutes for QNAP_FINDER and exited 60001

## Verification
- 149 focused packaging, dependency, QA profile, and PSADT contract tests pass
- full ESLint passes
- git diff --check passes