### PR TITLE
Reject unrelated ARP changes during package verification

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2259,9 +2259,6 @@ if ($useRegistryUninstall) {
     }
 
     $lines += @(
-        '        if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1) {'
-        '            $selectedApplications = @($changedApplications[0])'
-        '        }'
         '        if ($selectedApplications.Count -eq 1) { break }'
         '        if ($multiProductInstallationVerified) { break }'
         '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -895,6 +895,15 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     );
   });
 
+  it('never captures an unrelated background ARP change as the installed product', () => {
+    expect(packager).not.toContain(
+      'if ($selectedApplications.Count -eq 0 -and $changedApplications.Count -eq 1)'
+    );
+    expect(packager).not.toContain(
+      '$selectedApplications = @($changedApplications[0])'
+    );
+  });
+
   it('prefers a registered Burn helper and keeps the packaged fallback for disposable caches', () => {
     expect(packager).toContain("if ($originalInstallerType -eq 'burn')");
     expect(packager).toContain(


### PR DESCRIPTION
## Summary
- remove the fallback that accepted the only changed ARP entry even when it did not match the configured app identity
- fail closed so background updater noise cannot become the customer uninstall target
- add a regression contract covering the unsafe fallback

## Evidence
A NASM QA run captured Microsoft Edge as its uninstall identity because Edge was the only unrelated ARP change during installation.

## Verification
- 65 PSADT packager contract tests passed
- lint passed
- git diff --check passed