### PR TITLE
Verify exact vendor uninstall commands by registration

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -511,6 +511,55 @@ if ($psadtConfig.Contains('reviewedManagedUninstall') -and
     $reviewedManagedUninstallConfigured = $true
 }
 
+$reviewedExactUninstallConfigured = $false
+$reviewedExactUninstallExecutable = ''
+$reviewedExactUninstallArguments = @()
+$reviewedExactUninstallTimeoutMinutes = 0
+if ($psadtConfig.Contains('reviewedExactUninstall') -and
+    $null -ne $psadtConfig['reviewedExactUninstall']) {
+    $rawExactUninstall = $psadtConfig['reviewedExactUninstall']
+    if ($rawExactUninstall -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedExactUninstall must be an object.'
+    }
+    $reviewedExactUninstallExecutable = ([string]$rawExactUninstall['executablePath']).Trim()
+    if ($reviewedExactUninstallExecutable.Length -gt 260 -or
+        $reviewedExactUninstallExecutable -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
+        @($reviewedExactUninstallExecutable -split '\\') -contains '..') {
+        throw 'PSADT reviewedExactUninstall.executablePath must be a safe executable below a Program Files environment variable.'
+    }
+    $rawExactUninstallArguments = $rawExactUninstall['arguments']
+    if ($rawExactUninstallArguments -is [string] -or
+        $rawExactUninstallArguments -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedExactUninstall.arguments must be an array.'
+    }
+    foreach ($rawExactUninstallArgument in @($rawExactUninstallArguments)) {
+        if ($rawExactUninstallArgument -isnot [string]) {
+            throw 'Every PSADT reviewed exact uninstall argument must be a string.'
+        }
+        $exactUninstallArgument = $rawExactUninstallArgument.Trim()
+        if ([string]::IsNullOrWhiteSpace($exactUninstallArgument) -or
+            $exactUninstallArgument.Length -gt 260 -or
+            [regex]::IsMatch($exactUninstallArgument, '[\x00-\x1F\x7F]')) {
+            throw 'Every PSADT reviewed exact uninstall argument must be non-empty, bounded, and single-line.'
+        }
+        $reviewedExactUninstallArguments += $exactUninstallArgument
+    }
+    if ($reviewedExactUninstallArguments.Count -gt 20) {
+        throw 'PSADT reviewedExactUninstall.arguments must contain at most 20 entries.'
+    }
+    $rawExactUninstallTimeoutMinutes = $rawExactUninstall['completionTimeoutMinutes']
+    if (($rawExactUninstallTimeoutMinutes -isnot [byte] -and
+         $rawExactUninstallTimeoutMinutes -isnot [int16] -and
+         $rawExactUninstallTimeoutMinutes -isnot [int32] -and
+         $rawExactUninstallTimeoutMinutes -isnot [int64]) -or
+        [int]$rawExactUninstallTimeoutMinutes -lt 1 -or
+        [int]$rawExactUninstallTimeoutMinutes -gt 60) {
+        throw 'PSADT reviewedExactUninstall.completionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+    $reviewedExactUninstallTimeoutMinutes = [int]$rawExactUninstallTimeoutMinutes
+    $reviewedExactUninstallConfigured = $true
+}
+
 function ConvertTo-PSADTConfigValue {
     param(
         [AllowNull()][string]$Value,
@@ -762,6 +811,10 @@ $reviewedManagedInstallDirectoryEscaped = $reviewedManagedInstallDirectory -repl
 $reviewedManagedUninstallExecutableEscaped = $reviewedManagedUninstallExecutable -replace "'", "''"
 $reviewedManagedUninstallArgumentsLiteral = @(
     $reviewedManagedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
+) -join ', '
+$reviewedExactUninstallExecutableEscaped = $reviewedExactUninstallExecutable -replace "'", "''"
+$reviewedExactUninstallArgumentsLiteral = @(
+    $reviewedExactUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
@@ -2368,6 +2421,20 @@ if ($preUninstallPromptCalls) {
 # precedence because executing the vendor command could remove a prerequisite
 # used by Windows or unrelated applications. The ordinary marker cleanup below
 # still makes Intune's exact package detection transition to not installed.
+$reviewedExactUninstallOverrideLines = @(
+    '    $useReviewedExactUninstall = $false'
+)
+if ($reviewedExactUninstallConfigured) {
+    $reviewedExactUninstallOverrideLines += @(
+        '    $useReviewedExactUninstall = $true'
+        "    `$registeredUninstallFile = [Environment]::ExpandEnvironmentVariables('$reviewedExactUninstallExecutableEscaped')"
+        "    [string[]]`$registeredUninstallArguments = @($reviewedExactUninstallArgumentsLiteral) | ForEach-Object { [Environment]::ExpandEnvironmentVariables(`$_) }"
+        '    $hasQuietUninstall = $true'
+        '    $isVivaldiUninstall = $false'
+        '    $isAdobeCreativeCloudUninstall = $false'
+        '    Write-ADTLogEntry -Message "Using the reviewed exact vendor uninstall command [$registeredUninstallFile]." -Source ''Uninstall-ADTDeployment'''
+    )
+}
 if ($useManagedDirectoryLifecycle) {
     Write-Host 'Using reviewed managed-directory removal'
     $lines += @('', "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')")
@@ -2568,6 +2635,7 @@ if ($useManagedDirectoryLifecycle) {
             '    $registeredUninstallFile = [string]$registeredApplication."$($registeredUninstallProperty)FilePath"'
             '    $isAdobeCreativeCloudUninstall = (Split-Path -Leaf $registeredUninstallFile) -ieq ''Creative Cloud Uninstaller.exe'''
             '    [string[]]$registeredUninstallArguments = @($registeredApplication."$($registeredUninstallProperty)ArgumentList" | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })'
+            $reviewedExactUninstallOverrideLines
             '    $registeredArgumentText = ($registeredUninstallArguments -join '' '').Trim()'
             '    if (-not $hasQuietUninstall) {'
             ''
@@ -2628,9 +2696,11 @@ if ($useManagedDirectoryLifecycle) {
             '            Write-ADTLogEntry -Message "Executing the Adobe Creative Cloud desktop client silent uninstall command." -Source ''Uninstall-ADTDeployment'''
             '        }'
             "        `$reviewedUninstallArguments = @($reviewedUninstallArgumentsLiteral)"
-            '        foreach ($reviewedArgument in $reviewedUninstallArguments) {'
-            '            if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {'
-            '                $registeredUninstallArguments += $reviewedArgument'
+            '        if (-not $useReviewedExactUninstall) {'
+            '            foreach ($reviewedArgument in $reviewedUninstallArguments) {'
+            '                if (@($registeredUninstallArguments | Where-Object { [string]$_ -ieq $reviewedArgument }).Count -eq 0) {'
+            '                    $registeredUninstallArguments += $reviewedArgument'
+            '                }'
             '            }'
             '        }'
             '        $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile'
@@ -2667,7 +2737,8 @@ if ($useManagedDirectoryLifecycle) {
             '        if ($registeredUninstallArguments.Count -gt 0) {'
             '            $uninstallProcessParameters.ArgumentList = $registeredUninstallArguments'
             '        }'
-            "        `$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($uninstallCompletionTimeoutMinutes)"
+            "        `$effectiveUninstallCompletionTimeoutMinutes = if (`$useReviewedExactUninstall) { $reviewedExactUninstallTimeoutMinutes } else { $uninstallCompletionTimeoutMinutes }"
+            '        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes($effectiveUninstallCompletionTimeoutMinutes)'
             '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
             '        $uninstallProcessExitLogged = $false'
             '        $nextUninstallProgressLog = [DateTime]::UtcNow'

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -504,8 +504,7 @@ describe('GET /api/cron/qa-enqueue', () => {
         profileKind: 'catalog-default',
         psadtConfig: {
           processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-          reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
-          reviewedManagedUninstall: {
+          reviewedExactUninstall: {
             executablePath: '%ProgramFiles%\\Opera\\opera.exe',
             arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
             completionTimeoutMinutes: 5,

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -594,8 +594,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     const expectedAdapter = {
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
-      reviewedManagedUninstall: {
+      reviewedExactUninstall: {
         executablePath: '%ProgramFiles%\\Opera\\opera.exe',
         arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
         completionTimeoutMinutes: 5,

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -43,8 +43,7 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],
-      reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
-      reviewedManagedUninstall: {
+      reviewedExactUninstall: {
         executablePath: '%ProgramFiles%\\Opera\\opera.exe',
         arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
         completionTimeoutMinutes: 5,
@@ -169,6 +168,11 @@ describe('application packaging adapters', () => {
         arguments: ['/quiet'],
         completionTimeoutMinutes: 5,
       },
+      reviewedExactUninstall: {
+        executablePath: '%ProgramFiles%\\Example\\exact-uninstall.exe',
+        arguments: ['/quiet'],
+        completionTimeoutMinutes: 5,
+      },
     });
 
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
@@ -176,6 +180,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
     expect(adapted.reviewedManagedUninstall).toBeUndefined();
+    expect(adapted.reviewedExactUninstall).toBeUndefined();
   });
 
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {
@@ -225,8 +230,7 @@ describe('application packaging adapters', () => {
       { name: 'Opera', description: 'Customer browser session' },
     ]);
     expect(adapted.reviewedUninstallArguments).toEqual(['--RUNIMMEDIATELY', '--custom']);
-    expect(adapted.reviewedManagedInstallDirectory).toBe('%ProgramFiles%\\Opera');
-    expect(adapted.reviewedManagedUninstall).toEqual({
+    expect(adapted.reviewedExactUninstall).toEqual({
       executablePath: '%ProgramFiles%\\Opera\\opera.exe',
       arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
       completionTimeoutMinutes: 5,

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -20,6 +20,11 @@ interface ApplicationPackagingAdapter {
     arguments: readonly string[];
     completionTimeoutMinutes: number;
   }>;
+  reviewedExactUninstall?: Readonly<{
+    executablePath: string;
+    arguments: readonly string[];
+    completionTimeoutMinutes: number;
+  }>;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
   reviewedMultiProductInstallMinimumCount?: number;
 }
@@ -100,14 +105,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // the double-dash uninstall verb for a non-interactive removal. Appending
     // unattended arguments to the registered slash command exits successfully
     // without removing the application. Execute the reviewed launcher command
-    // exactly and verify that its machine installation directory disappears.
-    // Keep the browser profile and close the browser before upgrades/removals.
+    // exactly and retain the captured ARP identity as the completion signal.
+    // Opera removes its browser registration but intentionally leaves a small
+    // assistant payload, so directory disappearance would be a false failure.
+    // Keep the browser profile and close it before upgrades/removals.
     wingetId: 'Opera.Opera',
     requiredProcessesToClose: [
       { name: 'opera', description: 'Opera browser' },
     ],
-    reviewedManagedInstallDirectory: '%ProgramFiles%\\Opera',
-    reviewedManagedUninstall: {
+    reviewedExactUninstall: {
       executablePath: '%ProgramFiles%\\Opera\\opera.exe',
       arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
       completionTimeoutMinutes: 5,
@@ -333,7 +339,8 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedUninstallProcessGuard &&
       !config.reviewedManagedInstallDirectory &&
-      !config.reviewedManagedUninstall
+      !config.reviewedManagedUninstall &&
+      !config.reviewedExactUninstall
     ) return config;
     return {
       ...config,
@@ -343,6 +350,7 @@ export function applyApplicationPackagingAdapter(
       reviewedUninstallProcessGuard: undefined,
       reviewedManagedInstallDirectory: undefined,
       reviewedManagedUninstall: undefined,
+      reviewedExactUninstall: undefined,
     };
   }
 
@@ -419,6 +427,14 @@ export function applyApplicationPackagingAdapter(
           arguments: [...adapter.reviewedManagedUninstall.arguments],
           completionTimeoutMinutes:
             adapter.reviewedManagedUninstall.completionTimeoutMinutes,
+        }
+      : undefined,
+    reviewedExactUninstall: adapter.reviewedExactUninstall
+      ? {
+          executablePath: adapter.reviewedExactUninstall.executablePath,
+          arguments: [...adapter.reviewedExactUninstall.arguments],
+          completionTimeoutMinutes:
+            adapter.reviewedExactUninstall.completionTimeoutMinutes,
         }
       : undefined,
     reviewedMultiProductInstallDisplayNamePrefixes,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -311,6 +311,44 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses a reviewed exact vendor command while retaining ARP completion verification',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Opera Stable',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath: '%ProgramFiles%\\Opera\\opera.exe',
+            arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Opera.Opera'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\Opera\\opera.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallArguments = @('--uninstall', '--runimmediately', '--deleteuserprofile=0')"
+      );
+      expect(uninstallFunction).toContain(
+        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 5 }'
+      );
+      expect(uninstallFunction).toContain(
+        'Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed.'
+      );
+      expect(uninstallFunction).not.toContain('Using reviewed managed-directory removal');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'verifies and removes a reviewed self-extracted managed directory without ARP capture',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -235,6 +235,15 @@ export interface PSADTConfig {
     completionTimeoutMinutes: number;
   };
 
+  // Internal exact-command contract for a reviewed vendor uninstaller whose
+  // registered command is interactive or syntactically incorrect. The normal
+  // captured ARP identity remains the authoritative completion signal.
+  reviewedExactUninstall?: {
+    executablePath: string;
+    arguments: string[];
+    completionTimeoutMinutes: number;
+  };
+
   // Internal install-evidence contract for reviewed bundles that intentionally
   // install several independently registered products. The generated package
   // requires multiple matching ARP entries instead of weakening the ordinary


### PR DESCRIPTION
## Summary
- add a trusted exact vendor uninstall contract that retains the captured ARP identity as the completion signal
- move Opera to its exact double-dash launcher command without requiring its assistant directory to disappear
- apply the same shared adapter and generated PSADT lifecycle to QA and customer Intune packages

## Validation
- 129 focused adapter, packager contract, enqueue, and customer package tests pass