### PR TITLE
Reject ARM64 payloads on the x64 QA runner

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -271,6 +271,28 @@ describe('GET /api/cron/qa-dispatch', () => {
     expect(claimedIds).toEqual([deploymentConfig.id]);
   });
 
+  it('supersedes an ARM64 payload instead of sending it to the x64 VM', async () => {
+    const arm64 = candidate('deployment-config');
+    arm64.architecture = 'arm64';
+    const { client, supersededIds, supersedePayloads, claimedIds } =
+      createSupabaseStub([arm64]);
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({ dispatched: false, superseded: 1 });
+    expect(supersededIds).toEqual([arm64.id]);
+    expect(supersedePayloads).toEqual([
+      expect.objectContaining({
+        failure_summary:
+          'Superseded before dispatch: runner-architecture-unsupported.',
+      }),
+    ]);
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
   it('supersedes a row whose canonical profile does not match its installer', async () => {
     const invalid = candidate('catalog-default');
     invalid.installer_sha256 = 'B'.repeat(64);

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -4,6 +4,7 @@ import { dispatchQaCandidate } from '@/lib/qa/dispatch';
 import { validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
 import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
+import { isQaRunnerArchitectureSupported } from '@/lib/qa/candidate';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
 const RUN_TIMEOUT_MS = 5 * 60 * 60 * 1000;
@@ -129,6 +130,10 @@ export async function GET(request: Request) {
     for (const candidate of page) {
       if (!queueCursor(candidate)) {
         addInvalid('queue-metadata-invalid', candidate.id);
+        continue;
+      }
+      if (!isQaRunnerArchitectureSupported(candidate.architecture)) {
+        addInvalid('runner-architecture-unsupported', candidate.id);
         continue;
       }
       const validation = validateCurrentQaPackageProfile({

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isQaRunnerArchitectureSupported,
   normalizeInstallerSha256,
   normalizeQaArchitecture,
   normalizeQaInstallerType,
@@ -22,6 +23,12 @@ describe('QA candidate normalization', () => {
   it('does not silently substitute a different architecture', () => {
     expect(selectWingetInstaller(installers, 'arm64')).toBeNull();
     expect(normalizeQaArchitecture(undefined)).toBe('x64');
+  });
+
+  it('only sends architectures executable by the current x64 VM to QA', () => {
+    expect(isQaRunnerArchitectureSupported('x64')).toBe(true);
+    expect(isQaRunnerArchitectureSupported('x86')).toBe(true);
+    expect(isQaRunnerArchitectureSupported('arm64')).toBe(false);
   });
 
   it('uses x86 only as an explicit fallback supported by the x64 QA VM', () => {

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -26,6 +26,12 @@ export interface QaInstallerSelection {
 }
 
 const SUPPORTED_ARCHITECTURES = new Set(['x64', 'x86', 'arm64']);
+const QA_RUNNER_ARCHITECTURES = new Set(['x64', 'x86']);
+
+/** The current Hyper-V golden image is x64 and can execute x64/x86 payloads only. */
+export function isQaRunnerArchitectureSupported(value?: string | null): boolean {
+  return QA_RUNNER_ARCHITECTURES.has(value?.trim().toLowerCase() || 'x64');
+}
 
 function preferredScopeInstaller(
   installers: WingetInstallerCandidate[],

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -82,6 +82,23 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
+  it('fails closed before queueing an ARM64 payload on the x64 QA runner', async () => {
+    const client = { from: vi.fn() };
+    const result = await ensureQaDemand(client as never, {
+      ...demandInput(),
+      architecture: 'arm64',
+    });
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      candidateId: null,
+      failureSummary: 'This app is not currently available for deployment.',
+    });
+    expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
+    expect(getPackageEligibilityBlocksMock).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
   it('persists dependency download metadata on a newly queued customer candidate', async () => {
     const dependency = {
       packageIdentifier: 'Microsoft.VCRedist.2015+.x64',

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -1,5 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { normalizeQaInstallerType, qaInstallerFileName } from '@/lib/qa/candidate';
+import {
+  isQaRunnerArchitectureSupported,
+  normalizeQaInstallerType,
+  qaInstallerFileName,
+} from '@/lib/qa/candidate';
 import {
   normalizeQaWorkflowPackageInput,
   type QaPackageIdentity,
@@ -16,6 +20,9 @@ import {
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
 export type QaDemandState = 'passed' | 'failed' | 'waiting';
+
+const QA_ARCHITECTURE_UNAVAILABLE_MESSAGE =
+  'This app is not currently available for deployment.';
 
 export interface QaDemandInput extends QaWorkflowPackageInput {
   installerUrl: string;
@@ -48,6 +55,14 @@ export async function ensureQaDemand(
       },
     }),
   };
+  if (!isQaRunnerArchitectureSupported(input.architecture)) {
+    return {
+      identity: normalizeQaWorkflowPackageInput(baseResolvedInput).identity,
+      candidateId: null,
+      state: 'failed',
+      failureSummary: QA_ARCHITECTURE_UNAVAILABLE_MESSAGE,
+    };
+  }
   const eligibilityBlocks = await getPackageEligibilityBlocks(supabase, [input.wingetId]);
   if (eligibilityBlocks.length > 0) {
     return {


### PR DESCRIPTION
## Summary
- declare the current Hyper-V runner capable of x64 and x86 payloads only
- fail ARM64 customer demand before it consumes a VM slot
- supersede legacy queued ARM64 candidates during dispatch scanning
- keep the customer message concise while preserving an internal reason

## Evidence
7-Zip 26.02 ARM64 was dispatched to the x64 VM and failed with Windows architecture incompatibility.

## Verification
- 31 focused candidate, demand, and dispatch tests passed
- lint passed
- git diff --check passed