### PR TITLE
Apply unattended lifecycle to PostgreSQL family

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -24,10 +24,21 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);
+    for (const wingetId of [
+      'PostgreSQL.PostgreSQL.9.6',
+      'PostgreSQL.PostgreSQL.13',
+      'PostgreSQL.PostgreSQL.18',
+      'postgresql.postgresql.19',
+    ]) {
+      expect(
+        applyApplicationPackagingAdapter(wingetId, DEFAULT_PSADT_CONFIG)
+          .reviewedUninstallArguments
+      ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
+    }
     expect(
-      applyApplicationPackagingAdapter('PostgreSQL.PostgreSQL.18', DEFAULT_PSADT_CONFIG)
+      applyApplicationPackagingAdapter('PostgreSQL.pgAdmin', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
-    ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
+    ).toEqual([]);
     expect(
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -13,6 +13,19 @@ interface ApplicationPackagingAdapter {
   reviewedMultiProductInstallMinimumCount?: number;
 }
 
+const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
+  // EnterpriseDB's registered uninstaller is interactive unless BitRock's
+  // unattended mode is supplied. Apply this to every versioned PostgreSQL
+  // package ID so a new major release cannot silently lose the lifecycle fix.
+  wingetId: 'PostgreSQL.PostgreSQL.*',
+  reviewedUninstallArguments: [
+    '--mode',
+    'unattended',
+    '--unattendedmodeui',
+    'none',
+  ],
+};
+
 const VISUAL_STUDIO_WINGET_IDS = [
   'Microsoft.VisualStudio.BuildTools',
   'Microsoft.VisualStudio.Community',
@@ -70,10 +83,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
-  },
-  {
-    wingetId: 'PostgreSQL.PostgreSQL.18',
-    reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
   },
   {
     // Opera registers `opera.exe --uninstall`, which waits for confirmation
@@ -182,9 +191,14 @@ function applicationPackagingAdapter(
   wingetId: string
 ): ApplicationPackagingAdapter | undefined {
   const normalizedWingetId = wingetId.trim().toLowerCase();
-  return APPLICATION_PACKAGING_ADAPTERS.find(
+  const exactAdapter = APPLICATION_PACKAGING_ADAPTERS.find(
     ({ wingetId: adapterWingetId }) => adapterWingetId.toLowerCase() === normalizedWingetId
   );
+  if (exactAdapter) return exactAdapter;
+  if (/^postgresql\.postgresql\.\d+(?:\.\d+)?$/.test(normalizedWingetId)) {
+    return POSTGRESQL_PACKAGING_ADAPTER;
+  }
+  return undefined;
 }
 
 export function resolveApplicationInstallScope(


### PR DESCRIPTION
## Summary
- apply EnterpriseDB BitRock unattended uninstall arguments to every versioned PostgreSQL WinGet ID
- replace the PostgreSQL 18-only exception with a family adapter
- leave pgAdmin and unrelated PostgreSQL IDs untouched

## Verification
- 69 adapter and package-profile tests
- ESLint