### PR TITLE
Support reviewed multi-product runtime bundles

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -263,6 +263,54 @@ $reviewedUninstallArgumentsLiteral = @(
     $reviewedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
 
+$reviewedMultiProductInstallDisplayNamePrefixes = @()
+if ($psadtConfig.Contains('reviewedMultiProductInstallDisplayNamePrefixes') -and
+    $null -ne $psadtConfig['reviewedMultiProductInstallDisplayNamePrefixes']) {
+    $rawMultiProductPrefixes = $psadtConfig['reviewedMultiProductInstallDisplayNamePrefixes']
+    if ($rawMultiProductPrefixes -is [string] -or
+        $rawMultiProductPrefixes -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedMultiProductInstallDisplayNamePrefixes must be an array.'
+    }
+
+    $seenMultiProductPrefixes = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($rawMultiProductPrefix in @($rawMultiProductPrefixes)) {
+        if ($rawMultiProductPrefix -isnot [string]) {
+            throw 'Every reviewed multi-product display-name prefix must be a string.'
+        }
+        $multiProductPrefix = $rawMultiProductPrefix.Trim()
+        if ([string]::IsNullOrWhiteSpace($multiProductPrefix) -or
+            $multiProductPrefix.Length -gt 128 -or
+            [regex]::IsMatch($multiProductPrefix, '[\x00-\x1F\x7F]')) {
+            throw 'Every reviewed multi-product display-name prefix must be non-empty, bounded, and single-line.'
+        }
+        if ($seenMultiProductPrefixes.Add($multiProductPrefix)) {
+            $reviewedMultiProductInstallDisplayNamePrefixes += $multiProductPrefix
+        }
+    }
+    if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 20) {
+        throw 'PSADT reviewedMultiProductInstallDisplayNamePrefixes must contain at most 20 entries.'
+    }
+}
+$reviewedMultiProductInstallDisplayNamePrefixesLiteral = @(
+    $reviewedMultiProductInstallDisplayNamePrefixes | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
+) -join ', '
+$reviewedMultiProductInstallMinimumCount = 0
+if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
+    $rawMultiProductMinimumCount = $psadtConfig['reviewedMultiProductInstallMinimumCount']
+    if (-not $psadtConfig.Contains('reviewedMultiProductInstallMinimumCount') -or
+        ($rawMultiProductMinimumCount -isnot [byte] -and
+         $rawMultiProductMinimumCount -isnot [int16] -and
+         $rawMultiProductMinimumCount -isnot [int32] -and
+         $rawMultiProductMinimumCount -isnot [int64]) -or
+        [int]$rawMultiProductMinimumCount -lt 2 -or
+        [int]$rawMultiProductMinimumCount -gt 100) {
+        throw 'PSADT reviewedMultiProductInstallMinimumCount must be an integer from 2 to 100 when multi-product evidence is configured.'
+    }
+    $reviewedMultiProductInstallMinimumCount = [int]$rawMultiProductMinimumCount
+}
+
 $uninstallCompletionTimeoutMinutes = 5
 if ($psadtConfig.Contains('uninstallCompletionTimeoutMinutes') -and
     $null -ne $psadtConfig['uninstallCompletionTimeoutMinutes']) {
@@ -1478,6 +1526,7 @@ if ($useRegistryUninstall) {
         "    `$configuredUninstallLocaleHint = '$registryUninstallLocaleHintEscaped'"
         '    $capturedUninstallKey = $null'
         '    $capturedUninstallName = $null'
+        '    $multiProductInstallationVerified = $false'
         ''
     )
 }
@@ -1907,6 +1956,19 @@ if ($useRegistryUninstall) {
         '        }'
     )
 
+    if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
+        $lines += @(
+            "        `$reviewedMultiProductPrefixes = @($reviewedMultiProductInstallDisplayNamePrefixesLiteral)"
+            '        $reviewedMultiProductMatches = @($postInstallApplications | Where-Object {'
+            '            $candidateDisplayName = [string]$_.DisplayName'
+            '            @($reviewedMultiProductPrefixes | Where-Object { $candidateDisplayName.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) }).Count -gt 0'
+            '        })'
+            "        if (`$reviewedMultiProductMatches.Count -ge $reviewedMultiProductInstallMinimumCount) {"
+            '            $multiProductInstallationVerified = $true'
+            '        }'
+        )
+    }
+
     # Shared Windows runtimes can already be installed at the requested (or a
     # newer) version. Their vendor installer then succeeds without changing ARP.
     # Accept that no-op only for a reviewed retention adapter, and only when one
@@ -1947,12 +2009,15 @@ if ($useRegistryUninstall) {
         '            $selectedApplications = @($changedApplications[0])'
         '        }'
         '        if ($selectedApplications.Count -eq 1) { break }'
+        '        if ($multiProductInstallationVerified) { break }'
         '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'
         '    }'
         '    if ($selectedApplications.Count -eq 1) {'
         '        $capturedUninstallKey = [string]$selectedApplications[0].PSChildName'
         '        $capturedUninstallName = [string]$selectedApplications[0].DisplayName'
         '        Write-ADTLogEntry -Message "Captured vendor uninstall entry [$capturedUninstallName] ($capturedUninstallKey)." -Source ''Install-ADTDeployment'''
+        '    } elseif ($multiProductInstallationVerified) {'
+        '        Write-ADTLogEntry -Message "Verified reviewed multi-product installation from $($reviewedMultiProductMatches.Count) matching vendor registrations." -Source ''Install-ADTDeployment'''
         '    } else {'
         '        throw "Could not select one vendor uninstall entry. The installer changed $($changedApplications.Count) entries and $($selectedApplications.Count) matched the configured identity."'
         '    }'
@@ -1963,7 +2028,17 @@ if ($useRegistryUninstall) {
 if ($verifyInstall) {
     Write-Host "Post-install verification enabled"
     if ($useRegistryUninstall) {
-        $lines += @(
+        if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
+            $lines += @(
+                ''
+                '    ## Verify the reviewed multi-product bundle evidence established above.'
+                '    if (-not $multiProductInstallationVerified) {'
+                '        throw "Post-install verification failed: the reviewed multi-product registrations were not found."'
+                '    }'
+                "    Write-ADTLogEntry -Message `"Post-install verification passed for reviewed multi-product bundle`" -Source 'Install-ADTDeployment'"
+            )
+        } else {
+            $lines += @(
             ''
             '    ## Verify the exact uninstall identity captured from this installation.'
             '    $verifyApps = if ($capturedUninstallKey) {'
@@ -1973,7 +2048,8 @@ if ($verifyInstall) {
             '        throw "Post-install verification failed: the captured vendor uninstall entry was not found."'
             '    }'
             "    Write-ADTLogEntry -Message `"Post-install verification passed for captured vendor identity`" -Source 'Install-ADTDeployment'"
-        )
+            )
+        }
     } else {
         $lines += @(
             ''

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -73,13 +73,30 @@ describe('application packaging adapters', () => {
     ).toBe(true);
   });
 
+  it('uses reviewed multi-product evidence for the shared Visual C++ runtime bundle', () => {
+    expect(
+      applyApplicationPackagingAdapter('ABBODI1406.VCREDIST', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedMultiProductInstallDisplayNamePrefixes: [
+        'Microsoft Visual C++',
+        'Visual C++',
+      ],
+      reviewedMultiProductInstallMinimumCount: 10,
+    });
+  });
+
   it('does not accept shared-runtime retention from customer-controlled config', () => {
     const adapted = applyApplicationPackagingAdapter('Example.App', {
       ...DEFAULT_PSADT_CONFIG,
       preserveVendorInstallationOnUninstall: true,
+      reviewedMultiProductInstallDisplayNamePrefixes: ['Anything'],
+      reviewedMultiProductInstallMinimumCount: 2,
     });
 
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
+    expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
+    expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
   });
 
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -9,6 +9,8 @@ interface ApplicationPackagingAdapter {
   reviewedUninstallArguments?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
+  reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
+  reviewedMultiProductInstallMinimumCount?: number;
 }
 
 const VISUAL_STUDIO_WINGET_IDS = [
@@ -94,6 +96,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // newer version, then removes only its own management marker on uninstall.
     wingetId: 'Microsoft.EdgeWebView2Runtime',
     preserveVendorInstallationOnUninstall: true,
+  },
+  {
+    // VisualCppRedist AIO is intentionally a bundle of independently registered
+    // Visual C++ runtimes. Version 104+ creates several unified ARP entries, so
+    // no single vendor identity represents the package. These runtimes are also
+    // shared prerequisites: Intune removal relinquishes the IntuneGet marker
+    // instead of invoking the vendor's /aiR switch, which removes every runtime.
+    wingetId: 'abbodi1406.vcredist',
+    preserveVendorInstallationOnUninstall: true,
+    reviewedMultiProductInstallDisplayNamePrefixes: [
+      'Microsoft Visual C++',
+      'Visual C++',
+    ],
+    reviewedMultiProductInstallMinimumCount: 10,
   },
   ...VISUAL_STUDIO_WINGET_IDS.map((wingetId) => ({
     wingetId,
@@ -191,15 +207,35 @@ function normalizeReviewedArgument(argument: string, wingetId: string): string {
   return normalized;
 }
 
+function normalizeReviewedDisplayNamePrefix(
+  prefix: string,
+  wingetId: string
+): string {
+  const normalized = prefix.trim();
+  if (!normalized || normalized.length > 128 || /[\x00-\x1f\x7f]/.test(normalized)) {
+    throw new Error(`Invalid reviewed install display-name prefix for ${wingetId}`);
+  }
+  return normalized;
+}
+
 export function applyApplicationPackagingAdapter(
   wingetId: string,
   config: PSADTConfig
 ): PSADTConfig {
   const adapter = applicationPackagingAdapter(wingetId);
   if (!adapter) {
-    // This internal switch is never accepted from customer-controlled config.
-    if (!config.preserveVendorInstallationOnUninstall) return config;
-    return { ...config, preserveVendorInstallationOnUninstall: undefined };
+    // These internal lifecycle fields are never accepted from customer config.
+    if (
+      !config.preserveVendorInstallationOnUninstall &&
+      !config.reviewedMultiProductInstallDisplayNamePrefixes &&
+      !config.reviewedMultiProductInstallMinimumCount
+    ) return config;
+    return {
+      ...config,
+      preserveVendorInstallationOnUninstall: undefined,
+      reviewedMultiProductInstallDisplayNamePrefixes: undefined,
+      reviewedMultiProductInstallMinimumCount: undefined,
+    };
   }
 
   const processesToClose = (config.processesToClose || []).map((process) => {
@@ -249,6 +285,11 @@ export function applyApplicationPackagingAdapter(
     }
   }
 
+  const reviewedMultiProductInstallDisplayNamePrefixes =
+    adapter.reviewedMultiProductInstallDisplayNamePrefixes?.map((prefix) =>
+      normalizeReviewedDisplayNamePrefix(prefix, adapter.wingetId)
+    );
+
   return {
     ...config,
     processesToClose,
@@ -259,5 +300,8 @@ export function applyApplicationPackagingAdapter(
       : {}),
     preserveVendorInstallationOnUninstall:
       adapter.preserveVendorInstallationOnUninstall || undefined,
+    reviewedMultiProductInstallDisplayNamePrefixes,
+    reviewedMultiProductInstallMinimumCount:
+      adapter.reviewedMultiProductInstallMinimumCount,
   };
 }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -216,6 +216,82 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies a reviewed multi-product runtime without weakening ordinary identity selection',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Visual C++ Redistributable AIO',
+        [],
+        {
+          preserveVendorInstallationOnUninstall: true,
+          reviewedMultiProductInstallDisplayNamePrefixes: [
+            'Microsoft Visual C++',
+            'Visual C++',
+          ],
+          reviewedMultiProductInstallMinimumCount: 10,
+        },
+        [],
+        'abbodi1406.vcredist'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "$reviewedMultiProductPrefixes = @('Microsoft Visual C++', 'Visual C++')"
+      );
+      expect(installFunction).toContain('$reviewedMultiProductMatches.Count -ge 10');
+      expect(installFunction).toContain(
+        'if ($multiProductInstallationVerified) { break }'
+      );
+      expect(installFunction).toContain('Verified reviewed multi-product installation');
+      expect(uninstallFunction).toContain(
+        'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
+      );
+      expect(uninstallFunction).not.toContain('Could not find one unambiguous vendor uninstall');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects malformed reviewed multi-product evidence',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'inno',
+          'Unsafe Multi Product',
+          [],
+          {
+            reviewedMultiProductInstallDisplayNamePrefixes: [''],
+            reviewedMultiProductInstallMinimumCount: 2,
+          }
+        )
+      ).toThrow('reviewed multi-product display-name prefix must be non-empty');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'requires a bounded evidence threshold for reviewed multi-product installs',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'inno',
+          'Unsafe Multi Product Threshold',
+          [],
+          {
+            reviewedMultiProductInstallDisplayNamePrefixes: ['Visual C++'],
+            reviewedMultiProductInstallMinimumCount: 1,
+          }
+        )
+      ).toThrow('reviewedMultiProductInstallMinimumCount must be an integer from 2 to 100');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects a non-boolean shared-runtime lifecycle flag',
     () => {
       expect(() =>

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -214,6 +214,13 @@ export interface PSADTConfig {
   // the only trusted source for this value; it is not customer-configurable.
   preserveVendorInstallationOnUninstall?: boolean;
 
+  // Internal install-evidence contract for reviewed bundles that intentionally
+  // install several independently registered products. The generated package
+  // requires multiple matching ARP entries instead of weakening the ordinary
+  // single-product identity rule. Application adapters are the only source.
+  reviewedMultiProductInstallDisplayNamePrefixes?: string[];
+  reviewedMultiProductInstallMinimumCount?: number;
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.


### PR DESCRIPTION
## Summary
- add a bounded, adapter-only install-evidence contract for multi-product bundles
- treat VisualCppRedist AIO as shared runtime ownership and preserve vendor runtimes on Intune removal
- require at least ten reviewed Visual C++ registrations before writing the IntuneGet marker
- keep the ordinary one-vendor-entry safeguard unchanged

## Verification
- 77 focused adapter and generated-PSADT contract tests
- 65 package-profile tests
- ESLint