### PR TITLE
fix: make AnyDesk removal unattended

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -47,6 +47,16 @@ describe('application packaging adapters', () => {
       reviewedUninstallArguments: ['/S'],
     });
     expect(
+      applyApplicationPackagingAdapter('AnyDesk.AnyDesk', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      processesToClose: [{ name: 'AnyDesk', description: 'AnyDesk' }],
+      reviewedExactUninstall: {
+        executablePath: '%ProgramFiles(x86)%\\AnyDesk\\AnyDesk.exe',
+        arguments: ['--silent', '--remove'],
+        completionTimeoutMinutes: 5,
+      },
+    });
+    expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -131,6 +131,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // AnyDesk's ARP entry can invoke its interactive removal path, which exits
+    // without removing the product under Intune's non-interactive SYSTEM
+    // context. AnyDesk documents this exact CLI contract for automated silent
+    // removal. Close the desktop/service process family first, then keep the
+    // captured ARP identity as the authoritative completion signal.
+    wingetId: 'AnyDesk.AnyDesk',
+    requiredProcessesToClose: [
+      { name: 'AnyDesk', description: 'AnyDesk' },
+    ],
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles(x86)%\\AnyDesk\\AnyDesk.exe',
+      arguments: ['--silent', '--remove'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     wingetId: 'RARLab.WinRAR',
     reviewedUninstallArguments: ['/S'],
   },


### PR DESCRIPTION
## Summary
- stop the AnyDesk desktop/service process family before managed removal
- invoke AnyDesk's documented unattended command: AnyDesk.exe --silent --remove
- retain the exact captured ARP identity as the completion signal for both QA and customer packages

## Failure evidence
- QA run 31799440118 installed and detected AnyDesk 9.7.14 successfully
- the registered removal path left the exact AnyDesk ARP registration present until the 310-second deadline
- PSADT correctly failed with exit 60001 instead of publishing a false pass

## Validation
- npm test -- lib/packaging-adapters.test.ts lib/qa/test-config.test.ts lib/qa/package-profile.test.ts lib/qa/demand.test.ts lib/qa/psadt-packager-contract.test.ts app/api/package/route.test.ts app/api/cron/qa-enqueue/route.test.ts (219 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts

## Safety
Customer packaging remains QA-gated. The adapter changes the execution profile, so AnyDesk must pass a fresh isolated lifecycle before customer upload can use the new profile.

Vendor reference: https://support.anydesk.com/docs/command-line-interface-for-windows