### PR TITLE
Generate requirement rules for update-only deployments at every entry point

### DIFF
--- a/app/(app)/dashboard/sccm/[migrationId]/migrate/page.tsx
+++ b/app/(app)/dashboard/sccm/[migrationId]/migrate/page.tsx
@@ -33,6 +33,9 @@ import type {
   SccmMigrationResult,
   SccmMigrationOptions,
 } from '@/types/sccm';
+import type { Win32CartItem } from '@/types/upload';
+import type { MsiDetectionRule } from '@/types/intune';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 
 interface PageProps {
   params: Promise<{ migrationId: string }>;
@@ -154,7 +157,21 @@ export default function MigratePage({ params }: PageProps) {
       // Add cart items
       if (data.cartItems && Array.isArray(data.cartItems)) {
         for (const item of data.cartItems) {
-          addItem(item);
+          const cartItem = item as Win32CartItem;
+          const productCode = (
+            cartItem.detectionRules?.find((rule) => rule.type === 'msi') as
+              | MsiDetectionRule
+              | undefined
+          )?.productCode;
+          addItem({
+            ...cartItem,
+            requirementRules: buildCartItemRequirementRules(
+              cartItem.displayName,
+              cartItem.installerType,
+              productCode,
+              cartItem.assignments
+            ),
+          });
         }
         openCart();
       }

--- a/app/api/intune/apps/[id]/settings/route.ts
+++ b/app/api/intune/apps/[id]/settings/route.ts
@@ -12,7 +12,9 @@ import {
   assignToGroups,
   convertToGraphAssignments,
   syncAppCategories,
+  setAppRules,
 } from '@/lib/intune-api';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 import { parseAccessToken } from '@/lib/auth-utils';
 import type { PackageAssignment, IntuneAppCategorySelection } from '@/types/upload';
 import type { Json } from '@/types/database';
@@ -98,6 +100,26 @@ export async function PATCH(
 
     // Apply assignments
     if (assignments) {
+      const productCode = existingApp.msiInformation?.productCode;
+      const requirementRules = buildCartItemRequirementRules(
+        existingApp.displayName,
+        productCode ? 'msi' : 'exe',
+        productCode,
+        assignments
+      );
+      // Skip when the app already carries requirement rules so repeated
+      // settings updates do not stack duplicates onto the rules array.
+      const existingRules = existingApp.rules ?? [];
+      const hasRequirementRule = existingRules.some(
+        (rule) => rule.ruleType === 'requirement'
+      );
+      if (requirementRules && !hasRequirementRule) {
+        await setAppRules(graphToken, intuneAppId, [
+          ...existingRules,
+          ...requirementRules,
+        ]);
+      }
+
       const graphAssignments = convertToGraphAssignments(assignments);
       await assignToGroups(graphToken, intuneAppId, graphAssignments);
     }

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -21,6 +21,7 @@ import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { checkStoredConsent } from '@/lib/msp/consent-cache';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { buildIntuneAppDescription } from '@/lib/intune-description';
+import { sanitizeAssignmentsForDispatch } from '@/lib/assignment-intents';
 import { acquireGraphToken } from '@/lib/graph-token';
 import { deployStoreApp } from '@/lib/store-app-deploy';
 import {
@@ -670,7 +671,14 @@ export async function POST(request: NextRequest) {
               psadtConfig: item.psadtConfig ? JSON.stringify(item.psadtConfig) : undefined,
               detectionRules: item.detectionRules ? JSON.stringify(item.detectionRules) : undefined,
               requirementRules: item.requirementRules ? JSON.stringify(item.requirementRules) : undefined,
-              assignments: item.assignments ? JSON.stringify(item.assignments) : undefined,
+              assignments: item.assignments
+                ? JSON.stringify(
+                    sanitizeAssignmentsForDispatch(
+                      item.assignments,
+                      Boolean(item.requirementRules?.length)
+                    )
+                  )
+                : undefined,
               categories: item.categories ? JSON.stringify(item.categories) : undefined,
               espProfiles: item.espProfiles ? JSON.stringify(item.espProfiles) : undefined,
               relationships: item.relationships && item.relationships.length > 0

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { sanitizeAssignmentsForDispatch } from '@/lib/assignment-intents';
 import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
 import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
@@ -368,7 +369,12 @@ export async function POST(request: NextRequest) {
                 ? JSON.stringify(deploymentConfig.psadtConfig)
                 : undefined,
               assignments: deploymentConfig.assignments
-                ? JSON.stringify(deploymentConfig.assignments)
+                ? JSON.stringify(
+                    sanitizeAssignmentsForDispatch(
+                      deploymentConfig.assignments,
+                      Boolean(deploymentConfig.requirementRules?.length)
+                    )
+                  )
                 : undefined,
               categories: deploymentConfig.categories
                 ? JSON.stringify(deploymentConfig.categories)

--- a/components/CartItemConfig.tsx
+++ b/components/CartItemConfig.tsx
@@ -40,7 +40,7 @@ import { EspProfileSelector } from '@/components/EspProfileSelector';
 import type { CartItem, StoreCartItem, IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
 import type { EspProfileSelection } from '@/types/esp';
 import { isStoreCartItem, isWin32CartItem } from '@/types/upload';
-import type { RequirementRule, AppRelationship } from '@/types/intune';
+import type { AppRelationship, MsiDetectionRule } from '@/types/intune';
 import type {
   PSADTConfig,
   ProcessToClose,
@@ -54,7 +54,7 @@ import type {
 } from '@/types/psadt';
 import type { WingetScope } from '@/types/winget';
 import { useCartStore } from '@/stores/cart-store';
-import { generateRequirementRules } from '@/lib/requirement-rules';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 
 interface CartItemConfigProps {
@@ -191,13 +191,17 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
       } else {
         // Win32 apps: full config update
         // Generate requirement rules if any assignment uses "Update Only"
-        let requirementRules: RequirementRule[] | undefined;
-        if (isWin32 && assignments.some((a) => a.intent === 'updateOnly')) {
-          requirementRules = generateRequirementRules(
-            item.displayName,
-            item.installerType
-          );
-        }
+        const msiProductCode = isWin32
+          ? (item.detectionRules.find((rule) => rule.type === 'msi') as MsiDetectionRule | undefined)?.productCode
+          : undefined;
+        const requirementRules = isWin32
+          ? buildCartItemRequirementRules(
+              item.displayName,
+              item.installerType,
+              msiProductCode,
+              assignments
+            )
+          : undefined;
 
         updateItem(item.id, {
           installScope: selectedScope,

--- a/components/CustomAppModal.tsx
+++ b/components/CustomAppModal.tsx
@@ -18,6 +18,7 @@ import {
   type CustomInstallerType,
 } from '@/lib/custom-app';
 import type { WingetArchitecture, WingetScope } from '@/types/winget';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 
 interface CustomAppModalProps {
   onClose: () => void;
@@ -147,7 +148,15 @@ export function CustomAppModal({ onClose }: CustomAppModalProps) {
         iconUrl,
       });
 
-      addItem(item);
+      addItem({
+        ...item,
+        requirementRules: buildCartItemRequirementRules(
+          item.displayName,
+          item.installerType,
+          undefined,
+          item.assignments
+        ),
+      });
       toast.success(`${item.displayName} added`, {
         description: `v${item.version} -- ${item.architecture}`,
       });

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -66,6 +66,7 @@ import { useUpdateAppSettings } from '@/hooks/use-update-app-settings';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
 import { INTUNE_APP_SOURCE_MARKER } from '@/lib/intune-description';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 
 // Strip the auto-appended "Source: IntuneGet.com" marker so the description
 // editor shows only the human-authored text. The marker is re-appended at
@@ -452,6 +453,12 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
           detectionRules: config.detectionRules,
           psadtConfig: config,
           assignments: assignments.length > 0 ? assignments : undefined,
+          requirementRules: buildCartItemRequirementRules(
+            displayName,
+            selectedInstaller!.type,
+            selectedInstaller!.productCode,
+            assignments
+          ),
           categories: categories.length > 0 ? categories : undefined,
           espProfiles: espProfiles.length > 0 ? espProfiles : undefined,
           relationships: relationships.length > 0 ? relationships : undefined,

--- a/components/PackageDetails.tsx
+++ b/components/PackageDetails.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/detection-rules';
 import { cn } from '@/lib/utils';
 import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 
 interface PackageDetailsProps {
   package: NormalizedPackage;
@@ -123,6 +124,12 @@ export function PackageDetails({ package: pkg, onClose }: PackageDetailsProps) {
       installCommand: generateInstallCommand(selectedInstaller, selectedScope),
       uninstallCommand: generateUninstallCommand(selectedInstaller, pkg.name),
       detectionRules,
+      requirementRules: buildCartItemRequirementRules(
+        pkg.name,
+        selectedInstaller.type,
+        selectedInstaller.productCode,
+        undefined
+      ),
       psadtConfig: {
         ...DEFAULT_PSADT_CONFIG,
         processesToClose,

--- a/hooks/use-unmanaged-apps.ts
+++ b/hooks/use-unmanaged-apps.ts
@@ -6,6 +6,7 @@ import { useMspOptional } from '@/hooks/useMspOptional';
 import { useUserSettings } from '@/components/providers/UserSettingsProvider';
 import { useCartStore } from '@/stores/cart-store';
 import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt';
 import { toast } from '@/hooks/use-toast';
 import type {
@@ -421,6 +422,12 @@ export function useUnmanagedApps(): UseUnmanagedAppsReturn {
           manifest?.name || app.displayName
         ),
         detectionRules,
+        requirementRules: buildCartItemRequirementRules(
+          manifest?.name || app.displayName,
+          recommendedInstaller.type,
+          recommendedInstaller.productCode,
+          undefined
+        ),
         psadtConfig: {
           ...DEFAULT_PSADT_CONFIG,
           processesToClose,

--- a/hooks/useQuickAdd.ts
+++ b/hooks/useQuickAdd.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { useCartStore } from '@/stores/cart-store';
 import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt';
 import { toast } from 'sonner';
 import type { NormalizedPackage } from '@/types/winget';
@@ -97,6 +98,12 @@ export function useQuickAdd(
             installCommand: generateInstallCommand(installer, installer.scope || 'machine'),
             uninstallCommand: generateUninstallCommand(installer, pkg.name),
             detectionRules,
+            requirementRules: buildCartItemRequirementRules(
+              pkg.name,
+              installer.type,
+              installer.productCode,
+              undefined
+            ),
             psadtConfig: {
               ...DEFAULT_PSADT_CONFIG,
               processesToClose,

--- a/lib/__tests__/assignment-intents.test.ts
+++ b/lib/__tests__/assignment-intents.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeAssignmentsForDispatch } from '@/lib/assignment-intents';
+import type { PackageAssignment } from '@/types/upload';
+
+describe('sanitizeAssignmentsForDispatch', () => {
+  it('maps updateOnly to required while preserving all other fields and intents', () => {
+    const assignments: PackageAssignment[] = [
+      {
+        type: 'group',
+        intent: 'updateOnly',
+        groupId: 'group-1',
+        groupName: 'Pilot devices',
+        filterId: 'filter-1',
+        filterName: 'Windows 11',
+        filterType: 'include',
+        notifications: 'hideAll',
+        deliveryOptimizationPriority: 'foreground',
+      },
+      { type: 'allUsers', intent: 'available', notifications: 'showAll' },
+      { type: 'allDevices', intent: 'uninstall' },
+    ];
+
+    expect(sanitizeAssignmentsForDispatch(assignments, true)).toEqual([
+      { ...assignments[0], intent: 'required' },
+      assignments[1],
+      assignments[2],
+    ]);
+  });
+
+  it('leaves updateOnly untouched when no requirement rules accompany the deployment', () => {
+    const assignments: PackageAssignment[] = [
+      { type: 'group', intent: 'updateOnly', groupId: 'group-1' },
+    ];
+
+    expect(sanitizeAssignmentsForDispatch(assignments, false)).toEqual(assignments);
+  });
+});

--- a/lib/__tests__/requirement-rules.test.ts
+++ b/lib/__tests__/requirement-rules.test.ts
@@ -1,0 +1,56 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
+import type { PackageAssignment } from '@/types/upload';
+
+const updateOnlyAssignments: PackageAssignment[] = [
+  { type: 'allDevices', intent: 'updateOnly' },
+];
+
+describe('buildCartItemRequirementRules', () => {
+  it('builds an MSI registry requirement from the product code', () => {
+    const rules = buildCartItemRequirementRules(
+      'Contoso App',
+      'msi',
+      '{PRODUCT-CODE}',
+      updateOnlyAssignments
+    );
+
+    expect(rules).toEqual([
+      expect.objectContaining({
+        '@odata.type': '#microsoft.graph.win32LobAppRegistryRule',
+        ruleType: 'requirement',
+        keyPath: expect.stringContaining('{PRODUCT-CODE}'),
+        operationType: 'exists',
+      }),
+    ]);
+  });
+
+  it('builds an uninstall-registry script requirement for an EXE', () => {
+    const rules = buildCartItemRequirementRules(
+      'Contoso App',
+      'exe',
+      undefined,
+      updateOnlyAssignments
+    );
+    const scriptRule = rules?.[0];
+
+    expect(scriptRule?.['@odata.type']).toBe(
+      '#microsoft.graph.win32LobAppPowerShellScriptRule'
+    );
+    if (scriptRule?.['@odata.type'] !== '#microsoft.graph.win32LobAppPowerShellScriptRule') {
+      throw new Error('Expected a PowerShell script requirement rule');
+    }
+    expect(Buffer.from(scriptRule.scriptContent, 'base64').toString('utf8')).toContain(
+      "DisplayName -like '*Contoso App*'"
+    );
+  });
+
+  it('returns undefined when no assignment is updateOnly', () => {
+    expect(
+      buildCartItemRequirementRules('Contoso App', 'exe', undefined, [
+        { type: 'allDevices', intent: 'required' },
+      ])
+    ).toBeUndefined();
+  });
+});

--- a/lib/assignment-intents.ts
+++ b/lib/assignment-intents.ts
@@ -1,0 +1,21 @@
+import type { PackageAssignment } from '@/types/upload';
+
+/**
+ * Convert internal-only assignment intents before sending them to a workflow.
+ * updateOnly only maps to required when requirement rules accompany the
+ * deployment; without them a required intent would install on every targeted
+ * device instead of gating to devices that already have the app.
+ */
+export function sanitizeAssignmentsForDispatch(
+  assignments: PackageAssignment[],
+  hasRequirementRules: boolean
+): PackageAssignment[] {
+  if (!hasRequirementRules) {
+    return assignments;
+  }
+  return assignments.map((assignment) =>
+    assignment.intent === 'updateOnly'
+      ? { ...assignment, intent: 'required' }
+      : assignment
+  );
+}

--- a/lib/intune-api.ts
+++ b/lib/intune-api.ts
@@ -13,6 +13,7 @@ import type {
   IntuneMobileAppCategory,
   IntuneAssignmentFilter,
   GraphApiResponse,
+  Win32LobAppRule,
 } from '@/types/intune';
 import type { PackageAssignment } from '@/types/upload';
 
@@ -574,6 +575,29 @@ export async function getApp(
   }
 
   return response.json();
+}
+
+/** Replace an app's Graph rules array. Callers must preserve existing rules. */
+export async function setAppRules(
+  accessToken: string,
+  appId: string,
+  rules: Win32LobAppRule[]
+): Promise<void> {
+  const response = await fetch(
+    `${GRAPH_API_BASE}/deviceAppManagement/mobileApps/${appId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ rules }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to update app requirement rules');
+  }
 }
 
 /**

--- a/lib/requirement-rules.ts
+++ b/lib/requirement-rules.ts
@@ -19,6 +19,20 @@ import type {
   ScriptRequirementRule,
 } from '@/types/intune';
 import type { WingetInstallerType, WingetScope } from '@/types/winget';
+import type { PackageAssignment } from '@/types/upload';
+
+export function buildCartItemRequirementRules(
+  displayName: string,
+  installerType: WingetInstallerType,
+  productCode: string | undefined,
+  assignments: PackageAssignment[] | undefined
+): RequirementRule[] | undefined {
+  if (!assignments?.some((assignment) => assignment.intent === 'updateOnly')) {
+    return undefined;
+  }
+
+  return generateRequirementRules(displayName, installerType, productCode);
+}
 
 /**
  * Generate requirement rules that check whether the app is already installed.


### PR DESCRIPTION
Fixes the app half of #340, together with ugurkocde/IntuneGet-Workflows#796.

Update Only deployments had two app-side gaps:

- Only the cart edit panel (CartItemConfig) generated requirement rules, so deployments configured through the main deploy modal, discovered apps, quick add, package details, custom apps, or the SCCM migrate page reached dispatch without any requirement rules.
- The dispatch payload carried the internal updateOnly intent verbatim, which Graph rejects.

Changes:

- New lib/assignment-intents.ts with sanitizeAssignmentsForDispatch: maps updateOnly to required while preserving every other field, and only when requirement rules accompany the deployment. Without rules the intent passes through unchanged, since a bare required intent would install on every targeted device, which is worse than a failed assignment. Applied in app/api/package/route.ts and app/api/updates/trigger/route.ts.
- New buildCartItemRequirementRules helper in lib/requirement-rules.ts, wired into all seven cart entry points so requirement rules are generated whenever an assignment is update-only.
- app/api/intune/apps/[id]/settings/route.ts now appends generated requirement rules to the app's existing Graph rules before assigning when switching to update-only, and skips apps that already carry a requirement rule so repeated updates do not stack duplicates.

Tests cover intent sanitation with and without requirement rules and MSI versus EXE rule generation. Full suite passes.