### PR TITLE
chore(qa): activate nested installer engine fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2eea7f106971cda783665a60eb4d0e25846dae46',
+  packagerCommit: '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -53,6 +53,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',
   'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
   '2dca138ee2fe27dc45166dba536511aa80d8937e',
+  '2eea7f106971cda783665a60eb4d0e25846dae46',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,16 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '54515b6566ff4e7c9040fa24a8eba6b6347ef09e': [
+    // ZIP is the package transport, not the registered uninstall engine.
+    // This release carries the nested Inno type into both QA and customer
+    // packages so MPC-BE receives the fully unattended uninstall switches.
+    'MPC-BE.MPC-BE',
+    // Carry the two reviewed lifecycle retries through the atomic toolchain
+    // rollout; neither completed successfully on the preceding pin.
+    'Elgato.CameraHub',
+    'Microsoft.VSTOR',
+  ],
   '2eea7f106971cda783665a60eb4d0e25846dae46': [
     // MPC-BE's Inno QuietUninstallString uses only /SILENT and can wait behind
     // an invisible prompt in SYSTEM context. This release normalizes all Inno


### PR DESCRIPTION
Activates packager commit 54515b6566ff4e7c9040fa24a8eba6b6347ef09e for QA after the protected Workflows pin is updated. Carries only the three affected failed lifecycle tests forward once; successful immutable payloads remain compatible and are not replayed.\n\nValidation: 91 focused Vitest tests passed; ESLint passed; git diff --check passed.