### PR TITLE
Send valid Win32 app create payload from the local packager

### DIFF
--- a/packager/src/intune-uploader.ts
+++ b/packager/src/intune-uploader.ts
@@ -184,6 +184,7 @@ export class IntuneUploader {
    */
   async uploadToIntune(
     job: PackagingJob,
+    packageFileName: string,
     encryptedContentPath: string,
     encryptionInfo: EncryptionInfo,
     sizes: { unencryptedSize: number; encryptedSize: number },
@@ -202,7 +203,7 @@ export class IntuneUploader {
 
     // Step 1: Create Win32 LOB App (5%)
     await onProgress?.(5, 'Creating app in Intune...');
-    const app = await this.createWin32App(graphClient, job);
+    const app = await this.createWin32App(graphClient, job, packageFileName);
     this.logger.info('Created Win32 LOB App', { appId: app.id });
 
     // Step 2: Create content version (10%)
@@ -275,10 +276,9 @@ export class IntuneUploader {
     await this.commitContentVersion(graphClient, app.id, contentVersion.id);
     this.logger.info('Content version committed');
 
-    // Step 9: Add detection rules (98%)
-    await onProgress?.(98, 'Adding detection rules...');
-    await this.addDetectionRules(graphClient, app.id, job);
-    this.logger.info('Detection rules added');
+    // Step 9: Add requirement rules (98%)
+    await onProgress?.(98, 'Adding requirement rules...');
+    await this.addRequirementRules(graphClient, app.id, job);
 
     // Step 10: Apply assignment configuration (99%)
     await onProgress?.(99, 'Applying assignments...');
@@ -333,7 +333,8 @@ export class IntuneUploader {
    */
   private async createWin32App(
     graphClient: GraphClient,
-    job: PackagingJob
+    job: PackagingJob,
+    packageFileName: string
   ): Promise<{ id: string }> {
     const commands = this.buildCommandLines(job);
     const baseDescription = extractPackageDescription(
@@ -357,9 +358,10 @@ export class IntuneUploader {
       installCommandLine: commands.install,
       uninstallCommandLine: commands.uninstall,
       applicableArchitectures: this.mapArchitecture(job.architecture),
-      minimumSupportedWindowsRelease: 'v10_1903',
+      minimumSupportedWindowsRelease: '1903',
       runAs32Bit: false,
       setupFilePath: 'Invoke-AppDeployToolkit.exe',
+      fileName: packageFileName,
       installExperience: {
         runAsAccount: job.install_scope === 'user' ? 'user' : 'system',
         deviceRestartBehavior: 'suppress',
@@ -371,7 +373,7 @@ export class IntuneUploader {
         { returnCode: 1641, type: 'hardReboot' },
         { returnCode: 1618, type: 'retry' },
       ],
-      rules: [], // Will add detection/requirement rules later
+      rules: this.buildDetectionRules(job),
     };
 
     if (largeIcon) {
@@ -672,29 +674,15 @@ export class IntuneUploader {
   }
 
   /**
-   * Add detection rules (and requirement rules if present) to the app
+   * Append requirement rules to the detection rules supplied at creation time
    */
-  private async addDetectionRules(
+  private async addRequirementRules(
     graphClient: GraphClient,
     appId: string,
     job: PackagingJob
   ): Promise<void> {
-    const detectionRules = this.buildDetectionRules(job);
     const requirementRules = this.extractRequirementRules(job);
 
-    // Set detection rules using the detectionRules property (old format,
-    // compatible with the win32LobAppDetection type names used by buildDetectionRules)
-    if (detectionRules.length > 0) {
-      await graphClient.patch(`/deviceAppManagement/mobileApps/${appId}`, {
-        '@odata.type': '#microsoft.graph.win32LobApp',
-        detectionRules: detectionRules,
-      });
-    }
-
-    // If requirement rules exist (for "Update Only" mode), read the current
-    // unified rules array (which now includes the detection rules set above,
-    // converted to win32LobAppRule format by Graph internally), append the
-    // requirement rules, and PATCH back the complete set.
     if (requirementRules.length > 0) {
       const app = await graphClient.get<{ rules?: unknown[] }>(
         `/deviceAppManagement/mobileApps/${appId}`
@@ -1222,37 +1210,42 @@ export class IntuneUploader {
 
         if (ruleObj.type === 'file') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppFileSystemDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+            ruleType: 'detection',
             path: ruleObj.path,
             fileOrFolderName: ruleObj.fileOrFolderName,
             check32BitOn64System: ruleObj.check32BitOn64System || false,
-            detectionType: ruleObj.detectionType || 'exists',
-            operator: ruleObj.operator,
-            detectionValue: ruleObj.detectionValue,
+            operationType: this.mapFileDetectionType(String(ruleObj.detectionType || 'exists')),
+            operator: ruleObj.operator || 'notConfigured',
+            comparisonValue: ruleObj.detectionValue,
           });
         } else if (ruleObj.type === 'registry') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppRegistryDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppRegistryRule',
+            ruleType: 'detection',
             keyPath: ruleObj.keyPath,
             valueName: ruleObj.valueName,
             check32BitOn64System: ruleObj.check32BitOn64System || false,
-            detectionType: ruleObj.detectionType || 'exists',
-            operator: ruleObj.operator,
-            detectionValue: ruleObj.detectionValue,
+            operationType: this.mapRegistryDetectionType(String(ruleObj.detectionType || 'exists')),
+            operator: ruleObj.operator || 'notConfigured',
+            comparisonValue: ruleObj.detectionValue,
           });
         } else if (ruleObj.type === 'msi') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppProductCodeDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppProductCodeRule',
+            ruleType: 'detection',
             productCode: ruleObj.productCode,
             productVersionOperator: ruleObj.productVersionOperator || 'notConfigured',
             productVersion: ruleObj.productVersion,
           });
         } else if (ruleObj.type === 'script') {
           rules.push({
-            '@odata.type': '#microsoft.graph.win32LobAppPowerShellScriptDetectionRule',
+            '@odata.type': '#microsoft.graph.win32LobAppPowerShellScriptRule',
+            ruleType: 'detection',
             scriptContent: Buffer.from(ruleObj.scriptContent as string).toString('base64'),
             enforceSignatureCheck: ruleObj.enforceSignatureCheck || false,
             runAs32Bit: ruleObj.runAs32Bit || false,
+            operationType: 'notConfigured',
           });
         }
       }
@@ -1261,15 +1254,43 @@ export class IntuneUploader {
     // Add default detection rule if none specified
     if (rules.length === 0) {
       rules.push({
-        '@odata.type': '#microsoft.graph.win32LobAppFileSystemDetectionRule',
+        '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+        ruleType: 'detection',
         path: '%ProgramFiles%',
         fileOrFolderName: job.display_name.replace(/[^a-zA-Z0-9]/g, ''),
         check32BitOn64System: false,
-        detectionType: 'exists',
+        operationType: 'exists',
+        operator: 'notConfigured',
+        comparisonValue: undefined,
       });
     }
 
     return rules;
+  }
+
+  // Mirrors the unified detection rule mappings in lib/intune-api.ts.
+  private mapFileDetectionType(type: string): string {
+    const mapping: Record<string, string> = {
+      exists: 'exists',
+      notExists: 'doesNotExist',
+      version: 'version',
+      dateModified: 'modifiedDate',
+      dateCreated: 'createdDate',
+      string: 'string',
+      sizeInMB: 'sizeInMB',
+    };
+    return mapping[type] || 'exists';
+  }
+
+  private mapRegistryDetectionType(type: string): string {
+    const mapping: Record<string, string> = {
+      exists: 'exists',
+      notExists: 'doesNotExist',
+      string: 'string',
+      integer: 'integer',
+      version: 'version',
+    };
+    return mapping[type] || 'exists';
   }
 
   /**

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -95,6 +95,7 @@ export class JobProcessor {
       try {
         intuneApp = await this.uploader.uploadToIntune(
           job,
+          path.basename(result.intunewinPath),
           result.encryptedContentPath,
           result.encryptionInfo,
           {

--- a/packager/tests/intune-uploader-payload.test.ts
+++ b/packager/tests/intune-uploader-payload.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PackagerConfig } from '../src/config';
+import { IntuneUploader } from '../src/intune-uploader';
+import type { PackagingJob } from '../src/job-poller';
+
+type GraphMock = {
+  post: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+};
+
+type TestableUploader = {
+  createWin32App(graphClient: GraphMock, job: PackagingJob, packageFileName: string): Promise<{ id: string }>;
+  addRequirementRules(graphClient: GraphMock, appId: string, job: PackagingJob): Promise<void>;
+};
+
+const config: PackagerConfig = {
+  packagerId: 'test-packager',
+  mode: 'api',
+  supabase: { url: '', serviceRoleKey: '' },
+  api: { url: 'https://example.com', key: 'test-key' },
+  azure: { clientId: '00000000-0000-0000-0000-000000000000', useManagedIdentity: false },
+  polling: { interval: 5000, staleJobTimeout: 300000 },
+  paths: { work: 'work', tools: 'tools' },
+};
+
+function packagingJob(overrides: Partial<PackagingJob> = {}): PackagingJob {
+  return {
+    id: 'job-1',
+    user_id: 'user-1',
+    user_email: 'qa@example.com',
+    tenant_id: 'tenant-1',
+    winget_id: 'Contoso.Example',
+    version: '1.2.3',
+    display_name: 'Contoso Example',
+    publisher: 'Contoso',
+    architecture: 'x64',
+    installer_type: 'exe',
+    installer_url: 'https://example.com/setup.exe',
+    installer_sha256: 'A'.repeat(64),
+    install_command: '',
+    uninstall_command: '',
+    install_scope: 'machine',
+    detection_rules: [],
+    package_config: {},
+    status: 'queued',
+    progress_percent: 0,
+    created_at: '2026-08-13T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function graphMock(): GraphMock {
+  return {
+    post: vi.fn().mockResolvedValue({ id: 'app-1' }),
+    get: vi.fn(),
+    patch: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('IntuneUploader Win32 app payload', () => {
+  it('creates the app with package metadata and unified detection rules', async () => {
+    const graph = graphMock();
+    const uploader = new IntuneUploader(config) as unknown as TestableUploader;
+    const job = packagingJob({
+      detection_rules: [
+        {
+          type: 'file',
+          path: '%ProgramFiles%\\Contoso',
+          fileOrFolderName: 'example.exe',
+          detectionType: 'notExists',
+        },
+        {
+          type: 'registry',
+          keyPath: 'HKEY_LOCAL_MACHINE\\Software\\Contoso',
+          valueName: 'Version',
+          detectionType: 'version',
+          operator: 'greaterThanOrEqual',
+          detectionValue: '1.2.3',
+        },
+        { type: 'msi', productCode: '{00000000-0000-0000-0000-000000000001}' },
+        { type: 'script', scriptContent: 'Write-Output installed' },
+      ],
+    });
+
+    await uploader.createWin32App(graph, job, 'Invoke-AppDeployToolkit.intunewin');
+
+    const body = graph.post.mock.calls[0][1] as Record<string, unknown>;
+    const rules = body.rules as Array<Record<string, unknown>>;
+    expect(body).toMatchObject({
+      fileName: 'Invoke-AppDeployToolkit.intunewin',
+      setupFilePath: 'Invoke-AppDeployToolkit.exe',
+      minimumSupportedWindowsRelease: '1903',
+    });
+    expect(rules).toHaveLength(4);
+    expect(rules.map((rule) => rule['@odata.type'])).toEqual([
+      '#microsoft.graph.win32LobAppFileSystemRule',
+      '#microsoft.graph.win32LobAppRegistryRule',
+      '#microsoft.graph.win32LobAppProductCodeRule',
+      '#microsoft.graph.win32LobAppPowerShellScriptRule',
+    ]);
+    expect(rules.every((rule) => rule.ruleType === 'detection')).toBe(true);
+    expect(rules[0]).toMatchObject({
+      operationType: 'doesNotExist',
+      operator: 'notConfigured',
+    });
+    expect(rules[1]).toMatchObject({
+      operationType: 'version',
+      operator: 'greaterThanOrEqual',
+      comparisonValue: '1.2.3',
+    });
+    expect(rules[3].scriptContent).toBe(
+      Buffer.from('Write-Output installed').toString('base64'),
+    );
+  });
+
+  it('uses a unified fallback detection rule when none are configured', async () => {
+    const graph = graphMock();
+    const uploader = new IntuneUploader(config) as unknown as TestableUploader;
+
+    await uploader.createWin32App(
+      graph,
+      packagingJob(),
+      'Invoke-AppDeployToolkit.intunewin',
+    );
+
+    const rules = graph.post.mock.calls[0][1].rules as Array<Record<string, unknown>>;
+    expect(rules).toEqual([
+      expect.objectContaining({
+        '@odata.type': '#microsoft.graph.win32LobAppFileSystemRule',
+        ruleType: 'detection',
+        operationType: 'exists',
+      }),
+    ]);
+  });
+
+  it('appends requirement rules while preserving existing detection rules', async () => {
+    const graph = graphMock();
+    const detectionRule = { ruleType: 'detection', operationType: 'exists' };
+    const requirementRule = { ruleType: 'requirement', operationType: 'exists' };
+    graph.get.mockResolvedValue({ rules: [detectionRule] });
+    const uploader = new IntuneUploader(config) as unknown as TestableUploader;
+
+    await uploader.addRequirementRules(
+      graph,
+      'app-1',
+      packagingJob({ package_config: { requirementRules: [requirementRule] } }),
+    );
+
+    expect(graph.get).toHaveBeenCalledOnce();
+    expect(graph.patch).toHaveBeenCalledWith('/deviceAppManagement/mobileApps/app-1', {
+      '@odata.type': '#microsoft.graph.win32LobApp',
+      rules: [detectionRule, requirementRule],
+    });
+  });
+
+  it('skips the post-create read and patch when no requirement rules exist', async () => {
+    const graph = graphMock();
+    const uploader = new IntuneUploader(config) as unknown as TestableUploader;
+
+    await uploader.addRequirementRules(graph, 'app-1', packagingJob());
+
+    expect(graph.get).not.toHaveBeenCalled();
+    expect(graph.patch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Part of #170 (the Win32LobApp must have at least one detection rule specified).

The self-hosted local packager created the Win32 app with an empty rules array, no fileName, and minimumSupportedWindowsRelease set to the object-form key v10_1903. Graph rejects all three, so every local packager upload failed at the create call before detection rules were ever patched in.

Changes in packager/src/intune-uploader.ts:

- Detection rules now ride the create body using the unified rules schema (win32LobAppFileSystemRule, win32LobAppRegistryRule, win32LobAppProductCodeRule, win32LobAppPowerShellScriptRule with ruleType detection, operationType, comparisonValue), mirroring the mappings in lib/intune-api.ts including notExists to doesNotExist. The ProgramFiles fallback rule guarantees the array is never empty.
- fileName is set from the generated intunewin file name and minimumSupportedWindowsRelease is now 1903, matching the hosted pipeline.
- The post-create step now only appends requirement rules (read-modify-write) when present, since detection rules are already on the app.

New tests in packager/tests/intune-uploader-payload.test.ts cover the payload shape, schema types, operator mappings, the fallback rule, and requirement rule appending.

Note for self-hosters: this fix reaches npm users with the next packager release, which is prepared separately.