### PR TITLE
fix(qa): preflight original WinGet installer type

### DIFF
--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -44,7 +44,11 @@ describe('dispatchQaCandidate', () => {
       installer_type: 'exe',
       test_level: 'psadt-package',
       package_profile_sha256: 'B'.repeat(64),
-      test_config: { mode: 'psadt-package' },
+      test_config: {
+        mode: 'psadt-package',
+        scope: 'user',
+        sourceInstallerType: 'wix',
+      },
     });
 
     const [url, request] = fetchMock.mock.calls[0];
@@ -70,8 +74,8 @@ describe('dispatchQaCandidate', () => {
       architecture: 'x64',
       installerUrl: 'https://example.test/setup.exe',
       installerSha256: 'A'.repeat(64),
-      installerType: 'exe',
-      installScope: 'machine',
+      installerType: 'wix',
+      installScope: 'user',
       sourceType: 'winget',
     });
   });

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -22,6 +22,9 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
     ? candidate.test_config as Record<string, Json | undefined>
     : {};
   const installScope = testConfig.scope === 'user' ? 'user' : 'machine';
+  const sourceInstallerType = typeof testConfig.sourceInstallerType === 'string' && testConfig.sourceInstallerType.trim()
+    ? testConfig.sourceInstallerType.trim()
+    : candidate.installer_type;
 
   // Keep the QA dispatch boundary aligned with customer packaging. A vendor
   // can replace the bytes behind a mutable URL after WinGet publishes its
@@ -33,7 +36,10 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
     architecture: candidate.architecture,
     installerUrl: candidate.installer_url,
     installerSha256: candidate.installer_sha256,
-    installerType: candidate.installer_type,
+    // The candidate column is the normalized execution type (for example,
+    // WinGet Wix becomes MSI). Preflight must compare the original WinGet
+    // manifest type or it will incorrectly quarantine a valid installer.
+    installerType: sourceInstallerType,
     installScope,
     sourceType: 'winget',
   });


### PR DESCRIPTION
## Summary
- compare live installer identity with the original WinGet installer type
- retain the normalized execution type only for package preparation
- prevent valid Wix and other normalized installers from being quarantined

## Verification
- 14 focused QA dispatch tests passed
- targeted ESLint passed
- git diff --check passed