### PR TITLE
Fix packager TypeScript build and compile it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Build packager
+        working-directory: packager
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
   lint:
     name: Lint
     runs-on: ubuntu-24.04

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -970,7 +970,7 @@ catch
   private getUninstallCompletionTimeoutMinutes(job: PackagingJob): number {
     const raw = this.getPsadtConfig(job)?.uninstallCompletionTimeoutMinutes;
     if (raw === undefined || raw === null) return 5;
-    if (!Number.isInteger(raw) || raw < 1 || raw > 30) {
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1 || raw > 30) {
       throw new Error('PSADT uninstallCompletionTimeoutMinutes must be an integer from 1 to 30');
     }
     return raw;


### PR DESCRIPTION
The packager-v1.4.0 publish run failed because packager/src/job-processor.ts no longer compiled under the packager's own tsc: the uninstall completion timeout guard compared an unknown value with relational operators. The repo test suite never caught it because vitest transpiles without type checking and CI never built the packager.

- Adds an explicit typeof check to the guard with identical runtime behavior.
- Adds a packager build step to the CI Test job so the publish build is exercised on every PR.

After this merges the packager-v1.4.0 tag will be repointed and the publish workflow rerun.