### PR TITLE
fix(qa): enforce installer preflight before dispatch

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock })
 vi.mock('@/lib/qa/dispatch', () => ({ dispatchQaCandidate: dispatchQaCandidateMock }));
 
 import { GET } from './route';
+import { InstallerPreflightError } from '@/lib/installer-preflight';
 import { buildQaPackageIdentity } from '@/lib/qa/package-profile';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
@@ -401,6 +402,33 @@ describe('GET /api/cron/qa-dispatch', () => {
     await expect(GET(cronRequest())).rejects.toThrow('GitHub unavailable');
 
     expect(rollbackIds).toEqual([row.id]);
+  });
+
+  it('supersedes an installer quarantined by the shared customer preflight', async () => {
+    const row = candidate('catalog-default');
+    const { client, supersededIds, rollbackIds } = createSupabaseStub([row]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock.mockRejectedValueOnce(new InstallerPreflightError(
+      'HASH_MISMATCH',
+      'The publisher currently serves different bytes for this version.',
+      false,
+      'B'.repeat(64),
+    ));
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      dispatched: false,
+      reason: 'installer_quarantined',
+      candidateId: row.id,
+      code: 'HASH_MISMATCH',
+      superseded: 1,
+    });
+    expect(supersededIds).toEqual([row.id]);
+    expect(rollbackIds).toEqual([]);
   });
 
   it('does not claim anything when superseding an invalid profile fails', async () => {

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -4,6 +4,7 @@ import { dispatchQaCandidate } from '@/lib/qa/dispatch';
 import { validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
 import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
+import { InstallerPreflightError } from '@/lib/installer-preflight';
 import { isQaRunnerArchitectureSupported } from '@/lib/qa/candidate';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
@@ -238,6 +239,36 @@ export async function GET(request: Request) {
         });
       } catch (error) {
         console.error(`QA dispatch failed for candidate ${claimed.id}:`, error);
+        if (error instanceof InstallerPreflightError && !error.retryable) {
+          const quarantinedAt = new Date().toISOString();
+          const summary = `Installer source quarantined before QA: ${error.code}. ${error.message}`
+            .slice(0, 1000);
+          const { error: quarantineError } = await supabase
+            .from('qa_candidates')
+            .update({
+              status: 'superseded',
+              finished_at: quarantinedAt,
+              phase: 'preparing_package',
+              phase_started_at: claimed.dispatched_at || quarantinedAt,
+              phase_updated_at: quarantinedAt,
+              failure_summary: summary,
+              updated_at: quarantinedAt,
+            })
+            .in('id', [claimed.id])
+            .eq('status', 'dispatched')
+            .select('id');
+          if (quarantineError) throw quarantineError;
+          return NextResponse.json({
+            success: true,
+            dispatched: false,
+            reason: 'installer_quarantined',
+            candidateId: claimed.id,
+            code: error.code,
+            reconciled,
+            scanned,
+            superseded: superseded + 1,
+          });
+        }
         await supabase
           .from('qa_candidates')
           .update({

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { dispatchQaCandidate } from './dispatch';
 
+const { enforceInstallerPreflightMock } = vi.hoisted(() => ({
+  enforceInstallerPreflightMock: vi.fn(),
+}));
+
 vi.mock('@/lib/github-actions', () => ({
   getGitHubActionsConfig: () => ({
     token: 'secret-token',
@@ -10,10 +14,22 @@ vi.mock('@/lib/github-actions', () => ({
   }),
 }));
 
-afterEach(() => vi.unstubAllGlobals());
+vi.mock('@/lib/installer-preflight', () => ({
+  enforceInstallerPreflight: enforceInstallerPreflightMock,
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  enforceInstallerPreflightMock.mockReset();
+});
 
 describe('dispatchQaCandidate', () => {
   it('dispatches only exact public candidate metadata', async () => {
+    enforceInstallerPreflightMock.mockResolvedValue({
+      cacheKey: 'healthy',
+      status: 'healthy',
+      source: 'live',
+    });
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);
     await dispatchQaCandidate({
@@ -48,9 +64,24 @@ describe('dispatchQaCandidate', () => {
       packageProfileSha256: 'B'.repeat(64),
     });
     expect(JSON.stringify(body)).not.toContain('secret-token');
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith({
+      wingetId: 'Example.App',
+      version: '2.0.0',
+      architecture: 'x64',
+      installerUrl: 'https://example.test/setup.exe',
+      installerSha256: 'A'.repeat(64),
+      installerType: 'exe',
+      installScope: 'machine',
+      sourceType: 'winget',
+    });
   });
 
   it('surfaces a rejected GitHub dispatch', async () => {
+    enforceInstallerPreflightMock.mockResolvedValue({
+      cacheKey: 'healthy',
+      status: 'healthy',
+      source: 'live',
+    });
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('denied', { status: 403 })));
     await expect(
       dispatchQaCandidate({

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -1,4 +1,5 @@
 import { getGitHubActionsConfig } from '@/lib/github-actions';
+import { enforceInstallerPreflight } from '@/lib/installer-preflight';
 import type { Json } from '@/types/database';
 
 export interface QaDispatchCandidate {
@@ -17,6 +18,26 @@ export interface QaDispatchCandidate {
 }
 
 export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promise<void> {
+  const testConfig = candidate.test_config && typeof candidate.test_config === 'object' && !Array.isArray(candidate.test_config)
+    ? candidate.test_config as Record<string, Json | undefined>
+    : {};
+  const installScope = testConfig.scope === 'user' ? 'user' : 'machine';
+
+  // Keep the QA dispatch boundary aligned with customer packaging. A vendor
+  // can replace the bytes behind a mutable URL after WinGet publishes its
+  // manifest. Verify the exact URL/hash tuple before consuming the runner so
+  // QA never tests bytes that a customer upload would reject.
+  await enforceInstallerPreflight({
+    wingetId: candidate.winget_id,
+    version: candidate.version,
+    architecture: candidate.architecture,
+    installerUrl: candidate.installer_url,
+    installerSha256: candidate.installer_sha256,
+    installerType: candidate.installer_type,
+    installScope,
+    sourceType: 'winget',
+  });
+
   const config = getGitHubActionsConfig();
   const url = `https://api.github.com/repos/${config.owner}/${config.workflowsRepo}/actions/workflows/intune-qa.yml/dispatches`;
   const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- apply the same live installer hash preflight used by customer packaging before QA dispatch
- quarantine non-retryable upstream hash mismatches without consuming the runner
- keep retryable infrastructure failures queued for recovery

## Verification
- npx vitest run lib/qa/dispatch.test.ts app/api/cron/qa-dispatch/route.test.ts
- npx eslint lib/qa/dispatch.ts lib/qa/dispatch.test.ts app/api/cron/qa-dispatch/route.ts app/api/cron/qa-dispatch/route.test.ts
- git diff --check