### PR TITLE
Close Camera Hub before MSI removal

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -59,6 +59,14 @@ describe('application packaging adapters', () => {
     ]);
     expect(
       applyApplicationPackagingAdapter(
+        'Elgato.CameraHub',
+        DEFAULT_PSADT_CONFIG
+      ).processesToClose
+    ).toEqual([
+      { name: 'Camera Hub', description: 'Elgato Camera Hub' },
+    ]);
+    expect(
+      applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -112,6 +112,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Camera Hub starts its desktop process after MSI installation. The MSI
+    // Pre_Uninstall custom action launches that same executable with --quit
+    // and waits indefinitely when the original process remains open under the
+    // interactive user. Close it through PSADT before upgrades and removal.
+    wingetId: 'Elgato.CameraHub',
+    requiredProcessesToClose: [
+      { name: 'Camera Hub', description: 'Elgato Camera Hub' },
+    ],
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -221,6 +221,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Camera Hub once after adding its process-close lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'elgato.camerahub', status: 'failed' }
+    )).toBe(true);
+  });
+
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -15,6 +15,10 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // an invisible prompt in SYSTEM context. This release normalizes all Inno
     // registrations to the fully unattended, message-box-free switch set.
     'MPC-BE.MPC-BE',
+    // Camera Hub starts its desktop process during install and its MSI removal
+    // custom action waits for that process. The shared application adapter now
+    // closes it before invoking the exact MSI product uninstall.
+    'Elgato.CameraHub',
   ],
   '2dca138ee2fe27dc45166dba536511aa80d8937e': [
     // EAUninstall.exe remains blocked while the EA client/background process


### PR DESCRIPTION
## Summary
- close the Elgato Camera Hub desktop process before PSADT install/removal lifecycle actions
- apply the adapter to both QA and customer packages
- allow one bounded retry of the failed Camera Hub candidate

## Evidence
Camera Hub 2.3.0.7295 installed successfully, then MSI's Pre_Uninstall custom action spawned Camera Hub.exe --pre-uninstall --quit while the original Camera Hub.exe remained running. MSI made no further progress.

## Validation
- 123 focused adapter, profile, retry, and enqueue tests passed
- ESLint passed