### PR TITLE
Reconcile installers at dispatch and retire upstream-removed apps

### DIFF
--- a/app/(app)/dashboard/apps/page.tsx
+++ b/app/(app)/dashboard/apps/page.tsx
@@ -41,6 +41,7 @@ import {
   useCategories,
   useInfinitePackages,
   useCatalogPackage,
+  ManifestFetchError,
 } from '@/hooks/use-packages';
 import { useDeployedPackages } from '@/hooks/use-deployed-packages';
 import { useDeployedConfig } from '@/hooks/use-deployed-config';
@@ -235,7 +236,12 @@ export default function AppCatalogPage() {
   );
 
   const isSelectedStoreApp = selectedPackage?.appSource === 'store';
-  const { data: manifestData, isLoading: isLoadingInstallers } = usePackageManifest(
+  const {
+    data: manifestData,
+    isLoading: isLoadingInstallers,
+    isError: isInstallerError,
+    error: installerError,
+  } = usePackageManifest(
     selectedPackage?.id || '',
     selectedPackage?.version,
     undefined,
@@ -1058,8 +1064,17 @@ export default function AppCatalogPage() {
               </div>
               <h3 className="text-text-primary font-medium mb-2"><T>No installers found</T></h3>
               <p className="text-text-secondary text-sm mb-4">
-                <T>Unable to find installer information for this package version.</T>
+                {isInstallerError && installerError instanceof Error ? (
+                  installerError.message
+                ) : (
+                  <T>Unable to find installer information for this package version.</T>
+                )}
               </p>
+              {installerError instanceof ManifestFetchError && installerError.suggestions.length > 0 && (
+                <p className="text-text-secondary text-sm mb-4">
+                  <T>Suggestions:</T> {installerError.suggestions.join(', ')}
+                </p>
+              )}
               <button
                 onClick={handleCloseConfig}
                 className="px-4 py-2 bg-bg-elevated hover:bg-overlay/10 text-text-primary rounded-lg transition-colors"

--- a/app/api/cron/sync-packages/route.ts
+++ b/app/api/cron/sync-packages/route.ts
@@ -30,6 +30,7 @@ interface CuratedAppUpdate {
   homepage?: string;
   license?: string;
   updated_at: string;
+  upstream_miss_count: number;
 }
 
 export async function GET(request: Request) {
@@ -124,6 +125,26 @@ export async function GET(request: Request) {
                 id: winget_id,
                 reason: resolution.reason || 'upstream_unavailable',
               });
+              if (resolution.reason === 'package_or_version_missing') {
+                const missCount = (app.upstream_miss_count || 0) + 1;
+                if (missCount >= 3) {
+                  const { error: blockError } = await supabase
+                    .from('package_eligibility_blocks')
+                    .upsert({
+                      winget_id,
+                      block_code: 'upstream_removed',
+                      detail: `WinGet package resolution failed ${missCount} consecutive times with package_or_version_missing.`,
+                      source_url: `https://github.com/microsoft/winget-pkgs/tree/master/manifests/${winget_id[0].toLowerCase()}`,
+                      updated_at: new Date().toISOString(),
+                    }, { onConflict: 'winget_id' });
+                  if (blockError) throw new Error(`eligibility block upsert failed: ${blockError.message}`);
+                }
+                const { error: missError } = await supabase
+                  .from('curated_apps')
+                  .update({ upstream_miss_count: missCount, updated_at: new Date().toISOString() })
+                  .eq('winget_id', winget_id);
+                if (missError) throw new Error(`upstream miss update failed: ${missError.message}`);
+              }
               return;
             }
 
@@ -171,6 +192,7 @@ export async function GET(request: Request) {
             const appUpdate: CuratedAppUpdate = {
               winget_id,
               latest_version: latestVersion,
+              upstream_miss_count: 0,
               updated_at: new Date().toISOString(),
             };
 

--- a/app/api/cron/sync-packages/select-apps.ts
+++ b/app/api/cron/sync-packages/select-apps.ts
@@ -16,6 +16,7 @@ export interface AppToSync {
   winget_id: string;
   latest_version: string | null;
   description: string | null;
+  upstream_miss_count: number;
 }
 
 export async function selectAppsToSync(
@@ -24,7 +25,7 @@ export async function selectAppsToSync(
   // Top ranked apps
   const { data: rankedApps, error: rankedError } = await supabase
     .from('curated_apps')
-    .select('winget_id, latest_version, description')
+    .select('winget_id, latest_version, description, upstream_miss_count')
     .eq('is_verified', true)
     .eq('is_winget_verified', true)
     .eq('app_source', 'win32')
@@ -38,7 +39,7 @@ export async function selectAppsToSync(
   // Apps that have never been synced (no version data yet)
   const { data: unsyncedApps, error: unsyncedError } = await supabase
     .from('curated_apps')
-    .select('winget_id, latest_version, description')
+    .select('winget_id, latest_version, description, upstream_miss_count')
     .eq('is_verified', true)
     .eq('is_winget_verified', true)
     .eq('app_source', 'win32')

--- a/app/api/msp/batch-deployments/route.ts
+++ b/app/api/msp/batch-deployments/route.ts
@@ -14,6 +14,7 @@ interface BatchDeploymentInput {
   winget_id: string;
   display_name: string;
   version: string;
+  architecture?: 'x64' | 'x86' | 'arm64' | 'arm' | 'neutral';
   tenant_ids: string[];
   concurrency_limit?: number;
 }
@@ -209,6 +210,7 @@ export async function POST(request: NextRequest) {
         winget_id: body.winget_id,
         display_name: body.display_name,
         version: body.version,
+        architecture: body.architecture || 'x64',
         total_tenants: tenants.length,
         concurrency_limit: concurrencyLimit,
       })

--- a/hooks/use-packages.ts
+++ b/hooks/use-packages.ts
@@ -28,6 +28,13 @@ interface ManifestResponse {
   versions?: string[];
 }
 
+export class ManifestFetchError extends Error {
+  constructor(message: string, public readonly suggestions: string[]) {
+    super(message);
+    this.name = 'ManifestFetchError';
+  }
+}
+
 interface Category {
   category: string;
   count: number;
@@ -164,7 +171,7 @@ export function useCatalogPackage(packageId: string | null) {
 }
 
 export function usePackageManifest(id: string, version?: string, arch?: string, skip?: boolean) {
-  return useQuery<ManifestResponse>({
+  return useQuery<ManifestResponse, ManifestFetchError>({
     queryKey: ['packages', 'manifest', id, version, arch],
     queryFn: async () => {
       const params = new URLSearchParams({ id });
@@ -173,7 +180,18 @@ export function usePackageManifest(id: string, version?: string, arch?: string, 
 
       const response = await fetch(`/api/winget/manifest?${params.toString()}`);
       if (!response.ok) {
-        throw new Error('Failed to fetch manifest');
+        const body = await response.json().catch(() => null) as {
+          message?: string;
+          suggestions?: Array<{ id?: string; name?: string }>;
+        } | null;
+        const suggestions = body?.suggestions
+          ?.map((suggestion) => suggestion.name || suggestion.id)
+          .filter(Boolean)
+          .map(String) || [];
+        throw new ManifestFetchError(
+          body?.message || 'Failed to fetch manifest',
+          suggestions,
+        );
       }
       return response.json();
     },

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -124,7 +124,7 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
-  it('quarantines a stale tuple when the trusted manifest has changed', async () => {
+  it('caches manifest drift as a retryable TTL error instead of permanent quarantine', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',
       url: request.installerUrl,
@@ -136,7 +136,7 @@ describe('installer dispatch preflight', () => {
     await expect(enforceInstallerPreflight(request)).rejects.toBeInstanceOf(InstallerPreflightError);
     await expect(enforceInstallerPreflight(request)).rejects.toMatchObject({
       code: 'MANIFEST_CHANGED',
-      retryable: false,
+      retryable: true,
     });
     expect(hashRemoteInstallerMock).not.toHaveBeenCalled();
   });

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -10,6 +10,7 @@ import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
 import { hashesEqual } from '@/lib/installer-download';
 import type { Win32CartItem } from '@/types/upload';
 import type { NormalizedInstaller, WingetScope } from '@/types/winget';
+import { createClient } from '@supabase/supabase-js';
 
 export interface TrustedCatalogInstallerRequest {
   wingetId: string;
@@ -125,21 +126,69 @@ export async function reconcileCatalogInstaller(
 
   const customInstallCommand = item.psadtConfig?.installCommand?.trim();
   const customUninstallCommand = item.psadtConfig?.uninstallCommand?.trim();
+  const refreshedItem: Win32CartItem = {
+    ...item,
+    installScope,
+    installerUrl: installer.url,
+    installerSha256: installer.sha256.toUpperCase(),
+    installerType: installer.type,
+    nestedInstallerType: installer.nestedInstallerType,
+    nestedInstallerPath: installer.nestedInstallerPath,
+    installerSuccessCodes: installer.installerSuccessCodes,
+    manifestDependencies: installer.packageDependencies,
+    installCommand: customInstallCommand || generateInstallCommand(installer, installScope),
+    uninstallCommand: customUninstallCommand ||
+      generateUninstallCommand(installer, item.displayName),
+  };
+
+  if (
+    item.installerUrl !== refreshedItem.installerUrl ||
+    !hashesEqual(item.installerSha256, refreshedItem.installerSha256)
+  ) {
+    await healCatalogInstaller(item.wingetId, item.version, installer, trustedInstallers);
+  }
+
   return {
-    item: {
-      ...item,
-      installScope,
-      installerUrl: installer.url,
-      installerSha256: installer.sha256.toUpperCase(),
-      installerType: installer.type,
-      nestedInstallerType: installer.nestedInstallerType,
-      nestedInstallerPath: installer.nestedInstallerPath,
-      installerSuccessCodes: installer.installerSuccessCodes,
-      manifestDependencies: installer.packageDependencies,
-      installCommand: customInstallCommand || generateInstallCommand(installer, installScope),
-      uninstallCommand: customUninstallCommand ||
-        generateUninstallCommand(installer, item.displayName),
-    },
+    item: refreshedItem,
     trustedInstallers,
   };
+}
+
+async function healCatalogInstaller(
+  wingetId: string,
+  version: string,
+  selected: NormalizedInstaller,
+  installers: NormalizedInstaller[],
+): Promise<void> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return;
+
+  const rawInstallers = installers.map((value) => ({
+    Architecture: value.architecture,
+    InstallerLocale: value.installerLocale,
+    InstallerUrl: value.url,
+    InstallerSha256: value.sha256,
+    InstallerType: value.type,
+    NestedInstallerType: value.nestedInstallerType,
+    Scope: value.scope,
+    InstallerSuccessCodes: value.installerSuccessCodes,
+    ProductCode: value.productCode,
+    PackageFamilyName: value.packageFamilyName,
+  }));
+  const { error } = await createClient(url, key).from('version_history').upsert({
+    winget_id: wingetId,
+    version,
+    installer_url: selected.url,
+    installer_sha256: selected.sha256.toUpperCase(),
+    installer_type: selected.type,
+    installer_scope: selected.scope || null,
+    silent_args: selected.silentArgs || null,
+    installers: rawInstallers,
+    manifest_fetched_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'winget_id,version' });
+  if (error) {
+    console.warn(`Could not refresh catalog installer for ${wingetId} ${version}: ${error.message}`);
+  }
 }

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -210,6 +210,7 @@ export class SnapshotCatalogSource implements CatalogSource {
             JOIN curated_apps ca ON ca.id = f.rowid
             WHERE curated_fts MATCH @match
               AND ca.is_verified = 1
+              AND ca.latest_version IS NOT NULL
               AND ca.is_locale_variant = 0
               ${categoryClause}
             ORDER BY
@@ -239,6 +240,7 @@ export class SnapshotCatalogSource implements CatalogSource {
             SELECT ${CURATED_RPC_COLUMNS}
             FROM curated_apps ca
             WHERE ca.is_verified = 1
+              AND ca.latest_version IS NOT NULL
               AND ca.is_locale_variant = 0
               ${categoryClause}
               AND (
@@ -284,7 +286,7 @@ export class SnapshotCatalogSource implements CatalogSource {
         const countRow = db
           .prepare(
             `SELECT COUNT(*) AS c FROM curated_apps
-             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}`
+             WHERE is_verified = 1 AND latest_version IS NOT NULL AND is_locale_variant = 0 ${categoryClause}`
           )
           .get(baseParams) as { c: number };
 
@@ -306,7 +308,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           .prepare(
             `SELECT ${CURATED_RPC_COLUMNS}
              FROM curated_apps
-             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}
+             WHERE is_verified = 1 AND latest_version IS NOT NULL AND is_locale_variant = 0 ${categoryClause}
              ORDER BY ${orderBy}
              LIMIT @limit OFFSET @offset`
           )
@@ -335,7 +337,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           .prepare(
             `SELECT ${CURATED_RPC_COLUMNS}
              FROM curated_apps
-             WHERE is_verified = 1 AND is_locale_variant = 0 ${categoryClause}
+             WHERE is_verified = 1 AND latest_version IS NOT NULL AND is_locale_variant = 0 ${categoryClause}
              ORDER BY popularity_rank IS NULL, popularity_rank ASC, name ASC
              LIMIT @limit`
           )
@@ -354,7 +356,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           .prepare(
             `SELECT category, COUNT(*) AS count
              FROM curated_apps
-             WHERE is_verified = 1 AND category IS NOT NULL
+             WHERE is_verified = 1 AND latest_version IS NOT NULL AND category IS NOT NULL
              GROUP BY category`
           )
           .all() as { category: string; count: number }[];
@@ -368,7 +370,9 @@ export class SnapshotCatalogSource implements CatalogSource {
   async getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null> {
     return withDb(
       (db) => {
-        const where = opts.verifiedOnly ? 'WHERE is_verified = 1' : '';
+        const where = opts.verifiedOnly
+          ? 'WHERE is_verified = 1 AND latest_version IS NOT NULL'
+          : 'WHERE latest_version IS NOT NULL';
         const row = db
           .prepare(`SELECT COUNT(*) AS c FROM curated_apps ${where}`)
           .get() as { c: number };

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -77,7 +77,9 @@ export class SupabaseCatalogSource implements CatalogSource {
     );
 
     return {
-      data: (curatedData || null) as CuratedAppRpcRow[] | null,
+      data: curatedData
+        ? (curatedData as CuratedAppRpcRow[]).filter((app) => app.latest_version != null)
+        : null,
       error: curatedError,
     };
   }
@@ -104,6 +106,7 @@ export class SupabaseCatalogSource implements CatalogSource {
       .from('curated_apps')
       .select('*', { count: 'exact', head: true })
       .eq('is_verified', true)
+      .not('latest_version', 'is', null)
       .eq('is_locale_variant', false);
 
     const countQuery = category ? baseQuery.eq('category', category) : baseQuery;
@@ -120,6 +123,7 @@ export class SupabaseCatalogSource implements CatalogSource {
         'id, winget_id, name, publisher, latest_version, description, homepage, category, tags, icon_path, popularity_rank, app_source, store_package_id'
       )
       .eq('is_verified', true)
+      .not('latest_version', 'is', null)
       .eq('is_locale_variant', false);
 
     if (category) {
@@ -172,7 +176,9 @@ export class SupabaseCatalogSource implements CatalogSource {
     );
 
     return {
-      data: (curatedData || null) as CuratedAppRpcRow[] | null,
+      data: curatedData
+        ? (curatedData as CuratedAppRpcRow[]).filter((app) => app.latest_version != null)
+        : null,
       error: curatedError,
     };
   }
@@ -213,6 +219,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     if (opts.verifiedOnly) {
       query = query.eq('is_verified', true);
     }
+    query = query.not('latest_version', 'is', null);
 
     const { count } = await query;
     return count ?? null;

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -6,10 +6,15 @@ import {
 } from './github-actions';
 import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
 
-const { enforceInstallerPreflightMock, enforceQaGateMock, resolveDependenciesMock } = vi.hoisted(() => ({
+const { enforceInstallerPreflightMock, enforceQaGateMock, reconcileCatalogInstallerMock, resolveDependenciesMock } = vi.hoisted(() => ({
   enforceInstallerPreflightMock: vi.fn(),
   enforceQaGateMock: vi.fn(),
+  reconcileCatalogInstallerMock: vi.fn(),
   resolveDependenciesMock: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('./catalog-installer-reconciliation', () => ({
+  reconcileCatalogInstaller: reconcileCatalogInstallerMock,
 }));
 
 vi.mock('./installer-preflight', async (importOriginal) => {
@@ -68,7 +73,55 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+reconcileCatalogInstallerMock.mockImplementation(async (item) => ({
+  item,
+  trustedInstallers: [],
+}));
+
 describe('triggerPackagingWorkflow hash validation payload', () => {
+  it('reconciles a WinGet tuple and passes trusted installers to preflight', async () => {
+    const trustedInstallers = [{
+      architecture: 'x64',
+      url: 'https://example.com/refreshed.exe',
+      sha256: 'B'.repeat(64),
+      type: 'exe',
+      scope: 'machine',
+    }];
+    reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
+      item: {
+        ...item,
+        installerUrl: trustedInstallers[0].url,
+        installerSha256: trustedInstallers[0].sha256,
+        installCommand: '/quiet',
+        uninstallCommand: 'uninstall.exe /quiet',
+      },
+      trustedInstallers,
+    }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Example.App',
+      sourceType: 'winget',
+      installerSha256: 'A'.repeat(64),
+    }), config, { skipRunCapture: true });
+
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installerUrl: trustedInstallers[0].url,
+        installerSha256: trustedInstallers[0].sha256,
+      }),
+      trustedInstallers,
+    );
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer).toEqual(expect.objectContaining({
+      url: trustedInstallers[0].url,
+      sha256: trustedInstallers[0].sha256,
+      silentSwitches: '/quiet',
+    }));
+  });
+
   it('dispatches calculate mode for a custom installer without a trusted hash', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -7,7 +7,8 @@
 import { createHmac } from 'node:crypto';
 
 import { applyInstallerUrlOverride } from './installer-url-overrides';
-import { enforceInstallerPreflight } from './installer-preflight';
+import { reconcileCatalogInstaller } from './catalog-installer-reconciliation';
+import { enforceInstallerPreflight, InstallerPreflightError } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
 import {
   normalizeQaWorkflowPackageInput,
@@ -16,6 +17,8 @@ import {
   resolveWingetPackageDependencies,
   type PackagedWingetDependency,
 } from './winget-dependencies';
+import type { Win32CartItem } from '@/types/upload';
+import type { NormalizedInstaller } from '@/types/winget';
 
 export interface WorkflowInputs {
   jobId: string;
@@ -120,24 +123,76 @@ export async function triggerPackagingWorkflow(
 ): Promise<TriggerResult> {
   const cfg = config || getGitHubActionsConfig();
 
+  let effectiveInputs = inputs;
+  let trustedInstallers: NormalizedInstaller[] | undefined;
+  if (inputs.sourceType !== 'custom') {
+    try {
+      const reconciled = await reconcileCatalogInstaller({
+        id: inputs.jobId,
+        addedAt: new Date().toISOString(),
+        appSource: 'win32',
+        sourceType: 'winget',
+        wingetId: inputs.wingetId,
+        displayName: inputs.displayName,
+        description: inputs.description,
+        publisher: inputs.publisher,
+        version: inputs.version,
+        architecture: (inputs.architecture || 'x64') as Win32CartItem['architecture'],
+        installScope: inputs.installScope || 'machine',
+        installerType: inputs.installerType as Win32CartItem['installerType'],
+        installerUrl: inputs.installerUrl,
+        installerSha256: inputs.installerSha256,
+        installerSuccessCodes: inputs.installerSuccessCodes,
+        installCommand: inputs.silentSwitches,
+        uninstallCommand: inputs.uninstallCommand,
+        detectionRules: [],
+        requirementRules: [],
+        psadtConfig: {
+          installCommand: inputs.silentSwitches,
+          uninstallCommand: inputs.uninstallCommand,
+        } as Win32CartItem['psadtConfig'],
+      });
+      effectiveInputs = {
+        ...inputs,
+        installerUrl: reconciled.item.installerUrl,
+        installerSha256: reconciled.item.installerSha256,
+        installerType: reconciled.item.installerType,
+        nestedInstallerType: reconciled.item.nestedInstallerType,
+        nestedInstallerPath: reconciled.item.nestedInstallerPath,
+        silentSwitches: reconciled.item.installCommand,
+        installerSuccessCodes: reconciled.item.installerSuccessCodes,
+        uninstallCommand: reconciled.item.uninstallCommand,
+        installScope: reconciled.item.installScope,
+      };
+      trustedInstallers = reconciled.trustedInstallers;
+    } catch (error) {
+      if (!(error instanceof InstallerPreflightError && error.retryable)) {
+        throw error;
+      }
+      console.warn(`Live installer reconciliation unavailable for ${inputs.wingetId} ${inputs.version}; using the catalog tuple.`);
+    }
+  }
+
   const finalInstallerUrl = applyInstallerUrlOverride(
-    inputs.wingetId,
-    inputs.version,
-    inputs.architecture ?? '',
-    inputs.installerUrl,
+    effectiveInputs.wingetId,
+    effectiveInputs.version,
+    effectiveInputs.architecture ?? '',
+    effectiveInputs.installerUrl,
   );
   // This is the final dispatch boundary shared by manual, MSP, update-policy,
   // and auto-update paths. Never create a packaging run for a known-bad tuple.
   await enforceInstallerPreflight({
-    wingetId: inputs.wingetId,
-    version: inputs.version,
-    architecture: inputs.architecture,
+    wingetId: effectiveInputs.wingetId,
+    version: effectiveInputs.version,
+    architecture: effectiveInputs.architecture,
     installerUrl: finalInstallerUrl,
-    installerSha256: inputs.installerSha256,
-    installerType: inputs.installerType,
-    installScope: inputs.installScope,
-    sourceType: inputs.sourceType,
-  });
+    manifestInstallerUrl: effectiveInputs.installerUrl,
+    installerSha256: effectiveInputs.installerSha256,
+    installerType: effectiveInputs.installerType,
+    installScope: effectiveInputs.installScope,
+    sourceType: effectiveInputs.sourceType,
+  }, trustedInstallers);
+  inputs = effectiveInputs;
   const packageDependencies = inputs.sourceType === 'custom'
     ? []
     : await resolveWingetPackageDependencies({

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -11,6 +11,7 @@ import type { NormalizedInstaller } from '@/types/winget';
 const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
 const HEALTHY_VERSIONED_TTL_MS = 6 * 60 * 60 * 1000;
 const ERROR_TTL_MS = 60 * 1000;
+const MANIFEST_CHANGED_TTL_MS = 6 * 60 * 60 * 1000;
 const LEASE_SECONDS = 240;
 const WAIT_FOR_CLAIM_MS = 240_000;
 const POLL_INTERVAL_MS = 1_500;
@@ -38,6 +39,7 @@ export interface InstallerPreflightRequest {
   version: string;
   architecture?: string;
   installerUrl: string;
+  manifestInstallerUrl?: string;
   installerSha256: string;
   installerType?: string;
   installScope?: 'machine' | 'user';
@@ -230,7 +232,7 @@ function installerExistsInManifest(
   const requestedArchitecture = (input.architecture || 'x64').toLowerCase();
   const requestedType = input.installerType?.toLowerCase();
   const requestedScope = input.installScope?.toLowerCase();
-  const requestedUrl = input.installerUrl.trim();
+  const requestedUrl = (input.manifestInstallerUrl || input.installerUrl).trim();
 
   return installers.some((installer) => {
     if (!hashesEqual(installer.sha256 || '', expectedHash)) return false;
@@ -296,9 +298,10 @@ async function performLivePreflight(
         'MANIFEST_CHANGED',
         `The selected installer for ${input.wingetId} ${input.version} no longer matches the trusted WinGet manifest`,
       );
-      await writeHealth(buildHealthRow(cacheKey, input, 'quarantined', {
+      await writeHealth(buildHealthRow(cacheKey, input, 'error', {
         reason_code: error.code,
         reason_message: error.message,
+        expires_at: new Date(Date.now() + MANIFEST_CHANGED_TTL_MS).toISOString(),
       }));
       throw error;
     }

--- a/lib/msp/batch-orchestrator.test.ts
+++ b/lib/msp/batch-orchestrator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { getCatalogSourceMock } = vi.hoisted(() => ({
+  getCatalogSourceMock: vi.fn(),
+}));
+
+vi.mock('@/lib/catalog', () => ({ getCatalogSource: getCatalogSourceMock }));
+vi.mock('@/lib/supabase', () => ({ createServerClient: vi.fn() }));
+vi.mock('@/lib/db', () => ({ getDatabase: vi.fn() }));
+
+import { lookupInstallerDetails } from './batch-orchestrator';
+
+describe('lookupInstallerDetails', () => {
+  it('selects the requested architecture from PascalCase installer JSON', async () => {
+    getCatalogSourceMock.mockReturnValue({
+      getLatestVersionInstallerInfo: vi.fn().mockResolvedValue({
+        installer_url: 'https://example.com/arm64.exe',
+        installer_sha256: 'A'.repeat(64),
+        installer_type: 'exe',
+        installers: [
+          {
+            Architecture: 'arm64',
+            InstallerUrl: 'https://example.com/arm64.exe',
+            InstallerSha256: 'A'.repeat(64),
+            InstallerType: 'exe',
+            Scope: 'machine',
+          },
+          {
+            Architecture: 'x64',
+            InstallerUrl: 'https://example.com/x64.exe',
+            InstallerSha256: 'B'.repeat(64),
+            InstallerType: 'exe',
+            Scope: 'machine',
+          },
+        ],
+      }),
+    });
+
+    await expect(lookupInstallerDetails('Example.App', '1.0.0', 'x64')).resolves.toMatchObject({
+      architecture: 'x64',
+      installer_url: 'https://example.com/x64.exe',
+      installer_sha256: 'B'.repeat(64),
+    });
+  });
+});

--- a/lib/msp/batch-orchestrator.ts
+++ b/lib/msp/batch-orchestrator.ts
@@ -19,11 +19,15 @@ import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { queueWebhookDelivery } from '@/lib/msp/webhook-service';
 import { createAuditLog } from '@/lib/audit-logger';
 import { describeQaGateError, enforceQaGate, QaGateError } from '@/lib/qa/gate';
+import { normalizeInstaller } from '@/lib/manifest-api';
+import { selectTrustedCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
+import type { WingetInstaller } from '@/types/winget';
 
 // Stale timeout: items in_progress longer than this are marked failed
 const STALE_TIMEOUT_MINUTES = 45;
 
 interface InstallerDetails {
+  architecture: string;
   installer_url: string;
   installer_sha256: string;
   installer_type: string;
@@ -248,7 +252,8 @@ async function startBatchItems(batchId: string): Promise<number> {
   // Get installer details from version_history
   const installerDetails = await lookupInstallerDetails(
     batch.winget_id,
-    batch.version
+    batch.version,
+    batch.architecture || 'x64',
   );
 
   // Get the curated app description (falls back to the generic marker text)
@@ -272,6 +277,7 @@ async function startBatchItems(batchId: string): Promise<number> {
       await enforceQaGate({
         wingetId: batch.winget_id,
         version: batch.version,
+        architecture: installerDetails.architecture,
       });
     } catch (error) {
       if (error instanceof QaGateError) qaGateError = error;
@@ -592,9 +598,10 @@ async function lookupAppDescription(wingetId: string): Promise<string | undefine
  * Look up installer details from the version_history table.
  * Falls back to parsing the installers JSONB if the top-level fields are null.
  */
-async function lookupInstallerDetails(
+export async function lookupInstallerDetails(
   wingetId: string,
-  version: string
+  version: string,
+  architecture: string,
 ): Promise<InstallerDetails | null> {
   const data = await getCatalogSource().getLatestVersionInstallerInfo(wingetId, version);
 
@@ -602,35 +609,24 @@ async function lookupInstallerDetails(
     return null;
   }
 
-  // Try top-level fields first
-  if (data.installer_url) {
-    const type = data.installer_type || 'exe';
-    return {
-      installer_url: data.installer_url,
-      installer_sha256: data.installer_sha256 || '',
-      installer_type: type,
-      silent_args: extractSilentSwitches('', type),
-      installer_scope: data.installer_scope || 'machine',
-    };
-  }
-
-  // Fall back to installers JSONB array
   if (data.installers && Array.isArray(data.installers) && data.installers.length > 0) {
-    // Prefer x64 architecture
-    const installers = data.installers as Array<Record<string, unknown>>;
-    const preferred =
-      installers.find((i) => i.architecture === 'x64') || installers[0];
-
-    if (preferred && typeof preferred.url === 'string') {
-      const type = (typeof preferred.type === 'string' ? preferred.type : 'exe').toLowerCase();
+    const installers = (data.installers as Array<Record<string, unknown>>)
+      .map((value) => normalizeInstaller(value as unknown as WingetInstaller));
+    const preferred = selectTrustedCatalogInstaller(installers, {
+      wingetId,
+      version,
+      architecture,
+      installScope: 'machine',
+    });
+    if (preferred?.url) {
+      const type = preferred.type || 'exe';
       return {
+        architecture: preferred.architecture || architecture,
         installer_url: preferred.url,
-        installer_sha256: typeof preferred.sha256 === 'string' ? preferred.sha256 : '',
+        installer_sha256: preferred.sha256 || '',
         installer_type: type,
-        silent_args: typeof preferred.silent_args === 'string'
-          ? preferred.silent_args
-          : extractSilentSwitches('', type),
-        installer_scope: typeof preferred.scope === 'string' ? preferred.scope : 'machine',
+        silent_args: preferred.silentArgs || extractSilentSwitches('', type),
+        installer_scope: preferred.scope || 'machine',
       };
     }
   }

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 
-export type PackageEligibilityBlockCode = 'vendor_retired';
+export type PackageEligibilityBlockCode = 'vendor_retired' | 'upstream_removed';
 
 export interface PackageEligibilityBlock {
   wingetId: string;

--- a/supabase/migrations/20260813090000_recoverable_manifest_changed.sql
+++ b/supabase/migrations/20260813090000_recoverable_manifest_changed.sql
@@ -1,0 +1,54 @@
+-- Allow transient manifest drift results to be reclaimed after their TTL.
+
+create or replace function public.claim_installer_preflight(
+  p_cache_key text,
+  p_winget_id text,
+  p_version text,
+  p_architecture text,
+  p_installer_url text,
+  p_expected_sha256 text,
+  p_lease_seconds integer default 240
+)
+returns boolean
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  affected_rows bigint := 0;
+begin
+  insert into public.installer_health (
+    cache_key, winget_id, version, architecture, installer_url,
+    expected_sha256, status, lease_expires_at, updated_at
+  ) values (
+    p_cache_key, p_winget_id, p_version, p_architecture, p_installer_url,
+    upper(p_expected_sha256), 'checking',
+    now() + make_interval(secs => greatest(30, least(p_lease_seconds, 600))), now()
+  )
+  on conflict (cache_key) do nothing;
+
+  get diagnostics affected_rows = row_count;
+  if affected_rows > 0 then return true; end if;
+
+  update public.installer_health
+  set status = 'checking',
+      reason_code = null,
+      reason_message = null,
+      lease_expires_at = now() + make_interval(secs => greatest(30, least(p_lease_seconds, 600))),
+      updated_at = now()
+  where cache_key = p_cache_key
+    and status <> 'quarantined'
+    and (
+      (status = 'checking' and lease_expires_at <= now())
+      or (status in ('healthy', 'error') and coalesce(expires_at, '-infinity'::timestamptz) <= now())
+    );
+
+  get diagnostics affected_rows = row_count;
+  return affected_rows > 0;
+end;
+$$;
+
+revoke all on function public.claim_installer_preflight(text, text, text, text, text, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.claim_installer_preflight(text, text, text, text, text, text, integer)
+  to service_role;

--- a/supabase/migrations/20260813091000_upstream_removed_retirement.sql
+++ b/supabase/migrations/20260813091000_upstream_removed_retirement.sql
@@ -1,0 +1,36 @@
+-- Retire packages only after repeated confirmation that WinGet no longer
+-- publishes the package or its recorded version.
+
+alter table public.curated_apps
+  add column if not exists upstream_miss_count integer not null default 0
+  check (upstream_miss_count >= 0);
+
+alter table public.package_eligibility_blocks
+  drop constraint if exists package_eligibility_blocks_block_code_check;
+alter table public.package_eligibility_blocks
+  add constraint package_eligibility_blocks_block_code_check
+  check (block_code in ('vendor_retired', 'upstream_removed'));
+
+comment on column public.curated_apps.upstream_miss_count is
+  'Consecutive package_or_version_missing results from the manifest sync.';
+
+alter table public.msp_batch_deployments
+  add column if not exists architecture text not null default 'x64'
+  check (architecture in ('x64', 'x86', 'arm64', 'arm', 'neutral'));
+
+create or replace function public.get_curated_categories()
+returns table (category text, app_count bigint)
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select app.category, count(*) as app_count
+  from public.curated_apps as app
+  where app.is_verified is true
+    and app.latest_version is not null
+    and app.category is not null
+    and app.is_locale_variant is false
+  group by app.category
+  order by app_count desc;
+$$;

--- a/types/database.ts
+++ b/types/database.ts
@@ -287,7 +287,7 @@ export interface Database {
       package_eligibility_blocks: {
         Row: {
           winget_id: string;
-          block_code: 'vendor_retired';
+          block_code: 'vendor_retired' | 'upstream_removed';
           detail: string;
           source_url: string;
           blocked_at: string;
@@ -1418,6 +1418,7 @@ export interface Database {
           winget_id: string;
           display_name: string;
           version: string;
+          architecture: 'x64' | 'x86' | 'arm64' | 'arm' | 'neutral';
           total_tenants: number;
           completed_tenants: number;
           failed_tenants: number;
@@ -1438,6 +1439,7 @@ export interface Database {
           winget_id: string;
           display_name: string;
           version: string;
+          architecture?: 'x64' | 'x86' | 'arm64' | 'arm' | 'neutral';
           total_tenants: number;
           completed_tenants?: number;
           failed_tenants?: number;
@@ -1458,6 +1460,7 @@ export interface Database {
           winget_id?: string;
           display_name?: string;
           version?: string;
+          architecture?: 'x64' | 'x86' | 'arm64' | 'arm' | 'neutral';
           total_tenants?: number;
           completed_tenants?: number;
           failed_tenants?: number;
@@ -1538,6 +1541,7 @@ export interface Database {
           is_winget_verified: boolean | null;
           is_locale_variant: boolean | null;
           app_source: string | null;
+          upstream_miss_count: number;
           created_at: string;
           updated_at: string;
         };
@@ -1564,6 +1568,7 @@ export interface Database {
           is_winget_verified?: boolean | null;
           is_locale_variant?: boolean | null;
           app_source?: string | null;
+          upstream_miss_count?: number;
           created_at?: string;
           updated_at?: string;
         };
@@ -1590,6 +1595,7 @@ export interface Database {
           is_winget_verified?: boolean | null;
           is_locale_variant?: boolean | null;
           app_source?: string | null;
+          upstream_miss_count?: number;
           created_at?: string;
           updated_at?: string;
         };


### PR DESCRIPTION
Fixes #209 and #202.

VS Code updates failed with 'no longer matches the trusted WinGet manifest' because update triggers, cron update checks, MSP batches, and QA resume dispatched installer tuples straight from the catalog, which drifts whenever a publisher respins a release. The failure then wrote a quarantine row that never expired, so retries failed from cache forever. FileZilla showed 'no installer found' because the package was removed from winget-pkgs entirely, yet the catalog kept it listed as a verified popular app and retried it hourly with no retirement path.

Changes:

- lib/github-actions.ts reconciles non-custom dispatches against the live WinGet manifest at the shared dispatch boundary used by every path, passing the trusted installer list into preflight. Installer URL overrides apply after reconciliation without tripping the manifest URL check. When the live manifest is unavailable the catalog tuple is used as before.
- MANIFEST_CHANGED preflight results are now recorded with a six hour TTL and can be reclaimed after expiry; HASH_MISMATCH stays permanently quarantined. A migration updates claim_installer_preflight accordingly.
- Drifted version_history rows self-heal with the reconciled installer data.
- MSP batch deployments select the installer for the requested architecture and pass it through workflow inputs; the dead lowercase JSONB fallback is removed.
- Catalog search, browse, popular, and category queries hide apps with no latest_version; direct lookups still work so deep links reach the improved error message.
- The sync cron tracks consecutive package_or_version_missing results per app and inserts an upstream_removed eligibility block after three misses, which the existing trigger uses to unverify the app.
- The apps page surfaces the manifest API's real error message and suggestions instead of the generic no installer text.

Tests cover the dispatch boundary reconciliation, TTL semantics, and MSP architecture selection. Full suite passes.