### PR TITLE
Honor nested installer type during PSADT uninstall

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -777,6 +777,16 @@ if ($installerTypeLower -eq 'zip' -and -not [string]::IsNullOrWhiteSpace($Nested
     }
 }
 
+# Registry uninstall behavior belongs to the executable inside an archive, not
+# to the ZIP transport. Preserve the outer type for extraction while carrying
+# the effective nested engine into quiet-uninstall normalization.
+$registeredInstallerTypeLower = if ($installerTypeLower -eq 'zip' -and
+    -not [string]::IsNullOrWhiteSpace($NestedInstallerType)) {
+    $NestedInstallerType.Trim().ToLowerInvariant()
+} else {
+    $installerTypeLower
+}
+
 $isNestedPortable = $installerTypeLower -eq 'zip' -and
     -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
     $NestedInstallerType.Trim().ToLowerInvariant() -eq 'portable'
@@ -2212,7 +2222,7 @@ if ($preserveVendorInstallationOnUninstall) {
         '        @(Get-ADTApplication -Name $appName -NameMatch ''Exact'')'
         '    }'
         ''
-        "    `$allowContainsFallback = '$installerTypeLower' -notin @('msi', 'wix')"
+        "    `$allowContainsFallback = '$registeredInstallerTypeLower' -notin @('msi', 'wix')"
         '    if ($installedApps.Count -eq 0 -and -not $capturedUninstallKey -and -not $configuredProductCode -and $allowContainsFallback) {'
         '        $containsMatches = @(Get-ADTApplication -Name $appName -NameMatch ''Contains'')'
         '        $bundleMatches = @($containsMatches | Where-Object {'
@@ -2318,7 +2328,7 @@ if ($preserveVendorInstallationOnUninstall) {
     } else {
         $lines += @(
             '    $registeredApplication = $installedApps[0]'
-            "    `$registeredInstallerType = '$installerTypeLower'"
+            "    `$registeredInstallerType = '$registeredInstallerTypeLower'"
             '    $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName'
             '    $capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode) {'
             '        $registeredApplication.ProductCode'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -998,6 +998,13 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     }
   });
 
+  it('carries the effective nested installer engine into uninstall normalization', () => {
+    expect(packager).toContain("$registeredInstallerTypeLower = if ($installerTypeLower -eq 'zip'");
+    expect(packager).toContain("`$registeredInstallerType = '$registeredInstallerTypeLower'");
+    expect(hostedPackager).toContain("const registeredInstallerType = installerType === 'zip'");
+    expect(hostedPackager).toContain("'${registeredInstallerType}' -eq 'inno'");
+  });
+
   it('monitors exact registry removal for both quiet and fallback EXE uninstall commands', () => {
     expect(packager).toContain(
       "$registeredUninstallProperty = if ($hasQuietUninstall) { ''QuietUninstallString'' } else { ''UninstallString'' }"
@@ -1120,7 +1127,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
 
   it('keeps non-MSI fallback visible, non-WindowsInstaller, and fail-closed', () => {
     expect(packager).toContain(
-      "$allowContainsFallback = '$installerTypeLower' -notin @('msi', 'wix')"
+      "$allowContainsFallback = '$registeredInstallerTypeLower' -notin @('msi', 'wix')"
     );
     expect(packager).toContain(
       "$systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']"

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1426,6 +1426,10 @@ ${steps}
     const registryIdentity = this.getRegistryUninstallIdentity(job);
     if (registryIdentity) {
       const installerType = job.installer_type.toLowerCase();
+      const nestedInstaller = this.getNestedInstaller(job);
+      const registeredInstallerType = installerType === 'zip' && nestedInstaller.type
+        ? nestedInstaller.type.toLowerCase()
+        : installerType;
       const fileNameEscaped = installerFileName.replace(/'/g, "''");
       const silentSwitches = this.extractSilentSwitches(
         job.install_command,
@@ -1575,7 +1579,7 @@ ${steps}
         if (-not $hasQuietUninstall) {
             if ((Split-Path -Leaf $registeredUninstallFile) -ieq 'setup.exe' -and $registeredArgumentText -match '(?i)(^|\\s)--vivaldi(\\s|$)') {
                 $isVivaldiUninstall = $true
-            } elseif ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${installerType}' -eq 'nullsoft' -and $registeredArgumentText -notmatch '(?i)(^|\\s)/S(\\s|$)') {
+            } elseif ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${registeredInstallerType}' -eq 'nullsoft' -and $registeredArgumentText -notmatch '(?i)(^|\\s)/S(\\s|$)') {
                 $additionalUninstallArguments += '/S'
             }
             if ((Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and $registeredArgumentText -match '(?i)(^|\\s)(/uninstall|-uninstall|--uninstall|/x)(\\s|$|\\{)') {
@@ -1587,7 +1591,7 @@ ${steps}
                 }
             }
         }
-        if (-not $isVivaldiUninstall -and (Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${installerType}' -eq 'inno') {
+        if (-not $isVivaldiUninstall -and (Split-Path -Leaf $registeredUninstallFile) -ine 'msiexec.exe' -and '${registeredInstallerType}' -eq 'inno') {
             # Inno's registered QuietUninstallString is not consistently fully unattended.
             # Normalize weak /SILENT registrations to the vendor-documented, message-box-free
             # switches so SYSTEM deployments cannot wait behind an invisible prompt.

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -627,6 +627,26 @@ describe('EXE product identity PSADT generation', () => {
     expect(inno).toContain("$safeManifestUninstallArguments = @('/VERYSILENT /NORESTART' -split '\\s+'");
   });
 
+  it('uses the nested engine for ZIP-wrapped Inno uninstall normalization', () => {
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'zip',
+        install_command: 'MPC-BE.zip /VERYSILENT /NORESTART',
+        uninstall_command: 'REGISTRY_UNINSTALL:MPC-BE x64 1.9.1',
+        package_config: {
+          nestedInstallerType: 'inno',
+          nestedInstallerPath: 'MPC-BE.1.9.1.x64.exe',
+          psadtConfig: {},
+        },
+      }),
+      'MPC-BE.zip'
+    );
+
+    expect(uninstall).toContain("'inno' -eq 'inno'");
+    expect(uninstall).not.toContain("'zip' -eq 'inno'");
+  });
+
   it('appends only bounded reviewed arguments to the exact registered vendor uninstaller', () => {
     const uninstall = generator.getUninstallCommand.call(
       generator,


### PR DESCRIPTION
## Summary
- carry the effective nested installer type through ZIP package uninstall generation
- apply Inno/NSIS quiet-uninstall normalization to ZIP-wrapped installers
- keep the fix identical in the protected workflow and hosted customer packager

## Validation
- 165 focused tests passed
- ESLint passed
- git diff --check passed