### PR TITLE
Activate ARP-safe PSADT packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '1490844284f84f807e207fb9970bddc499bbe446',
+  packagerCommit: '0dd82872b737a8e97cde16e6d86833ba43d09057',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -110,9 +110,13 @@ describe('QA toolchain targeted retries', () => {
   it('retries Evernote and the pending HP validation on the process-close release', () => {
     for (const wingetId of ['Evernote.Evernote', 'HP.ImageAssistant']) {
       expect(shouldRetryTerminalToolchainCandidate(
-        QA_PSADT_TOOLCHAIN.packagerCommit,
+        '1490844284f84f807e207fb9970bddc499bbe446',
         { wingetId, status: 'failed' }
       )).toBe(true);
+      expect(shouldRetryTerminalToolchainCandidate(
+        QA_PSADT_TOOLCHAIN.packagerCommit,
+        { wingetId, status: 'failed' }
+      )).toBe(false);
     }
     expect(shouldRetryTerminalToolchainCandidate(
       '34189c6876f0fe4539b971ba1b9e962ff66cd259',


### PR DESCRIPTION
## Summary
- activate the reviewed packager commit containing ARP-safe uninstall capture and the Bitvise unattended lifecycle adapter
- keep prior passing profiles compatible when the changed behavior is irrelevant
- keep historical targeted retries scoped to the release that introduced them

## Activation
This is intentionally held until the current 100-app cohort reaches its boundary, then merged before the next cohort starts.

## Verification
- 92 focused tests passed
- focused ESLint passed