### PR TITLE
Fix Google Chrome EXE uninstall identity

### DIFF
--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -110,4 +110,15 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.item.installCommand).toBe('custom-install.exe /tenant-approved');
     expect(reconciled.item.uninstallCommand).toBe('custom-uninstall.exe /tenant-approved');
   });
+
+  it('uses the reviewed vendor ARP identity for the Chrome EXE catalog package', async () => {
+    getLiveInstallersMock.mockResolvedValue([{ ...operaInstallers[1], silentArgs: '/S' }]);
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Google.Chrome.EXE',
+      displayName: 'Google Chrome (EXE)',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Google Chrome (EXE)',
+    }));
+
+    expect(reconciled.item.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
+  });
 });

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -6,7 +6,10 @@ import {
   InstallerPreflightError,
 } from '@/lib/installer-preflight';
 import { getLiveInstallers } from '@/lib/manifest-api';
-import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
+import {
+  resolveApplicationInstallScope,
+  resolveApplicationUninstallCommand,
+} from '@/lib/packaging-adapters';
 import { hashesEqual } from '@/lib/installer-download';
 import type { Win32CartItem } from '@/types/upload';
 import type { NormalizedInstaller, WingetScope } from '@/types/winget';
@@ -137,8 +140,10 @@ export async function reconcileCatalogInstaller(
     installerSuccessCodes: installer.installerSuccessCodes,
     manifestDependencies: installer.packageDependencies,
     installCommand: customInstallCommand || generateInstallCommand(installer, installScope),
-    uninstallCommand: customUninstallCommand ||
+    uninstallCommand: customUninstallCommand || resolveApplicationUninstallCommand(
+      item.wingetId,
       generateUninstallCommand(installer, item.displayName),
+    ),
   };
 
   if (

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -10,6 +10,7 @@ import { applyInstallerUrlOverride } from './installer-url-overrides';
 import { reconcileCatalogInstaller } from './catalog-installer-reconciliation';
 import { enforceInstallerPreflight, InstallerPreflightError } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
+import { resolveApplicationUninstallCommand } from './packaging-adapters';
 import {
   normalizeQaWorkflowPackageInput,
 } from './qa/package-profile';
@@ -126,6 +127,10 @@ export async function triggerPackagingWorkflow(
   let effectiveInputs = inputs;
   let trustedInstallers: NormalizedInstaller[] | undefined;
   if (inputs.sourceType !== 'custom') {
+    const resolvedUninstallCommand = resolveApplicationUninstallCommand(
+      inputs.wingetId,
+      inputs.uninstallCommand,
+    );
     try {
       const reconciled = await reconcileCatalogInstaller({
         id: inputs.jobId,
@@ -149,7 +154,7 @@ export async function triggerPackagingWorkflow(
         requirementRules: [],
         psadtConfig: {
           installCommand: inputs.silentSwitches,
-          uninstallCommand: inputs.uninstallCommand,
+          uninstallCommand: resolvedUninstallCommand,
         } as Win32CartItem['psadtConfig'],
       });
       effectiveInputs = {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -3,9 +3,25 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationUninstallCommand,
 } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome.EXE',
+      'REGISTRY_UNINSTALL:Google Chrome (EXE)'
+    )).toBe('REGISTRY_UNINSTALL:Google Chrome');
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome',
+      'REGISTRY_UNINSTALL:Google Chrome'
+    )).toBe('REGISTRY_UNINSTALL:Google Chrome');
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome.EXE',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -361,6 +361,32 @@ export function resolveApplicationInstallScope(
   return applicationPackagingAdapter(wingetId)?.requiredInstallScope || requested;
 }
 
+const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
+  generatedDisplayName: string;
+  registeredDisplayName: string;
+}>>> = {
+  // The EXE package's catalog name distinguishes it from Google.Chrome, but
+  // Google's machine installer registers the ordinary `Google Chrome` ARP
+  // identity. Keep that exact vendor identity for capture, verification, and
+  // Intune removal instead of weakening the generic one-product matcher.
+  'google.chrome.exe': {
+    generatedDisplayName: 'Google Chrome (EXE)',
+    registeredDisplayName: 'Google Chrome',
+  },
+};
+
+export function resolveApplicationUninstallCommand(
+  wingetId: string,
+  uninstallCommand: string
+): string {
+  const reviewed = REVIEWED_REGISTRY_UNINSTALL_IDENTITIES[wingetId.trim().toLowerCase()];
+  if (!reviewed) return uninstallCommand;
+  const expected = `REGISTRY_UNINSTALL:${reviewed.generatedDisplayName}`;
+  return uninstallCommand.trim() === expected
+    ? `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`
+    : uninstallCommand;
+}
+
 function normalizeProcessName(name: string): string {
   return name.trim().replace(/\.exe$/i, '');
 }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -277,6 +277,29 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds the reviewed Google Chrome EXE ARP identity to customer packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Google.Chrome.EXE',
+      displayName: 'Google Chrome (EXE)',
+      publisher: 'Google',
+      version: '151.0.7922.76',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/silent /install',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Google Chrome (EXE)',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
+    expect(profile.installer.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
+  });
+
   it('binds shared-runtime retention to both the normalized config and QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.EdgeWebView2Runtime',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
@@ -703,6 +704,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
   psadtConfig: PSADTConfig;
   detectionRulesJson: string;
   psadtConfigJson: string;
+  uninstallCommand: string;
   identity: QaPackageIdentity;
 } {
   assertPackagingContract({
@@ -735,6 +737,10 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     input.wingetId,
     normalizeQaPsadtConfig(rawConfig, detectionRules)
   );
+  const uninstallCommand = resolveApplicationUninstallCommand(
+    input.wingetId,
+    input.uninstallCommand
+  );
   const identity = buildQaPackageIdentity({
     profileKind: 'deployment-config',
     wingetId: input.wingetId,
@@ -746,7 +752,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     sourceInstallerType: input.installerType,
     silentArgs: input.silentSwitches,
     successCodes: input.installerSuccessCodes,
-    uninstallCommand: input.uninstallCommand,
+    uninstallCommand,
     installScope,
     nestedInstallerType: input.nestedInstallerType || '',
     nestedInstallerFiles: input.nestedInstallerPath ? [input.nestedInstallerPath] : [],
@@ -760,6 +766,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     psadtConfig,
     detectionRulesJson: JSON.stringify(detectionRules),
     psadtConfigJson: JSON.stringify(psadtConfig),
+    uninstallCommand,
     identity,
   };
 }

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -227,6 +227,25 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('uses the reviewed ARP identity for the Google Chrome EXE catalog variant', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Google.Chrome.EXE',
+        name: 'Google Chrome (EXE)',
+        publisher: 'Google',
+        version: '151.0.7922.76',
+      },
+      manifest: { InstallerType: 'exe' },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'exe',
+        InstallerSwitches: { Silent: '/silent /install' },
+      },
+    });
+
+    expect(config.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
+  });
+
   it('prefers architecture-specific AppsAndFeatures identity over a root product code', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import { normalizeQaPsadtConfig } from './package-profile';
 import type {
@@ -185,7 +186,10 @@ export function buildQaCatalogTestConfig({
     scope,
     nestedInstallerType: nestedInstallerType || '',
     nestedInstallerFiles: nestedFiles,
-    uninstallCommand: generateUninstallCommand(normalizedInstaller, app.name),
+    uninstallCommand: resolveApplicationUninstallCommand(
+      app.wingetId,
+      generateUninstallCommand(normalizedInstaller, app.name)
+    ),
     psadtConfig,
     detectionRules,
     ...(packageDependencies.length > 0 ? { packageDependencies } : {}),


### PR DESCRIPTION
## Summary
- map the Google.Chrome.EXE catalog label to the vendor's actual Google Chrome ARP identity
- apply the identity consistently to catalog QA and customer package dispatch
- bind the corrected command into the package profile

## Verification
- 106 focused tests passed
- lint passed
- git diff --check passed