### PR TITLE
Point the packager package metadata at the current repository

### DIFF
--- a/packager/package.json
+++ b/packager/package.json
@@ -33,12 +33,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ugurkocde/IntuneGet-Website.git",
+    "url": "https://github.com/ugurkocde/IntuneGet.git",
     "directory": "packager"
   },
-  "homepage": "https://github.com/ugurkocde/IntuneGet-Website/tree/main/packager#readme",
+  "homepage": "https://github.com/ugurkocde/IntuneGet/tree/main/packager#readme",
   "bugs": {
-    "url": "https://github.com/ugurkocde/IntuneGet-Website/issues"
+    "url": "https://github.com/ugurkocde/IntuneGet/issues"
   },
   "dependencies": {
     "@azure/identity": "^4.13.1",


### PR DESCRIPTION
The packager-v1.4.0 publish failed npm provenance validation:

Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: repository.url is git+https://github.com/ugurkocde/IntuneGet-Website.git, expected to match https://github.com/ugurkocde/IntuneGet from provenance

packager/package.json still carried the former IntuneGet-Website repository name in its repository, homepage, and bugs fields. All three now point at the current repository so the provenance statement matches.

After this merges the packager-v1.4.0 tag will be repointed and the publish rerun.