### PR TITLE
Activate managed lifecycle QA release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
+  packagerCommit: '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -55,6 +55,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '2dca138ee2fe27dc45166dba536511aa80d8937e',
   '2eea7f106971cda783665a60eb4d0e25846dae46',
   '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
+  'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -4,6 +4,17 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
   it.each([
+    'Microsoft.OfficeDeploymentTool',
+    'Microsoft.VisualStudio.BuildTools',
+    'Opera.Opera',
+  ])('retries %s once on the managed lifecycle release', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+  });
+
+  it.each([
     'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.SQLServerManagementStudio.22.Preview',
@@ -64,7 +75,7 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Opera.Opera', status: 'failed' }
-    )).toBe(false);
+    )).toBe(true);
   });
 
   it('keeps WebView2 replay scoped to its shared-runtime lifecycle releases', () => {
@@ -98,7 +109,6 @@ describe('QA toolchain targeted retries', () => {
   });
 
   it.each([
-    'Microsoft.VisualStudio.BuildTools',
     'Microsoft.VisualStudio.Community',
     'Microsoft.VisualStudio.Enterprise',
     'Microsoft.VisualStudio.Professional',
@@ -223,9 +233,13 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Camera Hub once after guarding its MSI pre-uninstall helper', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
       { wingetId: 'elgato.camerahub', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'elgato.camerahub', status: 'failed' }
+    )).toBe(false);
   });
 
   it('retries VSTO once with its reviewed external-installer removal switches', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,16 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807': [
+    // These extractors have no single vendor ARP identity. The new managed
+    // directory contract verifies their real payload and removes it through
+    // either exact folder ownership or the documented vendor lifecycle.
+    'Microsoft.OfficeDeploymentTool',
+    'Microsoft.VisualStudio.BuildTools',
+    // Opera now receives an explicit profile-retention choice so its SYSTEM
+    // uninstaller cannot wait behind that unresolved prompt.
+    'Opera.Opera',
+  ],
   'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272': [
     // Camera Hub's MSI launches a fresh --pre-uninstall --quit helper after
     // PSADT closes the desktop process. This release gives only that reviewed


### PR DESCRIPTION
Pins QA profile generation to the merged managed extractor lifecycle packager release. Adds bounded retries only for Office Deployment Tool, Visual Studio Build Tools, and Opera failures affected by that release, while retaining the prior release in compatibility history. Both customer uploads and QA profiles resolve through the same pinned packager commit.\n\nValidation: 104 targeted tests passed; targeted ESLint passed; git diff --check passed.