### PR TITLE
Activate Inno uninstall normalization in QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2dca138ee2fe27dc45166dba536511aa80d8937e',
+  packagerCommit: '2eea7f106971cda783665a60eb4d0e25846dae46',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -52,6 +52,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '670357c92fefa433036d8667dd5f382731d8326e',
   '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
   'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
+  '2dca138ee2fe27dc45166dba536511aa80d8937e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -190,7 +190,7 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries EA Desktop once with the registered Burn helper lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
       { wingetId: 'electronicarts.eadesktop', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
@@ -201,13 +201,24 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries EA Desktop once after adding its process-close lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '2dca138ee2fe27dc45166dba536511aa80d8937e',
       { wingetId: 'ELECTRONICARTS.EADESKTOP', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
       { wingetId: 'ElectronicArts.EADesktop', status: 'failed' }
     )).toBe(true);
+  });
+
+  it('retries MPC-BE once after strengthening Inno quiet uninstall arguments', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'mpc-be.mpc-be', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '2dca138ee2fe27dc45166dba536511aa80d8937e',
+      { wingetId: 'MPC-BE.MPC-BE', status: 'failed' }
+    )).toBe(false);
   });
 
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2eea7f106971cda783665a60eb4d0e25846dae46': [
+    // MPC-BE's Inno QuietUninstallString uses only /SILENT and can wait behind
+    // an invisible prompt in SYSTEM context. This release normalizes all Inno
+    // registrations to the fully unattended, message-box-free switch set.
+    'MPC-BE.MPC-BE',
+  ],
   '2dca138ee2fe27dc45166dba536511aa80d8937e': [
     // EAUninstall.exe remains blocked while the EA client/background process
     // family owns the installation. This release closes those reviewed


### PR DESCRIPTION
## Summary
- activate packager commit 2eea7f106971cda783665a60eb4d0e25846dae46
- retain successful prior profiles as compatible
- scope one terminal retry to MPC-BE

## Validation
- 100 focused QA profile, retry, and enqueue tests passed
- ESLint passed