### PR TITLE
fix: normalize installer aliases in preflight

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -102,6 +102,35 @@ describe('installer dispatch preflight', () => {
     }));
   });
 
+  it('treats WinGet installer aliases as the same executable contract', async () => {
+    const msiRequest = {
+      ...request,
+      installerUrl: 'https://example.test/releases/1.2.3/setup.msi',
+      installerType: 'msi',
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: msiRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'wix',
+      scope: 'machine',
+    }]);
+    hashRemoteInstallerMock.mockResolvedValueOnce({
+      sha256: expectedSha256,
+      bytes: 42,
+      finalUrl: msiRequest.installerUrl,
+    });
+
+    await expect(enforceInstallerPreflight(msiRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(createInstallerHealthKey(msiRequest)).toBe(createInstallerHealthKey({
+      ...msiRequest,
+      installerType: 'wix',
+    }));
+  });
+
   it('quarantines a hash mismatch and blocks later dispatch without another download', async () => {
     hashRemoteInstallerMock.mockResolvedValueOnce({
       sha256: actualSha256,
@@ -124,7 +153,7 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
-  it('caches manifest drift as a retryable TTL error instead of permanent quarantine', async () => {
+  it('caches manifest drift as a deterministic tuple error', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',
       url: request.installerUrl,
@@ -136,7 +165,7 @@ describe('installer dispatch preflight', () => {
     await expect(enforceInstallerPreflight(request)).rejects.toBeInstanceOf(InstallerPreflightError);
     await expect(enforceInstallerPreflight(request)).rejects.toMatchObject({
       code: 'MANIFEST_CHANGED',
-      retryable: true,
+      retryable: false,
     });
     expect(hashRemoteInstallerMock).not.toHaveBeenCalled();
   });

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -6,6 +6,7 @@ import {
   hashesEqual,
   isLikelyMutableInstallerUrl,
 } from '@/lib/installer-download';
+import { normalizeQaInstallerType } from '@/lib/qa/candidate';
 import type { NormalizedInstaller } from '@/types/winget';
 
 const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
@@ -102,12 +103,16 @@ export function createInstallerHealthKey(input: InstallerPreflightRequest): stri
       input.wingetId.trim().toLowerCase(),
       input.version.trim(),
       (input.architecture || 'x64').trim().toLowerCase(),
-      (input.installerType || '').trim().toLowerCase(),
+      normalizePreflightInstallerType(input.installerType),
       (input.installScope || '').trim().toLowerCase(),
       input.installerUrl.trim(),
       input.installerSha256.trim().toUpperCase(),
     ].join('\0'))
     .digest('hex');
+}
+
+function normalizePreflightInstallerType(type?: string): string {
+  return type?.trim() ? normalizeQaInstallerType(type) : '';
 }
 
 function assertTrustedInput(input: InstallerPreflightRequest): void {
@@ -130,7 +135,7 @@ function throwForRow(row: InstallerHealthRow): never {
   throw new InstallerPreflightError(
     row.reason_code || 'INSTALLER_QUARANTINED',
     row.reason_message || 'This installer tuple is quarantined and cannot be dispatched',
-    row.status === 'error',
+    row.status === 'error' && row.reason_code !== 'MANIFEST_CHANGED',
     row.actual_sha256 || undefined,
   );
 }
@@ -230,7 +235,7 @@ function installerExistsInManifest(
 ): boolean {
   const expectedHash = input.installerSha256.toUpperCase();
   const requestedArchitecture = (input.architecture || 'x64').toLowerCase();
-  const requestedType = input.installerType?.toLowerCase();
+  const requestedType = normalizePreflightInstallerType(input.installerType);
   const requestedScope = input.installScope?.toLowerCase();
   const requestedUrl = (input.manifestInstallerUrl || input.installerUrl).trim();
 
@@ -242,7 +247,8 @@ function installerExistsInManifest(
       installer.architecture.toLowerCase() !== requestedArchitecture &&
       installer.architecture.toLowerCase() !== 'neutral'
     ) return false;
-    if (requestedType && installer.type && installer.type.toLowerCase() !== requestedType) return false;
+    const manifestType = normalizePreflightInstallerType(installer.type);
+    if (requestedType && manifestType && manifestType !== requestedType) return false;
     if (requestedScope && installer.scope && installer.scope.toLowerCase() !== requestedScope) return false;
     return true;
   });


### PR DESCRIPTION
## Summary
- compare WinGet installer aliases by the shared execution contract instead of literal labels
- treat wix/msi and vendor bootstrapper/exe aliases consistently in both customer and QA preflight
- use the normalized installer type in the shared health-cache identity
- keep true manifest drift deterministic so a cached mismatch cannot block the queue forever

## Production evidence
- Adobe.Brackets 1.14.17770 was the highest-priority customer candidate
- its URL and SHA exactly match the current WinGet manifest
- WinGet labels the MSI as wix while the QA/customer execution profile stores msi, causing repeated MANIFEST_CHANGED errors every minute

## Validation
- npm test -- lib/__tests__/installer-preflight.test.ts lib/catalog-installer-reconciliation.test.ts lib/github-actions.test.ts lib/qa/dispatch.test.ts app/api/package/route.test.ts app/api/cron/qa-dispatch/route.test.ts (64 passed)
- npx eslint lib/installer-preflight.ts lib/__tests__/installer-preflight.test.ts

## Safety
The immutable URL and SHA checks remain exact. Only equivalent installer execution labels are normalized; publisher bytes are still downloaded and hash-verified before dispatch.