### PR TITLE
Install archives without a nested installer as portable apps

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1009,6 +1009,9 @@ $registeredInstallerTypeLower = if ($installerTypeLower -eq 'zip' -and
 $isNestedPortable = $installerTypeLower -eq 'zip' -and
     -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
     $NestedInstallerType.Trim().ToLowerInvariant() -eq 'portable'
+$isPlainPortableArchive = $installerTypeLower -eq 'zip' -and
+    [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
+    [string]::IsNullOrWhiteSpace($NestedInstallerPath)
 
 $portableFolderName = ($DisplayName -replace '[<>:"/\\|?*\x00-\x1f]', '_').Trim().TrimEnd('.')
 if ([string]::IsNullOrWhiteSpace($portableFolderName) -or
@@ -1030,7 +1033,7 @@ $registryUninstallDisplayName = ''
 $registryUninstallProductCode = ''
 $msixPackageName = ''
 
-if ($installerTypeLower -eq 'portable' -or $isNestedPortable) {
+if ($installerTypeLower -eq 'portable' -or $isNestedPortable -or $isPlainPortableArchive) {
     $usePortableUninstall = $true
     Write-Host "Using portable uninstall (folder removal)"
 } elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$') {
@@ -1881,20 +1884,12 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
             }
         }
         'zip' {
-            # Zip archives carry a nested installer (winget nestedInstallerType/nestedInstallerPath)
-            # Never execute the .zip itself - extract it and run the declared nested installer
-            if ([string]::IsNullOrWhiteSpace($NestedInstallerPath)) {
-                Write-Host "Zip installer without nested installer path - emitting install-time error"
-                $lines += @(
-                    '    # Zip archives cannot be executed directly and no nested installer was declared'
-                    '    throw "Zip package does not declare a nested installer; cannot install"'
-                )
-            } else {
-                $nestedInstallerPathEscaped = $NestedInstallerPath -replace "'", "''"
-                $nestedInstallerTypeLower = if ($NestedInstallerType) { $NestedInstallerType.ToLower() } else { '' }
-                Write-Host "Zip installer with nested installer: type='$nestedInstallerTypeLower' path='$NestedInstallerPath'"
-
-                if ($isNestedPortable) {
+            # Archives without a nested contract and nested portable archives are
+            # safely staged as complete portable application folders.
+            $nestedInstallerPathEscaped = $NestedInstallerPath -replace "'", "''"
+            $nestedInstallerTypeLower = if ($NestedInstallerType) { $NestedInstallerType.ToLower() } else { '' }
+            if ($isNestedPortable -or $isPlainPortableArchive) {
+                    Write-Host "Staging zip as portable archive"
                     $lines += @(
                         ''
                         '    # Safely stage every portable archive entry before replacing the installed app'
@@ -1928,13 +1923,19 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                         '        finally {'
                         '            if ($archive) { $archive.Dispose() }'
                         '        }'
-                        "        `$declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path `$stageRoot '$nestedInstallerPathEscaped'))"
-                        '        if (-not $declaredNestedPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {'
-                        '            throw "Nested installer path escapes the portable staging directory"'
-                        '        }'
-                        '        if (-not (Test-Path -LiteralPath $declaredNestedPath -PathType Leaf)) {'
-                        "            throw `"Nested installer not found in archive: $nestedInstallerPathEscaped`""
-                        '        }'
+                    )
+                    if ($isNestedPortable) {
+                        $lines += @(
+                            "        `$declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path `$stageRoot '$nestedInstallerPathEscaped'))"
+                            '        if (-not $declaredNestedPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {'
+                            '            throw "Nested installer path escapes the portable staging directory"'
+                            '        }'
+                            '        if (-not (Test-Path -LiteralPath $declaredNestedPath -PathType Leaf)) {'
+                            "            throw `"Nested installer not found in archive: $nestedInstallerPathEscaped`""
+                            '        }'
+                        )
+                    }
+                    $lines += @(
                         '        $installParent = [System.IO.Path]::GetDirectoryName($installPath)'
                         '        if ($installParent) { $null = New-Item -Path $installParent -ItemType Directory -Force }'
                         '        $replacementStarted = $true'
@@ -2010,7 +2011,6 @@ if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
                         '    }'
                     )
                 }
-            }
         }
         'portable' {
             $lines += @(

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -710,6 +710,32 @@ describe('generateInstallCommand', () => {
     expect(generateInstallCommand(installer)).toContain('Expand-Archive');
   });
 
+  it('should describe copying a bare portable executable', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/claude.exe',
+      sha256: 'abc123',
+      type: 'portable',
+    };
+
+    expect(generateInstallCommand(installer)).toBe(
+      'Copy-Item -Path "claude.exe" -Destination "%ProgramFiles%\\claude\\claude.exe" -Force'
+    );
+  });
+
+  it('should describe extracting a portable zip archive', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/claude.zip',
+      sha256: 'abc123',
+      type: 'portable',
+    };
+
+    expect(generateInstallCommand(installer)).toContain(
+      'Expand-Archive -Path "claude.zip" -DestinationPath "%ProgramFiles%\\claude"'
+    );
+  });
+
   it('should reject a nested path without a nested installer type', () => {
     const installer: NormalizedInstaller = {
       architecture: 'x64',

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -364,8 +364,13 @@ export function generateInstallCommand(
       }
       return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${installerName.replace(/\.[^/.]+$/, '')}" -Force`;
 
-    case 'portable':
-      return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${installerName.replace(/\.[^/.]+$/, '')}" -Force`;
+    case 'portable': {
+      const portableFolder = installerName.replace(/\.[^/.]+$/, '');
+      if (/\.zip$/i.test(installerName)) {
+        return `Expand-Archive -Path "${installerName}" -DestinationPath "%ProgramFiles%\\${portableFolder}" -Force`;
+      }
+      return `Copy-Item -Path "${installerName}" -Destination "%ProgramFiles%\\${portableFolder}\\${installerName}" -Force`;
+    }
 
     default:
       return `"${installerName}" ${silentArgs}`.trim();

--- a/lib/packaging-contract.test.ts
+++ b/lib/packaging-contract.test.ts
@@ -24,11 +24,23 @@ describe('evaluatePackagingContract', () => {
     if (!result.valid) expect(result.code).toBe('required-argument-missing');
   });
 
-  it('rejects an archive without an explicit nested installer contract', () => {
+  it('accepts an archive without a nested installer contract as portable', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Contoso.Archive',
+      installerType: 'zip',
+      silentArgs: '/S',
+    }).valid).toBe(true);
+  });
+
+  it.each([
+    { nestedInstallerType: 'nullsoft' },
+    { nestedInstallerFiles: ['setup.exe'] },
+  ])('rejects a half-declared archive contract: %o', (nestedContract) => {
     const result = evaluatePackagingContract({
       wingetId: 'Contoso.Archive',
       installerType: 'zip',
       silentArgs: '/S',
+      ...nestedContract,
     });
     expect(result.valid).toBe(false);
     if (!result.valid) expect(result.code).toBe('archive-contract-incomplete');

--- a/lib/packaging-contract.ts
+++ b/lib/packaging-contract.ts
@@ -103,7 +103,7 @@ export function evaluatePackagingContract(
   if (family === 'archive') {
     const nestedType = input.nestedInstallerType?.trim().toLowerCase() || '';
     const nestedFiles = (input.nestedInstallerFiles || []).filter((value) => value.trim());
-    if (!nestedType || nestedFiles.length === 0) {
+    if (Boolean(nestedType) !== (nestedFiles.length > 0)) {
       return {
         valid: false,
         family,

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -410,7 +410,12 @@ export class JobProcessor {
    * Generate Invoke-AppDeployToolkit.ps1 script (PSADT v4)
    */
   private generateDeployScript(job: PackagingJob, installerFileName: string): string {
-    const silentSwitches = this.extractSilentSwitches(job.install_command, job.installer_type).replace(/'/g, "''");
+    const nestedInstaller = this.getNestedInstaller(job);
+    const silentSwitches = this.extractSilentSwitches(
+      job.install_command,
+      job.installer_type,
+      nestedInstaller.type ?? undefined
+    ).replace(/'/g, "''");
     const successExitCodes = this.getInstallerSuccessCodes(job);
     const psadtVersion = '4.1.8';
     const appVendor = job.publisher.replace(/'/g, "''");
@@ -806,7 +811,8 @@ catch
       return true;
     }
     const nested = this.getNestedInstaller(job);
-    return job.installer_type.toLowerCase() === 'zip' && nested.type?.toLowerCase() === 'portable';
+    return job.installer_type.toLowerCase() === 'zip' &&
+      (!nested.type || nested.type.toLowerCase() === 'portable');
   }
 
   private normalizeNestedInstallerPath(nestedPath: string): string {
@@ -1232,12 +1238,6 @@ ${steps}
     const installerType = job.installer_type;
     const ext = path.extname(fileName).toLowerCase();
 
-    // Zip archives carry a nested installer - never execute the .zip itself
-    // (a zip-declared installer that is actually an .exe or .msi still runs natively)
-    if (ext === '.zip' || (installerType === 'zip' && ext !== '.exe' && ext !== '.msi')) {
-      return this.getZipInstallCommand(job, fileName, silentSwitches);
-    }
-
     if (ext === '.msi' || installerType === 'msi' || installerType === 'wix') {
       const msiProperties = this.extractMsiProperties(silentSwitches);
       if (msiProperties) {
@@ -1255,6 +1255,9 @@ ${steps}
     }
 
     if (installerType === 'portable') {
+      if (ext === '.zip') {
+        return this.getPortableZipInstallCommand(job, fileName);
+      }
       const fileNameEscaped = fileName.replace(/'/g, "''");
       return `${this.getPortableInstallPathLine(job)}
     $sourcePath = Join-Path $adtSession.DirFiles '${fileNameEscaped}'
@@ -1262,6 +1265,12 @@ ${steps}
     $targetPath = Join-Path $installPath '${fileNameEscaped}'
     Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force
     Write-ADTLogEntry -Message "Portable app installed to: $installPath" -Severity 'Success' -Source 'Install-ADTDeployment'`;
+    }
+
+    // Zip archives carry a nested installer or are installed as portable archives.
+    // A zip-declared installer that is actually an .exe or .msi still runs natively.
+    if (ext === '.zip' || (installerType === 'zip' && ext !== '.exe' && ext !== '.msi')) {
+      return this.getZipInstallCommand(job, fileName, silentSwitches);
     }
 
     if (installerType === 'inno') {
@@ -1340,12 +1349,12 @@ ${steps}
    * Get install command for zip installers (PSADT v4 cmdlets)
    * Extracts the archive to a unique temp directory and runs the nested
    * installer declared by package_config.nestedInstallerType/nestedInstallerPath
-   * Emits an install-time error when no nested installer is declared
+   * Treats archives without a nested installer contract as portable archives
    */
   private getZipInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string {
     const nested = this.getNestedInstaller(job);
     if (!nested.path) {
-      return 'throw "Zip package does not declare a nested installer; cannot install"';
+      return this.getPortableZipInstallCommand(job, fileName);
     }
 
     const normalizedNestedPath = this.normalizeNestedInstallerPath(nested.path);
@@ -1387,7 +1396,7 @@ ${steps}
   private getPortableZipInstallCommand(
     job: PackagingJob,
     fileName: string,
-    nestedPathEscaped: string
+    nestedPathEscaped?: string
   ): string {
     const fileNameEscaped = fileName.replace(/'/g, "''");
     return `${this.getPortableInstallPathLine(job)}
@@ -1421,14 +1430,13 @@ ${steps}
         finally {
             if ($archive) { $archive.Dispose() }
         }
-        $declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path $stageRoot '${nestedPathEscaped}'))
+${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPath((Join-Path $stageRoot '${nestedPathEscaped}'))
         if (-not $declaredNestedPath.StartsWith($stageRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
             throw "Nested installer path escapes the portable staging directory"
         }
         if (-not (Test-Path -LiteralPath $declaredNestedPath -PathType Leaf)) {
             throw "Nested installer not found in archive: ${nestedPathEscaped}"
-        }
-        $installParent = [System.IO.Path]::GetDirectoryName($installPath)
+        }\n` : ''}        $installParent = [System.IO.Path]::GetDirectoryName($installPath)
         if ($installParent) { $null = New-Item -Path $installParent -ItemType Directory -Force }
         $replacementStarted = $true
         if (Test-Path -LiteralPath $installPath) { Remove-Item -LiteralPath $installPath -Recurse -Force -ErrorAction Stop }
@@ -1499,7 +1507,8 @@ ${steps}
       const fileNameEscaped = installerFileName.replace(/'/g, "''");
       const silentSwitches = this.extractSilentSwitches(
         job.install_command,
-        job.installer_type
+        job.installer_type,
+        nestedInstaller.type ?? undefined
       ).replace(/'/g, "''");
       const hiveLongName = job.install_scope === 'user' ? 'HKEY_CURRENT_USER' : 'HKEY_LOCAL_MACHINE';
       const markerProviderPath = `Registry::${hiveLongName}\\${this.getRegistryMarkerPath(job)}\\${this.sanitizeWingetId(job.winget_id)}`;
@@ -1924,7 +1933,11 @@ ${capturedIdentityValues}
   /**
    * Extract silent switches from install command
    */
-  private extractSilentSwitches(installCommand: string, installerType: string): string {
+  private extractSilentSwitches(
+    installCommand: string,
+    installerType: string,
+    nestedInstallerType?: string
+  ): string {
     const defaultSwitches: Record<string, string> = {
       msi: '/qn /norestart',
       exe: '/S',
@@ -1933,20 +1946,32 @@ ${capturedIdentityValues}
       wix: '/qn /norestart',
       burn: '/q /norestart',
       msix: '',
+      portable: '',
+      zip: '',
     };
 
-    const cleaned = installCommand
+    const sourceType = installerType.toLowerCase();
+    const effectiveType = sourceType === 'zip' && nestedInstallerType
+      ? nestedInstallerType.toLowerCase()
+      : sourceType;
+
+    if (/\bExpand-Archive\b/i.test(installCommand)) {
+      return defaultSwitches[effectiveType] ?? '';
+    }
+
+    let cleaned = installCommand
       .replace(/^"[^"]+"\s*/, '')
       .replace(/^\S+\.(exe|msi|msix|appx)\s*/i, '')
       .replace(/\/[ixp]\s+"[^"]+"\s*/gi, '')
       .replace(/\/[ixp]\s+\{[^}]+\}\s*/gi, '')
       .replace(/\/[ixp]\s+\S+\.(msi|msp)\s*/gi, '')
-      .trim();
+      .replace(/\/[ixp]\s+/gi, '');
+    cleaned = cleaned.trim();
     if (/^(?:\/\S+|-{1,2}\S+)/.test(cleaned) && cleaned !== '-DeploymentType') {
       return cleaned;
     }
 
-    return defaultSwitches[installerType] || '/S';
+    return defaultSwitches[effectiveType] ?? (sourceType === 'zip' ? '' : '/S');
   }
 
   private getInstallerSuccessCodes(job: PackagingJob): number[] {

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -9,6 +9,11 @@ type ScriptGenerator = {
   getInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string;
   getUninstallCommand(job: PackagingJob, fileName: string): string;
   getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string;
+  extractSilentSwitches(
+    installCommand: string,
+    installerType: string,
+    nestedInstallerType?: string
+  ): string;
 };
 
 const generator = JobProcessor.prototype as unknown as ScriptGenerator;
@@ -52,6 +57,46 @@ function uninstallScript(job: PackagingJob): string {
 }
 
 describe('nested portable PSADT generation', () => {
+  it('safely stages a top-level portable zip payload', () => {
+    const script = installScript(packagingJob({
+      installer_type: 'portable',
+      package_config: {},
+    }));
+
+    expect(script).toContain('[System.IO.Compression.ZipFile]::OpenRead($archivePath)');
+    expect(script).toContain('Move-Item -LiteralPath $portableStageDir -Destination $installPath');
+    expect(script).not.toContain('Zip package does not declare');
+  });
+
+  it('treats a zip without nested metadata as a portable archive', () => {
+    const job = packagingJob({ package_config: {} });
+    const script = installScript(job);
+
+    expect(script).toContain('[System.IO.Compression.ZipFile]::OpenRead($archivePath)');
+    expect(script).toContain('Move-Item -LiteralPath $portableStageDir -Destination $installPath');
+    expect(script).not.toContain('$declaredNestedPath');
+    expect(uninstallScript(job)).toContain('Remove-Item -LiteralPath $installPath -Recurse -Force');
+  });
+
+  it.each([
+    ['Expand-Archive -Path "app.zip" -DestinationPath app -Force', 'zip', 'inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
+    ['powershell.exe -Command Expand-Archive -Path app.zip -DestinationPath app', 'zip', 'inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
+    ['"setup.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-', 'zip', 'inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
+    ['"setup.exe" /configure https://aka.ms/fhlwingetconfig', 'exe', undefined, '/configure https://aka.ms/fhlwingetconfig'],
+    ['msiexec.exe /i "agent.msi" /qn REBOOT=ReallySuppress ALLUSERS=1', 'msi', undefined, '/qn REBOOT=ReallySuppress ALLUSERS=1'],
+    ['Expand-Archive -Path "app.zip" -DestinationPath app -Force', 'zip', undefined, ''],
+    ['Expand-Archive -Path "app.zip" -DestinationPath app -Force', 'portable', undefined, ''],
+  ])('extracts local silent switches without archive arguments', (command, type, nestedType, expected) => {
+    expect(generator.extractSilentSwitches.call(generator, command, type, nestedType)).toBe(expected);
+  });
+
+  it('does not emit PowerShell archive tokens into a generated argument list', () => {
+    const script = generator.generateDeployScript.call(generator, packagingJob({
+      install_command: 'powershell.exe -Command Expand-Archive -Path app.zip -DestinationPath app',
+    }), 'piicrawler.zip');
+
+    expect(script).not.toMatch(/-ArgumentList '[^']*(?:-Command|-Archive)/);
+  });
   it('preserves manifest-declared installer success exit codes', () => {
     const script = generator.generateDeployScript.call(generator, packagingJob({
       package_config: {
@@ -274,10 +319,13 @@ describe('hosted PSADT portable generator', () => {
     const script = readFileSync(scriptPath, 'utf8');
 
     expect(script).toContain("$isNestedPortable = $installerTypeLower -eq 'zip'");
-    expect(script).toContain("if ($installerTypeLower -eq 'portable' -or $isNestedPortable)");
+    expect(script).toContain("if ($installerTypeLower -eq 'portable' -or $isNestedPortable -or $isPlainPortableArchive)");
     expect(script).toContain('[System.IO.Compression.ZipFile]::OpenRead($installerPath)');
     expect(script).toContain('Archive entry escapes the portable staging directory');
     expect(script).not.toContain('Portable nested installers are not supported yet');
+    expect(script).not.toContain('Zip package does not declare a nested installer');
+    expect(script).toContain('if ($isNestedPortable -or $isPlainPortableArchive)');
+    expect(script).toContain('Move-Item -LiteralPath $portableStageDir -Destination $installPath');
   });
 
   it('uses the non-admin PSADT log setting for user-scope packages', () => {


### PR DESCRIPTION
Fixes #223 and the remaining gaps from #224.

The original failures (claude.exe -Archive -Path with an empty path, and the Google.PlatformTools ZIP aborting with 'Zip package does not declare a nested installer') were partially fixed by earlier releases. This closes the residual defects in both PSADT generators:

- Plain ZIP archives with no nested installer contract now install as portable apps: the archive stages safely with every zip-slip guard retained, then replaces the install folder. Both the hosted Create-PSADTPackage.ps1 and the local packager take the same path, and uninstall stays paired through folder removal plus the registry marker.
- A portable job whose payload is a .zip previously hit the zip check first and threw; the portable branch is now evaluated before the zip check and reuses the staged extractor.
- The packager's private silent switch extractor had drifted from lib/msp/silent-switches.ts: it lacked the Expand-Archive guard, so commands like 'powershell.exe -Command Expand-Archive -Path app.zip' leaked -Command as vendor switches. It now matches the canonical semantics including empty defaults for zip and portable types.
- lib/packaging-contract.ts only rejects half-declared nested metadata (type without path or vice versa); a fully absent nested contract is a valid portable archive.
- Displayed install commands for bare portable executables now show the Copy-Item operation the generated script actually performs instead of a bogus Expand-Archive on an exe.

Tests mirror every change across both generators, including the QA parity contract. Full suite passes (1038 tests).

Note: re-packaging Anthropic.ClaudeCode and Google.PlatformTools requires the QA toolchain activation that follows this PR, and self-hosted npm packager users need the upcoming packager release.