### PR TITLE
Degrade dashboard pages gracefully in SQLite self-host mode

### DIFF
--- a/app/(app)/dashboard/layout.tsx
+++ b/app/(app)/dashboard/layout.tsx
@@ -24,6 +24,7 @@ import { NotificationBell } from '@/components/notifications';
 import { Sidebar, DeploymentStatusIndicator } from '@/components/dashboard';
 import { CommandPalette } from '@/components/dashboard/CommandPalette';
 import { springPresets } from '@/lib/animations/variants';
+import { getClientFeatureFlags } from '@/lib/features';
 
 export default function DashboardLayout({
   children,
@@ -48,6 +49,7 @@ export default function DashboardLayout({
 
   const cartItemCount = useCartStore((state) => state.getItemCount());
   const toggleCart = useCartStore((state) => state.toggleCart);
+  const { hostedServices } = getClientFeatureFlags();
 
   const handleOpenCommandPalette = useCallback(() => {
     setCommandPaletteOpen(true);
@@ -77,7 +79,7 @@ export default function DashboardLayout({
     }
 
     // Only act on a definitive errorType. errorType=null + !isOnboardingComplete
-    // is a transient state during MSAL hydration / verification — redirecting
+    // is a transient state during MSAL hydration / verification; redirecting
     // here would push known-good users to /onboarding on browser refresh.
     if (errorType === null) return;
 
@@ -170,7 +172,7 @@ export default function DashboardLayout({
             <div className="flex items-center gap-3">
               <TenantSwitcher />
               <DeploymentStatusIndicator />
-              <NotificationBell />
+              {hostedServices && <NotificationBell />}
               <Button
                 variant="ghost"
                 onClick={toggleCart}

--- a/app/api/analytics/export/route.ts
+++ b/app/api/analytics/export/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getDatabase } from '@/lib/db';
 import { parseAccessToken } from '@/lib/auth-utils';
 
 export async function GET(request: NextRequest) {
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
       now.getUTCDate() - days
     ));
 
-    const supabase = createServerClient();
+    const database = getDatabase();
 
     // Define the shape of jobs returned from the query
     interface PackagingJobExport {
@@ -50,32 +50,9 @@ export async function GET(request: NextRequest) {
     }
 
     // Get all jobs in date range
-    const { data: jobs, error: jobsError } = await supabase
-      .from('packaging_jobs')
-      .select(`
-        id,
-        winget_id,
-        display_name,
-        publisher,
-        version,
-        architecture,
-        installer_type,
-        status,
-        error_message,
-        intune_app_id,
-        created_at,
-        completed_at
-      `)
-      .eq('user_id', user.userId)
-      .gte('created_at', startDate.toISOString())
-      .order('created_at', { ascending: false });
-
-    if (jobsError) {
-      return NextResponse.json(
-        { error: 'Failed to fetch data for export' },
-        { status: 500 }
-      );
-    }
+    const jobs = (await database.jobs.getByUserId(user.userId)).filter(
+      (job) => new Date(job.created_at) >= startDate
+    );
 
     // Build CSV
     const headers = [

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getDatabase } from '@/lib/db';
 import { parseAccessToken } from '@/lib/auth-utils';
 
 interface DailyDeployment {
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
       now.getUTCDate() - days
     ));
 
-    const supabase = createServerClient();
+    const database = getDatabase();
 
     // Define the shape of jobs returned from the query
     interface PackagingJobAnalytics {
@@ -67,19 +67,9 @@ export async function GET(request: NextRequest) {
     }
 
     // Get all jobs in date range
-    const { data: jobs, error: jobsError } = await supabase
-      .from('packaging_jobs')
-      .select('id, winget_id, display_name, publisher, status, error_message, created_at, completed_at')
-      .eq('user_id', user.userId)
-      .gte('created_at', startDate.toISOString())
-      .order('created_at', { ascending: false });
-
-    if (jobsError) {
-      return NextResponse.json(
-        { error: 'Failed to fetch analytics data' },
-        { status: 500 }
-      );
-    }
+    const jobs = (await database.jobs.getByUserId(user.userId)).filter(
+      (job) => new Date(job.created_at) >= startDate
+    );
 
     const allJobs = (jobs || []) as PackagingJobAnalytics[];
 

--- a/app/api/analytics/stats/route.test.ts
+++ b/app/api/analytics/stats/route.test.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: vi.fn().mockResolvedValue({ userId: 'user-1', tenantId: 'tenant-1' }),
+}));
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => ({ jobs: { getByUserId: vi.fn().mockResolvedValue([]) } }),
+}));
+
+import { GET } from './route';
+
+describe('GET /api/analytics/stats', () => {
+  it('returns a well-formed zero payload with no SQLite jobs', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/analytics/stats'));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      totalDeployed: 0,
+      thisMonth: 0,
+      pending: 0,
+      failed: 0,
+      recentActivity: [],
+    });
+  });
+});

--- a/app/api/analytics/stats/route.ts
+++ b/app/api/analytics/stats/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getDatabase } from '@/lib/db';
 import { parseAccessToken } from '@/lib/auth-utils';
 
 export async function GET(request: NextRequest) {
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const database = getDatabase();
 
     // Define the shape of jobs returned from the queries
     interface PackagingJobStats {
@@ -44,29 +44,8 @@ export async function GET(request: NextRequest) {
 
     // Fetch all jobs in a single query and aggregate in memory
     // This is more efficient than 4 separate count queries
-    const { data: jobs, error: jobsError } = await supabase
-      .from('packaging_jobs')
-      .select('status, completed_at')
-      .eq('user_id', user.userId);
-
-    // Fetch 5 most recent jobs for activity feed
-    const { data: recentJobs, error: recentJobsError } = await supabase
-      .from('packaging_jobs')
-      .select('id, winget_id, display_name, status, created_at, intune_app_url')
-      .eq('user_id', user.userId)
-      .order('created_at', { ascending: false })
-      .limit(5);
-
-    if (recentJobsError) {
-      // Failed to fetch recent jobs - continue with empty array
-    }
-
-    if (jobsError) {
-      return NextResponse.json(
-        { error: 'Failed to fetch statistics' },
-        { status: 500 }
-      );
-    }
+    const jobs = await database.jobs.getByUserId(user.userId);
+    const recentJobs = jobs.slice(0, 5);
 
     const allJobs = (jobs || []) as PackagingJobStats[];
 

--- a/app/api/community/suggestions/[id]/vote/route.ts
+++ b/app/api/community/suggestions/[id]/vote/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { isValidUuid } from '@/lib/validators/community';
 import {
@@ -23,6 +23,12 @@ interface RouteParams {
  * Add a vote to a suggestion
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isSupabaseServerConfigured()) {
+    return NextResponse.json(
+      { error: 'App request voting requires hosted services' },
+      { status: 503 }
+    );
+  }
   try {
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
@@ -136,6 +142,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
  * Remove a vote from a suggestion
  */
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  if (!isSupabaseServerConfigured()) {
+    return NextResponse.json(
+      { error: 'App request voting requires hosted services' },
+      { status: 503 }
+    );
+  }
   try {
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {

--- a/app/api/community/suggestions/route.test.ts
+++ b/app/api/community/suggestions/route.test.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase', () => ({
+  createServerClient: vi.fn(),
+  isSupabaseServerConfigured: () => false,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  applyRateLimit: vi.fn().mockResolvedValue(null),
+  getIpKey: vi.fn(),
+  getUserKey: vi.fn(),
+  SUGGESTION_RATE_LIMIT: {},
+  PUBLIC_RATE_LIMIT: {},
+}));
+
+import { GET } from './route';
+
+describe('GET /api/community/suggestions', () => {
+  it('returns an empty list without hosted services', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/community/suggestions'));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      suggestions: [],
+      userVotes: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+  });
+});

--- a/app/api/community/suggestions/route.ts
+++ b/app/api/community/suggestions/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
   suggestionSchema,
@@ -52,6 +52,14 @@ export async function GET(request: NextRequest) {
 
     const { status, sort, page, limit } = queryValidation.data;
     const offset = (page - 1) * limit;
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({
+        suggestions: [],
+        userVotes: [],
+        pagination: { page, limit, total: 0, totalPages: 0 },
+      });
+    }
 
     const supabase = createServerClient();
 
@@ -132,6 +140,13 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'App requests require hosted services' },
+        { status: 503 }
+      );
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(

--- a/app/api/intune/apps/[id]/route.ts
+++ b/app/api/intune/apps/[id]/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getServicePrincipalToken } from '@/lib/intune/graph-client';
@@ -28,34 +28,24 @@ export async function GET(
     }
 
     // Verify admin consent
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+    let tenantId = user.tenantId;
 
-    const tenantResolution = await resolveTargetTenantId({
-      supabase,
-      userId: user.userId,
-      tokenTenantId: user.tenantId,
-      requestedTenantId: mspTenantId,
-    });
+    if (supabase) {
+      const tenantResolution = await resolveTargetTenantId({
+        supabase, userId: user.userId, tokenTenantId: user.tenantId,
+        requestedTenantId: mspTenantId,
+      });
+      if (tenantResolution.errorResponse) return tenantResolution.errorResponse;
+      tenantId = tenantResolution.tenantId;
 
-    if (tenantResolution.errorResponse) {
-      return tenantResolution.errorResponse;
-    }
-
-    const tenantId = tenantResolution.tenantId;
-
-    const { data: consentData, error: consentError } = await supabase
-      .from('tenant_consent')
-      .select('*')
-      .eq('tenant_id', tenantId)
-      .eq('is_active', true)
-      .single();
-
-    if (consentError || !consentData) {
-      return NextResponse.json(
-        { error: 'Admin consent not found' },
-        { status: 403 }
-      );
+      const { data: consentData, error: consentError } = await supabase
+        .from('tenant_consent').select('*').eq('tenant_id', tenantId)
+        .eq('is_active', true).single();
+      if (consentError || !consentData) {
+        return NextResponse.json({ error: 'Admin consent not found' }, { status: 403 });
+      }
     }
 
     // Get service principal token

--- a/app/api/intune/apps/[id]/settings/route.ts
+++ b/app/api/intune/apps/[id]/settings/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { getServicePrincipalToken } from '@/lib/intune/graph-client';
 import {
@@ -35,15 +35,15 @@ export async function PATCH(
     }
 
     // Resolve tenant (MSP-aware)
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
-    const tenantResolution = await resolveTargetTenantId({
+    const tenantResolution = supabase ? await resolveTargetTenantId({
       supabase,
       userId: user.userId,
       tokenTenantId: user.tenantId,
       requestedTenantId: mspTenantId,
-    });
+    }) : { tenantId: user.tenantId, errorResponse: null };
 
     if (tenantResolution.errorResponse) {
       return tenantResolution.errorResponse;
@@ -52,12 +52,12 @@ export async function PATCH(
     const tenantId = tenantResolution.tenantId;
 
     // Verify admin consent
-    const { data: consentData, error: consentError } = await supabase
+    const { data: consentData, error: consentError } = supabase ? await supabase
       .from('tenant_consent')
       .select('*')
       .eq('tenant_id', tenantId)
       .eq('is_active', true)
-      .single();
+      .single() : { data: true, error: null };
 
     if (consentError || !consentData) {
       return NextResponse.json(
@@ -130,7 +130,7 @@ export async function PATCH(
     }
 
     // Persist updated assignments/categories in the most recent packaging_jobs row
-    if (wingetId) {
+    if (wingetId && supabase) {
       const { data: latestJob } = await supabase
         .from('packaging_jobs')
         .select('id, package_config')

--- a/app/api/intune/apps/deployed/config/route.ts
+++ b/app/api/intune/apps/deployed/config/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
+import { getDatabase } from '@/lib/db';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 
@@ -23,8 +24,19 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+
+    if (!supabase) {
+      const job = (await getDatabase().jobs.getByUserId(user.userId)).find(
+        (item) => item.winget_id === wingetId && item.status === 'deployed'
+      );
+      return NextResponse.json({
+        config: job?.package_config ?? null,
+        deployedAt: job?.completed_at ?? null,
+        intuneAppId: job?.intune_app_id ?? null,
+      });
+    }
 
     const tenantResolution = await resolveTargetTenantId({
       supabase,

--- a/app/api/intune/apps/deployed/route.test.ts
+++ b/app/api/intune/apps/deployed/route.test.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const {
   parseAccessTokenMock,
-  createServerClientMock,
+  getServerClientOrNullMock,
   resolveTargetTenantIdMock,
 } = vi.hoisted(() => ({
   parseAccessTokenMock: vi.fn(),
-  createServerClientMock: vi.fn(),
+  getServerClientOrNullMock: vi.fn(),
   resolveTargetTenantIdMock: vi.fn(),
 }));
 
@@ -15,7 +15,7 @@ vi.mock('@/lib/auth-utils', () => ({
 }));
 
 vi.mock('@/lib/supabase', () => ({
-  createServerClient: createServerClientMock,
+  getServerClientOrNull: getServerClientOrNullMock,
 }));
 
 vi.mock('@/lib/msp/tenant-resolution', () => ({
@@ -70,7 +70,7 @@ describe('GET /api/intune/apps/deployed', () => {
       operations
     );
 
-    createServerClientMock.mockReturnValue({
+    getServerClientOrNullMock.mockReturnValue({
       from: (table: string) => {
         if (table === 'upload_history') {
           return uploadHistoryQuery;
@@ -118,7 +118,7 @@ describe('GET /api/intune/apps/deployed', () => {
       []
     );
 
-    createServerClientMock.mockReturnValue({
+    getServerClientOrNullMock.mockReturnValue({
       from: () => uploadHistoryQuery,
     });
 
@@ -163,7 +163,7 @@ describe('GET /api/intune/apps/deployed', () => {
       userName: 'User',
     });
 
-    createServerClientMock.mockReturnValue({
+    getServerClientOrNullMock.mockReturnValue({
       from: vi.fn(),
     });
 
@@ -199,7 +199,7 @@ describe('GET /api/intune/apps/deployed', () => {
       []
     );
 
-    createServerClientMock.mockReturnValue({
+    getServerClientOrNullMock.mockReturnValue({
       from: () => uploadHistoryQuery,
     });
 

--- a/app/api/intune/apps/deployed/route.ts
+++ b/app/api/intune/apps/deployed/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
+import { getDatabase } from '@/lib/db';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 
@@ -22,8 +23,28 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+
+    if (!supabase) {
+      const scope = new URL(request.url).searchParams.get('scope');
+      if (scope === 'tenant') {
+        const jobs = await getDatabase().jobs.getByTenantId(user.tenantId);
+        const tenantDeployments = jobs
+          .filter((job) => job.status === 'deployed')
+          .map((job) => ({ wingetId: job.winget_id, deployedBy: job.user_email }));
+        return NextResponse.json({
+          tenantDeployments,
+          deployedWingetIds: tenantDeployments.map((item) => item.wingetId),
+          count: tenantDeployments.length,
+          scope: 'tenant',
+        });
+      }
+
+      const history = await getDatabase().uploadHistory.getByUserId(user.userId);
+      const deployedWingetIds = Array.from(new Set(history.map((row) => row.winget_id)));
+      return NextResponse.json({ deployedWingetIds, count: deployedWingetIds.length });
+    }
 
     const tenantResolution = await resolveTargetTenantId({
       supabase,

--- a/app/api/intune/apps/route.test.ts
+++ b/app/api/intune/apps/route.test.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const { graphTokenMock } = vi.hoisted(() => ({ graphTokenMock: vi.fn() }));
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: vi.fn().mockResolvedValue({ userId: 'user-1', tenantId: 'tenant-1' }),
+}));
+vi.mock('@/lib/supabase', () => ({ getServerClientOrNull: () => null }));
+vi.mock('@/lib/intune/graph-client', () => ({ getServicePrincipalToken: graphTokenMock }));
+
+import { GET } from './route';
+
+describe('GET /api/intune/apps', () => {
+  it('serves Graph data without Supabase', async () => {
+    graphTokenMock.mockResolvedValue('graph-token');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      value: [{ id: 'app-1', displayName: 'Example App' }],
+    }), { status: 200 })));
+
+    const response = await GET(new NextRequest('http://localhost/api/intune/apps'));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      apps: [{ id: 'app-1', displayName: 'Example App' }],
+      count: 1,
+    });
+  });
+});

--- a/app/api/intune/apps/route.ts
+++ b/app/api/intune/apps/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getServicePrincipalToken } from '@/lib/intune/graph-client';
@@ -23,34 +23,27 @@ export async function GET(request: NextRequest) {
     }
 
     // Get the service principal access token from the database
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
+    let tenantId = user.tenantId;
 
-    const tenantResolution = await resolveTargetTenantId({
-      supabase,
-      userId: user.userId,
-      tokenTenantId: user.tenantId,
-      requestedTenantId: mspTenantId,
-    });
+    if (supabase) {
+      const tenantResolution = await resolveTargetTenantId({
+        supabase, userId: user.userId, tokenTenantId: user.tenantId,
+        requestedTenantId: mspTenantId,
+      });
+      if (tenantResolution.errorResponse) return tenantResolution.errorResponse;
+      tenantId = tenantResolution.tenantId;
 
-    if (tenantResolution.errorResponse) {
-      return tenantResolution.errorResponse;
-    }
-
-    const tenantId = tenantResolution.tenantId;
-
-    const { data: consentData, error: consentError } = await supabase
-      .from('tenant_consent')
-      .select('*')
-      .eq('tenant_id', tenantId)
-      .eq('is_active', true)
-      .single();
-
-    if (consentError || !consentData) {
-      return NextResponse.json(
-        { error: 'Admin consent not found. Please complete the admin consent flow.' },
-        { status: 403 }
-      );
+      const { data: consentData, error: consentError } = await supabase
+        .from('tenant_consent').select('*').eq('tenant_id', tenantId)
+        .eq('is_active', true).single();
+      if (consentError || !consentData) {
+        return NextResponse.json(
+          { error: 'Admin consent not found. Please complete the admin consent flow.' },
+          { status: 403 }
+        );
+      }
     }
 
     // Get the service principal token to call Graph API

--- a/app/api/intune/apps/updates/route.test.ts
+++ b/app/api/intune/apps/updates/route.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/supabase', () => ({
   // getCatalogSource() now branches on isSupabaseConfigured(); the route
   // imports it transitively, so the mock must provide it (Supabase mode).
   isSupabaseConfigured: () => true,
+  isSupabaseServerConfigured: () => true,
 }));
 
 vi.mock('@/lib/msp/tenant-resolution', () => ({

--- a/app/api/intune/apps/updates/route.ts
+++ b/app/api/intune/apps/updates/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { getServicePrincipalToken } from '@/lib/intune/graph-client';
 import {
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       return NextResponse.json(
         { error: 'Update checking requires Supabase and is not available on this self-hosted deployment' },
         { status: 503 }

--- a/app/api/intune/categories/route.ts
+++ b/app/api/intune/categories/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getMobileAppCategories } from '@/lib/intune-api';
@@ -20,34 +20,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
-
-    const tenantResolution = await resolveTargetTenantId({
-      supabase,
-      userId: user.userId,
-      tokenTenantId: user.tenantId,
-      requestedTenantId: mspTenantId,
-    });
-
-    if (tenantResolution.errorResponse) {
-      return tenantResolution.errorResponse;
-    }
-
-    const tenantId = tenantResolution.tenantId;
-
-    const { data: consentData, error: consentError } = await supabase
-      .from('tenant_consent')
-      .select('*')
-      .eq('tenant_id', tenantId)
-      .eq('is_active', true)
-      .single();
-
-    if (consentError || !consentData) {
-      return NextResponse.json(
-        { error: 'Admin consent not found. Please complete the admin consent flow.' },
-        { status: 403 }
-      );
+    let tenantId = user.tenantId;
+    if (supabase) {
+      const tenantResolution = await resolveTargetTenantId({ supabase, userId: user.userId, tokenTenantId: user.tenantId, requestedTenantId: mspTenantId });
+      if (tenantResolution.errorResponse) return tenantResolution.errorResponse;
+      tenantId = tenantResolution.tenantId;
+      const { data, error } = await supabase.from('tenant_consent').select('*').eq('tenant_id', tenantId).eq('is_active', true).single();
+      if (error || !data) return NextResponse.json({ error: 'Admin consent not found. Please complete the admin consent flow.' }, { status: 403 });
     }
 
     const graphToken = await getServicePrincipalToken(tenantId);

--- a/app/api/intune/claim/route.ts
+++ b/app/api/intune/claim/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import type { ClaimAppRequest, ClaimedApp } from '@/types/unmanaged';
@@ -57,6 +57,9 @@ async function ensureUserProfile(
  */
 export async function POST(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ error: 'App claims require hosted services' }, { status: 503 });
+    }
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(
@@ -175,6 +178,9 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ claims: [] });
+    }
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(
@@ -239,6 +245,9 @@ export async function GET(request: NextRequest) {
  */
 export async function PATCH(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ error: 'App claims require hosted services' }, { status: 503 });
+    }
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(

--- a/app/api/intune/detected-app-devices/route.ts
+++ b/app/api/intune/detected-app-devices/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
@@ -88,7 +88,7 @@ async function fetchDevicesForDetectedApp(
       if (response.status === 401) {
         invalidateServicePrincipalToken(tenantId);
       }
-      // Stale version id no longer present — treat as no devices.
+      // Stale version id no longer present; treat as no devices.
       if (response.status === 404) {
         await response.text().catch(() => {});
         return devices;
@@ -126,15 +126,15 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Missing appId parameter' }, { status: 400 });
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
-    const tenantResolution = await resolveTargetTenantId({
+    const tenantResolution = supabase ? await resolveTargetTenantId({
       supabase,
       userId: user.userId,
       tokenTenantId: user.tenantId,
       requestedTenantId: mspTenantId,
-    });
+    }) : { tenantId: user.tenantId, errorResponse: null };
 
     if (tenantResolution.errorResponse) {
       return tenantResolution.errorResponse;
@@ -143,12 +143,12 @@ export async function GET(request: NextRequest) {
     const tenantId = tenantResolution.tenantId;
 
     // Verify admin consent (mirrors the unmanaged-apps route)
-    const { data: consentData, error: consentError } = await supabase
+    const { data: consentData, error: consentError } = supabase ? await supabase
       .from('tenant_consent')
       .select('*')
       .eq('tenant_id', tenantId)
       .eq('is_active', true)
-      .single();
+      .single() : { data: true, error: null };
 
     if (consentError || !consentData) {
       return NextResponse.json(
@@ -160,12 +160,12 @@ export async function GET(request: NextRequest) {
     // Resolve the full set of detected-app (version) ids for this app from the
     // sync cache; fall back to the single id for rows written before this field
     // existed or evicted rows.
-    const { data: cacheRow } = await supabase
+    const { data: cacheRow } = supabase ? await supabase
       .from('discovered_apps_cache')
       .select('app_data, device_count')
       .eq('tenant_id', tenantId)
       .eq('discovered_app_id', appId)
-      .maybeSingle();
+      .maybeSingle() : { data: null };
 
     const appData = (cacheRow?.app_data ?? null) as unknown as { mergedAppIds?: string[] } | null;
     const allVersionIds =

--- a/app/api/intune/filters/route.ts
+++ b/app/api/intune/filters/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getAssignmentFilters } from '@/lib/intune-api';
@@ -20,15 +20,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
-    const tenantResolution = await resolveTargetTenantId({
+    const tenantResolution = supabase ? await resolveTargetTenantId({
       supabase,
       userId: user.userId,
       tokenTenantId: user.tenantId,
       requestedTenantId: mspTenantId,
-    });
+    }) : { tenantId: user.tenantId, errorResponse: null };
 
     if (tenantResolution.errorResponse) {
       return tenantResolution.errorResponse;
@@ -36,12 +36,12 @@ export async function GET(request: NextRequest) {
 
     const tenantId = tenantResolution.tenantId;
 
-    const { data: consentData, error: consentError } = await supabase
+    const { data: consentData, error: consentError } = supabase ? await supabase
       .from('tenant_consent')
       .select('*')
       .eq('tenant_id', tenantId)
       .eq('is_active', true)
-      .single();
+      .single() : { data: true, error: null };
 
     if (consentError || !consentData) {
       return NextResponse.json(

--- a/app/api/intune/groups/route.ts
+++ b/app/api/intune/groups/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { getServerClientOrNull } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getEntraIDGroups } from '@/lib/intune-api';
@@ -25,15 +25,15 @@ export async function GET(request: NextRequest) {
     }
 
     // Get the service principal access token from the database
-    const supabase = createServerClient();
+    const supabase = getServerClientOrNull();
     const mspTenantId = request.headers.get('X-MSP-Tenant-Id');
 
-    const tenantResolution = await resolveTargetTenantId({
+    const tenantResolution = supabase ? await resolveTargetTenantId({
       supabase,
       userId: user.userId,
       tokenTenantId: user.tenantId,
       requestedTenantId: mspTenantId,
-    });
+    }) : { tenantId: user.tenantId, errorResponse: null };
 
     if (tenantResolution.errorResponse) {
       return tenantResolution.errorResponse;
@@ -41,12 +41,12 @@ export async function GET(request: NextRequest) {
 
     const tenantId = tenantResolution.tenantId;
 
-    const { data: consentData, error: consentError } = await supabase
+    const { data: consentData, error: consentError } = supabase ? await supabase
       .from('tenant_consent')
       .select('*')
       .eq('tenant_id', tenantId)
       .eq('is_active', true)
-      .single();
+      .single() : { data: true, error: null };
 
     if (consentError || !consentData) {
       return NextResponse.json(

--- a/app/api/mappings/route.ts
+++ b/app/api/mappings/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { parseAccessToken } from '@/lib/auth-utils';
 import type { ManualAppMapping, CreateMappingRequest } from '@/types/unmanaged';
@@ -24,6 +24,10 @@ export async function GET(request: NextRequest) {
         { error: 'Authentication required' },
         { status: 401 }
       );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ mappings: [] });
     }
 
     const supabase = createServerClient();
@@ -81,6 +85,12 @@ export async function GET(request: NextRequest) {
  * POST - Create a new manual mapping
  */
 export async function POST(request: NextRequest) {
+  if (!isSupabaseServerConfigured()) {
+    return NextResponse.json(
+      { error: 'Manual mappings require hosted services' },
+      { status: 503 }
+    );
+  }
   try {
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
@@ -197,6 +207,12 @@ export async function POST(request: NextRequest) {
  * DELETE - Remove a manual mapping
  */
 export async function DELETE(request: NextRequest) {
+  if (!isSupabaseServerConfigured()) {
+    return NextResponse.json(
+      { error: 'Manual mappings require hosted services' },
+      { status: 503 }
+    );
+  }
   try {
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {

--- a/app/api/notifications/mark-all-read/route.ts
+++ b/app/api/notifications/mark-all-read/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { markAllNotificationsAsRead } from '@/lib/notification-service';
+import { isSupabaseServerConfigured } from '@/lib/supabase';
 
 /**
  * POST /api/notifications/mark-all-read
@@ -19,6 +20,10 @@ export async function POST(request: NextRequest) {
         { error: 'Authentication required' },
         { status: 401 }
       );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ success: true });
     }
 
     await markAllNotificationsAsRead(user.userId);

--- a/app/api/notifications/mark-read/route.ts
+++ b/app/api/notifications/mark-read/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 
 /**
@@ -20,6 +20,10 @@ export async function POST(request: NextRequest) {
         { error: 'Authentication required' },
         { status: 401 }
       );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ success: true, updated: 0 });
     }
 
     const body = await request.json();

--- a/app/api/notifications/preferences/route.ts
+++ b/app/api/notifications/preferences/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { sendTestEmail, isEmailConfigured } from '@/lib/email/service';
 import type {
@@ -29,6 +29,19 @@ export async function GET(request: NextRequest) {
         { error: 'Authentication required' },
         { status: 401 }
       );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({
+        preferences: {
+          user_id: user.userId,
+          email_enabled: false,
+          email_frequency: 'daily',
+          email_address: null,
+          notify_critical_only: false,
+        },
+        isEmailConfigured: false,
+      });
     }
 
     const supabase = createServerClient();
@@ -80,6 +93,13 @@ export async function GET(request: NextRequest) {
  */
 export async function PUT(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'Notification preferences require hosted services' },
+        { status: 503 }
+      );
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { getUserNotifications } from '@/lib/notification-service';
+import { isSupabaseServerConfigured } from '@/lib/supabase';
 
 /**
  * GET /api/notifications
@@ -19,6 +20,10 @@ export async function GET(request: NextRequest) {
         { error: 'Authentication required' },
         { status: 401 }
       );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ notifications: [], unread_count: 0 });
     }
 
     const { searchParams } = new URL(request.url);

--- a/app/api/update-policies/[id]/route.ts
+++ b/app/api/update-policies/[id]/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import type { AppUpdatePolicy, UpdatePolicyType } from '@/types/update-policies';
 import type { Database } from '@/types/database';
@@ -23,6 +23,10 @@ interface RouteParams {
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ policy: null });
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(
@@ -73,6 +77,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
  */
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'Auto-update policies require hosted services' },
+        { status: 503 }
+      );
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(
@@ -183,6 +194,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
  */
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'Auto-update policies require hosted services' },
+        { status: 503 }
+      );
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(

--- a/app/api/update-policies/route.test.ts
+++ b/app/api/update-policies/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/auth-utils', () => ({
 
 vi.mock('@/lib/supabase', () => ({
   createServerClient: createServerClientMock,
+  isSupabaseServerConfigured: () => true,
 }));
 
 vi.mock('@/lib/catalog', () => ({

--- a/app/api/update-policies/route.ts
+++ b/app/api/update-policies/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { buildDeploymentConfigForApp } from '@/lib/update-policies/build-deployment-config';
@@ -18,6 +18,10 @@ import type { Json } from '@/types/database';
  */
 export async function GET(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({ policies: [], count: 0 });
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(
@@ -70,6 +74,13 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'Auto-update policies require hosted services' },
+        { status: 503 }
+      );
+    }
+
     const user = await parseAccessToken(request.headers.get('Authorization'));
     if (!user) {
       return NextResponse.json(

--- a/app/api/updates/available/route.test.ts
+++ b/app/api/updates/available/route.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/auth-utils', () => ({
 vi.mock('@/lib/supabase', () => ({
   createServerClient: createServerClientMock,
   isSupabaseConfigured: () => true,
+  isSupabaseServerConfigured: () => true,
 }));
 
 import { GET } from '@/app/api/updates/available/route';

--- a/app/api/updates/available/route.ts
+++ b/app/api/updates/available/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { compareVersions } from '@/lib/version-compare';
 import type { AvailableUpdate } from '@/types/update-policies';
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     // apps are opt-in to avoid accidentally updating mismatched/customized apps.
     const includeUnmanaged = searchParams.get('include_unmanaged') === 'true';
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       return NextResponse.json({
         updates: [],
         count: 0,
@@ -194,7 +194,7 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       return NextResponse.json(
         {
           error:

--- a/app/api/updates/history/route.ts
+++ b/app/api/updates/history/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import type { AutoUpdateHistoryWithPolicy } from '@/types/update-policies';
 
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
     const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       return NextResponse.json({
         history: [],
         count: 0,

--- a/app/api/updates/refresh/route.ts
+++ b/app/api/updates/refresh/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { parseVersion } from '@/lib/version-compare';
-import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { resolveTargetTenantId } from '@/lib/msp/tenant-resolution';
 import { GET as getLiveIntuneUpdates } from '@/app/api/intune/apps/updates/route';
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     const body = (await request.json().catch(() => ({}))) as RefreshRequestBody;
     const requestedTenantId = body.tenant_id?.trim() || null;
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       return NextResponse.json(
         { error: 'Update checking requires Supabase and is not available on this self-hosted deployment' },
         { status: 503 }

--- a/app/api/updates/trigger/route.test.ts
+++ b/app/api/updates/trigger/route.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/auth-utils', () => ({
 vi.mock('@/lib/supabase', () => ({
   createServerClient: createServerClientMock,
   isSupabaseConfigured: () => true,
+  isSupabaseServerConfigured: () => true,
 }));
 
 vi.mock('@/lib/auto-update/trigger', () => ({

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { sanitizeAssignmentsForDispatch } from '@/lib/assignment-intents';
-import { createServerClient, isSupabaseConfigured } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { getCatalogSource } from '@/lib/catalog';
 import { parseAccessToken } from '@/lib/auth-utils';
 import {
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!isSupabaseConfigured()) {
+    if (!isSupabaseServerConfigured()) {
       const unavailableError =
         'Update deployment requires Supabase and is not available on this self-hosted deployment';
       return NextResponse.json(

--- a/app/api/user/settings/route.ts
+++ b/app/api/user/settings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServerClient } from '@/lib/supabase';
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
 import { parseAccessToken } from '@/lib/auth-utils';
 import { DEFAULT_USER_SETTINGS } from '@/types/user-settings';
 import type { UserSettings, UserSettingsUpdate } from '@/types/user-settings';
@@ -76,6 +76,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json({
+        settings: DEFAULT_USER_SETTINGS,
+        hasStoredSettings: false,
+      });
+    }
+
     const supabase = createServerClient() as ReturnType<typeof createServerClient> & {
       from: (relation: string, ...args: unknown[]) => any;
     };
@@ -128,6 +135,13 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
+      );
+    }
+
+    if (!isSupabaseServerConfigured()) {
+      return NextResponse.json(
+        { error: 'Saving user settings requires hosted services' },
+        { status: 503 }
       );
     }
 

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -107,15 +107,23 @@ export function Sidebar({ user, onSignOut }: SidebarProps) {
   const closeMobile = () => setMobileOpen(false);
 
   // NEXT_PUBLIC_DISABLE_SCCM=true hides the SCCM Migration nav item
-  const { sccm: sccmEnabled } = getClientFeatureFlags();
+  const { sccm: sccmEnabled, hostedServices } = getClientFeatureFlags();
   const managementItems = sccmEnabled
     ? managementNav
     : managementNav.filter((item) => item.href !== '/dashboard/sccm');
+  const visibleManagementItems = hostedServices
+    ? managementItems
+    : managementItems.filter((item) => item.href !== '/dashboard/updates');
 
   const navGroups: NavGroup[] = [
     { items: coreNav },
-    { label: 'Management', items: managementItems },
-    { label: 'Analytics', items: analyticsNav },
+    { label: 'Management', items: visibleManagementItems },
+    {
+      label: 'Analytics',
+      items: hostedServices
+        ? analyticsNav
+        : analyticsNav.filter((item) => item.href !== '/dashboard/app-requests'),
+    },
     ...(isMspUser
       ? [{ label: 'MSP', items: mspNav }]
       : [{ label: 'MSP', items: [{ name: 'MSP Dashboard', href: '/dashboard/msp', icon: Building2 }] }]),

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -4,6 +4,7 @@
  */
 
 import { getAppConfig } from "./config";
+import { isSupabaseServerConfigured } from "./supabase";
 
 export interface FeatureFlags {
   /** Analytics tracking enabled (Plausible) */
@@ -20,6 +21,9 @@ export interface FeatureFlags {
 
   /** SCCM Migration UI enabled (hidden when NEXT_PUBLIC_DISABLE_SCCM=true) */
   sccm: boolean;
+
+  /** Hosted services backed by Supabase */
+  hostedServices: boolean;
 }
 
 /**
@@ -38,6 +42,7 @@ export function getFeatureFlags(): FeatureFlags {
     pipeline: localPackager || githubPipeline,
     localPackager,
     sccm: process.env.NEXT_PUBLIC_DISABLE_SCCM !== "true",
+    hostedServices: isSupabaseServerConfigured(),
   };
 }
 
@@ -53,10 +58,14 @@ export function isFeatureEnabled(feature: keyof FeatureFlags): boolean {
  * Client-side feature flags (safe to expose)
  * Only includes features detectable from public env vars
  */
-export function getClientFeatureFlags(): Pick<FeatureFlags, "analytics" | "newsletter" | "sccm"> {
+export function getClientFeatureFlags(): Pick<FeatureFlags, "analytics" | "newsletter" | "sccm" | "hostedServices"> {
   return {
     analytics: Boolean(process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN),
     newsletter: true, // Always show newsletter UI, API will handle if not configured
     sccm: process.env.NEXT_PUBLIC_DISABLE_SCCM !== "true",
+    hostedServices: Boolean(
+      process.env.NEXT_PUBLIC_SUPABASE_URL &&
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    ),
   };
 }


### PR DESCRIPTION
Completes the SQLite self-host work for #167 and #170, following the deploy path fix in #436.

Every dashboard page that hard-required Supabase now degrades gracefully in DATABASE_MODE=sqlite:

- Inventory, app details and settings, categories, groups, filters, and the unmanaged apps device dialog keep working from Graph and simply skip the Supabase cache.
- Analytics stats, reports, and CSV export compute from the database adapter instead of Supabase tables.
- Deployment history and config read from the adapter.
- App Requests, notifications, mappings, user settings, update policies, and updates return empty results on reads and a clear 503 on writes where no sqlite equivalent exists.
- A new hostedServices feature flag hides App Requests, App Updates, and the notification bell in self-host mode, so users see a clean UI instead of 503 toasts.

Hosted behavior is unchanged whenever Supabase is configured. New route tests cover suggestions, analytics stats, and Graph inventory without Supabase. Full suite passes (1042 tests).