### PR TITLE
Handle HP Image Assistant as a managed extracted payload

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -453,9 +453,9 @@ if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
     }
     $reviewedManagedInstallDirectory = ([string]$psadtConfig['reviewedManagedInstallDirectory']).Trim()
     if ($reviewedManagedInstallDirectory.Length -gt 260 -or
-        $reviewedManagedInstallDirectory -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+$' -or
+        $reviewedManagedInstallDirectory -notmatch '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$' -or
         @($reviewedManagedInstallDirectory -split '\\') -contains '..') {
-        throw 'PSADT reviewedManagedInstallDirectory must be a safe path below a Program Files environment variable.'
+        throw 'PSADT reviewedManagedInstallDirectory must be a safe path below Program Files or the reviewed SystemDrive SWSetup root.'
     }
 }
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -67,6 +67,10 @@ describe('application packaging adapters', () => {
       ).reviewedManagedInstallDirectory
     ).toBe('%ProgramW6432%\\OfficeDeploymentTool');
     expect(
+      applyApplicationPackagingAdapter('HP.ImageAssistant', DEFAULT_PSADT_CONFIG)
+        .reviewedManagedInstallDirectory
+    ).toBe('%SystemDrive%\\SWSetup\\HPImageAssistant');
+    expect(
       applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.BuildTools',
         DEFAULT_PSADT_CONFIG

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -167,6 +167,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%ProgramW6432%\\OfficeDeploymentTool',
   },
   {
+    // HP Image Assistant is distributed as a SoftPaq extractor rather than an
+    // ARP-installed application. Its reviewed WinGet command extracts the
+    // portable payload to this exact machine-wide SWSetup directory. Verify
+    // and own only that directory instead of requiring a nonexistent vendor
+    // uninstall registration.
+    wingetId: 'HP.ImageAssistant',
+    reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant',
+  },
+  {
     // Visual Studio 2026 instances are owned by the Visual Studio Installer,
     // which intentionally creates several component registrations rather than
     // one ARP entry named after the bootstrapper. Use Microsoft's documented

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -413,6 +413,36 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies and removes the reviewed HP Image Assistant SWSetup payload',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'HP Image Assistant',
+        [],
+        { reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant' },
+        [],
+        'HP.ImageAssistant'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%SystemDrive%\\SWSetup\\HPImageAssistant')"
+      );
+      expect(installFunction).toContain('Verified managed extracted payload');
+      expect(installFunction).not.toContain('Captured vendor uninstall entry');
+      expect(uninstallFunction).toContain('Remove-Item -LiteralPath $managedInstallDirectory');
+      expect(uninstallFunction).not.toContain('Waiting for vendor uninstall registration');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects an unsafe reviewed managed install directory',
     () => {
       expect(() =>
@@ -422,7 +452,15 @@ describe('PSADT vendor argument contract', () => {
           [],
           { reviewedManagedInstallDirectory: '%ProgramFiles%\\..\\Windows' }
         )
-      ).toThrow('must be a safe path below a Program Files environment variable');
+      ).toThrow('must be a safe path below Program Files');
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe System Drive Extractor',
+          [],
+          { reviewedManagedInstallDirectory: '%SystemDrive%\\Windows' }
+        )
+      ).toThrow('must be a safe path below Program Files');
     }
   );
 


### PR DESCRIPTION
HP Image Assistant's WinGet installer is a SoftPaq extractor that creates no ARP registration. Model its reviewed C:\\SWSetup\\HPImageAssistant payload as a managed directory in the shared packager used by both customer and QA packages. Detection verifies the extracted files and uninstall removes only that owned directory. Path validation permits only the reviewed SystemDrive SWSetup subtree.\n\nVerified: 152 focused tests, targeted ESLint, and git diff checks.