### PR TITLE
Activate multi-product runtime QA toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7e83c363bcbafca153f00113b12ede2e332b2d2d',
+  packagerCommit: '670357c92fefa433036d8667dd5f382731d8326e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -48,6 +48,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '9ff409ddabd3b1b4f8c65ad03b1f9e37778589fc',
   '7d389dbd6e55b719e3d71772717cda0c8f724469',
   '681b7510f7f30bec92c17581213c9ebc7f72765a',
+  '7e83c363bcbafca153f00113b12ede2e332b2d2d',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -153,12 +153,27 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Qfinder Pro once with its runtime and process lifecycle fix', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '7e83c363bcbafca153f00113b12ede2e332b2d2d',
       { wingetId: 'QNAP.QfinderPro', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'QNAP.QfinderPro', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
       '681b7510f7f30bec92c17581213c9ebc7f72765a',
       { wingetId: 'QNAP.QfinderPro', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries VisualCppRedist once with reviewed multi-product evidence', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ABBODI1406.VCREDIST', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '7e83c363bcbafca153f00113b12ede2e332b2d2d',
+      { wingetId: 'abbodi1406.vcredist', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '670357c92fefa433036d8667dd5f382731d8326e': [
+    // VisualCppRedist AIO deliberately creates many independently registered
+    // shared runtimes. This release verifies that reviewed multi-product
+    // evidence without weakening the ordinary one-product identity rule.
+    'abbodi1406.vcredist',
+  ],
   '7e83c363bcbafca153f00113b12ede2e332b2d2d': [
     // Qfinder Pro omitted its x86 Visual C++ runtime from the WinGet
     // manifest and left its launched process blocking NSIS removal. This
@@ -143,8 +149,9 @@ export function shouldRetryTerminalToolchainCandidate(
   candidate: Pick<QaToolchainBackfillCandidate, 'wingetId' | 'status'>
 ): boolean {
   if (!['failed', 'error'].includes(candidate.status)) return true;
-  return (TOOLCHAIN_TERMINAL_RETRY_TARGETS[packagerCommit] || []).includes(
-    candidate.wingetId
+  const normalizedWingetId = candidate.wingetId.trim().toLowerCase();
+  return (TOOLCHAIN_TERMINAL_RETRY_TARGETS[packagerCommit] || []).some(
+    (wingetId) => wingetId.toLowerCase() === normalizedWingetId
   );
 }
 


### PR DESCRIPTION
## Summary
- activate the reviewed multi-product packager for QA profiles
- retain the preceding successful release as compatible
- retry only the failed VisualCppRedist payload on the new release
- normalize targeted retry IDs case-insensitively

## Verification
- 85 focused package-profile, demand, and backfill tests
- ESLint