### PR TITLE
fix(auto-update): refresh installer lifecycle metadata

### DIFF
--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -180,8 +180,14 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     if (!result.ok) throw new Error('Expected installer resolution to succeed');
     expect(result.info).toMatchObject({
       installCommand: '"Vivaldi.8.1.4087.62.x64.exe" --vivaldi-silent --do-not-launch-chrome',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Vivaldi',
       silentSwitches: '--vivaldi-silent --do-not-launch-chrome',
       installScope: 'user',
+      detectionRules: [expect.objectContaining({
+        type: 'registry',
+        detectionValue: '8.1.4087.62',
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Vivaldi_Vivaldi',
+      })],
     });
   });
 
@@ -489,6 +495,77 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ]);
     expect(storedConfig.psadtConfig?.processesToClose).toEqual([]);
+  });
+
+  it('replaces stale installer-family detection for QA and customer packaging', async () => {
+    const supabase = createSupabaseMock({});
+    const trigger = makeTrigger(supabase);
+    const staleMsixDetection = {
+      type: 'script' as const,
+      scriptContent: 'Get-AppxPackage -Name OldPackage',
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+    const currentExeDetection = {
+      type: 'registry' as const,
+      keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Anthropic_Claude',
+      valueName: 'Version',
+      detectionType: 'version' as const,
+      detectionValue: '1.30096.1',
+      operator: 'greaterThanOrEqual' as const,
+      check32BitOn64System: false,
+    };
+    const storedConfig: DeploymentConfig = {
+      displayName: 'Claude',
+      publisher: 'Anthropic',
+      architecture: 'x64',
+      installerType: 'msix',
+      installCommand: 'Add-AppxPackage old.msix',
+      uninstallCommand: 'MSIX_UNINSTALL:Claude',
+      installScope: 'user',
+      detectionRules: [staleMsixDetection],
+      psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [staleMsixDetection] },
+    };
+    const policy = makePolicy(storedConfig);
+    policy.original_upload_history_id = 'prior-upload';
+    policy.consecutive_failures = 0;
+
+    vi.spyOn(trigger as never, 'verifyTenantConsent' as never).mockResolvedValue(true as never);
+    vi.spyOn(trigger as never, 'ensurePsadtConfig' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'ensureCurrentPackageDefaults' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'createHistoryRecord' as never)
+      .mockResolvedValue({ id: 'history-claude' } as never);
+    const createPackagingJobSpy = vi.spyOn(trigger as never, 'createPackagingJob' as never)
+      .mockResolvedValue({ id: 'job-claude' } as never);
+    vi.spyOn(trigger as never, 'updateHistoryRecord' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'updatePolicyTracking' as never).mockResolvedValue(undefined as never);
+
+    const result = await trigger.triggerAutoUpdate(policy, {
+      ...UPDATE_INFO,
+      wingetId: 'Anthropic.Claude',
+      latestVersion: '1.30096.1',
+      installerType: 'exe',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Claude',
+      detectionRules: [currentExeDetection],
+      nestedInstallerType: undefined,
+      nestedInstallerPath: undefined,
+    }, { skipRateLimits: true });
+
+    expect(result).toMatchObject({ success: true, packagingJobId: 'job-claude' });
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        uninstallCommand: 'REGISTRY_UNINSTALL:Claude',
+        detectionRules: JSON.stringify([currentExeDetection]),
+      })
+    );
+    const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
+    expect((effectivePolicy.deployment_config as DeploymentConfig)).toMatchObject({
+      uninstallCommand: 'REGISTRY_UNINSTALL:Claude',
+      detectionRules: [currentExeDetection],
+    });
+    expect(storedConfig.uninstallCommand).toBe('MSIX_UNINSTALL:Claude');
+    expect(storedConfig.detectionRules).toEqual([staleMsixDetection]);
   });
 
   it('uses a reviewed user scope for both auto-update QA and the packaging job', async () => {

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -21,7 +21,11 @@ import {
 } from '@/lib/qa/candidate';
 import { ensureQaDemand, type QaDemandResult } from '@/lib/qa/demand';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
-import { generateInstallCommand } from '@/lib/detection-rules';
+import {
+  generateDetectionRules,
+  generateInstallCommand,
+  generateUninstallCommand,
+} from '@/lib/detection-rules';
 import { normalizeInstaller } from '@/lib/manifest-api';
 import { upgradeLegacyPackageDefaults } from '@/lib/update-policies/upgrade-legacy-package-defaults';
 import {
@@ -29,7 +33,7 @@ import {
   resolveApplicationInstallScope,
 } from '@/lib/packaging-adapters';
 import type { NormalizedInstaller, WingetInstaller, WingetScope } from '@/types/winget';
-import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { DEFAULT_PSADT_CONFIG, type DetectionRule } from '@/types/psadt';
 
 interface TriggerResult {
   success: boolean;
@@ -51,6 +55,8 @@ export interface UpdateInfo {
   installerSha256: string;
   installerType: string;
   installCommand?: string;
+  uninstallCommand?: string;
+  detectionRules?: DetectionRule[];
   silentSwitches?: string;
   installerSuccessCodes?: number[];
   installScope?: WingetScope;
@@ -236,6 +242,10 @@ export class AutoUpdateTrigger {
       const deploymentConfig: DeploymentConfig = {
         ...storedDeploymentConfig,
         installScope: effectiveInstallScope,
+        uninstallCommand:
+          updateInfo.uninstallCommand || storedDeploymentConfig.uninstallCommand,
+        detectionRules:
+          updateInfo.detectionRules || storedDeploymentConfig.detectionRules,
         psadtConfig: applyApplicationPackagingAdapter(
           updateInfo.wingetId,
           storedDeploymentConfig.psadtConfig || DEFAULT_PSADT_CONFIG
@@ -272,13 +282,15 @@ export class AutoUpdateTrigger {
               updateInfo.nestedInstallerType
             ),
         installerSuccessCodes: updateInfo.installerSuccessCodes,
-        uninstallCommand: deploymentConfig.uninstallCommand || '',
+        uninstallCommand: updateInfo.uninstallCommand || deploymentConfig.uninstallCommand || '',
         installScope: updateInfo.installScope ||
           (deploymentConfig.installScope === 'user' ? 'user' : 'machine'),
         psadtConfig: deploymentConfig.psadtConfig
           ? JSON.stringify(deploymentConfig.psadtConfig)
           : undefined,
-        detectionRules: JSON.stringify(deploymentConfig.detectionRules || []),
+        detectionRules: JSON.stringify(
+          updateInfo.detectionRules || deploymentConfig.detectionRules || []
+        ),
         priority: 1500,
         demandSource: 'auto_update',
       });
@@ -1003,6 +1015,16 @@ export async function getLatestInstallerInfo(
       installerSha256: normalizedSha256,
       installerType: installerType || 'exe',
       installCommand: buildCurrentVersionInstallCommand(normalizedInstaller),
+      uninstallCommand: generateUninstallCommand(
+        normalizedInstaller,
+        curatedApp.name
+      ),
+      detectionRules: generateDetectionRules(
+        normalizedInstaller,
+        curatedApp.name,
+        wingetId,
+        latestVersion
+      ),
       silentSwitches: normalizedInstaller.silentArgs,
       installerSuccessCodes: normalizedInstaller.installerSuccessCodes,
       installScope: normalizedInstaller.scope,


### PR DESCRIPTION
## Summary
- derive uninstall and detection rules from the currently selected WinGet installer
- pass the same current lifecycle metadata to QA and customer packaging
- prevent an installer-family change such as MSIX to EXE from reusing stale detection

## Verification
- 22 focused tests passed
- focused ESLint passed