### PR TITLE
Close Evernote before silent removal

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -51,6 +51,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual([]);
     expect(
+      applyApplicationPackagingAdapter('Evernote.Evernote', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([{ name: 'Evernote', description: 'Evernote' }]);
+    expect(
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -103,6 +103,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
+    // Evernote's machine-wide NSIS installer can launch the desktop client
+    // before the later removal cycle. Its registered uninstaller exits without
+    // removing the exact ARP entry while that client is still running, even
+    // with NSIS /S. Close every Evernote process through PSADT before install,
+    // upgrade, or uninstall so the vendor's silent lifecycle can complete.
+    wingetId: 'Evernote.Evernote',
+    requiredProcessesToClose: [
+      { name: 'Evernote', description: 'Evernote' },
+    ],
+  },
+  {
     wingetId: 'RARLab.WinRAR',
     reviewedUninstallArguments: ['/S'],
   },


### PR DESCRIPTION
## Summary
- add a declarative Evernote process-close adapter for install, upgrade, and uninstall
- prevent the registered NSIS uninstaller from exiting while the desktop client holds the lifecycle open
- apply the same adapter to customer and QA package generation

## Evidence
- QA run 31714927382 installed and detected successfully, but the exact Evernote ARP entry remained for the full five-minute uninstall deadline
- the tested profile had zero configured process-close rules

## Verification
- 88 focused tests passed
- affected-file ESLint passed
- git diff --check passed