### PR TITLE
Activate ASP.NET Core dependency release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
+  packagerCommit: '5f95d233998479791a49d1d784ea95137c098e73',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -56,6 +56,8 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '2eea7f106971cda783665a60eb4d0e25846dae46',
   '54515b6566ff4e7c9040fa24a8eba6b6347ef09e',
   'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
+  '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
+  'd0051e4b3972e9511935398e8b4f4e93e6289edd',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,12 +6,15 @@ describe('QA toolchain targeted retries', () => {
   it.each([
     'Microsoft.OfficeDeploymentTool',
     'Microsoft.VisualStudio.BuildTools',
-    'Opera.Opera',
-  ])('retries %s once on the managed lifecycle release', (wingetId) => {
+  ])('keeps the managed lifecycle retry scoped to its release for %s', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
-    )).toBe(true);
+    )).toBe(false);
   });
 
   it.each([

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '5f95d233998479791a49d1d784ea95137c098e73': [
+    // Opera's registered slash-form uninstall verb exits without removing the
+    // product. This release invokes the reviewed double-dash launcher command
+    // exactly and verifies that the machine installation directory disappears.
+    'Opera.Opera',
+  ],
   '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807': [
     // These extractors have no single vendor ARP identity. The new managed
     // directory contract verifies their real payload and removes it through


### PR DESCRIPTION
Pins package-profile generation to the merged ASP.NET Core dependency release and retains the prior managed-lifecycle release in compatibility history. Historical lifecycle retries remain scoped to the release that fixed them.\n\nValidation: 104 targeted tests passed; targeted ESLint passed; git diff --check passed.