### PR TITLE
Classify safe QA compatibility blocks

### DIFF
--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -312,7 +312,10 @@ describe('resolveWingetPackageDependencies', () => {
       version: '1.0.0',
       architecture: 'x64',
       installerSha256: ROOT_SHA,
-    }, io)).rejects.toThrow('not in the reviewed redistribution allowlist');
+    }, io)).rejects.toMatchObject({
+      blockCode: 'unreviewed_dependency',
+      message: expect.stringContaining('not in the reviewed redistribution allowlist'),
+    });
   });
 
   it('fails closed when WinGet declares an unsupported external dependency', async () => {
@@ -359,6 +362,9 @@ describe('resolveWingetPackageDependencies', () => {
       version: '1.0.0',
       architecture: 'x64',
       installerSha256: 'C'.repeat(64),
-    }, io)).rejects.toThrow('trusted WinGet installer tuple');
+    }, io)).rejects.toMatchObject({
+      blockCode: 'trusted_installer_tuple_unavailable',
+      message: expect.stringContaining('trusted WinGet installer tuple'),
+    });
   });
 });

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -73,11 +73,17 @@ const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
 ];
 
 export class WingetDependencyCompatibilityError extends Error {
-  readonly blockCode: 'user_scope_machine_dependencies';
+  readonly blockCode:
+    | 'user_scope_machine_dependencies'
+    | 'trusted_installer_tuple_unavailable'
+    | 'unreviewed_dependency';
 
   constructor(
     message: string,
-    blockCode: 'user_scope_machine_dependencies' = 'user_scope_machine_dependencies'
+    blockCode:
+      | 'user_scope_machine_dependencies'
+      | 'trusted_installer_tuple_unavailable'
+      | 'unreviewed_dependency' = 'user_scope_machine_dependencies'
   ) {
     super(message);
     this.name = 'WingetDependencyCompatibilityError';
@@ -257,8 +263,9 @@ export async function resolveWingetPackageDependencies(
   );
   const rootInstaller = chooseInstaller(rootCandidates, targetArchitecture);
   if (!rootInstaller) {
-    throw new Error(
-      `The trusted WinGet installer tuple for ${input.wingetId} ${input.version} could not be resolved.`
+    throw new WingetDependencyCompatibilityError(
+      `The trusted WinGet installer tuple for ${input.wingetId} ${input.version} could not be resolved.`,
+      'trusted_installer_tuple_unavailable'
     );
   }
   ensureSupportedDependencyShape(input.wingetId, rootInstaller);
@@ -292,8 +299,9 @@ export async function resolveWingetPackageDependencies(
     }
     const dependencyPolicy = reviewedDependencyPolicy(packageIdentifier);
     if (!dependencyPolicy) {
-      throw new Error(
-        `WinGet dependency ${packageIdentifier} is not in the reviewed redistribution allowlist.`
+      throw new WingetDependencyCompatibilityError(
+        `WinGet dependency ${packageIdentifier} is not in the reviewed redistribution allowlist.`,
+        'unreviewed_dependency'
       );
     }
 

--- a/supabase/migrations/20260813173000_expand_qa_package_compatibility_blocks.sql
+++ b/supabase/migrations/20260813173000_expand_qa_package_compatibility_blocks.sql
@@ -1,0 +1,15 @@
+alter table public.qa_package_blocks
+  drop constraint qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (
+    block_code in (
+      'user_scope_machine_dependencies',
+      'trusted_installer_tuple_unavailable',
+      'unreviewed_dependency'
+    )
+  );
+
+comment on column public.qa_package_blocks.block_code is
+  'Fail-closed compatibility reason that prevents unsafe or unverifiable package generation.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -269,7 +269,10 @@ export interface Database {
           version: string;
           architecture: 'x64' | 'x86' | 'arm64';
           installer_sha256: string;
-          block_code: 'user_scope_machine_dependencies';
+          block_code:
+            | 'user_scope_machine_dependencies'
+            | 'trusted_installer_tuple_unavailable'
+            | 'unreviewed_dependency';
           detail: string;
           observed_at: string;
           updated_at: string;


### PR DESCRIPTION
## Summary
- classify unresolved trusted installer tuples as a durable fail-closed QA compatibility block
- classify unreviewed WinGet dependency families without degrading the overall poll
- expand the compatibility block constraint for the two explicit reasons

## Verification
- 32 focused Vitest tests passed
- ESLint passed for affected QA and dependency files
- git diff --check passed