### PR TITLE
Fix Opera managed uninstall lifecycle

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -504,10 +504,12 @@ describe('GET /api/cron/qa-enqueue', () => {
         profileKind: 'catalog-default',
         psadtConfig: {
           processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-          reviewedUninstallArguments: [
-            '--runimmediately',
-            '--deleteuserprofile=0',
-          ],
+          reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
+          reviewedManagedUninstall: {
+            executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+            arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+            completionTimeoutMinutes: 5,
+          },
         },
       },
     });

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -594,7 +594,12 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     const expectedAdapter = {
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
+      reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+        arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+        completionTimeoutMinutes: 5,
+      },
     };
     expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
       expectedAdapter

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -43,7 +43,12 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
+      reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+        arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+        completionTimeoutMinutes: 5,
+      },
     });
     expect(
       applyApplicationPackagingAdapter(
@@ -207,7 +212,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual(['/s', '--custom']);
   });
 
-  it('preserves customer Opera lifecycle settings while adding the reviewed immediate removal contract', () => {
+  it('preserves customer Opera process settings while enforcing the exact reviewed removal contract', () => {
     const adapted = applyApplicationPackagingAdapter('opera.opera', {
       ...DEFAULT_PSADT_CONFIG,
       processesToClose: [
@@ -219,11 +224,13 @@ describe('application packaging adapters', () => {
     expect(adapted.processesToClose).toEqual([
       { name: 'Opera', description: 'Customer browser session' },
     ]);
-    expect(adapted.reviewedUninstallArguments).toEqual([
-      '--RUNIMMEDIATELY',
-      '--custom',
-      '--deleteuserprofile=0',
-    ]);
+    expect(adapted.reviewedUninstallArguments).toEqual(['--RUNIMMEDIATELY', '--custom']);
+    expect(adapted.reviewedManagedInstallDirectory).toBe('%ProgramFiles%\\Opera');
+    expect(adapted.reviewedManagedUninstall).toEqual({
+      executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+      arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+      completionTimeoutMinutes: 5,
+    });
   });
 
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -96,19 +96,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/silent', 'forall'],
   },
   {
-    // Opera registers `opera.exe --uninstall`, which waits for confirmation
-    // unless --runimmediately is supplied. Opera removed support for its old
-    // silent switch, so use the vendor's current unattended-start argument
-    // without deleting user profiles. Close the browser first so both upgrades
-    // and removals can complete deterministically.
+    // Opera registers `opera.exe /uninstall`, but its current launcher expects
+    // the double-dash uninstall verb for a non-interactive removal. Appending
+    // unattended arguments to the registered slash command exits successfully
+    // without removing the application. Execute the reviewed launcher command
+    // exactly and verify that its machine installation directory disappears.
+    // Keep the browser profile and close the browser before upgrades/removals.
     wingetId: 'Opera.Opera',
     requiredProcessesToClose: [
       { name: 'opera', description: 'Opera browser' },
     ],
-    // State the profile-retention choice explicitly. Current Opera builds can
-    // otherwise hand the SYSTEM uninstall to setup.exe without resolving the
-    // profile prompt, leaving the product registration behind.
-    reviewedUninstallArguments: ['--runimmediately', '--deleteuserprofile=0'],
+    reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
+    reviewedManagedUninstall: {
+      executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+      arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+      completionTimeoutMinutes: 5,
+    },
   },
   {
     // The Office Deployment Tool is a self-extracting payload, not an


### PR DESCRIPTION
## Summary
- invoke Opera's reviewed double-dash uninstall command exactly
- preserve user profiles while verifying the machine install directory is removed
- apply the adapter to the shared customer and QA PSADT packaging path

## Validation
- 22 packaging-adapter tests pass
- 83 focused packaging tests pass