### PR TITLE
Activate Qfinder dependency toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '681b7510f7f30bec92c17581213c9ebc7f72765a',
+  packagerCommit: '7e83c363bcbafca153f00113b12ede2e332b2d2d',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -47,6 +47,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'f4bc37886e490ece525c701562869734a7e366d5',
   '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
   '7d389dbd6e55b719e3d71772717cda0c8f724469',
+  '681b7510f7f30bec92c17581213c9ebc7f72765a',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -54,11 +54,15 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Opera once on the reviewed immediate-uninstall release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '681b7510f7f30bec92c17581213c9ebc7f72765a',
       { wingetId: 'Opera.Opera', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
+      { wingetId: 'Opera.Opera', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Opera.Opera', status: 'failed' }
     )).toBe(false);
   });
@@ -132,15 +136,30 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('carries the queued Greenshot retry across the current pin', () => {
+  it('keeps the resolved Greenshot retry on its tool-cache release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'acfe2d8692cc2b910281236ff47d3ee5b2ce2b99',
       { wingetId: 'Greenshot.Greenshot', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '681b7510f7f30bec92c17581213c9ebc7f72765a',
       { wingetId: 'Greenshot.Greenshot', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Greenshot.Greenshot', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Qfinder Pro once with its runtime and process lifecycle fix', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'QNAP.QfinderPro', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '681b7510f7f30bec92c17581213c9ebc7f72765a',
+      { wingetId: 'QNAP.QfinderPro', status: 'failed' }
+    )).toBe(false);
   });
 
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '7e83c363bcbafca153f00113b12ede2e332b2d2d': [
+    // Qfinder Pro omitted its x86 Visual C++ runtime from the WinGet
+    // manifest and left its launched process blocking NSIS removal. This
+    // release corrects both paths in QA and customer packages.
+    'QNAP.QfinderPro',
+  ],
   '681b7510f7f30bec92c17581213c9ebc7f72765a': [
     // Opera's former /silent adapter was removed by the vendor. This release
     // switches both QA and customer packaging to --runimmediately.


### PR DESCRIPTION
## Summary
- identify the catalog QA package profile with the reviewed Qfinder dependency/lifecycle packager commit
- preserve successful unchanged installer payloads across the release
- retry only QNAP Qfinder Pro's terminal result on this release; resolved Opera and Greenshot runs are not replayed

## Verification
- 197 focused scheduler, compatibility, dependency, adapter, customer packaging, and PSADT contract tests pass
- full ESLint passes
- git diff --check passes