### PR TITLE
Test CapCut with an unattended removal lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -39,6 +39,12 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/S']);
     expect(
+      applyApplicationPackagingAdapter('ByteDance.CapCut', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      processesToClose: [{ name: 'CapCut', description: 'CapCut' }],
+      reviewedUninstallArguments: ['/S'],
+    });
+    expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -127,6 +127,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // CapCut registers a signed custom uninst.exe with no arguments. The bare
+    // command opens a confirmation window and cannot complete from Intune's
+    // non-interactive execution context. Close the desktop client first and
+    // exercise the vendor uninstaller's unattended switch in isolated QA
+    // before this package can qualify for customer deployment.
+    wingetId: 'ByteDance.CapCut',
+    requiredProcessesToClose: [
+      { name: 'CapCut', description: 'CapCut' },
+    ],
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
   },


### PR DESCRIPTION
## Summary
- close the CapCut desktop process before removal
- append the vendor uninstaller's unattended /S switch
- apply the lifecycle adapter to both QA and customer PSADT packages

## Evidence
- QA installation and detection both passed for CapCut 9.2.0.3931
- the signed ByteDance uninstaller was registered without arguments and waited behind an invisible confirmation dialog
- customer deployment remains gated until the isolated retry proves the adapted uninstall and removal verification

## Validation
- 178 targeted tests passed across adapter, package identity, QA demand, customer package route, and generated PSADT contract
- git diff --check