### PR TITLE
Repair stale generated detection across installer changes

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -687,6 +687,55 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('repairs stale generated MSIX detection before both QA and customer MSI packaging', async () => {
+    const staleMsixRule = {
+      type: 'script',
+      scriptContent: [
+        '# MSIX Detection Script',
+        '# Package Family Name: Agilebits.1Password_amwd9z03whsfe',
+        'exit 0',
+      ].join('\n'),
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'AgileBits.1Password',
+          displayName: '1Password',
+          version: '8.12.30.21',
+          installerType: 'msi',
+          detectionRules: [staleMsixRule],
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [staleMsixRule] },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedRule = expect.objectContaining({
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\AgileBits_1Password',
+      detectionValue: '8.12.30.21',
+    });
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].detectionRules)).toEqual([
+      expectedRule,
+    ]);
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].detectionRules)).toEqual([
+      expectedRule,
+    ]);
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      detectionRules: [expectedRule],
+      psadtConfig: { detectionRules: [expectedRule] },
+    });
+  });
+
   it('preserves configured PSADT rules when the top-level list is unusable', async () => {
     const fileRule = {
       type: 'file',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -512,6 +512,7 @@ export async function POST(request: NextRequest) {
                 version: item.version,
                 installScope: item.installScope,
                 markerPath: requestedPsadtConfig.registryMarkerPath,
+                installerType: item.nestedInstallerType || item.installerType,
               });
               item.detectionRules = detectionRules;
               item.psadtConfig = applyApplicationPackagingAdapter(

--- a/lib/catalog-detection.test.ts
+++ b/lib/catalog-detection.test.ts
@@ -52,6 +52,68 @@ describe('catalog detection normalization', () => {
     expect(result[0]).toBe(customRule);
   });
 
+  it('replaces a generated MSIX rule after the catalog installer changes to MSI', () => {
+    const staleMsixRule = {
+      type: 'script' as const,
+      scriptContent: [
+        '# MSIX Detection Script',
+        '# Package Family Name: Agilebits.1Password_amwd9z03whsfe',
+        'exit 0',
+      ].join('\n'),
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+
+    expect(normalizeCatalogDetectionRules({
+      detectionRules: [staleMsixRule],
+      fallbackDetectionRules: [staleMsixRule],
+      wingetId: 'AgileBits.1Password',
+      version: '8.12.30.21',
+      installScope: 'machine',
+      installerType: 'msi',
+    })).toEqual([expect.objectContaining({
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\AgileBits_1Password',
+      detectionValue: '8.12.30.21',
+    })]);
+  });
+
+  it('keeps a generated MSIX rule for an MSIX-family installer', () => {
+    const generatedRule = {
+      type: 'script' as const,
+      scriptContent: [
+        '# MSIX Detection Script',
+        '# Package Family Name: Example.App_123',
+        'exit 0',
+      ].join('\n'),
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+
+    expect(normalizeCatalogDetectionRules({
+      detectionRules: [generatedRule],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      installerType: 'msix',
+    })).toEqual([generatedRule]);
+  });
+
+  it('does not discard a customer-authored script for an MSI installer', () => {
+    const customScript = {
+      type: 'script' as const,
+      scriptContent: 'if (Test-Path $env:ProgramFiles\\Example) { exit 0 }; exit 1',
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+
+    expect(normalizeCatalogDetectionRules({
+      detectionRules: [customScript],
+      wingetId: 'Example.App',
+      version: '1.0.0',
+      installerType: 'msi',
+    })).toEqual([customScript]);
+  });
+
   it('drops malformed legacy entries and repairs the resulting empty rule list', () => {
     const result = normalizeCatalogDetectionRules({
       detectionRules: [null, {}, { type: 'registry', keyPath: '' }],

--- a/lib/catalog-detection.ts
+++ b/lib/catalog-detection.ts
@@ -19,6 +19,7 @@ export function normalizeCatalogDetectionRules({
   version,
   installScope,
   markerPath,
+  installerType,
 }: {
   detectionRules: readonly unknown[] | null | undefined;
   fallbackDetectionRules?: readonly unknown[] | null;
@@ -26,6 +27,7 @@ export function normalizeCatalogDetectionRules({
   version: string;
   installScope?: string;
   markerPath?: string | null;
+  installerType?: string | null;
 }): DetectionRule[] {
   if (typeof wingetId !== 'string' || !wingetId.trim()) {
     throw new Error('Catalog package detection requires a non-empty Winget ID');
@@ -39,10 +41,10 @@ export function normalizeCatalogDetectionRules({
   const scope: WingetScope = typeof installScope === 'string' && installScope.toLowerCase() === 'user'
     ? 'user'
     : 'machine';
-  const primaryRules = usableDetectionRules(detectionRules);
+  const primaryRules = compatibleDetectionRules(detectionRules, installerType);
   const usableRules = primaryRules.length > 0
     ? primaryRules
-    : usableDetectionRules(fallbackDetectionRules);
+    : compatibleDetectionRules(fallbackDetectionRules, installerType);
   const reconciled = reconcileManagedMarkerDetectionRules({
     detectionRules: usableRules,
     wingetId,
@@ -54,6 +56,39 @@ export function normalizeCatalogDetectionRules({
   return reconciled.length > 0
     ? reconciled
     : generateRegistryMarkerDetectionRules(wingetId, version, scope, markerPath || undefined);
+}
+
+/**
+ * Discard only rules whose machine-generated shape proves they belong to a
+ * different installer family. This repairs saved catalog entries after a
+ * vendor changes formats (for example MSIX to MSI) without replacing genuine
+ * customer-authored scripts merely because they use a different mechanism.
+ */
+function compatibleDetectionRules(
+  values: readonly unknown[] | null | undefined,
+  installerType?: string | null
+): DetectionRule[] {
+  const rules = usableDetectionRules(values);
+  const effectiveType = installerType?.trim().toLowerCase();
+  if (!effectiveType) return rules;
+
+  return rules.filter((rule) => {
+    if (rule.type === 'script' && isGeneratedMsixDetectionRule(rule)) {
+      return effectiveType === 'msix' || effectiveType === 'appx';
+    }
+    if (rule.type === 'msi' && (effectiveType === 'msix' || effectiveType === 'appx')) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function isGeneratedMsixDetectionRule(rule: DetectionRule): boolean {
+  if (rule.type !== 'script') return false;
+  const script = (rule as { scriptContent?: unknown }).scriptContent;
+  return typeof script === 'string' &&
+    /^\s*# MSIX Detection Script\s*$/im.test(script) &&
+    /^\s*# Package Family Name:\s*\S+/im.test(script);
 }
 
 function usableDetectionRules(values: readonly unknown[] | null | undefined): DetectionRule[] {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -250,6 +250,42 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('repairs generated detection when a saved catalog profile changed from MSIX to MSI', () => {
+    const staleMsixRule = {
+      type: 'script',
+      scriptContent: [
+        '# MSIX Detection Script',
+        '# Package Family Name: Agilebits.1Password_amwd9z03whsfe',
+        'exit 0',
+      ].join('\n'),
+      enforceSignatureCheck: false,
+      runAs32Bit: false,
+    };
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'AgileBits.1Password',
+      displayName: '1Password',
+      publisher: 'AgileBits',
+      version: '8.12.30.21',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart',
+      uninstallCommand: 'msiexec /x "{598797D5-61EB-46AF-8F8B-0C2070B648A2}" /qn /norestart',
+      installScope: 'machine',
+      detectionRules: JSON.stringify([staleMsixRule]),
+      psadtConfig: JSON.stringify({ detectionRules: [staleMsixRule] }),
+    });
+
+    expect(normalized.detectionRules).toEqual([expect.objectContaining({
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\AgileBits_1Password',
+      detectionValue: '8.12.30.21',
+    })]);
+    expect(JSON.parse(normalized.psadtConfigJson).detectionRules).toEqual(
+      normalized.detectionRules
+    );
+  });
+
   it('normalizes reviewed per-user apps before hashing deployment QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'VNGCorp.Zalo',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -733,6 +733,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     version: input.version,
     installScope,
     markerPath: preliminaryConfig.registryMarkerPath,
+    installerType: input.nestedInstallerType || input.installerType,
   });
   const psadtConfig = applyApplicationPackagingAdapter(
     input.wingetId,


### PR DESCRIPTION
Repairs catalog packages when a saved machine-generated detection rule belongs to an older installer family, such as 1Password changing from MSIX to MSI. The server now removes only provably generated incompatible rules and falls back to the managed version marker. Genuine custom scripts remain intact. The same normalization runs before QA and customer packaging.\n\nValidation: 88 focused Vitest tests; targeted ESLint; git diff --check.