### PR TITLE
Close EA processes before package lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -47,6 +47,18 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
+        'ElectronicArts.EADesktop',
+        DEFAULT_PSADT_CONFIG
+      ).processesToClose
+    ).toEqual([
+      { name: 'EADesktop', description: 'EA app' },
+      { name: 'EALauncher', description: 'EA app launcher' },
+      { name: 'EACefSubProcess', description: 'EA app web process' },
+      { name: 'EALocalHostSvc', description: 'EA local host service' },
+      { name: 'EABackgroundService', description: 'EA background service' },
+    ]);
+    expect(
+      applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -97,6 +97,21 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--runimmediately'],
   },
   {
+    // EA Desktop's registered EAUninstall.exe helper is unattended, but it
+    // leaves the product registration intact while the client or its
+    // background service still owns the installation. Close the reviewed EA
+    // process family before both upgrades and Intune removal so the exact
+    // registered helper can complete under LocalSystem.
+    wingetId: 'ElectronicArts.EADesktop',
+    requiredProcessesToClose: [
+      { name: 'EADesktop', description: 'EA app' },
+      { name: 'EALauncher', description: 'EA app launcher' },
+      { name: 'EACefSubProcess', description: 'EA app web process' },
+      { name: 'EALocalHostSvc', description: 'EA local host service' },
+      { name: 'EABackgroundService', description: 'EA background service' },
+    ],
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the


### PR DESCRIPTION
## Summary
- close the reviewed EA Desktop client and background process family before install/uninstall
- keep the behavior declarative in the shared packaging adapter so QA and customer PSADT packages are identical

## Evidence
EAUninstall.exe remained blocked for five minutes while EABackgroundService was still running under LocalSystem.

## Verification
- 69 focused adapter/profile tests passed
- ESLint passed