### PR TITLE
Activate registered Burn helper toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
+  packagerCommit: 'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -50,6 +50,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '681b7510f7f30bec92c17581213c9ebc7f72765a',
   '7e83c363bcbafca153f00113b12ede2e332b2d2d',
   '670357c92fefa433036d8667dd5f382731d8326e',
+  '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -168,7 +168,7 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries VisualCppRedist once with reviewed multi-product evidence', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '670357c92fefa433036d8667dd5f382731d8326e',
       { wingetId: 'ABBODI1406.VCREDIST', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
@@ -179,12 +179,23 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries PostgreSQL 13 once with the family unattended lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
       { wingetId: 'postgresql.postgresql.13', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '670357c92fefa433036d8667dd5f382731d8326e',
       { wingetId: 'PostgreSQL.PostgreSQL.13', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries EA Desktop once with the registered Burn helper lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'electronicarts.eadesktop', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
+      { wingetId: 'ElectronicArts.EADesktop', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7': [
+    // EA Desktop registers a purpose-built EAUninstall.exe helper. This
+    // release prefers that exact helper while retaining the packaged Burn
+    // bootstrapper fallback for disposable cache registrations.
+    'ElectronicArts.EADesktop',
+  ],
   '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074': [
     // Carry the multi-product runtime replay through the atomic rollout; it
     // was queued but had not run before the PostgreSQL family fix superseded it.


### PR DESCRIPTION
## Summary
- activate the reviewed Burn-helper packager for QA profiles
- retain compatible successful history without replaying passed payloads
- schedule one bounded EA Desktop retry on the corrected lifecycle only

## Verification
- 78 focused profile and retry tests passed
- ESLint passed for changed files