### PR TITLE
Activate Opera GX lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4ca2932ca8ff26578cade36457f0fcc150513e4c',
+  packagerCommit: '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -63,6 +63,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
   '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
   '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
+  '4ca2932ca8ff26578cade36457f0fcc150513e4c',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -85,6 +85,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Opera GX on its reviewed machine-wide removal release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Opera.OperaGX', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '4ca2932ca8ff26578cade36457f0fcc150513e4c',
+      { wingetId: 'Opera.OperaGX', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the Viber retry scoped to its user-scope release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '9214e4b5b71508bfba9aa1a2d4de5c3c771d3fea',
@@ -119,9 +130,13 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Dell Optimizer on the packaged Dell Update removal release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '4ca2932ca8ff26578cade36457f0fcc150513e4c',
       { wingetId: 'Dell.Optimizer', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Dell.Optimizer', status: 'failed' }
+    )).toBe(false);
   });
 
   it('keeps WebView2 replay scoped to its shared-runtime lifecycle releases', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,11 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5': [
+    // Opera GX's registered slash command exits without removing the browser.
+    // This release uses the reviewed machine-wide double-dash lifecycle.
+    'Opera.OperaGX',
+  ],
   '4ca2932ca8ff26578cade36457f0fcc150513e4c': [
     // Dell's registered InstallShield helper ignored documented silent removal
     // switches. This release invokes the original hash-verified Dell Update


### PR DESCRIPTION
Activates the shared Opera GX managed-removal release and targets only the failed Opera GX candidate for replay.\n\nValidation: 201 focused tests passed; ESLint passed.