### PR TITLE
Activate EA process lifecycle toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
+  packagerCommit: '2dca138ee2fe27dc45166dba536511aa80d8937e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -51,6 +51,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '7e83c363bcbafca153f00113b12ede2e332b2d2d',
   '670357c92fefa433036d8667dd5f382731d8326e',
   '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
+  'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -199,6 +199,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries EA Desktop once after adding its process-close lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ELECTRONICARTS.EADESKTOP', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
+      { wingetId: 'ElectronicArts.EADesktop', status: 'failed' }
+    )).toBe(true);
+  });
+
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2dca138ee2fe27dc45166dba536511aa80d8937e': [
+    // EAUninstall.exe remains blocked while the EA client/background process
+    // family owns the installation. This release closes those reviewed
+    // processes before invoking the exact registered helper.
+    'ElectronicArts.EADesktop',
+  ],
   'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7': [
     // EA Desktop registers a purpose-built EAUninstall.exe helper. This
     // release prefers that exact helper while retaining the packaged Burn


### PR DESCRIPTION
## Summary
- activate the EA process-lifecycle profile release
- preserve prior successful profiles as compatible because the behavior change is EA-specific
- schedule one bounded EA Desktop retry after the new process-close adapter

## Verification
- 101 focused adapter/profile/retry tests passed
- ESLint passed