### PR TITLE
Block CapCut until unattended removal is supported

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -54,12 +54,6 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/S']);
     expect(
-      applyApplicationPackagingAdapter('ByteDance.CapCut', DEFAULT_PSADT_CONFIG)
-    ).toMatchObject({
-      processesToClose: [{ name: 'CapCut', description: 'CapCut' }],
-      reviewedUninstallArguments: ['/S'],
-    });
-    expect(
       applyApplicationPackagingAdapter('AnyDesk.AnyDesk', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'AnyDesk', description: 'AnyDesk' }],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -151,18 +151,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
-    // CapCut registers a signed custom uninst.exe with no arguments. The bare
-    // command opens a confirmation window and cannot complete from Intune's
-    // non-interactive execution context. Close the desktop client first and
-    // exercise the vendor uninstaller's unattended switch in isolated QA
-    // before this package can qualify for customer deployment.
-    wingetId: 'ByteDance.CapCut',
-    requiredProcessesToClose: [
-      { name: 'CapCut', description: 'CapCut' },
-    ],
-    reviewedUninstallArguments: ['/S'],
-  },
-  {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
   },

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -283,6 +283,25 @@ describe('unsupported managed uninstall migration contract', () => {
   });
 });
 
+describe('CapCut managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260814142700_block_capcut_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks CapCut consistently across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'ByteDance.CapCut'");
+    expect(sql).toContain('https://github.com/microsoft/winget-pkgs/pull/413669');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260814142700_block_capcut_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260814142700_block_capcut_unsupported_managed_uninstall.sql
@@ -1,0 +1,36 @@
+-- CapCut 9.2 installs silently but registers only its interactive, signed
+-- custom uninst.exe. The vendor binary does not publish a QuietUninstallString
+-- or a documented unattended removal switch. Isolated QA proved that adding
+-- the generic NSIS /S switch leaves the exact CapCut registration and payload
+-- installed. Do not offer this as a managed application until ByteDance ships
+-- a verifiable unattended removal contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'ByteDance.CapCut',
+  'unsupported_managed_uninstall',
+  'CapCut installs silently but its current signed custom uninstaller exposes no documented unattended removal contract. The generic /S switch was rejected by isolated lifecycle QA because the application remained installed.',
+  'https://github.com/microsoft/winget-pkgs/pull/413669'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'ByteDance.CapCut';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'ByteDance.CapCut'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- remove the ineffective generic /S CapCut uninstall adapter
- block CapCut in both customer packaging and QA through the shared eligibility gate
- supersede queued and failed CapCut candidates and keep the catalog unverified

## Evidence
- CapCut 9.2 installed and detected successfully in isolated PSADT QA
- its signed custom uninstaller left the exact CapCut ARP registration after the five-minute completion deadline
- archive inspection confirmed a custom ByteDance uninst.exe; the current WinGet manifest documents silent installation but no unattended uninstall contract

## Verification
- targeted Vitest: 61 tests passed
- targeted ESLint passed
- repository-wide TypeScript still reports pre-existing test-global and fixture errors unrelated to this change