### PR TITLE
Block packages without a managed uninstall

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -418,7 +418,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(409);
     expect(body).toMatchObject({
       error: 'App unavailable',
-      message: 'This app is no longer available for deployment.',
+      message: 'This app is not available for automated deployment.',
       code: 'PACKAGE_UNAVAILABLE',
       package: { wingetId: 'Autodesk.DesktopApp' },
     });

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -1,7 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 
-export type PackageEligibilityBlockCode = 'vendor_retired' | 'upstream_removed';
+export type PackageEligibilityBlockCode =
+  | 'vendor_retired'
+  | 'upstream_removed'
+  | 'unsupported_managed_uninstall';
 
 export interface PackageEligibilityBlock {
   wingetId: string;
@@ -9,7 +12,7 @@ export interface PackageEligibilityBlock {
 }
 
 export const PACKAGE_UNAVAILABLE_MESSAGE =
-  'This app is no longer available for deployment.';
+  'This app is not available for automated deployment.';
 
 export async function getPackageEligibilityBlocks(
   supabase: SupabaseClient<Database>,

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -81,7 +81,7 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     expect(result).toMatchObject({
       state: 'failed',
       candidateId: null,
-      failureSummary: 'This app is no longer available for deployment.',
+      failureSummary: 'This app is not available for automated deployment.',
     });
     expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
     expect(client.from).not.toHaveBeenCalled();

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -264,6 +264,25 @@ describe('retired catalog app migration contract', () => {
   });
 });
 
+describe('unsupported managed uninstall migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260814111854_block_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks Cygwin consistently across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Cygwin.Cygwin'");
+    expect(sql).toContain('https://cygwin.com/faq/faq.html#faq.setup.uninstall-all');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status = 'queued'");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260814111854_block_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260814111854_block_unsupported_managed_uninstall.sql
@@ -1,0 +1,44 @@
+-- Some WinGet packages can be installed silently but do not provide a
+-- supported automatic full-uninstall contract. IntuneGet must not publish
+-- those packages as managed applications because detection and removal could
+-- not be made reliable on customer devices.
+
+alter table public.package_eligibility_blocks
+  drop constraint if exists package_eligibility_blocks_block_code_check;
+alter table public.package_eligibility_blocks
+  add constraint package_eligibility_blocks_block_code_check
+  check (block_code in (
+    'vendor_retired',
+    'upstream_removed',
+    'unsupported_managed_uninstall'
+  ));
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Cygwin.Cygwin',
+  'unsupported_managed_uninstall',
+  'Cygwin Setup has no automatic full-uninstall facility. The vendor procedure requires manual service, process, filesystem, shortcut, and registry cleanup.',
+  'https://cygwin.com/faq/faq.html#faq.setup.uninstall-all'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Cygwin.Cygwin';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Cygwin.Cygwin'
+  and status = 'queued';

--- a/types/database.ts
+++ b/types/database.ts
@@ -291,7 +291,10 @@ export interface Database {
       package_eligibility_blocks: {
         Row: {
           winget_id: string;
-          block_code: 'vendor_retired' | 'upstream_removed';
+          block_code:
+            | 'vendor_retired'
+            | 'upstream_removed'
+            | 'unsupported_managed_uninstall';
           detail: string;
           source_url: string;
           blocked_at: string;


### PR DESCRIPTION
## What changed

- add a reviewed application-level eligibility reason for packages without a supported managed uninstall
- block Cygwin from catalog verification, customer packaging, auto-update demand, and future QA dispatch
- use one neutral customer-facing unavailable message for all eligibility reasons

## Root cause

Cygwin Setup can install non-interactively, but the vendor explicitly documents that it has no automatic full-uninstall facility. The supported removal procedure requires manual cleanup of services, processes, files, shortcuts, and registry state, which cannot satisfy IntuneGet's safe managed lifecycle contract.

## Impact

Customers can no longer request an Intune package that IntuneGet cannot reliably uninstall. The active QA queue keeps running because this change does not alter the protected PSADT toolchain pin.

## Validation

- 74 targeted Vitest tests passed
- migration DDL and Cygwin insert validated against production inside an explicit transaction that was rolled back
- `git diff --check` passed
- baseline full TypeScript check remains noisy because existing test files rely on Vitest globals outside the project TypeScript configuration