### PR TITLE
chore(qa): activate Camera Hub uninstall guard

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
+  packagerCommit: 'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -54,6 +54,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'e6a4ae2f4f9a3a672c6912ab8e309483f53003b7',
   '2dca138ee2fe27dc45166dba536511aa80d8937e',
   '2eea7f106971cda783665a60eb4d0e25846dae46',
+  '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -212,16 +212,16 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries MPC-BE once after strengthening Inno quiet uninstall arguments', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
       { wingetId: 'mpc-be.mpc-be', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      '2dca138ee2fe27dc45166dba536511aa80d8937e',
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'MPC-BE.MPC-BE', status: 'failed' }
     )).toBe(false);
   });
 
-  it('retries Camera Hub once after adding its process-close lifecycle', () => {
+  it('retries Camera Hub once after guarding its MSI pre-uninstall helper', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'elgato.camerahub', status: 'failed' }
@@ -230,9 +230,13 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries VSTO once with its reviewed external-installer removal switches', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
       { wingetId: 'microsoft.vstor', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Microsoft.VSTOR', status: 'failed' }
+    )).toBe(false);
   });
 
   it.each(['Autodesk.DesktopApp'])('does not replay retired %s on the current pin', (wingetId) => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272': [
+    // Camera Hub's MSI launches a fresh --pre-uninstall --quit helper after
+    // PSADT closes the desktop process. This release gives only that reviewed
+    // command line a grace period before ending it so MSI removal can finish.
+    'Elgato.CameraHub',
+  ],
   '54515b6566ff4e7c9040fa24a8eba6b6347ef09e': [
     // ZIP is the package transport, not the registered uninstall engine.
     // This release carries the nested Inno type into both QA and customer


### PR DESCRIPTION
## Summary
- activate the Camera Hub MSI helper guard as the current QA packager commit
- retain successful results from the preceding compatible packager release
- schedule one bounded Camera Hub retry only; MPC-BE and VSTOR already passed on the prior pin

## Verification
- 93 focused QA profile, retry, demand, and dispatch tests passed
- targeted ESLint and git diff checks passed