### PR TITLE
Support ASP.NET Core package dependencies

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -74,9 +74,10 @@ foreach ($dependency in $PackageDependencies) {
     $dependencyInstallerType = ([string]$dependency.installerType).ToLowerInvariant()
     $isVCRedistributable = $dependencyIdentifier -match '^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(x86|x64|arm64)$'
     $isDotNetDesktopRuntime = $dependencyIdentifier -match '^Microsoft\.DotNet\.DesktopRuntime\.\d+$'
+    $isDotNetAspNetCoreRuntime = $dependencyIdentifier -match '^Microsoft\.DotNet\.AspNetCore\.\d+$'
     $isPowerShell = $dependencyIdentifier -eq 'Microsoft.PowerShell'
     $isVCLibsDesktop = $dependencyIdentifier -eq 'Microsoft.VCLibs.Desktop.14'
-    if (-not ($isVCRedistributable -or $isDotNetDesktopRuntime -or $isPowerShell -or $isVCLibsDesktop)) {
+    if (-not ($isVCRedistributable -or $isDotNetDesktopRuntime -or $isDotNetAspNetCoreRuntime -or $isPowerShell -or $isVCLibsDesktop)) {
         throw "Package dependency is not in the reviewed redistribution allowlist: $($dependency.packageIdentifier)"
     }
     $reviewedInstallerTypes = if ($isPowerShell) {

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -189,6 +189,41 @@ describe('resolveWingetPackageDependencies', () => {
     });
   });
 
+  it('bundles a reviewed ASP.NET Core Runtime Burn prerequisite', async () => {
+    const io = fixtureIo(
+      {
+        'Example.App@1.0.0': [installer({
+          packageDependencies: [{
+            packageIdentifier: 'Microsoft.DotNet.AspNetCore.8',
+            minimumVersion: '8.0.29',
+          }],
+        })],
+        'Microsoft.DotNet.AspNetCore.8@8.0.30': [installer({
+          type: 'burn',
+          url: 'https://download.microsoft.com/aspnetcore-runtime-8.0.30-win-x64.exe',
+          sha256: VC_SHA,
+          silentArgs: '/quiet /norestart',
+        })],
+      },
+      { 'Microsoft.DotNet.AspNetCore.8': ['8.0.30'] }
+    );
+
+    const [dependency] = await resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+    }, io);
+
+    expect(dependency).toMatchObject({
+      packageIdentifier: 'Microsoft.DotNet.AspNetCore.8',
+      minimumVersion: '8.0.29',
+      version: '8.0.30',
+      installerType: 'burn',
+      silentArgs: '/quiet /norestart',
+    });
+  });
+
   it('selects the reviewed PowerShell Wix installer instead of its MSIX variant', async () => {
     const io = fixtureIo(
       {

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -22,6 +22,8 @@ const VC_REDISTRIBUTABLE_PACKAGE_PATTERN =
   /^Microsoft\.VCRedist\.[A-Za-z0-9+.-]+\.(?:x86|x64|arm64)$/i;
 const DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN =
   /^Microsoft\.DotNet\.DesktopRuntime\.\d+$/i;
+const DOTNET_ASPNETCORE_RUNTIME_PACKAGE_PATTERN =
+  /^Microsoft\.DotNet\.AspNetCore\.\d+$/i;
 const VCLIBS_DESKTOP_PACKAGE_PATTERN = /^Microsoft\.VCLibs\.Desktop\.14$/i;
 
 interface PackageDependencyReference {
@@ -54,6 +56,10 @@ const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
   },
   {
     packagePattern: DOTNET_DESKTOP_RUNTIME_PACKAGE_PATTERN,
+    installerTypes: new Set<WingetInstallerType>(['exe', 'burn']),
+  },
+  {
+    packagePattern: DOTNET_ASPNETCORE_RUNTIME_PACKAGE_PATTERN,
     installerTypes: new Set<WingetInstallerType>(['exe', 'burn']),
   },
   {


### PR DESCRIPTION
Adds the official Microsoft.DotNet.AspNetCore.<major> WinGet dependency family to the fail-closed redistribution policy. The resolver and PSADT packager accept only EXE/Burn installers, while retaining HTTPS, SHA-256, architecture, depth, count, and silent-command validation. This unblocks Veeam Agent through the same dependency bundle used by customer and QA packages.\n\nValidation: 12 dependency resolver tests passed; targeted ESLint passed; git diff --check passed.