### PR TITLE
fix(packaging): use Bitvise unattended installer mode

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -230,6 +230,20 @@ if ($psadtConfig.Contains('reviewedInstallArguments') -and
     }
 }
 
+$reviewedInstallArgumentsOverride = ''
+if ($psadtConfig.Contains('reviewedInstallArgumentsOverride') -and
+    $null -ne $psadtConfig['reviewedInstallArgumentsOverride']) {
+    if ($psadtConfig['reviewedInstallArgumentsOverride'] -isnot [string]) {
+        throw 'PSADT reviewedInstallArgumentsOverride must be a string.'
+    }
+    $reviewedInstallArgumentsOverride = $psadtConfig['reviewedInstallArgumentsOverride'].Trim()
+    if ([string]::IsNullOrWhiteSpace($reviewedInstallArgumentsOverride) -or
+        $reviewedInstallArgumentsOverride.Length -gt 256 -or
+        [regex]::IsMatch($reviewedInstallArgumentsOverride, '[\x00-\x1F\x7F]')) {
+        throw 'PSADT reviewedInstallArgumentsOverride must be a non-empty, bounded, single-line string.'
+    }
+}
+
 $reviewedUninstallArguments = @()
 if ($psadtConfig.Contains('reviewedUninstallArguments') -and
     $null -ne $psadtConfig['reviewedUninstallArguments']) {
@@ -794,7 +808,11 @@ function Get-PSADTAssetFileName {
 # Reviewed application adapters may append bounded vendor properties to the
 # manifest-derived command. Do this before quote encoding so MSI properties are
 # passed identically by QA and customer packages.
-$effectiveSilentSwitches = $SilentSwitches.Trim()
+$effectiveSilentSwitches = if ($reviewedInstallArgumentsOverride) {
+    $reviewedInstallArgumentsOverride
+} else {
+    $SilentSwitches.Trim()
+}
 foreach ($reviewedInstallArgument in $reviewedInstallArguments) {
     $argumentPattern = '(?i)(^|\s)' + [regex]::Escape($reviewedInstallArgument) + '(\s|$)'
     if ($effectiveSilentSwitches -notmatch $argumentPattern) {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -169,6 +169,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('replaces Bitvise generic switches with its documented unattended mode', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Bitvise.SSH.Client',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('-unat -acceptEula');
+    expect(adapted.reviewedUninstallArguments).toEqual(['-unat']);
+  });
+
   it('retains the shared WebView2 runtime while removing IntuneGet ownership', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -6,6 +6,7 @@ interface ApplicationPackagingAdapter {
   requiredInstallScope?: WingetScope;
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
+  reviewedInstallArgumentsOverride?: string;
   reviewedUninstallArguments?: readonly string[];
   reviewedUninstallProcessGuard?: Readonly<{
     processName: string;
@@ -101,6 +102,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // LocalSystem AppData profile, which otherwise rolls back with exit 1603.
     wingetId: 'AnalogDevices.LTspice',
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
+  },
+  {
+    // Bitvise uses its own unattended switch rather than the generic /S that
+    // WinGet currently publishes. The vendor documents -unat together with
+    // explicit EULA acceptance for scripted installation.
+    wingetId: 'Bitvise.SSH.Client',
+    reviewedInstallArgumentsOverride: '-unat -acceptEula',
+    reviewedUninstallArguments: ['-unat'],
   },
   {
     // Evernote's machine-wide NSIS installer can launch the desktop client
@@ -419,6 +428,7 @@ export function applyApplicationPackagingAdapter(
     // These internal lifecycle fields are never accepted from customer config.
     if (
       !config.preserveVendorInstallationOnUninstall &&
+      !config.reviewedInstallArgumentsOverride &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedUninstallProcessGuard &&
@@ -429,6 +439,7 @@ export function applyApplicationPackagingAdapter(
     return {
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
+      reviewedInstallArgumentsOverride: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedUninstallProcessGuard: undefined,
@@ -471,6 +482,13 @@ export function applyApplicationPackagingAdapter(
     }
   }
 
+  const reviewedInstallArgumentsOverride = adapter.reviewedInstallArgumentsOverride
+    ? normalizeReviewedArgument(
+        adapter.reviewedInstallArgumentsOverride,
+        adapter.wingetId
+      )
+    : undefined;
+
   const reviewedUninstallArguments = (config.reviewedUninstallArguments || []).map(
     (argument) => normalizeReviewedArgument(argument, adapter.wingetId)
   );
@@ -494,6 +512,7 @@ export function applyApplicationPackagingAdapter(
     ...config,
     processesToClose,
     reviewedInstallArguments,
+    reviewedInstallArgumentsOverride,
     reviewedUninstallArguments,
     reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard
       ? { ...adapter.reviewedUninstallProcessGuard }

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -600,6 +600,7 @@ export function normalizeQaPsadtConfig(
     postInstallCommands: value?.postInstallCommands || [],
     postUninstallCommands: value?.postUninstallCommands || [],
     reviewedInstallArguments: value?.reviewedInstallArguments || [],
+    reviewedInstallArgumentsOverride: value?.reviewedInstallArgumentsOverride,
     reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
   };
 }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -35,7 +35,7 @@ const canRunWindowsPowerShellPackager =
   ]).status === 0;
 
 function generateRegistryUninstallPackage(
-  installerType: 'inno' | 'burn',
+  installerType: 'exe' | 'inno' | 'burn',
   displayName = 'Contract Test App',
   installerSuccessCodes: number[] = [],
   psadtConfig: unknown = {},
@@ -539,6 +539,23 @@ describe('PSADT vendor argument contract', () => {
 
       expect(generated).toContain(
         "-ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- MY_SPECIAL_MODE=2'"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'uses a reviewed vendor-specific unattended argument override',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Bitvise SSH Client',
+        [],
+        { reviewedInstallArgumentsOverride: '-unat -acceptEula' }
+      );
+
+      expect(generated).toContain("-ArgumentList '-unat -acceptEula'");
+      expect(generated).not.toContain(
+        "-ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'"
       );
     }
   );

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -199,6 +199,11 @@ export interface PSADTConfig {
   // customer-facing free-form command surface.
   reviewedInstallArguments?: string[];
 
+  // Internal, reviewed replacement for manifest-derived silent arguments when
+  // a vendor documents a proprietary unattended command line. Application
+  // adapters populate this field; customers cannot supply it directly.
+  reviewedInstallArgumentsOverride?: string;
+
   // Internal, reviewed vendor arguments appended to an exact registered
   // uninstaller. Application adapters populate this field; it is intentionally
   // not exposed as a customer-facing free-form command surface.
@@ -330,6 +335,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   installCommand: undefined,
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
+  reviewedInstallArgumentsOverride: undefined,
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,
 };


### PR DESCRIPTION
## Summary
- add a bounded reviewed override for vendor-specific unattended install arguments
- use Bitvise's documented \-unat -acceptEula\ command instead of the incompatible generic WinGet switches
- include the override in QA profile identity so QA and customer packaging stay one-to-one

## Verification
- 139 focused tests passed
- focused ESLint passed