### PR TITLE
Use packaged Dell installer for removal

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -522,10 +522,12 @@ if ($psadtConfig.Contains('reviewedExactUninstall') -and
         throw 'PSADT reviewedExactUninstall must be an object.'
     }
     $reviewedExactUninstallExecutable = ([string]$rawExactUninstall['executablePath']).Trim()
-    if ($reviewedExactUninstallExecutable.Length -gt 260 -or
-        $reviewedExactUninstallExecutable -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
-        @($reviewedExactUninstallExecutable -split '\\') -contains '..') {
-        throw 'PSADT reviewedExactUninstall.executablePath must be a safe executable below a Program Files environment variable.'
+    $usesPackagedInstaller = $reviewedExactUninstallExecutable -eq '%PackageInstaller%'
+    if (-not $usesPackagedInstaller -and
+        ($reviewedExactUninstallExecutable.Length -gt 260 -or
+         $reviewedExactUninstallExecutable -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
+         @($reviewedExactUninstallExecutable -split '\\') -contains '..')) {
+        throw 'PSADT reviewedExactUninstall.executablePath must be %PackageInstaller% or a safe executable below a Program Files environment variable.'
     }
     $rawExactUninstallArguments = $rawExactUninstall['arguments']
     if ($rawExactUninstallArguments -is [string] -or
@@ -2427,7 +2429,11 @@ $reviewedExactUninstallOverrideLines = @(
 if ($reviewedExactUninstallConfigured) {
     $reviewedExactUninstallOverrideLines += @(
         '    $useReviewedExactUninstall = $true'
-        "    `$registeredUninstallFile = [Environment]::ExpandEnvironmentVariables('$reviewedExactUninstallExecutableEscaped')"
+        $(if ($reviewedExactUninstallExecutable -eq '%PackageInstaller%') {
+            "    `$registeredUninstallFile = Join-Path `$adtSession.DirFiles '$installerFileNameSingleQuoteEscaped'"
+        } else {
+            "    `$registeredUninstallFile = [Environment]::ExpandEnvironmentVariables('$reviewedExactUninstallExecutableEscaped')"
+        })
         "    [string[]]`$registeredUninstallArguments = @($reviewedExactUninstallArgumentsLiteral) | ForEach-Object { [Environment]::ExpandEnvironmentVariables(`$_) }"
         '    $hasQuietUninstall = $true'
         '    $isVivaldiUninstall = $false'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -28,8 +28,13 @@ describe('application packaging adapters', () => {
     ).toEqual(['/silent', 'forall']);
     expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
-        .reviewedUninstallArguments
-    ).toEqual(['/silent', '/remove']);
+    ).toMatchObject({
+      reviewedExactUninstall: {
+        executablePath: '%PackageInstaller%',
+        arguments: ['/passthrough', '/silent', '/remove'],
+        completionTimeoutMinutes: 10,
+      },
+    });
     for (const wingetId of [
       'PostgreSQL.PostgreSQL.9.6',
       'PostgreSQL.PostgreSQL.13',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -111,12 +111,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/silent', 'forall'],
   },
   {
-    // Dell Optimizer's registered removal command opens an interactive
-    // console and exits without removing the product. Dell's current 6.x
-    // deployment guide documents /silent /remove for an unattended EXE
-    // lifecycle, so apply those switches to the exact captured vendor entry.
+    // Dell Optimizer's registered InstallShield helper exits without removing
+    // the product even with Dell's documented switches. Invoke the original,
+    // hash-verified Dell Update Package instead; Dell documents the
+    // /passthrough /silent /remove lifecycle for this outer package.
     wingetId: 'Dell.Optimizer',
-    reviewedUninstallArguments: ['/silent', '/remove'],
+    reviewedExactUninstall: {
+      executablePath: '%PackageInstaller%',
+      arguments: ['/passthrough', '/silent', '/remove'],
+      completionTimeoutMinutes: 10,
+    },
   },
   {
     // Opera registers `opera.exe /uninstall`, but its current launcher expects

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -349,6 +349,40 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses the hash-verified packaged installer for a reviewed vendor removal lifecycle',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Dell Optimizer',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath: '%PackageInstaller%',
+            arguments: ['/passthrough', '/silent', '/remove'],
+            completionTimeoutMinutes: 10,
+          },
+        },
+        [],
+        'Dell.Optimizer'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallFile = Join-Path $adtSession.DirFiles 'setup.exe'"
+      );
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallArguments = @('/passthrough', '/silent', '/remove')"
+      );
+      expect(uninstallFunction).toContain(
+        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 10 }'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'verifies and removes a reviewed self-extracted managed directory without ARP capture',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
Dell Optimizer's registered InstallShield helper ignored reviewed silent removal arguments and retained the exact ARP identity. This adds a constrained internal %PackageInstaller% exact-uninstall target and uses the original hash-verified Dell Update Package with Dell's documented /passthrough /silent /remove lifecycle. The same packager path serves customer Intune uploads and QA.\n\nVerified: 129 focused tests and ESLint.