### PR TITLE
fix: use exact K-Lite uninstall identity

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1060,10 +1060,17 @@ if ($installerTypeLower -eq 'portable' -or $isNestedPortable -or $isPlainPortabl
     $useRegistryUninstall = $true
     $registryUninstallProductCode = $Matches[1]
     $registryUninstallDisplayName = $Matches[2]
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_KEY:([A-Za-z0-9][A-Za-z0-9._{}+-]{0,255}):(.+)$') {
+    # Reviewed non-MSI installers can expose a stable, edition-specific ARP
+    # key even when their display name embeds the version. Reuse the existing
+    # exact PSChildName lifecycle rather than broadening name matching.
+    $useRegistryUninstall = $true
+    $registryUninstallProductCode = $Matches[1]
+    $registryUninstallDisplayName = $Matches[2]
 } elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL:(.+)$') {
     $useRegistryUninstall = $true
     $registryUninstallDisplayName = $Matches[1]
-} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_PRODUCT:') {
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_(PRODUCT|KEY):') {
     throw 'The exact vendor uninstall identity is malformed; refusing to interpret any embedded GUID as an MSI product code.'
 } elseif ($installerTypeLower -in @('msi', 'wix') -and $uninstallCmd -match '(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\})') {
     # Deployment profiles commonly carry the concrete msiexec uninstall command

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -22,6 +22,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses K-Lite Full\'s exact stable Inno registry key', () => {
+    expect(resolveApplicationUninstallCommand(
+      'CodecGuide.K-LiteCodecPack.Full',
+      'REGISTRY_UNINSTALL:K-Lite Codec Pack Full'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:KLiteCodecPack_is1:K-Lite Codec Pack Full'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'CodecGuide.K-LiteCodecPack.Full',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -439,6 +439,7 @@ export function resolveApplicationInstallScope(
 const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   generatedDisplayName: string;
   registeredDisplayName: string;
+  registeredRegistryKey?: string;
 }>>> = {
   // The EXE package's catalog name distinguishes it from Google.Chrome, but
   // Google's machine installer registers the ordinary `Google Chrome` ARP
@@ -447,6 +448,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   'google.chrome.exe': {
     generatedDisplayName: 'Google Chrome (EXE)',
     registeredDisplayName: 'Google Chrome',
+  },
+  // K-Lite inserts the version between the family and edition in DisplayName
+  // (for example `K-Lite Codec Pack 19.9.0 Full`). Its Inno registry key is
+  // stable and edition-specific, so use that exact vendor identity instead of
+  // weakening the generic display-name matcher to a broad prefix search.
+  'codecguide.k-litecodecpack.full': {
+    generatedDisplayName: 'K-Lite Codec Pack Full',
+    registeredDisplayName: 'K-Lite Codec Pack Full',
+    registeredRegistryKey: 'KLiteCodecPack_is1',
   },
 };
 
@@ -457,9 +467,10 @@ export function resolveApplicationUninstallCommand(
   const reviewed = REVIEWED_REGISTRY_UNINSTALL_IDENTITIES[wingetId.trim().toLowerCase()];
   if (!reviewed) return uninstallCommand;
   const expected = `REGISTRY_UNINSTALL:${reviewed.generatedDisplayName}`;
-  return uninstallCommand.trim() === expected
-    ? `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`
-    : uninstallCommand;
+  if (uninstallCommand.trim() !== expected) return uninstallCommand;
+  return reviewed.registeredRegistryKey
+    ? `REGISTRY_UNINSTALL_KEY:${reviewed.registeredRegistryKey}:${reviewed.registeredDisplayName}`
+    : `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`;
 }
 
 function normalizeProcessName(name: string): string {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -735,6 +735,18 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).not.toContain('$existingNameMatches');
   });
 
+  it('supports a reviewed exact non-MSI uninstall registry key', () => {
+    expect(packager).toContain(
+      '^REGISTRY_UNINSTALL_KEY:([A-Za-z0-9][A-Za-z0-9._{}+-]{0,255}):(.+)$'
+    );
+    expect(packager).toContain(
+      "$uninstallCmd -match '^REGISTRY_UNINSTALL_(PRODUCT|KEY):'"
+    );
+    expect(packager).toContain(
+      '[string]$_.PSChildName -eq $configuredUninstallProductCode'
+    );
+  });
+
   it('selects one architecture-decorated ARP entry without accepting an ambiguous set', () => {
     expect(packager).toContain('$configuredUninstallComparableName = ((');
     expect(packager).toContain('$architectureAgnosticMatches = @($changedApplications');

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1045,6 +1045,18 @@ ${steps}
     productCode: string;
     displayName: string;
   } | null {
+    const exactRegistryKeyMatch = job.uninstall_command?.match(
+      /^REGISTRY_UNINSTALL_KEY:([A-Za-z0-9][A-Za-z0-9._{}+-]{0,255}):(.+)$/
+    );
+    if (exactRegistryKeyMatch) {
+      return {
+        // The runtime already compares this field to PSChildName. A reviewed
+        // non-MSI registry key is therefore as exact as an MSI product code.
+        productCode: exactRegistryKeyMatch[1],
+        displayName: exactRegistryKeyMatch[2].replace(/'/g, "''"),
+      };
+    }
+
     const exactProductMatch = job.uninstall_command?.match(
       /^REGISTRY_UNINSTALL_PRODUCT:(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}):(.+)$/
     );
@@ -1815,7 +1827,7 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
       return "Write-ADTLogEntry -Message 'No uninstall command specified' -Severity 'Warning' -Source 'Uninstall-ADTDeployment'";
     }
 
-    if (/^REGISTRY_UNINSTALL_PRODUCT:/.test(job.uninstall_command)) {
+    if (/^REGISTRY_UNINSTALL_(?:PRODUCT|KEY):/.test(job.uninstall_command)) {
       return 'throw "The exact vendor uninstall identity is malformed; refusing to interpret any embedded GUID as an MSI product code."';
     }
 

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -471,6 +471,46 @@ describe('Burn bundle PSADT generation', () => {
 });
 
 describe('EXE product identity PSADT generation', () => {
+  it('uses a reviewed exact non-MSI registry key for install capture and removal', () => {
+    const job = packagingJob({
+      winget_id: 'CodecGuide.K-LiteCodecPack.Full',
+      display_name: 'K-Lite Codec Pack Full',
+      installer_type: 'inno',
+      uninstall_command:
+        'REGISTRY_UNINSTALL_KEY:KLiteCodecPack_is1:K-Lite Codec Pack Full',
+    });
+
+    const snapshot = generator.getRegistryInstallSnapshotBlock.call(
+      generator,
+      job,
+      'K-Lite Codec Pack Full'
+    );
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'K-Lite Codec Pack Full'
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'klcp_full.exe'
+    );
+
+    expect(snapshot).toContain(
+      "$configuredUninstallProductCode = 'KLiteCodecPack_is1'"
+    );
+    expect(verification).toContain(
+      '[string]$_.PSChildName -eq $configuredUninstallProductCode'
+    );
+    expect(uninstall).toContain(
+      "$configuredProductCode = 'KLiteCodecPack_is1'"
+    );
+    expect(uninstall).toContain(
+      '$_.PSChildName -eq $configuredProductCode'
+    );
+    expect(uninstall).toContain("'inno' -eq 'inno'");
+  });
+
   it('captures MSI identity when Winget leaves a PRODUCT_CODE placeholder', () => {
     const job = packagingJob({
       winget_id: 'Yealink.YealinkUSBConnect',


### PR DESCRIPTION
## Summary
- add a reviewed exact non-MSI ARP registry-key identity
- map K-Lite Codec Pack Full to its stable edition-specific Inno key
- apply the same fail-closed identity in hosted and PowerShell PSADT packagers

## Validation
- 147 focused adapter, PSADT contract, and lifecycle tests pass
- related QA profile and reconciliation tests pass
- ESLint and git diff checks pass