### PR TITLE
Activate Viber user-scope packaging

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8235887e7126972b89c264e2053c1c4f7418ea74',
+  packagerCommit: '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -59,6 +59,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
   'd0051e4b3972e9511935398e8b4f4e93e6289edd',
   '5f95d233998479791a49d1d784ea95137c098e73',
+  '8235887e7126972b89c264e2053c1c4f7418ea74',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -76,8 +76,19 @@ describe('QA toolchain targeted retries', () => {
       { wingetId: 'Opera.Opera', status: 'failed' }
     )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(
+      '8235887e7126972b89c264e2053c1c4f7418ea74',
+      { wingetId: 'Opera.Opera', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Opera.Opera', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Viber once on the reviewed user-scope release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Rakuten.Viber', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea': [
+    // Viber's machine-declared MSI resolves LocalAppData into the SYSTEM
+    // profile and its VerifyInstalledFiles action then fails with 1603. The
+    // shared adapter now packages this vendor installer in reviewed user scope.
+    'Rakuten.Viber',
+  ],
   '8235887e7126972b89c264e2053c1c4f7418ea74': [
     // Opera removes its product registration while retaining a small assistant
     // payload. This release verifies the exact ARP identity after running the


### PR DESCRIPTION
Pins the shared QA and customer packager to the reviewed Viber user-scope adapter release and schedules only Rakuten.Viber for a terminal retry.\n\nVerified: 149 focused Vitest tests and ESLint.