### PR TITLE
Run Youdao in its supported user scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -25,6 +25,8 @@ describe('application packaging adapters', () => {
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Makeblock.xToolStudio', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' makeblock.xtoolstudio ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Rakuten.Viber', 'machine')).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -79,6 +79,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Youdao's signed NSIS installer requests `asInvoker` and its WinGet
+    // manifest omits Scope. Treating that omission as machine scope launches
+    // the per-user bootstrapper under LocalSystem, where it exits immediately
+    // without creating an application or uninstall registration.
+    wingetId: 'Youdao.YoudaoTranslate',
+    requiredInstallScope: 'user',
+  },
+  {
     // xTool Studio's NSIS bootstrapper likewise installs below the invoking
     // account's LocalAppData even when the WinGet manifest is selected as a
     // machine package. LocalSystem therefore registers an uninstaller below

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -432,4 +432,30 @@ describe('buildQaCatalogTestConfig', () => {
       }),
     ]);
   });
+
+  it('tests Youdao in user context when its NSIS manifest omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Youdao.YoudaoTranslate',
+        name: '网易有道翻译',
+        publisher: 'Youdao',
+        version: '11.3.16.0',
+      },
+      manifest: {
+        InstallerType: 'exe',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'exe',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Youdao_YoudaoTranslate',
+      }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- force the Youdao NSIS bootstrapper into user scope when WinGet omits Scope
- apply the same adapter to QA and customer packaging
- generate HKCU detection for the effective install context

## Evidence
- the exact 11.3.16.0 installer is validly signed by NetEase Youdao
- its embedded manifest is NSIS 3.12 with requestedExecutionLevel=asInvoker
- machine-scope QA ran it under LocalSystem, where it exited 1 in under two seconds and created no application or uninstall entry

## Validation
- 132 targeted tests passed across adapter, QA normalization, QA demand, test configuration, and customer package route
- git diff --check