### PR TITLE
fix(qa): keep quarantined installer tuples dormant

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/lib/winget-dependencies', async (importOriginal) => {
 });
 
 import { GET } from './route';
+import { shouldReactivateSupersededCandidate } from '@/lib/qa/candidate-reactivation';
 import { prioritizeToolchainBackfill } from '@/lib/qa/toolchain-backfill';
 import {
   buildQaPackageIdentity,
@@ -333,6 +334,18 @@ afterEach(() => {
 });
 
 describe('GET /api/cron/qa-enqueue', () => {
+  it('keeps an exact quarantined installer tuple dormant until its identity changes', () => {
+    expect(shouldReactivateSupersededCandidate(
+      'superseded',
+      'Installer source quarantined before QA: HASH_MISMATCH. Publisher bytes changed.',
+    )).toBe(false);
+    expect(shouldReactivateSupersededCandidate(
+      'superseded',
+      'Superseded before dispatch: wrong-toolchain.',
+    )).toBe(true);
+    expect(shouldReactivateSupersededCandidate('queued', null)).toBe(false);
+  });
+
   it('does not poll or mutate the queue while maintenance is paused', async () => {
     const { client, pollRunInserts, candidateInserts } = createSupabaseStub({ paused: true });
     createServerClientMock.mockReturnValue(client);

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -38,6 +38,7 @@ import {
   createWingetManifestClient,
   resolveWingetManifest,
 } from '@/lib/winget-sync-resolution.mjs';
+import { shouldReactivateSupersededCandidate } from '@/lib/qa/candidate-reactivation';
 
 const BATCH_SIZE = 3;
 const POLL_STATE_ID = 'microsoft/winget-pkgs';
@@ -748,7 +749,7 @@ export async function GET(request: Request) {
               summary.alreadyKnown++;
               const { data: existing, error: existingError } = await supabase!
                 .from('qa_candidates')
-                .select('id, status')
+                .select('id, status, failure_summary')
                 .eq('winget_id', app.winget_id)
                 .eq('version', resolution.version)
                 .eq('architecture', architecture)
@@ -758,7 +759,10 @@ export async function GET(request: Request) {
               if (existingError) {
                 throw new Error(`Could not read the existing QA candidate: ${existingError.message}`);
               }
-              if (existing?.status === 'superseded') {
+              if (existing && shouldReactivateSupersededCandidate(
+                existing.status,
+                existing.failure_summary,
+              )) {
                 const { error: reactivateError } = await supabase!
                   .from('qa_candidates')
                   .update({

--- a/lib/qa/candidate-reactivation.ts
+++ b/lib/qa/candidate-reactivation.ts
@@ -1,0 +1,9 @@
+const INSTALLER_SOURCE_QUARANTINE_PREFIX = 'Installer source quarantined before QA:';
+
+export function shouldReactivateSupersededCandidate(
+  status: string | null | undefined,
+  failureSummary: string | null | undefined,
+): boolean {
+  return status === 'superseded' &&
+    !failureSummary?.startsWith(INSTALLER_SOURCE_QUARANTINE_PREFIX);
+}


### PR DESCRIPTION
## Summary
- do not reactivate the same URL/hash/profile after live preflight quarantines it
- allow ordinary superseded candidates to retain their existing recovery path
- wait for a genuinely new installer tuple before retrying an upstream hash mismatch

## Verification
- 21 focused enqueue tests passed
- targeted ESLint passed
- git diff --check passed