### PR TITLE
chore: activate K-Lite packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0dd82872b737a8e97cde16e6d86833ba43d09057',
+  packagerCommit: '8ff0c569a8c7707726a9f5b47566cdf3087565af',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
## Summary
- make the merged exact-registry-key packager commit the protected QA toolchain
- supersede stale queued profiles built with the previous packager

## Validation
- 129 package-profile, backfill, enqueue, and dispatch tests pass