### PR TITLE
Add Opera GX managed removal lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -248,6 +248,22 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('uses the reviewed machine-wide Opera GX removal contract', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'opera.operagx',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'opera', description: 'Opera GX browser' },
+    ]);
+    expect(adapted.reviewedExactUninstall).toEqual({
+      executablePath: '%ProgramFiles%\\Opera GX\\opera.exe',
+      arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+      completionTimeoutMinutes: 5,
+    });
+  });
+
   it('closes the reviewed Adobe desktop processes before Creative Cloud removal', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Adobe.CreativeCloud',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -142,6 +142,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // Opera GX uses the same launcher contract as the standard Opera browser,
+    // but installs into its own machine-wide directory. Its registered slash
+    // command can exit without removing the browser, leaving the exact ARP
+    // identity behind. Invoke Opera's reviewed double-dash lifecycle directly
+    // and preserve the user profile during managed removal.
+    wingetId: 'Opera.OperaGX',
+    requiredProcessesToClose: [
+      { name: 'opera', description: 'Opera GX browser' },
+    ],
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles%\\Opera GX\\opera.exe',
+      arguments: ['--uninstall', '--runimmediately', '--deleteuserprofile=0'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // The Office Deployment Tool is a self-extracting payload, not an
     // installed application. It intentionally creates no ARP registration.
     // WinGet extracts it to this machine-wide directory, so verify that exact


### PR DESCRIPTION
Adds a shared Opera GX adapter for both customer Intune packages and QA. The registered vendor slash command exits without removing the browser; this uses Opera's reviewed machine-wide double-dash uninstall contract and preserves the user profile.\n\nValidation: 112 focused tests passed; ESLint passed.