### PR TITLE
fix(packaging): guard stuck Camera Hub uninstall helper

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -263,6 +263,100 @@ $reviewedUninstallArgumentsLiteral = @(
     $reviewedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
 
+$reviewedUninstallProcessGuardConfigured = $false
+$reviewedUninstallProcessGuardName = ''
+$reviewedUninstallProcessGuardPattern = ''
+$reviewedUninstallProcessGuardGraceSeconds = 0
+if ($psadtConfig.Contains('reviewedUninstallProcessGuard') -and
+    $null -ne $psadtConfig['reviewedUninstallProcessGuard']) {
+    $rawProcessGuard = $psadtConfig['reviewedUninstallProcessGuard']
+    if ($rawProcessGuard -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedUninstallProcessGuard must be an object.'
+    }
+
+    $reviewedUninstallProcessGuardName = ([string]$rawProcessGuard['processName']).Trim()
+    $reviewedUninstallProcessGuardPattern = ([string]$rawProcessGuard['argumentsPattern']).Trim()
+    $rawProcessGuardGraceSeconds = $rawProcessGuard['graceSeconds']
+    if ($reviewedUninstallProcessGuardName -notmatch '^[A-Za-z0-9 _().-]+\.exe$' -or
+        $reviewedUninstallProcessGuardName.Length -gt 128) {
+        throw 'PSADT reviewedUninstallProcessGuard.processName must be a bounded executable leaf name.'
+    }
+    if ([string]::IsNullOrWhiteSpace($reviewedUninstallProcessGuardPattern) -or
+        $reviewedUninstallProcessGuardPattern.Length -gt 256 -or
+        [regex]::IsMatch($reviewedUninstallProcessGuardPattern, '[\x00-\x1F\x7F]')) {
+        throw 'PSADT reviewedUninstallProcessGuard.argumentsPattern must be a bounded, single-line regular expression.'
+    }
+    try {
+        [void][regex]::new($reviewedUninstallProcessGuardPattern)
+    }
+    catch {
+        throw 'PSADT reviewedUninstallProcessGuard.argumentsPattern must be a valid regular expression.'
+    }
+    if (($rawProcessGuardGraceSeconds -isnot [byte] -and
+         $rawProcessGuardGraceSeconds -isnot [int16] -and
+         $rawProcessGuardGraceSeconds -isnot [int32] -and
+         $rawProcessGuardGraceSeconds -isnot [int64]) -or
+        [int]$rawProcessGuardGraceSeconds -lt 5 -or
+        [int]$rawProcessGuardGraceSeconds -gt 120) {
+        throw 'PSADT reviewedUninstallProcessGuard.graceSeconds must be an integer from 5 to 120.'
+    }
+    $reviewedUninstallProcessGuardGraceSeconds = [int]$rawProcessGuardGraceSeconds
+    $reviewedUninstallProcessGuardConfigured = $true
+}
+
+$reviewedUninstallProcessGuardMsiLines = @(
+    '        Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)'
+)
+if ($reviewedUninstallProcessGuardConfigured) {
+    $reviewedUninstallProcessGuardNameLiteral = $reviewedUninstallProcessGuardName -replace "'", "''"
+    $reviewedUninstallProcessGuardPatternLiteral = $reviewedUninstallProcessGuardPattern -replace "'", "''"
+    $reviewedUninstallProcessGuardMsiLines = @(
+        "        `$reviewedGuardProcessName = '$reviewedUninstallProcessGuardNameLiteral'"
+        "        `$reviewedGuardArgumentsPattern = '$reviewedUninstallProcessGuardPatternLiteral'"
+        "        `$reviewedGuardGraceSeconds = $reviewedUninstallProcessGuardGraceSeconds"
+        '        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-2)'
+        '        $reviewedGuardJob = Start-Job -ScriptBlock {'
+        '            param($ProcessName, $ArgumentsPattern, $StartedAt, $GraceSeconds)'
+        '            $deadline = [DateTime]::UtcNow.AddMinutes(3)'
+        '            do {'
+        '                $candidate = Get-CimInstance -ClassName Win32_Process -ErrorAction SilentlyContinue | Where-Object {'
+        '                    $_.Name -ieq $ProcessName -and'
+        '                    $null -ne $_.CreationDate -and'
+        '                    $_.CreationDate.ToUniversalTime() -ge $StartedAt -and'
+        '                    [regex]::IsMatch([string]$_.CommandLine, $ArgumentsPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)'
+        '                } | Select-Object -First 1'
+        '                if ($null -ne $candidate) {'
+        '                    Start-Sleep -Seconds $GraceSeconds'
+        '                    $current = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $($candidate.ProcessId)" -ErrorAction SilentlyContinue'
+        '                    if ($null -ne $current -and'
+        '                        $current.Name -ieq $ProcessName -and'
+        '                        [regex]::IsMatch([string]$current.CommandLine, $ArgumentsPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {'
+        '                        Stop-Process -Id $current.ProcessId -Force -ErrorAction Stop'
+        '                        return "Ended the reviewed vendor uninstall helper after its grace period."'
+        '                    }'
+        '                    return'
+        '                }'
+        '                Start-Sleep -Seconds 1'
+        '            } while ([DateTime]::UtcNow -lt $deadline)'
+        '        } -ArgumentList $reviewedGuardProcessName, $reviewedGuardArgumentsPattern, $reviewedGuardStartedAt, $reviewedGuardGraceSeconds'
+        '        try {'
+        '            Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)'
+        '        } finally {'
+        '            if ($null -ne $reviewedGuardJob) {'
+        '                if ($reviewedGuardJob.State -in @(''NotStarted'', ''Running'')) {'
+        '                    Stop-Job -Job $reviewedGuardJob -ErrorAction SilentlyContinue'
+        '                }'
+        '                foreach ($guardMessage in @(Receive-Job -Job $reviewedGuardJob -ErrorAction SilentlyContinue)) {'
+        '                    if (-not [string]::IsNullOrWhiteSpace([string]$guardMessage)) {'
+        '                        Write-ADTLogEntry -Message ([string]$guardMessage) -Source ''Uninstall-ADTDeployment'''
+        '                    }'
+        '                }'
+        '                Remove-Job -Job $reviewedGuardJob -Force -ErrorAction SilentlyContinue'
+        '            }'
+        '        }'
+    )
+}
+
 $reviewedMultiProductInstallDisplayNamePrefixes = @()
 if ($psadtConfig.Contains('reviewedMultiProductInstallDisplayNamePrefixes') -and
     $null -ne $psadtConfig['reviewedMultiProductInstallDisplayNamePrefixes']) {
@@ -2386,7 +2480,7 @@ if ($preserveVendorInstallationOnUninstall) {
             ''
             '    if ($capturedMsiProductCode) {'
             '        Write-ADTLogEntry -Message "Executing MSI uninstall with captured product code [$capturedMsiProductCode]." -Source ''Uninstall-ADTDeployment'''
-            '        Start-ADTMsiProcess -Action ''Uninstall'' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)'
+            $reviewedUninstallProcessGuardMsiLines
             '    } else {'
             '        # Vendor uninstallers can keep their bootstrapper open after removal or return before a'
             '        # child finishes. Launch the exact quiet/fallback command asynchronously and use the'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -58,13 +58,17 @@ describe('application packaging adapters', () => {
       { name: 'EABackgroundService', description: 'EA background service' },
     ]);
     expect(
-      applyApplicationPackagingAdapter(
-        'Elgato.CameraHub',
-        DEFAULT_PSADT_CONFIG
-      ).processesToClose
-    ).toEqual([
-      { name: 'Camera Hub', description: 'Elgato Camera Hub' },
-    ]);
+      applyApplicationPackagingAdapter('Elgato.CameraHub', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      processesToClose: [
+        { name: 'Camera Hub', description: 'Elgato Camera Hub' },
+      ],
+      reviewedUninstallProcessGuard: {
+        processName: 'Camera Hub.exe',
+        argumentsPattern: '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)',
+        graceSeconds: 20,
+      },
+    });
     expect(
       applyApplicationPackagingAdapter('Microsoft.VSTOR', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -7,6 +7,11 @@ interface ApplicationPackagingAdapter {
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedUninstallArguments?: readonly string[];
+  reviewedUninstallProcessGuard?: Readonly<{
+    processName: string;
+    argumentsPattern: string;
+    graceSeconds: number;
+  }>;
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
@@ -113,13 +118,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // Camera Hub starts its desktop process after MSI installation. The MSI
-    // Pre_Uninstall custom action launches that same executable with --quit
-    // and waits indefinitely when the original process remains open under the
-    // interactive user. Close it through PSADT before upgrades and removal.
+    // Pre_Uninstall custom action launches a new Camera Hub helper with
+    // --pre-uninstall --quit and can wait indefinitely even after the original
+    // desktop process is closed. Close the user process first, then allow the
+    // reviewed custom-action helper a short grace period before ending only
+    // that exact newly spawned command line.
     wingetId: 'Elgato.CameraHub',
     requiredProcessesToClose: [
       { name: 'Camera Hub', description: 'Elgato Camera Hub' },
     ],
+    reviewedUninstallProcessGuard: {
+      processName: 'Camera Hub.exe',
+      argumentsPattern: '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)',
+      graceSeconds: 20,
+    },
   },
   {
     // The VSTO redistributable registers a visible External Installer command
@@ -275,13 +287,15 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
-      !config.reviewedMultiProductInstallMinimumCount
+      !config.reviewedMultiProductInstallMinimumCount &&
+      !config.reviewedUninstallProcessGuard
     ) return config;
     return {
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
+      reviewedUninstallProcessGuard: undefined,
     };
   }
 
@@ -342,6 +356,9 @@ export function applyApplicationPackagingAdapter(
     processesToClose,
     reviewedInstallArguments,
     reviewedUninstallArguments,
+    reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard
+      ? { ...adapter.reviewedUninstallProcessGuard }
+      : undefined,
     ...(adapter.uninstallCompletionTimeoutMinutes
       ? { uninstallCompletionTimeoutMinutes: adapter.uninstallCompletionTimeoutMinutes }
       : {}),

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1030,6 +1030,16 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(packager).not.toContain('TotalSeconds -ge 15');
   });
 
+  it('keeps the reviewed MSI helper guard identical in both customer packagers', () => {
+    for (const source of [packager, hostedPackager]) {
+      expect(source).toContain('reviewedUninstallProcessGuard');
+      expect(source).toContain('Get-CimInstance -ClassName Win32_Process');
+      expect(source).toContain('CreationDate.ToUniversalTime()');
+      expect(source).toContain('Stop-Process -Id $current.ProcessId -Force');
+      expect(source).toContain('Ended the reviewed vendor uninstall helper after its grace period.');
+    }
+  });
+
   it('uses the same registry-aware completion rule for selected Burn uninstallers', () => {
     expect(packager).toContain(
       'Start-ADTProcess -FilePath $burnUninstaller -ArgumentList $registeredUninstallArguments'

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -890,6 +890,72 @@ catch
   }
 
   /**
+   * Validate the adapter-only guard for an MSI custom-action helper that can
+   * otherwise wait indefinitely. Both the executable leaf name and command
+   * line must match before a newly spawned process is ended after its grace
+   * period. This is intentionally not a general customer command surface.
+   */
+  private getReviewedUninstallProcessGuard(job: PackagingJob): {
+    processName: string;
+    argumentsPattern: string;
+    graceSeconds: number;
+  } | null {
+    const raw = this.getPsadtConfig(job)?.reviewedUninstallProcessGuard;
+    if (raw === undefined || raw === null) return null;
+    if (typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error('PSADT reviewedUninstallProcessGuard must be an object');
+    }
+
+    const record = raw as Record<string, unknown>;
+    const processName = typeof record.processName === 'string'
+      ? record.processName.trim()
+      : '';
+    const argumentsPattern = typeof record.argumentsPattern === 'string'
+      ? record.argumentsPattern.trim()
+      : '';
+    const graceSeconds = record.graceSeconds;
+    if (
+      !/^[A-Za-z0-9 _().-]+\.exe$/.test(processName) ||
+      processName.length > 128
+    ) {
+      throw new Error(
+        'PSADT reviewedUninstallProcessGuard.processName must be a bounded executable leaf name'
+      );
+    }
+    if (
+      !argumentsPattern ||
+      argumentsPattern.length > 256 ||
+      /[\x00-\x1f\x7f]/.test(argumentsPattern)
+    ) {
+      throw new Error(
+        'PSADT reviewedUninstallProcessGuard.argumentsPattern must be bounded and single-line'
+      );
+    }
+    try {
+      new RegExp(argumentsPattern);
+    } catch {
+      throw new Error(
+        'PSADT reviewedUninstallProcessGuard.argumentsPattern must be a valid regular expression'
+      );
+    }
+    if (
+      !Number.isInteger(graceSeconds) ||
+      (graceSeconds as number) < 5 ||
+      (graceSeconds as number) > 120
+    ) {
+      throw new Error(
+        'PSADT reviewedUninstallProcessGuard.graceSeconds must be an integer from 5 to 120'
+      );
+    }
+
+    return {
+      processName,
+      argumentsPattern,
+      graceSeconds: graceSeconds as number,
+    };
+  }
+
+  /**
    * Bound the registry-aware vendor completion window. Most uninstallers use
    * five minutes; reviewed adapters can extend it for asynchronous vendor
    * engines without turning it into an unbounded customer-controlled wait.
@@ -1442,6 +1508,53 @@ ${steps}
         .join(', ');
       const uninstallCompletionTimeoutMinutes =
         this.getUninstallCompletionTimeoutMinutes(job);
+      const reviewedUninstallProcessGuard =
+        this.getReviewedUninstallProcessGuard(job);
+      const capturedMsiUninstallBlock = reviewedUninstallProcessGuard
+        ? `$reviewedGuardProcessName = '${reviewedUninstallProcessGuard.processName.replace(/'/g, "''")}'
+        $reviewedGuardArgumentsPattern = '${reviewedUninstallProcessGuard.argumentsPattern.replace(/'/g, "''")}'
+        $reviewedGuardGraceSeconds = ${reviewedUninstallProcessGuard.graceSeconds}
+        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-2)
+        $reviewedGuardJob = Start-Job -ScriptBlock {
+            param($ProcessName, $ArgumentsPattern, $StartedAt, $GraceSeconds)
+            $deadline = [DateTime]::UtcNow.AddMinutes(3)
+            do {
+                $candidate = Get-CimInstance -ClassName Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+                    $_.Name -ieq $ProcessName -and
+                    $null -ne $_.CreationDate -and
+                    $_.CreationDate.ToUniversalTime() -ge $StartedAt -and
+                    [regex]::IsMatch([string]$_.CommandLine, $ArgumentsPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+                } | Select-Object -First 1
+                if ($null -ne $candidate) {
+                    Start-Sleep -Seconds $GraceSeconds
+                    $current = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $($candidate.ProcessId)" -ErrorAction SilentlyContinue
+                    if ($null -ne $current -and
+                        $current.Name -ieq $ProcessName -and
+                        [regex]::IsMatch([string]$current.CommandLine, $ArgumentsPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
+                        Stop-Process -Id $current.ProcessId -Force -ErrorAction Stop
+                        return "Ended the reviewed vendor uninstall helper after its grace period."
+                    }
+                    return
+                }
+                Start-Sleep -Seconds 1
+            } while ([DateTime]::UtcNow -lt $deadline)
+        } -ArgumentList $reviewedGuardProcessName, $reviewedGuardArgumentsPattern, $reviewedGuardStartedAt, $reviewedGuardGraceSeconds
+        try {
+            Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+        } finally {
+            if ($null -ne $reviewedGuardJob) {
+                if ($reviewedGuardJob.State -in @('NotStarted', 'Running')) {
+                    Stop-Job -Job $reviewedGuardJob -ErrorAction SilentlyContinue
+                }
+                foreach ($guardMessage in @(Receive-Job -Job $reviewedGuardJob -ErrorAction SilentlyContinue)) {
+                    if (-not [string]::IsNullOrWhiteSpace([string]$guardMessage)) {
+                        Write-ADTLogEntry -Message ([string]$guardMessage) -Source 'Uninstall-ADTDeployment'
+                    }
+                }
+                Remove-Job -Job $reviewedGuardJob -Force -ErrorAction SilentlyContinue
+            }
+        }`
+        : `Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)`;
       const reviewedUninstallArgumentsBlock = `$reviewedUninstallArguments = @(${reviewedUninstallArguments})
     foreach ($reviewedArgument in $reviewedUninstallArguments) {
         if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {
@@ -1566,7 +1679,7 @@ ${steps}
         $null
     }
     if ($capturedMsiProductCode) {
-        Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode -SuccessExitCodes @(0, 1605, 1614) -RebootExitCodes @(1641, 3010)
+        ${capturedMsiUninstallBlock}
     } else {
         $hasQuietUninstall = -not [string]::IsNullOrWhiteSpace($registeredApplication.QuietUninstallStringFilePath)
         $registeredUninstallProperty = if ($hasQuietUninstall) { 'QuietUninstallString' } else { 'UninstallString' }

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -685,6 +685,59 @@ describe('EXE product identity PSADT generation', () => {
     )).toThrow('single-line');
   });
 
+  it('guards only the reviewed newly spawned MSI uninstall helper', () => {
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        winget_id: 'Elgato.CameraHub',
+        installer_type: 'msi',
+        uninstall_command: 'REGISTRY_UNINSTALL:Elgato Camera Hub',
+        package_config: {
+          psadtConfig: {
+            reviewedUninstallProcessGuard: {
+              processName: 'Camera Hub.exe',
+              argumentsPattern: '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)',
+              graceSeconds: 20,
+            },
+          },
+        },
+      }),
+      'CameraHub.msi'
+    );
+
+    expect(uninstall).toContain("$reviewedGuardProcessName = 'Camera Hub.exe'");
+    expect(uninstall).toContain(
+      "$reviewedGuardArgumentsPattern = '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)'"
+    );
+    expect(uninstall).toContain('$reviewedGuardGraceSeconds = 20');
+    expect(uninstall).toContain('$_.CreationDate.ToUniversalTime() -ge $StartedAt');
+    expect(uninstall).toContain('$current.Name -ieq $ProcessName');
+    expect(uninstall).toContain('Stop-Process -Id $current.ProcessId -Force');
+    expect(uninstall).toContain(
+      "Start-ADTMsiProcess -Action 'Uninstall' -ProductCode $capturedMsiProductCode"
+    );
+  });
+
+  it('rejects an unsafe reviewed MSI uninstall process guard', () => {
+    expect(() => generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'msi',
+        uninstall_command: 'REGISTRY_UNINSTALL:Example',
+        package_config: {
+          psadtConfig: {
+            reviewedUninstallProcessGuard: {
+              processName: '..\\helper.exe',
+              argumentsPattern: '--quit',
+              graceSeconds: 20,
+            },
+          },
+        },
+      }),
+      'example.msi'
+    )).toThrow('executable leaf name');
+  });
+
   it('extends registry-aware completion only for a reviewed vendor profile', () => {
     const uninstall = generator.getUninstallCommand.call(
       generator,

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -204,6 +204,16 @@ export interface PSADTConfig {
   // not exposed as a customer-facing free-form command surface.
   reviewedUninstallArguments?: string[];
 
+  // Internal guard for a reviewed vendor MSI custom-action helper that can
+  // remain alive indefinitely during removal. The packager only accepts this
+  // value from an application adapter and matches both the executable name and
+  // command line before ending the newly spawned helper after a grace period.
+  reviewedUninstallProcessGuard?: {
+    processName: string;
+    argumentsPattern: string;
+    graceSeconds: number;
+  };
+
   // Internal completion window for vendor uninstallers that hand work to a
   // child process. Application adapters may extend the five-minute default;
   // the exact registry identity remains the authoritative completion signal.
@@ -301,6 +311,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
   reviewedUninstallArguments: [],
+  reviewedUninstallProcessGuard: undefined,
 };
 
 /**


### PR DESCRIPTION
## Summary
- add a reviewed, adapter-only MSI uninstall process guard for Elgato Camera Hub
- match only a newly spawned Camera Hub.exe with the exact --pre-uninstall --quit command line
- apply the same lifecycle behavior to the GitHub and self-hosted customer packagers
- validate and test the bounded internal guard configuration

## Verification
- 123 focused Vitest tests passed
- targeted ESLint passed
- production Next.js build passed
- PowerShell AST parse and git diff checks passed