### PR TITLE
fix: prevent stale preflight decisions from blocking QA

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -431,6 +431,37 @@ describe('GET /api/cron/qa-dispatch', () => {
     expect(rollbackIds).toEqual([]);
   });
 
+  it('dispatches the next candidate after quarantining a deterministic bad tuple', async () => {
+    const quarantined = candidate('catalog-default');
+    quarantined.id = testUuid(40);
+    const valid = candidate('catalog-default');
+    valid.id = testUuid(41);
+    const { client, supersededIds, claimedIds } = createSupabaseStub([
+      quarantined,
+      valid,
+    ]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock
+      .mockRejectedValueOnce(new InstallerPreflightError(
+        'MANIFEST_CHANGED',
+        'The exact tuple no longer exists in the trusted manifest.',
+        false,
+      ))
+      .mockResolvedValueOnce(undefined);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      dispatched: true,
+      candidateId: valid.id,
+      superseded: 1,
+    });
+    expect(supersededIds).toEqual([quarantined.id]);
+    expect(claimedIds).toEqual([quarantined.id, valid.id]);
+  });
+
   it('does not claim anything when superseding an invalid profile fails', async () => {
     const invalid = candidate('catalog-default');
     invalid.test_config.profileKind = 'legacy' as never;

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -94,6 +94,7 @@ export async function GET(request: Request) {
   let cursor: { priority: number; enqueuedAt: string; id: string } | null = null;
   let scanned = 0;
   let superseded = 0;
+  let lastInstallerQuarantine: { candidateId: string; code: string } | null = null;
   const supersededAt = new Date().toISOString();
 
   for (let pageIndex = 0; pageIndex < MAX_QUEUE_SCAN_PAGES; pageIndex++) {
@@ -243,7 +244,7 @@ export async function GET(request: Request) {
           const quarantinedAt = new Date().toISOString();
           const summary = `Installer source quarantined before QA: ${error.code}. ${error.message}`
             .slice(0, 1000);
-          const { error: quarantineError } = await supabase
+          const { data: quarantinedRows, error: quarantineError } = await supabase
             .from('qa_candidates')
             .update({
               status: 'superseded',
@@ -258,16 +259,15 @@ export async function GET(request: Request) {
             .eq('status', 'dispatched')
             .select('id');
           if (quarantineError) throw quarantineError;
-          return NextResponse.json({
-            success: true,
-            dispatched: false,
-            reason: 'installer_quarantined',
+          superseded += quarantinedRows?.length || 0;
+          lastInstallerQuarantine = {
             candidateId: claimed.id,
             code: error.code,
-            reconciled,
-            scanned,
-            superseded: superseded + 1,
-          });
+          };
+          // A deterministic bad tuple must not consume the entire dispatch
+          // tick. Continue scanning the already-validated queue page so one
+          // high-priority candidate cannot starve unrelated applications.
+          continue;
         }
         await supabase
           .from('qa_candidates')
@@ -293,7 +293,12 @@ export async function GET(request: Request) {
   return NextResponse.json({
     success: true,
     dispatched: false,
-    reason: scanned >= QUEUE_SCAN_PAGE_SIZE * MAX_QUEUE_SCAN_PAGES ? 'scan_limit' : 'queue_empty',
+    reason: lastInstallerQuarantine
+      ? 'installer_quarantined'
+      : scanned >= QUEUE_SCAN_PAGE_SIZE * MAX_QUEUE_SCAN_PAGES
+        ? 'scan_limit'
+        : 'queue_empty',
+    ...(lastInstallerQuarantine || {}),
     reconciled,
     scanned,
     superseded,

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -96,6 +96,9 @@ describe('installer dispatch preflight', () => {
   });
 
   it('keeps user and machine health identities separate', () => {
+    expect(createInstallerHealthKey(request)).toBe(
+      '327be777601869688f3f80fe55d2b1f7fe1da11fd7a7352d7c1f0328dfb589bb'
+    );
     expect(createInstallerHealthKey(request)).not.toBe(createInstallerHealthKey({
       ...request,
       installScope: 'user',

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -13,6 +13,7 @@ const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
 const HEALTHY_VERSIONED_TTL_MS = 6 * 60 * 60 * 1000;
 const ERROR_TTL_MS = 60 * 1000;
 const MANIFEST_CHANGED_TTL_MS = 6 * 60 * 60 * 1000;
+const PREFLIGHT_CACHE_SCHEMA_VERSION = '2';
 const LEASE_SECONDS = 240;
 const WAIT_FOR_CLAIM_MS = 240_000;
 const POLL_INTERVAL_MS = 1_500;
@@ -100,6 +101,7 @@ function isHostedRuntime(): boolean {
 export function createInstallerHealthKey(input: InstallerPreflightRequest): string {
   return createHash('sha256')
     .update([
+      PREFLIGHT_CACHE_SCHEMA_VERSION,
       input.wingetId.trim().toLowerCase(),
       input.version.trim(),
       (input.architecture || 'x64').trim().toLowerCase(),


### PR DESCRIPTION
## Summary
- version the shared installer-health cache identity
- invalidate decisions produced under older preflight semantics
- continue scanning after a deterministic installer quarantine so one high-priority tuple cannot starve unrelated apps
- pin the cache-key contract and queue progression with regression tests

## Production evidence
Adobe.Brackets reused a six-hour MANIFEST_CHANGED row created before installer aliases were normalized. The stale decision was safely rejected, but customer demand immediately requeued the same high-priority tuple and consumed every dispatcher tick.

## Validation
- npm test -- lib/__tests__/installer-preflight.test.ts lib/catalog-installer-reconciliation.test.ts lib/github-actions.test.ts lib/qa/dispatch.test.ts app/api/package/route.test.ts app/api/cron/qa-dispatch/route.test.ts (65 passed)
- npx eslint lib/installer-preflight.ts lib/__tests__/installer-preflight.test.ts app/api/cron/qa-dispatch/route.ts app/api/cron/qa-dispatch/route.test.ts

## Safety
The new key causes one fresh URL/SHA verification per immutable tuple. It does not weaken manifest or payload-hash checks. Quarantined tuples remain superseded and are never sent to the VM.