### PR TITLE
Activate packaged Dell Optimizer removal

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
+  packagerCommit: '4ca2932ca8ff26578cade36457f0fcc150513e4c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -62,6 +62,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '8235887e7126972b89c264e2053c1c4f7418ea74',
   '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
   '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
+  '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -110,7 +110,14 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Dell Optimizer once on the unattended removal release', () => {
+  it('keeps the registered-command Dell retry scoped to its release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
+      { wingetId: 'Dell.Optimizer', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries Dell Optimizer on the packaged Dell Update removal release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Dell.Optimizer', status: 'failed' }

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '4ca2932ca8ff26578cade36457f0fcc150513e4c': [
+    // Dell's registered InstallShield helper ignored documented silent removal
+    // switches. This release invokes the original hash-verified Dell Update
+    // Package with /passthrough /silent /remove.
+    'Dell.Optimizer',
+  ],
   '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006': [
     // Dell Optimizer's registered removal command is interactive and leaves
     // its exact ARP identity. This release applies Dell's documented


### PR DESCRIPTION
Pins QA to the shared packager release that uninstalls Dell Optimizer through the original verified Dell Update Package. Adds a targeted retry for Dell without replaying unrelated applications.\n\nValidation: 217 focused tests passed; ESLint passed.