### PR TITLE
Fix Dell Optimizer unattended removal

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -26,6 +26,10 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);
+    expect(
+      applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['/silent', '/remove']);
     for (const wingetId of [
       'PostgreSQL.PostgreSQL.9.6',
       'PostgreSQL.PostgreSQL.13',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -111,6 +111,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/silent', 'forall'],
   },
   {
+    // Dell Optimizer's registered removal command opens an interactive
+    // console and exits without removing the product. Dell's current 6.x
+    // deployment guide documents /silent /remove for an unattended EXE
+    // lifecycle, so apply those switches to the exact captured vendor entry.
+    wingetId: 'Dell.Optimizer',
+    reviewedUninstallArguments: ['/silent', '/remove'],
+  },
+  {
     // Opera registers `opera.exe /uninstall`, but its current launcher expects
     // the double-dash uninstall verb for a non-interactive removal. Appending
     // unattended arguments to the registered slash command exits successfully


### PR DESCRIPTION
Applies Dell's documented /silent /remove switches to the exact captured Dell Optimizer vendor uninstaller in the shared customer and QA packaging adapter.\n\nEvidence: the 6.3.3.0 QA lifecycle installed successfully, but the registered removal command printed an interactive prompt and left its exact ARP identity.\n\nVerified: 66 focused tests and ESLint.