### PR TITLE
Fix self-host Supabase migrations and bootstrap user_profiles

### DIFF
--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -1,252 +1,48 @@
 # Database Setup
 
-This guide covers configuring Supabase for IntuneGet.
+IntuneGet uses Supabase PostgreSQL for application state, catalog data, and server-side Microsoft authentication data.
 
-## Overview
+## Apply the migrations
 
-IntuneGet uses Supabase (PostgreSQL) for:
-- Storing deployment status and history
-- Real-time updates via Supabase Realtime
-- App catalog metadata
-
-## Options
-
-### Option 1: Supabase Cloud (Recommended)
-
-Easiest option with a generous free tier.
-
-1. Create account at [supabase.com](https://supabase.com)
-2. Create a new project
-3. Run migrations
-4. Copy credentials to environment
-
-### Option 2: Self-Hosted Supabase
-
-For enterprises requiring data sovereignty.
-
-See [Supabase Self-Hosting Docs](https://supabase.com/docs/guides/self-hosting)
-
-### Option 3: Plain PostgreSQL
-
-IntuneGet can work with plain PostgreSQL, but you'll lose:
-- Real-time subscriptions (deployment status updates)
-- Supabase Auth (if used in future)
-- Supabase Studio for management
-
-## Supabase Cloud Setup
-
-### Step 1: Create Project
-
-1. Go to [supabase.com](https://supabase.com)
-2. Sign up or log in
-3. Click **New Project**
-4. Fill in:
-   - **Name**: `intuneget`
-   - **Database Password**: Generate a strong password
-   - **Region**: Choose closest to your users
-5. Click **Create new project**
-6. Wait for project to provision
-
-### Step 2: Run Migrations
-
-The database schema is defined in `supabase/migrations/`.
-
-**Option A: Using Supabase CLI**
+The supported setup path is the Supabase CLI. It applies the files in `supabase/migrations/` in filename order and records migration history.
 
 ```bash
-# Install Supabase CLI
 npm install -g supabase
-
-# Login to Supabase
 supabase login
-
-# Link to your project
 supabase link --project-ref your-project-ref
-
-# Run migrations
 supabase db push
 ```
 
-**Option B: Using SQL Editor**
+Always start with `000_user_profiles.sql`. This migration creates the profile table required for authentication and token persistence.
 
-1. Go to your Supabase project dashboard
-2. Click **SQL Editor** in the left menu
-3. Open each file in `supabase/migrations/` in order
-4. Copy contents and run in SQL Editor
+If you must use the Supabase SQL Editor, run every file in `supabase/migrations/` in exact lexicographic filename order. The directory contains duplicate numeric prefixes, including two `014_` files and two `015_` files. The complete filename, not just its numeric prefix, determines the order. Do not rename existing migrations because their filenames are part of Supabase migration history.
 
-### Step 3: Get Credentials
+## Credentials
 
-1. Go to **Settings** > **API** in your Supabase dashboard
-2. Copy these values:
+From **Settings > API** in the Supabase dashboard, configure:
 
-| Setting | Environment Variable |
-|---------|---------------------|
+| Supabase value | Environment variable |
+|---|---|
 | Project URL | `NEXT_PUBLIC_SUPABASE_URL` |
-| anon public | `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
-| service_role | `SUPABASE_SERVICE_ROLE_KEY` |
+| Anonymous key | `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
+| Service role key | `SUPABASE_SERVICE_ROLE_KEY` |
 
-## Database Schema
+Keep the service role key server-side. The `user_profiles` table contains Microsoft access and refresh tokens and is accessible only to the service role through row level security.
 
-### Tables
+## Core tables
 
-#### `deployments`
+- `user_profiles`: Microsoft identity profile, tenant, and token persistence
+- `packaging_jobs`: packaging and Intune upload job state
+- `curated_apps`: curated application catalog metadata
 
-Tracks all deployment requests and their status.
+Additional feature tables are introduced by later migrations. Treat [`supabase/migrations/`](../supabase/migrations/) as the source of truth for the current schema.
 
-```sql
-CREATE TABLE deployments (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW(),
-  user_id TEXT NOT NULL,
-  tenant_id TEXT NOT NULL,
-  app_id TEXT NOT NULL,
-  app_name TEXT NOT NULL,
-  status TEXT DEFAULT 'pending',
-  error_message TEXT,
-  intune_app_id TEXT,
-  workflow_run_id TEXT
-);
-```
+## Updating an installation
 
-#### `apps`
-
-Stores app catalog metadata.
-
-```sql
-CREATE TABLE apps (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  publisher TEXT,
-  version TEXT,
-  description TEXT,
-  icon_url TEXT,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW()
-);
-```
-
-### Row Level Security (RLS)
-
-RLS policies ensure users can only access their own data:
-
-```sql
--- Users can only see their own deployments
-CREATE POLICY "Users can view own deployments"
-  ON deployments FOR SELECT
-  USING (auth.uid()::text = user_id);
-
--- Service role can insert/update all deployments
-CREATE POLICY "Service can manage deployments"
-  ON deployments FOR ALL
-  USING (auth.role() = 'service_role');
-```
-
-## Real-Time Configuration
-
-IntuneGet uses Supabase Realtime for live deployment status updates.
-
-### Enable Realtime
-
-1. Go to **Database** > **Replication** in Supabase dashboard
-2. Enable replication for the `deployments` table
-
-### Client Configuration
-
-The app subscribes to deployment updates:
-
-```typescript
-supabase
-  .channel('deployments')
-  .on('postgres_changes', {
-    event: 'UPDATE',
-    schema: 'public',
-    table: 'deployments',
-    filter: `user_id=eq.${userId}`
-  }, handleUpdate)
-  .subscribe()
-```
-
-## Backup and Recovery
-
-### Automated Backups (Supabase Cloud)
-
-- Free tier: Daily backups, 7-day retention
-- Pro tier: Point-in-time recovery
-
-### Manual Backup
-
-```bash
-# Using pg_dump
-pg_dump -h db.your-project.supabase.co \
-  -U postgres \
-  -d postgres \
-  -F c \
-  -f backup.dump
-
-# Restore
-pg_restore -h db.your-project.supabase.co \
-  -U postgres \
-  -d postgres \
-  backup.dump
-```
-
-## Performance Optimization
-
-### Indexes
-
-Recommended indexes for production:
-
-```sql
--- Speed up deployment queries by user
-CREATE INDEX idx_deployments_user_id ON deployments(user_id);
-
--- Speed up deployment queries by tenant
-CREATE INDEX idx_deployments_tenant_id ON deployments(tenant_id);
-
--- Speed up status filtering
-CREATE INDEX idx_deployments_status ON deployments(status);
-
--- Composite index for common queries
-CREATE INDEX idx_deployments_user_status ON deployments(user_id, status);
-```
-
-### Connection Pooling
-
-For high-traffic deployments, use Supabase's connection pooler:
-
-1. Go to **Settings** > **Database**
-2. Copy the **Connection pooling** URL
-3. Use for server-side connections
+After pulling a newer release, run `supabase db push` again to apply migrations that are not yet in the linked database's migration history.
 
 ## Troubleshooting
 
-### "Permission denied" errors
-
-Check RLS policies are correctly configured:
-
-```sql
--- View existing policies
-SELECT * FROM pg_policies WHERE tablename = 'deployments';
-```
-
-### Real-time not working
-
-1. Verify table is enabled for replication
-2. Check browser console for WebSocket errors
-3. Verify `NEXT_PUBLIC_SUPABASE_ANON_KEY` is correct
-
-### Connection timeouts
-
-1. Check if project is paused (free tier pauses after inactivity)
-2. Verify network allows connections to Supabase
-3. Check connection string is correct
-
-## Migration from Other Databases
-
-If migrating from another database:
-
-1. Export data in CSV format
-2. Use Supabase import tools or `COPY` command
-3. Verify data integrity
-4. Update application configuration
+- Confirm `000_user_profiles.sql` was applied before migrations that reference `user_profiles`.
+- Confirm the project URL and keys belong to the same Supabase project.
+- For manual execution, check that no migration filename was skipped and that files were run in lexicographic order.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -215,11 +215,11 @@ The app registration is still used for interactive user sign-in.
 
 ### 1. Database Setup
 
-See [DATABASE_SETUP.md](DATABASE_SETUP.md) for detailed Supabase configuration.
+See [DATABASE_SETUP.md](DATABASE_SETUP.md) for the supported migration procedure and detailed Supabase configuration. The `000_user_profiles.sql` migration is required for authentication and Microsoft token persistence.
 
 Quick start:
 1. Create a Supabase project at [supabase.com](https://supabase.com)
-2. Run the SQL migrations from the `supabase/migrations` folder
+2. Apply the migrations from `supabase/migrations` in filename order, starting with `000_user_profiles.sql`
 3. Copy the project URL and keys to your `.env.local`
 
 ### 2. Azure AD Setup

--- a/supabase/migrations/000_user_profiles.sql
+++ b/supabase/migrations/000_user_profiles.sql
@@ -1,0 +1,42 @@
+-- IntuneGet: User Profiles Schema
+-- Stores Microsoft identity details and tokens used by server-side authentication.
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id TEXT PRIMARY KEY,
+  email TEXT,
+  name TEXT,
+  microsoft_access_token TEXT,
+  microsoft_refresh_token TEXT,
+  token_expires_at TIMESTAMPTZ,
+  intune_tenant_id TEXT,
+  tenant_name TEXT,
+  profile_image TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role has full access to user_profiles" ON user_profiles;
+
+CREATE POLICY "Service role has full access to user_profiles"
+ON user_profiles
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE OR REPLACE FUNCTION update_user_profiles_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_user_profiles_updated_at ON user_profiles;
+
+CREATE TRIGGER update_user_profiles_updated_at
+  BEFORE UPDATE ON user_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_user_profiles_updated_at();

--- a/supabase/migrations/014_sccm_migration.sql
+++ b/supabase/migrations/014_sccm_migration.sql
@@ -237,23 +237,28 @@ ALTER TABLE sccm_winget_mappings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE sccm_migration_history ENABLE ROW LEVEL SECURITY;
 
 -- Service role has full access
+DROP POLICY IF EXISTS "Service role full access sccm_migrations" ON sccm_migrations;
 CREATE POLICY "Service role full access sccm_migrations"
   ON sccm_migrations FOR ALL
   USING (auth.role() = 'service_role');
 
+DROP POLICY IF EXISTS "Service role full access sccm_apps" ON sccm_apps;
 CREATE POLICY "Service role full access sccm_apps"
   ON sccm_apps FOR ALL
   USING (auth.role() = 'service_role');
 
+DROP POLICY IF EXISTS "Service role full access sccm_winget_mappings" ON sccm_winget_mappings;
 CREATE POLICY "Service role full access sccm_winget_mappings"
   ON sccm_winget_mappings FOR ALL
   USING (auth.role() = 'service_role');
 
+DROP POLICY IF EXISTS "Service role full access sccm_migration_history" ON sccm_migration_history;
 CREATE POLICY "Service role full access sccm_migration_history"
   ON sccm_migration_history FOR ALL
   USING (auth.role() = 'service_role');
 
 -- Public read access for global mappings
+DROP POLICY IF EXISTS "Public read global sccm_winget_mappings" ON sccm_winget_mappings;
 CREATE POLICY "Public read global sccm_winget_mappings"
   ON sccm_winget_mappings FOR SELECT
   USING (tenant_id IS NULL);
@@ -269,16 +274,19 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_sccm_migrations_updated_at ON sccm_migrations;
 CREATE TRIGGER trigger_sccm_migrations_updated_at
   BEFORE UPDATE ON sccm_migrations
   FOR EACH ROW
   EXECUTE FUNCTION update_sccm_updated_at();
 
+DROP TRIGGER IF EXISTS trigger_sccm_apps_updated_at ON sccm_apps;
 CREATE TRIGGER trigger_sccm_apps_updated_at
   BEFORE UPDATE ON sccm_apps
   FOR EACH ROW
   EXECUTE FUNCTION update_sccm_updated_at();
 
+DROP TRIGGER IF EXISTS trigger_sccm_mappings_updated_at ON sccm_winget_mappings;
 CREATE TRIGGER trigger_sccm_mappings_updated_at
   BEFORE UPDATE ON sccm_winget_mappings
   FOR EACH ROW
@@ -423,29 +431,26 @@ RETURNS TABLE (
 LANGUAGE sql STABLE AS $$
   SELECT
     COUNT(*) as total_apps,
-    COUNT(*) FILTER (WHERE match_status = 'matched') as matched_apps,
-    COUNT(*) FILTER (WHERE match_status = 'partial') as partial_match_apps,
-    COUNT(*) FILTER (WHERE match_status = 'unmatched') as unmatched_apps,
-    COUNT(*) FILTER (WHERE match_status IN ('excluded', 'skipped')) as excluded_apps,
-    COUNT(*) FILTER (WHERE match_status = 'pending') as pending_apps,
-    COUNT(*) FILTER (WHERE migration_status = 'completed') as migrated_apps,
-    COUNT(*) FILTER (WHERE migration_status = 'failed') as failed_apps,
-    COALESCE(SUM(deployment_count), 0) as total_deployment_count,
-    COUNT(*) FILTER (WHERE is_deployed = TRUE) as deployed_apps_count,
-    jsonb_object_agg(
-      COALESCE(technology, 'Unknown'),
-      tech_count
-    ) as technology_breakdown
-  FROM sccm_apps
-  WHERE migration_id = p_migration_id
-  CROSS JOIN LATERAL (
-    SELECT technology as tech, COUNT(*) as tech_count
-    FROM sccm_apps
-    WHERE migration_id = p_migration_id
-    GROUP BY technology
-  ) tech_counts
-  GROUP BY tech_counts.tech, tech_counts.tech_count
-  LIMIT 1;
+    COUNT(*) FILTER (WHERE a.match_status = 'matched') as matched_apps,
+    COUNT(*) FILTER (WHERE a.match_status = 'partial') as partial_match_apps,
+    COUNT(*) FILTER (WHERE a.match_status = 'unmatched') as unmatched_apps,
+    COUNT(*) FILTER (WHERE a.match_status IN ('excluded', 'skipped')) as excluded_apps,
+    COUNT(*) FILTER (WHERE a.match_status = 'pending') as pending_apps,
+    COUNT(*) FILTER (WHERE a.migration_status = 'completed') as migrated_apps,
+    COUNT(*) FILTER (WHERE a.migration_status = 'failed') as failed_apps,
+    COALESCE(SUM(a.deployment_count), 0) as total_deployment_count,
+    COUNT(*) FILTER (WHERE a.is_deployed = TRUE) as deployed_apps_count,
+    COALESCE((
+      SELECT jsonb_object_agg(tech_counts.technology, tech_counts.tech_count)
+      FROM (
+        SELECT COALESCE(technology, 'Unknown') AS technology, COUNT(*) AS tech_count
+        FROM sccm_apps
+        WHERE migration_id = p_migration_id
+        GROUP BY COALESCE(technology, 'Unknown')
+      ) tech_counts
+    ), '{}'::jsonb) as technology_breakdown
+  FROM sccm_apps a
+  WHERE a.migration_id = p_migration_id;
 $$;
 
 -- Get SCCM mapping by name (for matching)
@@ -518,7 +523,7 @@ INSERT INTO sccm_winget_mappings (
   winget_package_name,
   confidence,
   is_verified
-) VALUES
+) SELECT * FROM (VALUES
   -- Browsers
   ('Google Chrome', 'google chrome', 'Google', 'Google.Chrome', 'Google Chrome', 1.0, TRUE),
   ('Mozilla Firefox', 'mozilla firefox', 'Mozilla', 'Mozilla.Firefox', 'Mozilla Firefox', 1.0, TRUE),
@@ -552,4 +557,18 @@ INSERT INTO sccm_winget_mappings (
   -- Security
   ('KeePass', 'keepass', 'KeePass', 'DominikReichl.KeePass', 'KeePass', 1.0, TRUE),
   ('Bitwarden', 'bitwarden', 'Bitwarden', 'Bitwarden.Bitwarden', 'Bitwarden', 1.0, TRUE)
-ON CONFLICT (sccm_display_name_normalized, tenant_id) DO NOTHING;
+) AS seed (
+  sccm_display_name,
+  sccm_display_name_normalized,
+  sccm_manufacturer,
+  winget_package_id,
+  winget_package_name,
+  confidence,
+  is_verified
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM sccm_winget_mappings existing
+  WHERE existing.sccm_display_name_normalized = seed.sccm_display_name_normalized
+    AND existing.tenant_id IS NULL
+);


### PR DESCRIPTION
Fixes #158.

The self-host Supabase setup was not runnable from the repo:

- No migration created the user_profiles table, but eight runtime code paths depend on it, including auth token persistence and the sccm migration FK that failed for reporters with relation does not exist.
- supabase/migrations/014_sccm_migration.sql contained a CROSS JOIN LATERAL placed after the WHERE clause. LANGUAGE sql bodies are parsed at CREATE FUNCTION time, so both supabase db push and the SQL editor failed identically at line 441.
- Retrying 014 after a failure hit policy already exists errors, and the global mapping seed duplicated all 20 rows on every rerun because ON CONFLICT never fires on NULL tenant_id.

Changes:

- New supabase/migrations/000_user_profiles.sql: creates user_profiles (TEXT id, columns matching types/database.ts), enables RLS with a service-role-only policy since the table stores tokens, and adds an updated_at trigger. Fully idempotent, so existing installs are unaffected.
- 014_sccm_migration.sql: rewrites get_sccm_migration_stats with a valid scalar subquery for the technology breakdown, adds DROP POLICY IF EXISTS and DROP TRIGGER IF EXISTS before every create, and converts the seed to INSERT SELECT WHERE NOT EXISTS so reruns are safe. The runtime unique constraint is unchanged.
- docs/DATABASE_SETUP.md and docs/SELF_HOSTING.md: documents the supported CLI path, the lexicographic ordering rule including the duplicate 014 and 015 prefixes, and replaces the outdated schema section that described tables which do not exist.