### PR TITLE
Fix VSTO runtime silent uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -66,6 +66,10 @@ describe('application packaging adapters', () => {
       { name: 'Camera Hub', description: 'Elgato Camera Hub' },
     ]);
     expect(
+      applyApplicationPackagingAdapter('Microsoft.VSTOR', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['/uninstall', '/quiet', '/norestart']);
+    expect(
       applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -122,6 +122,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // The VSTO redistributable registers a visible External Installer command
+    // with no arguments. Invoking that bare install.exe returns successfully
+    // without removing the runtime. Supply the redistributable's unattended
+    // removal switches so Intune and QA use the same deterministic lifecycle.
+    wingetId: 'Microsoft.VSTOR',
+    reviewedUninstallArguments: ['/uninstall', '/quiet', '/norestart'],
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -228,6 +228,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('retries VSTO once with its reviewed external-installer removal switches', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'microsoft.vstor', status: 'failed' }
+    )).toBe(true);
+  });
+
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -19,6 +19,10 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // custom action waits for that process. The shared application adapter now
     // closes it before invoking the exact MSI product uninstall.
     'Elgato.CameraHub',
+    // VSTO's visible External Installer entry contains a bare install.exe.
+    // The shared application adapter now supplies its unattended removal
+    // switches instead of accepting the helper's no-op exit code.
+    'Microsoft.VSTOR',
   ],
   '2dca138ee2fe27dc45166dba536511aa80d8937e': [
     // EAUninstall.exe remains blocked while the EA client/background process


### PR DESCRIPTION
## Summary
- add reviewed VSTO External Installer removal switches to the shared packaging adapter
- apply the same lifecycle to QA and customer PSADT packages
- allow one bounded retry of the failed VSTO payload

## Validation
- 124 focused Vitest tests passed
- ESLint passed for all changed files
- git diff --check passed