### PR TITLE
Increase deployed-app QA reconciliation throughput

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -377,7 +377,7 @@ describe('GET /api/cron/qa-enqueue', () => {
       }),
     ]);
     expect(rpcCalls).toEqual([
-      { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 3 } },
+      { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 20 } },
     ]);
     expect(pollRunUpdates).toEqual([
       expect.objectContaining({

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -46,7 +46,11 @@ const MAX_RECORDED_ERRORS = 100;
 const MAX_ERROR_LENGTH = 1_000;
 const TOOLCHAIN_BACKFILL_BATCH_SIZE = 3;
 const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
-const DEMAND_BACKFILL_BATCH_SIZE = 3;
+// Reconciliation is metadata-only until an immutable installer payload is
+// found without a prior pass. Keep VM execution serialized, but scan enough
+// deployed-app demand per poll to avoid spending hours reclassifying known
+// payloads three at a time.
+const DEMAND_BACKFILL_BATCH_SIZE = 20;
 const MAX_TARGETED_PACKAGE_IDS = 20;
 const TARGETED_QA_PRIORITY = 1_000;
 


### PR DESCRIPTION
Reconcile up to 20 customer-deployed app records per poll while keeping VM execution serialized. This prevents catalog-profile metadata reuse from consuming hours in three-record batches.\n\nVerified: 51 focused tests and targeted ESLint.