### PR TITLE
Classify unsupported QA manifests as unavailable

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -604,6 +604,101 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
   });
 
+  it('persists an unsupported dependency shape without degrading polling', async () => {
+    const { client, candidateInserts, compatibilityBlocks, pollRunUpdates } =
+      createSupabaseStub({
+        demandBackfillApps: ['Feature.App'],
+        supportedApps: [
+          {
+            winget_id: 'Feature.App',
+            name: 'Feature App',
+            publisher: 'Contoso',
+            latest_version: '1.0.0',
+          },
+        ],
+      });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+    resolveDependenciesMock.mockRejectedValueOnce(
+      new WingetDependencyCompatibilityError(
+        'Feature.App declares unsupported dependencies: Windows feature NetFx3',
+        'unsupported_dependency_shape'
+      )
+    );
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      checked: 1,
+      queued: 0,
+      unavailable: 1,
+      errorCount: 0,
+    });
+    expect(candidateInserts).toHaveLength(0);
+    expect(compatibilityBlocks).toEqual([
+      expect.objectContaining({
+        winget_id: 'Feature.App',
+        block_code: 'unsupported_dependency_shape',
+      }),
+    ]);
+    expect(pollRunUpdates[0]).toMatchObject({
+      status: 'succeeded',
+      unavailable_count: 1,
+      error_count: 0,
+    });
+  });
+
+  it('treats missing trusted installer metadata as unavailable, not a poll failure', async () => {
+    const { client, candidateInserts, pollRunUpdates } = createSupabaseStub({
+      demandBackfillApps: ['Broken.Manifest'],
+      supportedApps: [
+        {
+          winget_id: 'Broken.Manifest',
+          name: 'Broken Manifest',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue({
+      ...resolvedManifest(),
+      manifest: {
+        InstallerType: 'nullsoft',
+        Installers: [
+          {
+            Architecture: 'x64',
+            InstallerUrl: '',
+            InstallerSha256: '',
+            InstallerType: 'nullsoft',
+          },
+        ],
+      },
+    });
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      checked: 1,
+      queued: 0,
+      unavailable: 1,
+      errorCount: 0,
+    });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveDependenciesMock).not.toHaveBeenCalled();
+    expect(pollRunUpdates[0]).toMatchObject({
+      status: 'succeeded',
+      unavailable_count: 1,
+      error_count: 0,
+    });
+  });
+
   it('does not queue an app payload that already passed under another PSADT profile', async () => {
     const { client, candidateInserts } = createSupabaseStub({
       demandBackfillApps: ['Covered.App'],

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -611,7 +611,14 @@ export async function GET(request: Request) {
               recipe?.installer_type || 'exe'
             );
             if (!installerUrl.startsWith('https://') || !installerSha256) {
-              throw new Error('resolved installer is missing a valid HTTPS URL or SHA-256');
+              summary.unavailable++;
+              structuredQaPollLog('info', 'qa_manifest_installer_unavailable', {
+                runId,
+                wingetId: app.winget_id,
+                version: resolution.version,
+                reason: 'missing_trusted_installer_metadata',
+              });
+              return;
             }
 
             const architecture = selectedForVm.architecture;

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -361,3 +361,18 @@ describe('QA package compatibility block expansion contract', () => {
     expect(sql).toContain("'unreviewed_dependency'");
   });
 });
+
+describe('unsupported dependency shape compatibility block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260814121500_block_unsupported_dependency_shapes.sql'
+    ),
+    'utf8'
+  );
+
+  it('keeps unsupported dependency shapes out of QA and customer packages', () => {
+    expect(sql).toContain('alter table public.qa_package_blocks');
+    expect(sql).toContain("'unsupported_dependency_shape'");
+  });
+});

--- a/lib/winget-dependencies.test.ts
+++ b/lib/winget-dependencies.test.ts
@@ -329,7 +329,10 @@ describe('resolveWingetPackageDependencies', () => {
       version: '1.0.0',
       architecture: 'x64',
       installerSha256: ROOT_SHA,
-    }, io)).rejects.toThrow('declares unsupported dependencies');
+    }, io)).rejects.toMatchObject({
+      blockCode: 'unsupported_dependency_shape',
+      message: expect.stringContaining('declares unsupported dependencies'),
+    });
   });
 
   it('refuses machine-wide prerequisites in a user-scope package', async () => {

--- a/lib/winget-dependencies.ts
+++ b/lib/winget-dependencies.ts
@@ -77,6 +77,7 @@ export class WingetDependencyCompatibilityError extends Error {
     | 'user_scope_machine_dependencies'
     | 'user_scope_elevation_required'
     | 'trusted_installer_tuple_unavailable'
+    | 'unsupported_dependency_shape'
     | 'unreviewed_dependency';
 
   constructor(
@@ -85,6 +86,7 @@ export class WingetDependencyCompatibilityError extends Error {
       | 'user_scope_machine_dependencies'
       | 'user_scope_elevation_required'
       | 'trusted_installer_tuple_unavailable'
+      | 'unsupported_dependency_shape'
       | 'unreviewed_dependency' = 'user_scope_machine_dependencies'
   ) {
     super(message);
@@ -181,8 +183,9 @@ function ensureSupportedDependencyShape(
     ...(installer.externalDependencies || []).map((value) => `external dependency ${value}`),
   ];
   if (unsupported.length > 0) {
-    throw new Error(
-      `${packageIdentifier} declares unsupported dependencies: ${unsupported.join(', ')}`
+    throw new WingetDependencyCompatibilityError(
+      `${packageIdentifier} declares unsupported dependencies: ${unsupported.join(', ')}`,
+      'unsupported_dependency_shape'
     );
   }
 }

--- a/supabase/migrations/20260814121500_block_unsupported_dependency_shapes.sql
+++ b/supabase/migrations/20260814121500_block_unsupported_dependency_shapes.sql
@@ -1,0 +1,16 @@
+-- Fail closed when WinGet expresses a dependency shape that the shared
+-- customer and QA packager cannot reproduce safely yet. A newer immutable
+-- installer tuple remains independently eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'unreviewed_dependency'
+  ));

--- a/types/database.ts
+++ b/types/database.ts
@@ -273,6 +273,7 @@ export interface Database {
             | 'user_scope_machine_dependencies'
             | 'user_scope_elevation_required'
             | 'trusted_installer_tuple_unavailable'
+            | 'unsupported_dependency_shape'
             | 'unreviewed_dependency';
           detail: string;
           observed_at: string;


### PR DESCRIPTION
## Summary
- classify reviewed unsupported dependency shapes as package compatibility blocks instead of poll failures
- classify resolved manifests without a trusted HTTPS URL/SHA-256 tuple as unavailable instead of a system error
- preserve true GitHub, database, and unexpected resolver failures as degraded polling signals

## Production evidence
The 12:10 UTC poll was marked partial only because three deterministic packages could not be packaged safely:
- IdeaMK.AIViewer and Zwift.Zwift require the unsupported Windows feature NetFx3
- Nadeo.TrackManiaUnitedForever has no valid trusted installer URL/SHA-256 tuple

These are package availability outcomes, not failures of WinGet polling.

## Validation
- `npm test -- lib/winget-dependencies.test.ts app/api/cron/qa-enqueue/route.test.ts` (36 passed)
- `npx eslint lib/winget-dependencies.ts lib/winget-dependencies.test.ts app/api/cron/qa-enqueue/route.ts app/api/cron/qa-enqueue/route.test.ts`