### PR TITLE
Activate PostgreSQL family QA toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '670357c92fefa433036d8667dd5f382731d8326e',
+  packagerCommit: '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -49,6 +49,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '7d389dbd6e55b719e3d71772717cda0c8f724469',
   '681b7510f7f30bec92c17581213c9ebc7f72765a',
   '7e83c363bcbafca153f00113b12ede2e332b2d2d',
+  '670357c92fefa433036d8667dd5f382731d8326e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -177,6 +177,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries PostgreSQL 13 once with the family unattended lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'postgresql.postgresql.13', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '670357c92fefa433036d8667dd5f382731d8326e',
+      { wingetId: 'PostgreSQL.PostgreSQL.13', status: 'failed' }
+    )).toBe(false);
+  });
+
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,14 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074': [
+    // Carry the multi-product runtime replay through the atomic rollout; it
+    // was queued but had not run before the PostgreSQL family fix superseded it.
+    'abbodi1406.vcredist',
+    // EnterpriseDB PostgreSQL releases share the same BitRock uninstaller.
+    // This release applies the reviewed unattended arguments to the family.
+    'PostgreSQL.PostgreSQL.13',
+  ],
   '670357c92fefa433036d8667dd5f382731d8326e': [
     // VisualCppRedist AIO deliberately creates many independently registered
     // shared runtimes. This release verifies that reviewed multi-product


### PR DESCRIPTION
## Summary
- activate the PostgreSQL-family packager release for QA profiles
- carry the pending VisualCppRedist replay across the atomic rollout
- retry only PostgreSQL 13 and VisualCppRedist on the new toolchain
- retain earlier successful releases as compatible

## Verification
- 86 focused package-profile, demand, and backfill tests
- ESLint