### PR TITLE
Activate Dell Optimizer removal fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
+  packagerCommit: '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -61,6 +61,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '5f95d233998479791a49d1d784ea95137c098e73',
   '8235887e7126972b89c264e2053c1c4f7418ea74',
   '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
+  '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -101,8 +101,19 @@ describe('QA toolchain targeted retries', () => {
     'Google.PlatformTools',
   ])('retries %s once on the portable archive release', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
+      '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Dell Optimizer once on the unattended removal release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Dell.Optimizer', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006': [
+    // Dell Optimizer's registered removal command is interactive and leaves
+    // its exact ARP identity. This release applies Dell's documented
+    // unattended /silent /remove lifecycle to QA and customer packages.
+    'Dell.Optimizer',
+  ],
   '3fce249f5021c120a23ed0ab5dc726baaf060f3e': [
     // Claude Code ships as a bare portable executable. Earlier releases
     // generated an incomplete archive command for it; this release installs


### PR DESCRIPTION
Atomically advances the QA profile to the shared Dell Optimizer unattended removal release, preserves portable archive compatibility, and targets only Dell.Optimizer for retry.\n\nVerified: 153 focused tests and ESLint.