### PR TITLE
Release packager 1.4.0

### DIFF
--- a/packager/package-lock.json
+++ b/packager/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ugurkocde/intuneget-packager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ugurkocde/intuneget-packager",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",

--- a/packager/package.json
+++ b/packager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ugurkocde/intuneget-packager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Local Windows packager service for IntuneGet - enables true self-hosting without GitHub Actions dependency",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bumps @ugurkocde/intuneget-packager to 1.4.0.

The npm package was last published as 1.3.0 on 2026-07-02, which predates every packager fix since, including the Win32 create payload fix (#435), the portable archive install path (#439), and earlier portable and silent switch fixes. Self-hosted users running the published package still hit the failures reported in #170, #224, and #223.

After this merges, pushing the packager-v1.4.0 tag triggers the publish workflow. Existing users update with npm update -g @ugurkocde/intuneget-packager.