### PR TITLE
Activate Evernote process-close packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -11,7 +11,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '34189c6876f0fe4539b971ba1b9e962ff66cd259',
+  packagerCommit: '1490844284f84f807e207fb9970bddc499bbe446',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -65,6 +65,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '4ca55ff8ac8d4d5f6d07665adbe06a07f0110006',
   '4ca2932ca8ff26578cade36457f0fcc150513e4c',
   '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
+  '34189c6876f0fe4539b971ba1b9e962ff66cd259',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -98,12 +98,25 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries HP Image Assistant on its managed extracted-payload release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '34189c6876f0fe4539b971ba1b9e962ff66cd259',
       { wingetId: 'HP.ImageAssistant', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
       { wingetId: 'HP.ImageAssistant', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Evernote and the pending HP validation on the process-close release', () => {
+    for (const wingetId of ['Evernote.Evernote', 'HP.ImageAssistant']) {
+      expect(shouldRetryTerminalToolchainCandidate(
+        QA_PSADT_TOOLCHAIN.packagerCommit,
+        { wingetId, status: 'failed' }
+      )).toBe(true);
+    }
+    expect(shouldRetryTerminalToolchainCandidate(
+      '34189c6876f0fe4539b971ba1b9e962ff66cd259',
+      { wingetId: 'Evernote.Evernote', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -10,6 +10,14 @@ export interface QaToolchainBackfillCandidate {
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '1490844284f84f807e207fb9970bddc499bbe446': [
+    // Evernote's NSIS uninstaller cannot finish while its desktop process is
+    // active. This release closes it through the shared PSADT lifecycle.
+    'Evernote.Evernote',
+    // Preserve the targeted validation for the immediately preceding HP Image
+    // Assistant lifecycle fix until that failed payload records a passing run.
+    'HP.ImageAssistant',
+  ],
   '34189c6876f0fe4539b971ba1b9e962ff66cd259': [
     // HP Image Assistant is a SoftPaq extractor with no ARP lifecycle. This
     // release verifies and removes its exact managed SWSetup payload for both


### PR DESCRIPTION
## Summary
- activate shared packager commit 1490844284f84f807e207fb9970bddc499bbe446
- retain the previous packager in compatibility history
- target Evernote and the pending HP Image Assistant validation without rerunning unrelated terminal failures

## Verification
- 111 focused tests passed
- affected-file ESLint passed
- git diff --check passed