### PR TITLE
Make Dell DDPM removal unattended

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -59,6 +59,24 @@ describe('application packaging adapters', () => {
         completionTimeoutMinutes: 10,
       },
     });
+    expect(
+      applyApplicationPackagingAdapter(
+        'Dell.DisplayAndPeripheralManager',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      processesToClose: expect.arrayContaining([
+        { name: 'DPM', description: 'Dell Display and Peripheral Manager' },
+        { name: 'DPMService', description: 'Dell Display and Peripheral Manager' },
+        { name: 'Dell.CoreServices.Client', description: 'Dell Core Services' },
+      ]),
+      reviewedExactUninstall: {
+        executablePath:
+          '%ProgramFiles%\\Dell\\Dell Display and Peripheral Manager\\Installer\\setup.exe',
+        arguments: ['/uninst', '/Silent'],
+        completionTimeoutMinutes: 20,
+      },
+    });
     for (const wingetId of [
       'PostgreSQL.PostgreSQL.9.6',
       'PostgreSQL.PostgreSQL.13',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,6 +163,36 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // DDPM registers its private setup helper with interactive removal
+    // arguments. Replaying that ARP command from Intune leaves the exact
+    // product registration, services, and drivers installed. Stop the reviewed
+    // DDPM process family, then invoke the installed helper's unattended
+    // uninstall contract exactly. Customer packaging remains QA-gated, so a
+    // new version cannot inherit this lifecycle until isolated removal passes.
+    wingetId: 'Dell.DisplayAndPeripheralManager',
+    requiredProcessesToClose: [
+      { name: 'DDPM.Subagent', description: 'Dell Display and Peripheral Manager' },
+      { name: 'DDPM.Subagent.User', description: 'Dell Display and Peripheral Manager' },
+      { name: 'Dell.CoreServices.Client', description: 'Dell Core Services' },
+      { name: 'Dell.TechHub.Analytics.SubAgent', description: 'Dell TechHub' },
+      { name: 'Dell.TechHub.DataManager.SubAgent', description: 'Dell TechHub' },
+      { name: 'Dell.TechHub', description: 'Dell TechHub' },
+      { name: 'Dell.TechHub.Instrumentation.SubAgent', description: 'Dell TechHub' },
+      { name: 'Dell.TechHub.Instrumentation.UserProcess', description: 'Dell TechHub' },
+      { name: 'Dell.UCA.Manager', description: 'Dell Update' },
+      { name: 'Dell.Update.SubAgent', description: 'Dell Update' },
+      { name: 'DPM', description: 'Dell Display and Peripheral Manager' },
+      { name: 'DPMCrashHandler', description: 'Dell Display and Peripheral Manager' },
+      { name: 'DPMService', description: 'Dell Display and Peripheral Manager' },
+    ],
+    reviewedExactUninstall: {
+      executablePath:
+        '%ProgramFiles%\\Dell\\Dell Display and Peripheral Manager\\Installer\\setup.exe',
+      arguments: ['/uninst', '/Silent'],
+      completionTimeoutMinutes: 20,
+    },
+  },
+  {
     // Opera registers `opera.exe /uninstall`, but its current launcher expects
     // the double-dash uninstall verb for a non-interactive removal. Appending
     // unattended arguments to the registered slash command exits successfully


### PR DESCRIPTION
## Summary
- stop the reviewed Dell Display and Peripheral Manager process family before managed removal
- invoke the installed DDPM setup helper with its unattended `/uninst /Silent` contract
- keep the exact ARP registration as the authoritative completion signal and allow up to 20 minutes for Dell's multi-component lifecycle

## Failure evidence
- QA run 31796830670 installed and detected DDPM 2.2.2.8 successfully
- the registered interactive removal path then left all 11 uninstall entries plus Dell services and drivers behind
- PSADT correctly failed the run with exit 60001 instead of publishing a false pass

## Validation
- `npm test -- lib/packaging-adapters.test.ts lib/qa/test-config.test.ts lib/qa/package-profile.test.ts lib/qa/demand.test.ts lib/qa/psadt-packager-contract.test.ts` (171 passed)
- `npm test -- app/api/package/route.test.ts app/api/cron/qa-enqueue/route.test.ts lib/qa/demand.test.ts lib/packaging-adapters.test.ts` (84 passed)
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`

## Safety
Customer packaging remains QA-gated. This adapter changes the execution profile so DDPM must pass a fresh isolated install, detection, uninstall, and removal-verification run before it can qualify for upload.