### PR TITLE
Fix transient installer manifest handling

### DIFF
--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeManifestInstallers,
   fetchLocaleManifest,
   getFullManifest,
+  getLiveInstallers,
   clearManifestCache,
 } from '../manifest-api';
 import type { WingetInstaller, NormalizedInstaller } from '@/types/winget';
@@ -903,6 +904,34 @@ function yamlResponse(body: string) {
 function notFound() {
   return { ok: false, status: 404, text: async () => '' };
 }
+
+describe('getLiveInstallers trust semantics', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns an empty list for an authoritative missing manifest', async () => {
+    mockFetch.mockResolvedValue(notFound());
+
+    await expect(getLiveInstallers('Foo.Missing', '1.0.0')).resolves.toEqual([]);
+  });
+
+  it('propagates GitHub throttling instead of treating it as a missing manifest', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429, text: async () => '' });
+
+    await expect(getLiveInstallers('Foo.Throttled', '1.0.0')).rejects.toThrow(
+      'GitHub fetch error: 429'
+    );
+  });
+
+  it('propagates network failures instead of creating a compatibility block', async () => {
+    mockFetch.mockRejectedValue(new Error('network unavailable'));
+
+    await expect(getLiveInstallers('Foo.Offline', '1.0.0')).rejects.toThrow(
+      'network unavailable'
+    );
+  });
+});
 
 describe('fetchLocaleManifest locale resolution', () => {
   beforeEach(() => {

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -149,32 +149,41 @@ export async function fetchAvailableVersionsLive(wingetId: string): Promise<stri
   }
 }
 
-/**
- * Fetch installer manifest from GitHub
- */
-export async function fetchInstallerManifest(
+async function fetchInstallerManifestFromGitHub(
   wingetId: string,
   version: string
 ): Promise<Record<string, unknown> | null> {
   const { basePath } = getManifestPaths(wingetId);
   const url = `${GITHUB_RAW_BASE}/${basePath}/${version}/${wingetId}.installer.yaml`;
 
-  try {
-    const response = await fetch(url, {
-      headers: githubReadHeaders('text/plain'),
-      cache: 'no-store',
-    });
+  const response = await fetch(url, {
+    headers: githubReadHeaders('text/plain'),
+    cache: 'no-store',
+  });
 
-    if (!response.ok) {
-      if (response.status === 404) {
-        console.warn(`Installer manifest not found: ${url}`);
-        return null;
-      }
-      throw new Error(`GitHub fetch error: ${response.status}`);
+  if (!response.ok) {
+    if (response.status === 404) {
+      console.warn(`Installer manifest not found: ${url}`);
+      return null;
     }
+    throw new Error(`GitHub fetch error: ${response.status}`);
+  }
 
-    const yamlContent = await response.text();
-    return YAML.parse(yamlContent);
+  const yamlContent = await response.text();
+  return YAML.parse(yamlContent);
+}
+
+/**
+ * Fetch installer manifest from GitHub for best-effort catalog reads.
+ * Live trust decisions use the strict helper below so a transient upstream
+ * failure cannot be mistaken for an authoritative missing manifest.
+ */
+export async function fetchInstallerManifest(
+  wingetId: string,
+  version: string
+): Promise<Record<string, unknown> | null> {
+  try {
+    return await fetchInstallerManifestFromGitHub(wingetId, version);
   } catch (error) {
     console.error(`Failed to fetch installer manifest for ${wingetId}@${version}:`, error);
     return null;
@@ -801,7 +810,7 @@ export async function getLiveInstallers(
   wingetId: string,
   version: string
 ): Promise<NormalizedInstaller[]> {
-  const installerManifest = await fetchInstallerManifest(wingetId, version);
+  const installerManifest = await fetchInstallerManifestFromGitHub(wingetId, version);
   if (!installerManifest) {
     return [];
   }


### PR DESCRIPTION
## Summary
- preserve authoritative 404 behavior for genuinely missing WinGet installer manifests
- propagate GitHub throttling and network failures from live trust checks
- prevent temporary upstream failures from becoming durable QA compatibility blocks

## Verification
- 108 focused tests passed
- ESLint passed
- repository-wide tsc still reports unrelated pre-existing test typing errors