### PR TITLE
Block elevation-required user installers before QA

### DIFF
--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -593,6 +593,7 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
   const defaultNestedType = manifest.NestedInstallerType as string;
   const defaultNestedFiles = manifest.NestedInstallerFiles as WingetInstaller['NestedInstallerFiles'];
   const defaultScope = manifest.Scope as string;
+  const defaultElevationRequirement = manifest.ElevationRequirement as string;
   const defaultSwitches = manifest.InstallerSwitches;
   const defaultPlatform = manifest.Platform as string[];
   const defaultMinOS = manifest.MinimumOSVersion as string;
@@ -626,6 +627,9 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
                           defaultNestedFiles,
     Scope: (installer.Scope as WingetInstaller['Scope']) ||
            (defaultScope as WingetInstaller['Scope']),
+    ElevationRequirement:
+      (installer.ElevationRequirement as WingetInstaller['ElevationRequirement']) ||
+      (defaultElevationRequirement as WingetInstaller['ElevationRequirement']),
     // WinGet inherits installer switches per field. An installer-level Custom
     // value must not discard a root-level Silent value (Vivaldi is one example).
     InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
@@ -768,6 +772,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     nestedInstallerType: installer.NestedInstallerType,
     nestedInstallerPath: installer.NestedInstallerFiles?.[0]?.RelativeFilePath,
     scope: installer.Scope,
+    elevationRequirement: installer.ElevationRequirement,
     silentArgs,
     ...(normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes)
       ? { installerSuccessCodes: normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) }

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { WingetDependencyCompatibilityError } from '@/lib/winget-dependencies';
 
 const { resolveWingetPackageDependenciesMock, getPackageEligibilityBlocksMock } = vi.hoisted(() => ({
   resolveWingetPackageDependenciesMock: vi.fn(),
   getPackageEligibilityBlocksMock: vi.fn(),
 }));
 
-vi.mock('@/lib/winget-dependencies', () => ({
-  resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
-}));
+vi.mock('@/lib/winget-dependencies', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/winget-dependencies')>();
+  return {
+    ...original,
+    resolveWingetPackageDependencies: resolveWingetPackageDependenciesMock,
+  };
+});
 
 vi.mock('@/lib/package-eligibility', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/lib/package-eligibility')>();
@@ -386,5 +391,41 @@ describe('ensureQaDemand app-version evidence reuse', () => {
       'Unreviewed package dependency'
     );
     expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('persists a reviewed compatibility block and returns a generic customer message', async () => {
+    const upsert = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_blocks') return { upsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+    resolveWingetPackageDependenciesMock.mockRejectedValue(
+      new WingetDependencyCompatibilityError(
+        'Example.App requires elevation in user scope.',
+        'user_scope_elevation_required'
+      )
+    );
+
+    const result = await ensureQaDemand(client as never, {
+      ...demandInput(),
+      installScope: 'user',
+    });
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      candidateId: null,
+      failureSummary: 'This app is not currently available for deployment.',
+    });
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      winget_id: 'Example.App',
+      version: '1.2.3',
+      architecture: 'x64',
+      installer_sha256: 'A'.repeat(64),
+      block_code: 'user_scope_elevation_required',
+    }), {
+      onConflict: 'winget_id,version,architecture,installer_sha256',
+    });
   });
 });

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -9,7 +9,10 @@ import {
   type QaPackageIdentity,
   type QaWorkflowPackageInput,
 } from '@/lib/qa/package-profile';
-import { resolveWingetPackageDependencies } from '@/lib/winget-dependencies';
+import {
+  isWingetDependencyCompatibilityError,
+  resolveWingetPackageDependencies,
+} from '@/lib/winget-dependencies';
 import type { Json } from '@/types/database';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
@@ -75,13 +78,42 @@ export async function ensureQaDemand(
   // Resolve at the QA-demand boundary as well as at final packaging dispatch.
   // This keeps both gates bound to the same server-trusted dependency graph;
   // caller-supplied dependency metadata is never authoritative.
-  const packageDependencies = await resolveWingetPackageDependencies({
-    wingetId: input.wingetId,
-    version: input.version,
-    architecture: input.architecture,
-    installerSha256: input.installerSha256,
-    installScope,
-  });
+  let packageDependencies: Awaited<ReturnType<typeof resolveWingetPackageDependencies>>;
+  try {
+    packageDependencies = await resolveWingetPackageDependencies({
+      wingetId: input.wingetId,
+      version: input.version,
+      architecture: input.architecture,
+      installerSha256: input.installerSha256,
+      installScope,
+    });
+  } catch (error) {
+    if (!isWingetDependencyCompatibilityError(error)) throw error;
+    const identity = normalizeQaWorkflowPackageInput(baseResolvedInput).identity;
+    const { error: blockError } = await supabase
+      .from('qa_package_blocks')
+      .upsert({
+        winget_id: input.wingetId,
+        version: input.version,
+        architecture: (input.architecture || 'x64').toLowerCase(),
+        installer_sha256: input.installerSha256.toUpperCase(),
+        block_code: error.blockCode,
+        detail: error.message,
+        observed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, {
+        onConflict: 'winget_id,version,architecture,installer_sha256',
+      });
+    if (blockError) {
+      throw new Error(`Could not persist the package compatibility block: ${blockError.message}`);
+    }
+    return {
+      identity,
+      candidateId: null,
+      state: 'failed',
+      failureSummary: QA_ARCHITECTURE_UNAVAILABLE_MESSAGE,
+    };
+  }
   // The VM validates the same PSADT packaging route used for customer uploads,
   // with one deterministic, non-blocking visual profile per immutable payload.
   // Customer presentation choices are applied later by customer packaging and

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -324,3 +324,21 @@ describe('QA candidate operator recovery migration contract', () => {
     expect(sql).toContain('to anon');
   });
 });
+
+describe('QA package compatibility block expansion contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260814085000_expand_qa_package_compatibility_blocks.sql'
+    ),
+    'utf8'
+  );
+
+  it('keeps every reviewed preflight incompatibility version-specific', () => {
+    expect(sql).toContain('alter table public.qa_package_blocks');
+    expect(sql).toContain("'user_scope_machine_dependencies'");
+    expect(sql).toContain("'user_scope_elevation_required'");
+    expect(sql).toContain("'trusted_installer_tuple_unavailable'");
+    expect(sql).toContain("'unreviewed_dependency'");
+  });
+});

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -351,6 +351,27 @@ describe('resolveWingetPackageDependencies', () => {
     }, io)).rejects.toThrow('cannot be installed safely in user scope');
   });
 
+  it('refuses a user-scope installer that explicitly requires elevation', async () => {
+    const io = fixtureIo(
+      { 'Example.App@1.0.0': [installer({
+        scope: 'user',
+        elevationRequirement: 'elevationRequired',
+      })] },
+      {}
+    );
+
+    await expect(resolveWingetPackageDependencies({
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      architecture: 'x64',
+      installerSha256: ROOT_SHA,
+      installScope: 'user',
+    }, io)).rejects.toMatchObject({
+      blockCode: 'user_scope_elevation_required',
+      message: expect.stringContaining('requires elevation'),
+    });
+  });
+
   it('requires the exact trusted root installer hash', async () => {
     const io = fixtureIo(
       { 'Example.App@1.0.0': [installer()] },

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -75,6 +75,7 @@ const REVIEWED_DEPENDENCY_POLICIES: readonly ReviewedDependencyPolicy[] = [
 export class WingetDependencyCompatibilityError extends Error {
   readonly blockCode:
     | 'user_scope_machine_dependencies'
+    | 'user_scope_elevation_required'
     | 'trusted_installer_tuple_unavailable'
     | 'unreviewed_dependency';
 
@@ -82,6 +83,7 @@ export class WingetDependencyCompatibilityError extends Error {
     message: string,
     blockCode:
       | 'user_scope_machine_dependencies'
+      | 'user_scope_elevation_required'
       | 'trusted_installer_tuple_unavailable'
       | 'unreviewed_dependency' = 'user_scope_machine_dependencies'
   ) {
@@ -269,6 +271,16 @@ export async function resolveWingetPackageDependencies(
     );
   }
   ensureSupportedDependencyShape(input.wingetId, rootInstaller);
+  const rootScope = (input.installScope || rootInstaller.scope || '').trim().toLowerCase();
+  if (
+    rootScope === 'user' &&
+    rootInstaller.elevationRequirement === 'elevationRequired'
+  ) {
+    throw new WingetDependencyCompatibilityError(
+      `${input.wingetId} declares a user-scope installer that requires elevation and cannot run under the supported Intune user-install contract.`,
+      'user_scope_elevation_required'
+    );
+  }
   const rootDependencies = rootPackageDependencies(
     input.wingetId,
     rootInstaller.packageDependencies

--- a/supabase/migrations/20260814085000_expand_qa_package_compatibility_blocks.sql
+++ b/supabase/migrations/20260814085000_expand_qa_package_compatibility_blocks.sql
@@ -1,0 +1,14 @@
+-- Keep unsupported immutable installer contracts out of both the QA VM and
+-- customer packaging. A newer payload remains independently eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'trusted_installer_tuple_unavailable',
+    'unreviewed_dependency'
+  ));

--- a/types/database.ts
+++ b/types/database.ts
@@ -271,6 +271,7 @@ export interface Database {
           installer_sha256: string;
           block_code:
             | 'user_scope_machine_dependencies'
+            | 'user_scope_elevation_required'
             | 'trusted_installer_tuple_unavailable'
             | 'unreviewed_dependency';
           detail: string;

--- a/types/winget.ts
+++ b/types/winget.ts
@@ -36,6 +36,7 @@ export interface WingetInstaller {
   NestedInstallerType?: WingetInstallerType;
   NestedInstallerFiles?: Array<{ RelativeFilePath: string; PortableCommandAlias?: string }>;
   Scope?: WingetScope;
+  ElevationRequirement?: WingetElevationRequirement;
   InstallerSwitches?: WingetInstallerSwitches;
   InstallerSuccessCodes?: number[];
   ProductCode?: string;
@@ -110,6 +111,12 @@ export type WingetInstallerType =
 // Installation scope
 export type WingetScope = 'user' | 'machine';
 
+// Installer privilege behavior declared by WinGet manifests.
+export type WingetElevationRequirement =
+  | 'elevationRequired'
+  | 'elevationProhibited'
+  | 'elevatesSelf';
+
 // API response wrapper for search
 export interface WingetSearchResponse {
   Packages: WingetSearchResult[];
@@ -172,6 +179,7 @@ export interface NormalizedInstaller {
   nestedInstallerType?: WingetInstallerType;
   nestedInstallerPath?: string;
   scope?: WingetScope;
+  elevationRequirement?: WingetElevationRequirement;
   silentArgs?: string;
   installerSuccessCodes?: number[];
   productCode?: string;


### PR DESCRIPTION
## What changed
- inherit WinGet ElevationRequirement into normalized installer metadata
- fail closed when a user-scope installer requires elevation
- persist version-specific compatibility blocks and return generic customer wording
- expand the compatibility-block constraint and generated database type

## Root cause
The reMarkable companion installer declares user scope together with elevationRequired. The supported Intune user-install contract cannot satisfy that combination, so invoking it in the VM returned exit code 1 and wasted a test slot.

## Validation
- 76 focused Vitest tests passed
- focused ESLint passed
- full Next.js production build passed