### PR TITLE
Make the deploy path work in SQLite self-host mode

### DIFF
--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -15,6 +15,10 @@ vi.mock('@/lib/db', () => ({
   getDatabase: vi.fn(),
 }));
 
+vi.mock('@/lib/supabase', () => ({
+  isSupabaseServerConfigured: vi.fn(() => true),
+}));
+
 import { GET } from '@/app/api/health/route';
 
 describe('GET /api/health', () => {
@@ -48,6 +52,7 @@ describe('GET /api/health', () => {
       status: 'healthy',
       mode: 'hosted',
       databaseMode: 'supabase',
+      supabaseServerConfigured: true,
       services: {
         database: true,
         auth: true,

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { getDatabase, getDatabaseMode } from "@/lib/db";
+import { isSupabaseServerConfigured } from "@/lib/supabase";
 
 interface HealthStatus {
   status: "healthy" | "degraded" | "unhealthy";
   mode: "hosted" | "self-hosted";
   databaseMode: "sqlite" | "supabase";
+  supabaseServerConfigured: boolean;
   timestamp: string;
   services: {
     database: boolean;
@@ -24,6 +26,7 @@ export async function GET() {
     status: "healthy",
     mode: process.env.VERCEL === "1" ? "hosted" : "self-hosted",
     databaseMode,
+    supabaseServerConfigured: isSupabaseServerConfigured(),
     timestamp: new Date().toISOString(),
     services: {
       database: false,

--- a/app/api/intune/esp-profiles/add-app/route.ts
+++ b/app/api/intune/esp-profiles/add-app/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { acquireGraphToken } from '@/lib/graph-token';
@@ -50,7 +50,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
+    if (!supabase) {
+      return NextResponse.json(
+        { error: 'ESP profile updates require Supabase server configuration' },
+        { status: 503 }
+      );
+    }
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
     const tenantResolution = await resolveTargetTenantId({

--- a/app/api/intune/esp-profiles/route.test.ts
+++ b/app/api/intune/esp-profiles/route.test.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const { parseAccessTokenMock, getServerClientOrNullMock } = vi.hoisted(() => ({
+  parseAccessTokenMock: vi.fn(),
+  getServerClientOrNullMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: parseAccessTokenMock,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  getServerClientOrNull: getServerClientOrNullMock,
+}));
+
+import { GET } from '@/app/api/intune/esp-profiles/route';
+
+describe('GET /api/intune/esp-profiles', () => {
+  it('returns an empty profile list when Supabase server access is not configured', async () => {
+    parseAccessTokenMock.mockResolvedValue({
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      userEmail: 'user@example.com',
+    });
+    getServerClientOrNullMock.mockReturnValue(null);
+
+    const response = await GET(new NextRequest('http://localhost/api/intune/esp-profiles'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ profiles: [], count: 0 });
+  });
+});

--- a/app/api/intune/esp-profiles/route.ts
+++ b/app/api/intune/esp-profiles/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { acquireGraphToken } from '@/lib/graph-token';
@@ -20,7 +20,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
+    if (!supabase) {
+      return NextResponse.json({ profiles: [], count: 0 });
+    }
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
     const tenantResolution = await resolveTargetTenantId({

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 
 /**
@@ -21,7 +21,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
+    if (!supabase) {
+      return NextResponse.json({ count: 0 });
+    }
 
     const { count, error } = await supabase
       .from('user_notifications')

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -19,6 +19,7 @@ const {
   getLiveInstallersMock,
   ensureQaDemandMock,
   getPackageEligibilityBlocksMock,
+  isSupabaseServerConfiguredMock,
 } = vi.hoisted(() => ({
   getDatabaseMock: vi.fn(),
   getByUserIdMock: vi.fn(),
@@ -36,6 +37,7 @@ const {
   getLiveInstallersMock: vi.fn(),
   ensureQaDemandMock: vi.fn(),
   getPackageEligibilityBlocksMock: vi.fn(),
+  isSupabaseServerConfiguredMock: vi.fn(),
 }));
 
 vi.mock('@/lib/manifest-api', () => ({
@@ -91,6 +93,7 @@ vi.mock('@/lib/package-eligibility', async (importOriginal) => {
 
 vi.mock('@/lib/supabase', () => ({
   createServerClient: vi.fn(),
+  isSupabaseServerConfigured: isSupabaseServerConfiguredMock,
 }));
 
 vi.mock('@/lib/msp/tenant-resolution', () => ({
@@ -357,6 +360,38 @@ describe('POST /api/package (workflow dispatch)', () => {
       },
     });
     getPackageEligibilityBlocksMock.mockResolvedValue([]);
+    isSupabaseServerConfiguredMock.mockReturnValue(true);
+  });
+
+  it('creates a queued local-packager job without Supabase or QA', async () => {
+    isSupabaseServerConfiguredMock.mockReturnValue(false);
+    getFeatureFlagsMock.mockReturnValue({ pipeline: true, localPackager: true });
+    ensureQaDemandMock.mockResolvedValue({
+      state: 'waiting',
+      candidateId: 'candidate-1',
+      identity: {
+        executionProfileSha256: 'A'.repeat(64),
+        packageProfileSha256: 'A'.repeat(64),
+        presentationProfileSha256: 'B'.repeat(64),
+      },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ items: [makeWin32Item()] }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(getPackageEligibilityBlocksMock).not.toHaveBeenCalled();
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'queued' }));
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
   it('blocks a retired catalog app before QA or customer packaging begins', async () => {

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { getDatabase } from '@/lib/db';
 import {
   isGitHubActionsConfigured,
@@ -88,13 +88,16 @@ export async function POST(request: NextRequest) {
 
     // Check for MSP tenant override header and enforce tenant access checks
     // (membership, managed tenant consent, and customer-only access mode)
+    const supabaseServerConfigured = isSupabaseServerConfigured();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
-    const { tenantId, errorResponse: tenantError } = await resolveTargetTenantId({
-      supabase: createServerClient(),
-      userId,
-      tokenTenantId,
-      requestedTenantId: mspTenantId,
-    });
+    const { tenantId, errorResponse: tenantError } = supabaseServerConfigured
+      ? await resolveTargetTenantId({
+          supabase: createServerClient(),
+          userId,
+          tokenTenantId,
+          requestedTenantId: mspTenantId,
+        })
+      : { tenantId: tokenTenantId, errorResponse: null };
 
     if (tenantError) {
       return tenantError;
@@ -187,10 +190,12 @@ export async function POST(request: NextRequest) {
     const catalogWin32Items = win32Items.filter(
       (item) => item.sourceType !== 'custom' && typeof item.wingetId === 'string'
     );
-    const eligibilityBlocks = await getPackageEligibilityBlocks(
-      createServerClient(),
-      catalogWin32Items.map((item) => item.wingetId)
-    );
+    const eligibilityBlocks = supabaseServerConfigured
+      ? await getPackageEligibilityBlocks(
+          createServerClient(),
+          catalogWin32Items.map((item) => item.wingetId)
+        )
+      : [];
     if (eligibilityBlocks.length > 0) {
       const block = eligibilityBlocks[0];
       const blockedItem = catalogWin32Items.find(
@@ -515,7 +520,7 @@ export async function POST(request: NextRequest) {
             }
             const jobId = crypto.randomUUID();
             const installerSha256 = item.installerSha256?.trim() || '';
-            const qaDemand = item.sourceType === 'custom'
+            const qaDemand = item.sourceType === 'custom' || !supabaseServerConfigured
               ? null
               : await ensureQaDemand(createServerClient(), {
                   wingetId: item.wingetId,
@@ -541,11 +546,14 @@ export async function POST(request: NextRequest) {
                   priority: 2000,
                   demandSource: 'customer',
                 });
-            const initialStatus = qaDemand?.state === 'waiting'
-              ? 'awaiting_qa'
-              : qaDemand?.state === 'failed'
-                ? 'qa_failed'
-                : 'queued';
+            // Self-hosted installs have no QA pipeline, so local jobs must remain pollable.
+            const initialStatus = isLocalPackagerMode && !supabaseServerConfigured
+              ? 'queued'
+              : qaDemand?.state === 'waiting'
+                ? 'awaiting_qa'
+                : qaDemand?.state === 'failed'
+                  ? 'qa_failed'
+                  : 'queued';
             const now = new Date().toISOString();
 
             const jobRecord = await db.jobs.create({
@@ -763,9 +771,12 @@ export async function POST(request: NextRequest) {
             ? `${storeDeployed} Store app(s) deployed successfully`
             : `${win32Queued} job(s) queued successfully`,
     });
-  } catch {
+  } catch (err) {
+    console.error('[Package] Failed to create packaging jobs:', err);
+    // Self-hosted operators read their own logs, so surface the real message there.
+    const detail = !isSupabaseServerConfigured() && err instanceof Error ? err.message : null;
     return NextResponse.json(
-      { error: 'Internal server error' },
+      { error: detail ?? 'Internal server error' },
       { status: 500 }
     );
   }
@@ -908,9 +919,11 @@ export async function GET(request: NextRequest) {
     const healedJobs = await healStaleJobs(db, jobs);
 
     return NextResponse.json({ jobs: healedJobs });
-  } catch {
+  } catch (err) {
+    console.error('[Package] Failed to fetch jobs:', err);
+    const detail = !isSupabaseServerConfigured() && err instanceof Error ? err.message : null;
     return NextResponse.json(
-      { error: 'Failed to fetch jobs' },
+      { error: detail ?? 'Failed to fetch jobs' },
       { status: 500 }
     );
   }

--- a/lib/supabase.test.ts
+++ b/lib/supabase.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(() => ({ client: true })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock,
+}));
+
+async function loadSupabase(url?: string, serviceKey?: string) {
+  vi.resetModules();
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', url || '');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', serviceKey || '');
+  return import('@/lib/supabase');
+}
+
+describe('Supabase server configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    createClientMock.mockClear();
+  });
+
+  it.each([
+    [undefined, undefined],
+    ['https://example.supabase.co', undefined],
+    [undefined, 'service-key'],
+  ])('is not configured without both URL and service key', async (url, serviceKey) => {
+    const { getServerClientOrNull, isSupabaseServerConfigured } = await loadSupabase(
+      url,
+      serviceKey
+    );
+
+    expect(isSupabaseServerConfigured()).toBe(false);
+    expect(getServerClientOrNull()).toBeNull();
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a server client when both values are configured', async () => {
+    const { getServerClientOrNull, isSupabaseServerConfigured } = await loadSupabase(
+      'https://example.supabase.co',
+      'service-key'
+    );
+
+    expect(isSupabaseServerConfigured()).toBe(true);
+    expect(getServerClientOrNull()).toEqual({ client: true });
+    expect(createClientMock).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'service-key',
+      expect.any(Object)
+    );
+  });
+});

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -63,6 +63,14 @@ export function createServerClient(): SupabaseClientType {
   });
 }
 
+export function isSupabaseServerConfigured(): boolean {
+  return Boolean(supabaseUrl && supabaseServiceKey);
+}
+
+export function getServerClientOrNull(): SupabaseClientType | null {
+  return isSupabaseServerConfigured() ? createServerClient() : null;
+}
+
 // Check if Supabase is configured
 export function isSupabaseConfigured(): boolean {
   return Boolean(supabaseUrl && supabaseAnonKey);

--- a/packager/src/config.ts
+++ b/packager/src/config.ts
@@ -84,10 +84,15 @@ export function loadConfig(): PackagerConfig {
   }
 
   // Determine communication mode based on available config
-  // If INTUNEGET_API_URL is set, use API mode; otherwise use Supabase mode
   const apiUrl = getEnvVar('INTUNEGET_API_URL');
   const apiKey = getEnvVar('PACKAGER_API_KEY');
-  const mode: 'supabase' | 'api' = (apiUrl && apiKey) ? 'api' : 'supabase';
+  const supabaseUrl = getEnvVar('SUPABASE_URL');
+  if ((!supabaseUrl && (!apiUrl || !apiKey)) || (apiKey && !apiUrl)) {
+    throw new Error(
+      'INTUNEGET_API_URL and PACKAGER_API_KEY are required for self-hosted (HTTP API) mode'
+    );
+  }
+  const mode: 'supabase' | 'api' = apiUrl && apiKey ? 'api' : 'supabase';
 
   // In Supabase mode, require Supabase credentials
   const requireSupabase = mode === 'supabase';


### PR DESCRIPTION
Fixes the deploy half of #167, #170, and #159.

In DATABASE_MODE=sqlite the deploy route threw at three unconditional Supabase call sites before any packaging job was created, returning a bare 500 with no logging. Even with those fixed, the newer QA demand gate could put jobs into awaiting_qa, a status the local packager never polls, so self-hosted packagers sat idle forever.

Changes:

- lib/supabase.ts: new isSupabaseServerConfigured (checks the service role key, unlike isSupabaseConfigured which checks the anon key) and getServerClientOrNull.
- app/api/package/route.ts: MSP tenant resolution falls back to the token tenant, eligibility blocks are skipped, and QA demand is bypassed when the Supabase server client is not configured. Jobs for the local packager in self-host mode are always created as queued. The bare catch blocks now log the real error and surface its message to self-hosters while hosted responses stay generic.
- app/api/intune/esp-profiles/route.ts: returns an empty profile list instead of throwing, since the deploy dialog renders it and its error was masking the real failure. The add-app mutation returns a clear 503.
- app/api/notifications/unread-count/route.ts: returns zero gracefully.
- app/api/health/route.ts: reports supabaseServerConfigured so self-hosters can see the actual state instead of a misleading healthy.
- packager/src/config.ts: fails fast with a clear message when HTTP API mode is intended but INTUNEGET_API_URL or PACKAGER_API_KEY is missing, instead of silently selecting Supabase mode.

Hosted behavior is unchanged: every new branch is behind the not-configured check.

Tests: new unit tests for the Supabase config helpers, queued status in sqlite plus local packager mode, ESP profile fallback, and the health field. Full suite passes (1030 tests).

Thanks to the community diagnosis in PR #220 which confirmed the same root causes; this implements the deploy path natively on current main. Dashboard pages (inventory, reports, analytics, app requests) get the same treatment in a follow-up.