### PR TITLE
chore(qa): activate portable archive packaging release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
+  packagerCommit: '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -60,6 +60,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'd0051e4b3972e9511935398e8b4f4e93e6289edd',
   '5f95d233998479791a49d1d784ea95137c098e73',
   '8235887e7126972b89c264e2053c1c4f7418ea74',
+  '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -85,10 +85,24 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Viber once on the reviewed user-scope release', () => {
+  it('keeps the Viber retry scoped to its user-scope release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
+      { wingetId: 'Rakuten.Viber', status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Rakuten.Viber', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it.each([
+    'Anthropic.ClaudeCode',
+    'Google.PlatformTools',
+  ])('retries %s once on the portable archive release', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,16 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3fce249f5021c120a23ed0ab5dc726baaf060f3e': [
+    // Claude Code ships as a bare portable executable. Earlier releases
+    // generated an incomplete archive command for it; this release installs
+    // bare portable payloads through the reviewed copy lifecycle.
+    'Anthropic.ClaudeCode',
+    // Platform Tools is a plain zip with no nested installer contract. This
+    // release stages such archives as complete portable folders instead of
+    // failing with the nested installer requirement.
+    'Google.PlatformTools',
+  ],
   '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea': [
     // Viber's machine-declared MSI resolves LocalAppData into the SYSTEM
     // profile and its VerifyInstalledFiles action then fails with 1603. The


### PR DESCRIPTION
Activates the packager release from #439 for QA and customer packaging.

- Pins QA_PSADT_TOOLCHAIN.packagerCommit to the #439 squash commit and appends the previous pin to the release history.
- Adds targeted terminal retries for Anthropic.ClaudeCode (#224) and Google.PlatformTools (#223), whose QA candidates failed on the old toolchain and would otherwise never be re-packaged.
- Updates the retry scoping tests for the new pin.

Follows the established two-step fix and activation pattern.