### PR TITLE
Fix managed extractor package lifecycles

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -444,6 +444,20 @@ $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
     -Config $psadtConfig `
     -Name 'preserveVendorInstallationOnUninstall'
 
+$reviewedManagedInstallDirectory = ''
+if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
+    $null -ne $psadtConfig['reviewedManagedInstallDirectory']) {
+    if ($psadtConfig['reviewedManagedInstallDirectory'] -isnot [string]) {
+        throw 'PSADT reviewedManagedInstallDirectory must be a string.'
+    }
+    $reviewedManagedInstallDirectory = ([string]$psadtConfig['reviewedManagedInstallDirectory']).Trim()
+    if ($reviewedManagedInstallDirectory.Length -gt 260 -or
+        $reviewedManagedInstallDirectory -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+$' -or
+        @($reviewedManagedInstallDirectory -split '\\') -contains '..') {
+        throw 'PSADT reviewedManagedInstallDirectory must be a safe path below a Program Files environment variable.'
+    }
+}
+
 function ConvertTo-PSADTConfigValue {
     param(
         [AllowNull()][string]$Value,
@@ -691,6 +705,7 @@ $silentSwitchesEscaped = $effectiveSilentSwitches -replace "'", "''"
 $versionSingleQuoteEscaped = $Version -replace "'", "''"
 $uninstallCmd = [string]$UninstallCommand
 $uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
+$reviewedManagedInstallDirectoryEscaped = $reviewedManagedInstallDirectory -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
@@ -943,6 +958,14 @@ if ($fileExtension -eq '.msi') {
     } else {
         throw 'The MSI database did not expose a valid ProductCode; refusing ambiguous detection or removal.'
     }
+}
+
+$useManagedDirectoryLifecycle = -not [string]::IsNullOrWhiteSpace($reviewedManagedInstallDirectory)
+if ($useManagedDirectoryLifecycle) {
+    # A reviewed extractor lifecycle is deliberately not an ARP lifecycle.
+    # Never let unrelated background servicing become the captured identity.
+    $useRegistryUninstall = $false
+    Write-Host "Using reviewed managed-directory lifecycle: $reviewedManagedInstallDirectory"
 }
 
 if ($useRegistryUninstall) {
@@ -1953,6 +1976,21 @@ $lines += @(
     '    Close-ADTInstallationProgress'
 )
 
+if ($useManagedDirectoryLifecycle) {
+    $lines += @(
+        ''
+        "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')"
+        '    if (-not (Test-Path -LiteralPath $managedInstallDirectory -PathType Container)) {'
+        '        throw "The reviewed managed install directory was not created: $managedInstallDirectory"'
+        '    }'
+        '    $managedPayloadFile = Get-ChildItem -LiteralPath $managedInstallDirectory -File -Recurse -ErrorAction Stop | Select-Object -First 1'
+        '    if (-not $managedPayloadFile) {'
+        '        throw "The reviewed managed install directory contains no payload files: $managedInstallDirectory"'
+        '    }'
+        '    Write-ADTLogEntry -Message "Verified managed extracted payload at [$managedInstallDirectory]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+    )
+}
+
 # Optional post-install verification (opt-in via PSADT config)
 # Throwing here routes through the standard catch -> Close-ADTSession error exit,
 # and the detection marker write below is skipped because it never runs
@@ -2273,7 +2311,19 @@ if ($preUninstallPromptCalls) {
 # precedence because executing the vendor command could remove a prerequisite
 # used by Windows or unrelated applications. The ordinary marker cleanup below
 # still makes Intune's exact package detection transition to not installed.
-if ($preserveVendorInstallationOnUninstall) {
+if ($useManagedDirectoryLifecycle) {
+    Write-Host 'Using reviewed managed-directory removal'
+    $lines += @(
+        ''
+        "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')"
+        '    if (Test-Path -LiteralPath $managedInstallDirectory) {'
+        '        Remove-Item -LiteralPath $managedInstallDirectory -Recurse -Force -ErrorAction Stop'
+        '        Write-ADTLogEntry -Message "Removed managed extracted payload from [$managedInstallDirectory]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+        '    } else {'
+        '        Write-ADTLogEntry -Message "Managed extracted payload was already absent: $managedInstallDirectory" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+        '    }'
+    )
+} elseif ($preserveVendorInstallationOnUninstall) {
     Write-Host 'Preserving the shared vendor installation during package removal'
     $lines += @(
         ''

--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -458,6 +458,58 @@ if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
     }
 }
 
+$reviewedManagedUninstallConfigured = $false
+$reviewedManagedUninstallExecutable = ''
+$reviewedManagedUninstallArguments = @()
+$reviewedManagedUninstallTimeoutMinutes = 0
+if ($psadtConfig.Contains('reviewedManagedUninstall') -and
+    $null -ne $psadtConfig['reviewedManagedUninstall']) {
+    $rawManagedUninstall = $psadtConfig['reviewedManagedUninstall']
+    if ($rawManagedUninstall -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedManagedUninstall must be an object.'
+    }
+    if ([string]::IsNullOrWhiteSpace($reviewedManagedInstallDirectory)) {
+        throw 'PSADT reviewedManagedUninstall requires reviewedManagedInstallDirectory.'
+    }
+    $reviewedManagedUninstallExecutable = ([string]$rawManagedUninstall['executablePath']).Trim()
+    if ($reviewedManagedUninstallExecutable.Length -gt 260 -or
+        $reviewedManagedUninstallExecutable -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
+        @($reviewedManagedUninstallExecutable -split '\\') -contains '..') {
+        throw 'PSADT reviewedManagedUninstall.executablePath must be a safe executable below a Program Files environment variable.'
+    }
+    $rawManagedUninstallArguments = $rawManagedUninstall['arguments']
+    if ($rawManagedUninstallArguments -is [string] -or
+        $rawManagedUninstallArguments -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedManagedUninstall.arguments must be an array.'
+    }
+    foreach ($rawManagedUninstallArgument in @($rawManagedUninstallArguments)) {
+        if ($rawManagedUninstallArgument -isnot [string]) {
+            throw 'Every PSADT reviewed managed uninstall argument must be a string.'
+        }
+        $managedUninstallArgument = $rawManagedUninstallArgument.Trim()
+        if ([string]::IsNullOrWhiteSpace($managedUninstallArgument) -or
+            $managedUninstallArgument.Length -gt 260 -or
+            [regex]::IsMatch($managedUninstallArgument, '[\x00-\x1F\x7F]')) {
+            throw 'Every PSADT reviewed managed uninstall argument must be non-empty, bounded, and single-line.'
+        }
+        $reviewedManagedUninstallArguments += $managedUninstallArgument
+    }
+    if ($reviewedManagedUninstallArguments.Count -gt 20) {
+        throw 'PSADT reviewedManagedUninstall.arguments must contain at most 20 entries.'
+    }
+    $rawManagedUninstallTimeoutMinutes = $rawManagedUninstall['completionTimeoutMinutes']
+    if (($rawManagedUninstallTimeoutMinutes -isnot [byte] -and
+         $rawManagedUninstallTimeoutMinutes -isnot [int16] -and
+         $rawManagedUninstallTimeoutMinutes -isnot [int32] -and
+         $rawManagedUninstallTimeoutMinutes -isnot [int64]) -or
+        [int]$rawManagedUninstallTimeoutMinutes -lt 1 -or
+        [int]$rawManagedUninstallTimeoutMinutes -gt 60) {
+        throw 'PSADT reviewedManagedUninstall.completionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+    $reviewedManagedUninstallTimeoutMinutes = [int]$rawManagedUninstallTimeoutMinutes
+    $reviewedManagedUninstallConfigured = $true
+}
+
 function ConvertTo-PSADTConfigValue {
     param(
         [AllowNull()][string]$Value,
@@ -706,6 +758,10 @@ $versionSingleQuoteEscaped = $Version -replace "'", "''"
 $uninstallCmd = [string]$UninstallCommand
 $uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
 $reviewedManagedInstallDirectoryEscaped = $reviewedManagedInstallDirectory -replace "'", "''"
+$reviewedManagedUninstallExecutableEscaped = $reviewedManagedUninstallExecutable -replace "'", "''"
+$reviewedManagedUninstallArgumentsLiteral = @(
+    $reviewedManagedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
+) -join ', '
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
@@ -2313,16 +2369,39 @@ if ($preUninstallPromptCalls) {
 # still makes Intune's exact package detection transition to not installed.
 if ($useManagedDirectoryLifecycle) {
     Write-Host 'Using reviewed managed-directory removal'
-    $lines += @(
-        ''
-        "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')"
-        '    if (Test-Path -LiteralPath $managedInstallDirectory) {'
-        '        Remove-Item -LiteralPath $managedInstallDirectory -Recurse -Force -ErrorAction Stop'
-        '        Write-ADTLogEntry -Message "Removed managed extracted payload from [$managedInstallDirectory]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
-        '    } else {'
-        '        Write-ADTLogEntry -Message "Managed extracted payload was already absent: $managedInstallDirectory" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
-        '    }'
-    )
+    $lines += @('', "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')")
+    if ($reviewedManagedUninstallConfigured) {
+        $lines += @(
+            "    `$managedUninstallExecutable = [Environment]::ExpandEnvironmentVariables('$reviewedManagedUninstallExecutableEscaped')"
+            "    `$managedUninstallArguments = @($reviewedManagedUninstallArgumentsLiteral) | ForEach-Object { [Environment]::ExpandEnvironmentVariables(`$_) }"
+            '    if (-not (Test-Path -LiteralPath $managedUninstallExecutable -PathType Leaf)) {'
+            '        throw "The reviewed managed uninstaller was not found: $managedUninstallExecutable"'
+            '    }'
+            '    if (Test-Path -LiteralPath $managedInstallDirectory) {'
+            '        Write-ADTLogEntry -Message "Starting reviewed managed uninstaller [$managedUninstallExecutable]." -Source ''Uninstall-ADTDeployment'''
+            '        $null = Start-ADTProcess -FilePath $managedUninstallExecutable -ArgumentList $managedUninstallArguments -WindowStyle Hidden -NoWait -PassThru'
+            "        `$managedUninstallDeadline = [DateTime]::UtcNow.AddMinutes($reviewedManagedUninstallTimeoutMinutes)"
+            '        while ((Test-Path -LiteralPath $managedInstallDirectory) -and [DateTime]::UtcNow -lt $managedUninstallDeadline) {'
+            '            Start-Sleep -Seconds 5'
+            '        }'
+            '        if (Test-Path -LiteralPath $managedInstallDirectory) {'
+            '            throw "The reviewed managed uninstaller did not remove [$managedInstallDirectory] before the completion deadline."'
+            '        }'
+            '        Write-ADTLogEntry -Message "Reviewed managed uninstall completed for [$managedInstallDirectory]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+            '    } else {'
+            '        Write-ADTLogEntry -Message "Managed installation was already absent: $managedInstallDirectory" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '    }'
+        )
+    } else {
+        $lines += @(
+            '    if (Test-Path -LiteralPath $managedInstallDirectory) {'
+            '        Remove-Item -LiteralPath $managedInstallDirectory -Recurse -Force -ErrorAction Stop'
+            '        Write-ADTLogEntry -Message "Removed managed extracted payload from [$managedInstallDirectory]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+            '    } else {'
+            '        Write-ADTLogEntry -Message "Managed extracted payload was already absent: $managedInstallDirectory" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '    }'
+        )
+    }
 } elseif ($preserveVendorInstallationOnUninstall) {
     Write-Host 'Preserving the shared vendor installation during package removal'
     $lines += @(

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -504,7 +504,10 @@ describe('GET /api/cron/qa-enqueue', () => {
         profileKind: 'catalog-default',
         psadtConfig: {
           processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-          reviewedUninstallArguments: ['--runimmediately'],
+          reviewedUninstallArguments: [
+            '--runimmediately',
+            '--deleteuserprofile=0',
+          ],
         },
       },
     });

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -594,7 +594,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     const expectedAdapter = {
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['--runimmediately'],
+      reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
     };
     expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
       expectedAdapter

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -43,7 +43,7 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['--runimmediately'],
+      reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
     });
     expect(
       applyApplicationPackagingAdapter(
@@ -192,7 +192,11 @@ describe('application packaging adapters', () => {
     expect(adapted.processesToClose).toEqual([
       { name: 'Opera', description: 'Customer browser session' },
     ]);
-    expect(adapted.reviewedUninstallArguments).toEqual(['--RUNIMMEDIATELY', '--custom']);
+    expect(adapted.reviewedUninstallArguments).toEqual([
+      '--RUNIMMEDIATELY',
+      '--custom',
+      '--deleteuserprofile=0',
+    ]);
   });
 
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -53,6 +53,27 @@ describe('application packaging adapters', () => {
     ).toBe('%ProgramW6432%\\OfficeDeploymentTool');
     expect(
       applyApplicationPackagingAdapter(
+        'Microsoft.VisualStudio.BuildTools',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'ElectronicArts.EADesktop',
         DEFAULT_PSADT_CONFIG
       ).processesToClose
@@ -138,12 +159,18 @@ describe('application packaging adapters', () => {
       reviewedMultiProductInstallDisplayNamePrefixes: ['Anything'],
       reviewedMultiProductInstallMinimumCount: 2,
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramFiles%\\Example\\uninstall.exe',
+        arguments: ['/quiet'],
+        completionTimeoutMinutes: 5,
+      },
     });
 
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
+    expect(adapted.reviewedManagedUninstall).toBeUndefined();
   });
 
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -47,6 +47,12 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
+        'Microsoft.OfficeDeploymentTool',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedManagedInstallDirectory
+    ).toBe('%ProgramW6432%\\OfficeDeploymentTool');
+    expect(
+      applyApplicationPackagingAdapter(
         'ElectronicArts.EADesktop',
         DEFAULT_PSADT_CONFIG
       ).processesToClose
@@ -131,11 +137,13 @@ describe('application packaging adapters', () => {
       preserveVendorInstallationOnUninstall: true,
       reviewedMultiProductInstallDisplayNamePrefixes: ['Anything'],
       reviewedMultiProductInstallMinimumCount: 2,
+      reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
     });
 
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
+    expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
   });
 
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -100,7 +100,10 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredProcessesToClose: [
       { name: 'opera', description: 'Opera browser' },
     ],
-    reviewedUninstallArguments: ['--runimmediately'],
+    // State the profile-retention choice explicitly. Current Opera builds can
+    // otherwise hand the SYSTEM uninstall to setup.exe without resolving the
+    // profile prompt, leaving the product registration behind.
+    reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
   },
   {
     // The Office Deployment Tool is a self-extracting payload, not an

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -14,6 +14,7 @@ interface ApplicationPackagingAdapter {
   }>;
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
+  reviewedManagedInstallDirectory?: string;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
   reviewedMultiProductInstallMinimumCount?: number;
 }
@@ -100,6 +101,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       { name: 'opera', description: 'Opera browser' },
     ],
     reviewedUninstallArguments: ['--runimmediately'],
+  },
+  {
+    // The Office Deployment Tool is a self-extracting payload, not an
+    // installed application. It intentionally creates no ARP registration.
+    // WinGet extracts it to this machine-wide directory, so verify that exact
+    // payload and remove it directly instead of capturing an unrelated ARP
+    // change made by Windows servicing during the extraction.
+    wingetId: 'Microsoft.OfficeDeploymentTool',
+    reviewedManagedInstallDirectory: '%ProgramW6432%\\OfficeDeploymentTool',
   },
   {
     // EA Desktop's registered EAUninstall.exe helper is unattended, but it
@@ -288,7 +298,8 @@ export function applyApplicationPackagingAdapter(
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
-      !config.reviewedUninstallProcessGuard
+      !config.reviewedUninstallProcessGuard &&
+      !config.reviewedManagedInstallDirectory
     ) return config;
     return {
       ...config,
@@ -296,6 +307,7 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedUninstallProcessGuard: undefined,
+      reviewedManagedInstallDirectory: undefined,
     };
   }
 
@@ -364,6 +376,8 @@ export function applyApplicationPackagingAdapter(
       : {}),
     preserveVendorInstallationOnUninstall:
       adapter.preserveVendorInstallationOnUninstall || undefined,
+    reviewedManagedInstallDirectory:
+      adapter.reviewedManagedInstallDirectory || undefined,
     reviewedMultiProductInstallDisplayNamePrefixes,
     reviewedMultiProductInstallMinimumCount:
       adapter.reviewedMultiProductInstallMinimumCount,

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -15,6 +15,11 @@ interface ApplicationPackagingAdapter {
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedManagedInstallDirectory?: string;
+  reviewedManagedUninstall?: Readonly<{
+    executablePath: string;
+    arguments: readonly string[];
+    completionTimeoutMinutes: number;
+  }>;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
   reviewedMultiProductInstallMinimumCount?: number;
 }
@@ -113,6 +118,28 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // change made by Windows servicing during the extraction.
     wingetId: 'Microsoft.OfficeDeploymentTool',
     reviewedManagedInstallDirectory: '%ProgramW6432%\\OfficeDeploymentTool',
+  },
+  {
+    // Visual Studio 2026 instances are owned by the Visual Studio Installer,
+    // which intentionally creates several component registrations rather than
+    // one ARP entry named after the bootstrapper. Use Microsoft's documented
+    // instance path and setup.exe lifecycle instead of guessing among those
+    // registrations.
+    wingetId: 'Microsoft.VisualStudio.BuildTools',
+    reviewedManagedInstallDirectory:
+      '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+    reviewedManagedUninstall: {
+      executablePath:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+      arguments: [
+        'uninstall',
+        '--installPath',
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+        '--quiet',
+        '--norestart',
+      ],
+      completionTimeoutMinutes: 15,
+    },
   },
   {
     // EA Desktop's registered EAUninstall.exe helper is unattended, but it
@@ -302,7 +329,8 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedUninstallProcessGuard &&
-      !config.reviewedManagedInstallDirectory
+      !config.reviewedManagedInstallDirectory &&
+      !config.reviewedManagedUninstall
     ) return config;
     return {
       ...config,
@@ -311,6 +339,7 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedUninstallProcessGuard: undefined,
       reviewedManagedInstallDirectory: undefined,
+      reviewedManagedUninstall: undefined,
     };
   }
 
@@ -381,6 +410,14 @@ export function applyApplicationPackagingAdapter(
       adapter.preserveVendorInstallationOnUninstall || undefined,
     reviewedManagedInstallDirectory:
       adapter.reviewedManagedInstallDirectory || undefined,
+    reviewedManagedUninstall: adapter.reviewedManagedUninstall
+      ? {
+          executablePath: adapter.reviewedManagedUninstall.executablePath,
+          arguments: [...adapter.reviewedManagedUninstall.arguments],
+          completionTimeoutMinutes:
+            adapter.reviewedManagedUninstall.completionTimeoutMinutes,
+        }
+      : undefined,
     reviewedMultiProductInstallDisplayNamePrefixes,
     reviewedMultiProductInstallMinimumCount:
       adapter.reviewedMultiProductInstallMinimumCount,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -354,6 +354,52 @@ describe('PSADT vendor argument contract', () => {
     }
   );
 
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'uses a reviewed vendor command for a managed installation instance',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Visual Studio BuildTools 2026',
+        [],
+        {
+          reviewedManagedInstallDirectory:
+            '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+          reviewedManagedUninstall: {
+            executablePath:
+              '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+            arguments: [
+              'uninstall',
+              '--installPath',
+              '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+              '--quiet',
+              '--norestart',
+            ],
+            completionTimeoutMinutes: 15,
+          },
+        },
+        [],
+        'Microsoft.VisualStudio.BuildTools'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$managedUninstallArguments = @('uninstall', '--installPath', '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools', '--quiet', '--norestart')"
+      );
+      expect(uninstallFunction).toContain(
+        '$managedUninstallDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(uninstallFunction).not.toContain(
+        'Remove-Item -LiteralPath $managedInstallDirectory'
+      );
+    }
+  );
+
   it('honors additional success exit codes declared by the WinGet manifest', () => {
     if (!canRunWindowsPowerShellPackager) return;
     const generated = generateRegistryUninstallPackage(

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -310,6 +310,50 @@ describe('PSADT vendor argument contract', () => {
     }
   );
 
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies and removes a reviewed self-extracted managed directory without ARP capture',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'Office Deployment Tool',
+        [],
+        { reviewedManagedInstallDirectory: '%ProgramW6432%\\OfficeDeploymentTool' },
+        [],
+        'Microsoft.OfficeDeploymentTool'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramW6432%\\OfficeDeploymentTool')"
+      );
+      expect(installFunction).toContain('Verified managed extracted payload');
+      expect(installFunction).not.toContain('Captured vendor uninstall entry');
+      expect(uninstallFunction).toContain('Remove-Item -LiteralPath $managedInstallDirectory');
+      expect(uninstallFunction).not.toContain('Waiting for vendor uninstall registration');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects an unsafe reviewed managed install directory',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'inno',
+          'Unsafe Extractor',
+          [],
+          { reviewedManagedInstallDirectory: '%ProgramFiles%\\..\\Windows' }
+        )
+      ).toThrow('must be a safe path below a Program Files environment variable');
+    }
+  );
+
   it('honors additional success exit codes declared by the WinGet manifest', () => {
     if (!canRunWindowsPowerShellPackager) return;
     const generated = generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -224,6 +224,12 @@ export interface PSADTConfig {
   // the only trusted source for this value; it is not customer-configurable.
   preserveVendorInstallationOnUninstall?: boolean;
 
+  // Internal lifecycle contract for reviewed self-extracting packages that do
+  // not register an application in Add/Remove Programs. The generated package
+  // verifies this exact directory after install and removes it on uninstall.
+  // Application adapters are the only trusted source for this value.
+  reviewedManagedInstallDirectory?: string;
+
   // Internal install-evidence contract for reviewed bundles that intentionally
   // install several independently registered products. The generated package
   // requires multiple matching ARP entries instead of weakening the ordinary

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -229,6 +229,11 @@ export interface PSADTConfig {
   // verifies this exact directory after install and removes it on uninstall.
   // Application adapters are the only trusted source for this value.
   reviewedManagedInstallDirectory?: string;
+  reviewedManagedUninstall?: {
+    executablePath: string;
+    arguments: string[];
+    completionTimeoutMinutes: number;
+  };
 
   // Internal install-evidence contract for reviewed bundles that intentionally
   // install several independently registered products. The generated package


### PR DESCRIPTION
## Summary
- model reviewed self-extracting tools as managed directory lifecycles
- verify extracted payload files instead of capturing unrelated ARP updates
- remove the exact managed payload directory during Intune uninstall
- apply the Office Deployment Tool adapter to QA and customer packages

## Verification
- 82 targeted tests passed
- targeted ESLint passed
- git diff --check passed
- repository-wide tsc still reports pre-existing test typing failures unrelated to this change