### PR TITLE
Activate HP Image Assistant managed lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
+  packagerCommit: '34189c6876f0fe4539b971ba1b9e962ff66cd259',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -64,6 +64,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '3fce249f5021c120a23ed0ab5dc726baaf060f3e',
   '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
   '4ca2932ca8ff26578cade36457f0fcc150513e4c',
+  '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -87,12 +87,23 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Opera GX on its reviewed machine-wide removal release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
       { wingetId: 'Opera.OperaGX', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '4ca2932ca8ff26578cade36457f0fcc150513e4c',
       { wingetId: 'Opera.OperaGX', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries HP Image Assistant on its managed extracted-payload release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'HP.ImageAssistant', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
+      { wingetId: 'HP.ImageAssistant', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,12 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '34189c6876f0fe4539b971ba1b9e962ff66cd259': [
+    // HP Image Assistant is a SoftPaq extractor with no ARP lifecycle. This
+    // release verifies and removes its exact managed SWSetup payload for both
+    // QA and customer packages.
+    'HP.ImageAssistant',
+  ],
   '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5': [
     // Opera GX's registered slash command exits without removing the browser.
     // This release uses the reviewed machine-wide double-dash lifecycle.


### PR DESCRIPTION
Pin the shared packager release, retain prior successful profiles as compatible, and schedule one bounded HP Image Assistant retry. Verified with 121 focused tests and targeted ESLint.