### PR TITLE
Fix Viber per-user packaging scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -11,6 +11,8 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Makeblock.xToolStudio', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' makeblock.xtoolstudio ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope('Rakuten.Viber', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' rakuten.viber ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -86,6 +86,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Viber's MSI is declared machine-scope by WinGet, but its Directory
+    // table targets LocalAppData. Under LocalSystem that resolves to the
+    // system profile and the vendor's VerifyInstalledFiles action rolls the
+    // installation back with 1603. Run the same PSADT package in the signed-in
+    // user's context so both the application and its uninstall registration
+    // belong to the intended user instead of the disposable system profile.
+    wingetId: 'Rakuten.Viber',
+    requiredInstallScope: 'user',
+  },
+  {
     // Analog Devices documents this enterprise/server mode for silent SYSTEM
     // deployment. It prevents the MSI from extracting example data into the
     // LocalSystem AppData profile, which otherwise rolls back with exit 1603.


### PR DESCRIPTION
## Summary
- treat Viber's LocalAppData MSI as a reviewed per-user package
- prevent LocalSystem/systemprofile installs that roll back in the vendor VerifyInstalledFiles action
- apply the same scope to customer Intune packaging and QA profiles

## Verification
- 65 focused Vitest tests passed
- ESLint passed for changed files
- captured vendor MSI failure at VerifyInstalledFiles with exit 1603 under LocalSystem