### PR TITLE
Activate exact vendor uninstall release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '5f95d233998479791a49d1d784ea95137c098e73',
+  packagerCommit: '8235887e7126972b89c264e2053c1c4f7418ea74',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -58,6 +58,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'cf24633576b6c5efcca5fbde8ffe7fb4f0f57272',
   '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
   'd0051e4b3972e9511935398e8b4f4e93e6289edd',
+  '5f95d233998479791a49d1d784ea95137c098e73',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '8235887e7126972b89c264e2053c1c4f7418ea74': [
+    // Opera removes its product registration while retaining a small assistant
+    // payload. This release verifies the exact ARP identity after running the
+    // reviewed launcher command instead of waiting for the directory to vanish.
+    'Opera.Opera',
+  ],
   '5f95d233998479791a49d1d784ea95137c098e73': [
     // Opera's registered slash-form uninstall verb exits without removing the
     // product. This release invokes the reviewed double-dash launcher command


### PR DESCRIPTION
## Summary
- pin QA profiles to the exact vendor uninstall release
- preserve release compatibility history
- replay only Opera's corrected lifecycle once

## Validation
- 103 focused QA profile, retry, and enqueue tests pass