### PR TITLE
fix: harden reviewed non-ARP package lifecycles

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -487,6 +487,13 @@ if ($psadtConfig.Contains('reviewedManagedUninstall') -and
         throw 'PSADT reviewedManagedUninstall requires reviewedManagedInstallDirectory.'
     }
     $reviewedManagedUninstallExecutable = ([string]$rawManagedUninstall['executablePath']).Trim()
+    if ($reviewedManagedUninstallExecutable.Contains('<VERSION>')) {
+        if ([regex]::Matches($reviewedManagedUninstallExecutable, '<VERSION>').Count -ne 1 -or
+            $Version -notmatch '^[0-9A-Za-z][0-9A-Za-z._+-]{0,127}$') {
+            throw 'PSADT reviewedManagedUninstall.executablePath contains an invalid version placeholder or package version.'
+        }
+        $reviewedManagedUninstallExecutable = $reviewedManagedUninstallExecutable.Replace('<VERSION>', $Version)
+    }
     if ($reviewedManagedUninstallExecutable.Length -gt 260 -or
         $reviewedManagedUninstallExecutable -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
         @($reviewedManagedUninstallExecutable -split '\\') -contains '..') {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -35,6 +35,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Maestro 2025\'s reviewed embedded-MSI product key', () => {
+    expect(resolveApplicationUninstallCommand(
+      'MaestroSoft.MaestroAarsoppgjoer.2025',
+      'REGISTRY_UNINSTALL:Maestro Årsoppgjør 2025'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'MaestroSoft.MaestroAarsoppgjoer.2025',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -213,8 +213,39 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
-      reviewedUninstallArguments: ['--quiet', '--norestart'],
-      uninstallCompletionTimeoutMinutes: 15,
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.VisualStudio.2019.BuildTools',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools',
+      reviewedManagedUninstall: {
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
     });
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -134,6 +134,18 @@ describe('application packaging adapters', () => {
         .reviewedManagedInstallDirectory
     ).toBe('%SystemDrive%\\SWSetup\\HPImageAssistant');
     expect(
+      applyApplicationPackagingAdapter('Google.GoogleUpdater', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Google\\GoogleUpdater',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Google\\GoogleUpdater\\<VERSION>\\updater.exe',
+        arguments: ['--uninstall', '--system'],
+        completionTimeoutMinutes: 5,
+      },
+    });
+    expect(
       applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.BuildTools',
         DEFAULT_PSADT_CONFIG

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -43,20 +43,32 @@ const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
   ],
 };
 
-const VISUAL_STUDIO_WINGET_IDS = [
-  'Microsoft.VisualStudio.BuildTools',
-  'Microsoft.VisualStudio.Community',
-  'Microsoft.VisualStudio.Enterprise',
-  'Microsoft.VisualStudio.Professional',
-  'Microsoft.VisualStudio.2019.BuildTools',
-  'Microsoft.VisualStudio.2019.Community',
-  'Microsoft.VisualStudio.2019.Enterprise',
-  'Microsoft.VisualStudio.2019.Professional',
-  'Microsoft.VisualStudio.2022.BuildTools',
-  'Microsoft.VisualStudio.2022.Community',
-  'Microsoft.VisualStudio.2022.Enterprise',
-  'Microsoft.VisualStudio.2022.Professional',
-] as const;
+const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
+  'Microsoft.VisualStudio.BuildTools':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+  'Microsoft.VisualStudio.Community':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Community',
+  'Microsoft.VisualStudio.Enterprise':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Enterprise',
+  'Microsoft.VisualStudio.Professional':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Professional',
+  'Microsoft.VisualStudio.2019.BuildTools':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools',
+  'Microsoft.VisualStudio.2019.Community':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\Community',
+  'Microsoft.VisualStudio.2019.Enterprise':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise',
+  'Microsoft.VisualStudio.2019.Professional':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\Professional',
+  'Microsoft.VisualStudio.2022.BuildTools':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
+  'Microsoft.VisualStudio.2022.Community':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Community',
+  'Microsoft.VisualStudio.2022.Enterprise':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise',
+  'Microsoft.VisualStudio.2022.Professional':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+} as const;
 
 const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
   'Microsoft.SQLServerManagementStudio.21',
@@ -266,28 +278,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
-    // Visual Studio 2026 instances are owned by the Visual Studio Installer,
-    // which intentionally creates several component registrations rather than
-    // one ARP entry named after the bootstrapper. Use Microsoft's documented
-    // instance path and setup.exe lifecycle instead of guessing among those
-    // registrations.
-    wingetId: 'Microsoft.VisualStudio.BuildTools',
-    reviewedManagedInstallDirectory:
-      '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
-    reviewedManagedUninstall: {
-      executablePath:
-        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
-      arguments: [
-        'uninstall',
-        '--installPath',
-        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
-        '--quiet',
-        '--norestart',
-      ],
-      completionTimeoutMinutes: 15,
-    },
-  },
-  {
     // EA Desktop's registered EAUninstall.exe helper is unattended, but it
     // leaves the product registration intact while the client or its
     // background service still owns the installation. Close the reviewed EA
@@ -351,15 +341,28 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
     reviewedMultiProductInstallMinimumCount: 10,
   },
-  ...VISUAL_STUDIO_WINGET_IDS.map((wingetId) => ({
-    wingetId,
-    reviewedUninstallArguments: ['--quiet', '--norestart'],
-    // Visual Studio's registered setup.exe command returns before its child
-    // installer engine has removed the exact product registration. Microsoft
-    // documents --wait for the bootstrapper only, not setup.exe, so retain
-    // registry-aware completion polling for this longer vendor lifecycle.
-    uninstallCompletionTimeoutMinutes: 15,
-  })),
+  ...Object.entries(VISUAL_STUDIO_MANAGED_INSTALL_PATHS).map(
+    ([wingetId, installPath]) => ({
+      // Visual Studio Installer instances create several component records,
+      // not one reliable ARP delta named after the bootstrapper. Verify the
+      // exact edition directory and use Microsoft's setup.exe instance
+      // lifecycle for every supported Visual Studio generation and edition.
+      wingetId,
+      reviewedManagedInstallDirectory: installPath,
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          installPath,
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    })
+  ),
   ...SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS.map((wingetId) => ({
     wingetId,
     // SSMS 21+ is serviced by the Visual Studio Installer. Its setup.exe

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -462,6 +462,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'K-Lite Codec Pack Full',
     registeredRegistryKey: 'KLiteCodecPack_is1',
   },
+  // Maestro's signed EXE wraps an MSI whose authoritative ProductCode is not
+  // published in the WinGet manifest. The wrapper updates that existing ARP
+  // key rather than adding a new display-name entry. Bind the reviewed key so
+  // both customer packages and QA verify and remove the exact MSI product.
+  'maestrosoft.maestroaarsoppgjoer.2025': {
+    generatedDisplayName: 'Maestro Årsoppgjør 2025',
+    registeredDisplayName: 'Maestro Årsoppgjør 2025',
+    registeredRegistryKey: '{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}',
+  },
 };
 
 export function resolveApplicationUninstallCommand(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -250,6 +250,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant',
   },
   {
+    // Google Updater is a shared system updater, not a conventional ARP app.
+    // Its enterprise installer can update an existing registration without
+    // creating a new uninstall entry, so ARP delta capture is not a reliable
+    // lifecycle identity. Verify Google's machine-wide payload and invoke the
+    // documented versioned updater command during managed removal.
+    wingetId: 'Google.GoogleUpdater',
+    reviewedManagedInstallDirectory:
+      '%ProgramFiles(x86)%\\Google\\GoogleUpdater',
+    reviewedManagedUninstall: {
+      executablePath:
+        '%ProgramFiles(x86)%\\Google\\GoogleUpdater\\<VERSION>\\updater.exe',
+      arguments: ['--uninstall', '--system'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // Visual Studio 2026 instances are owned by the Visual Studio Installer,
     // which intentionally creates several component registrations rather than
     // one ARP entry named after the bootstrapper. Use Microsoft's documented

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -336,6 +336,31 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
   });
 
+  it('binds Maestro 2025 embedded-MSI identity to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'MaestroSoft.MaestroAarsoppgjoer.2025',
+      displayName: 'Maestro Årsoppgjør 2025',
+      publisher: 'MaestroSoft',
+      version: '38.05.21',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/s',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Maestro Årsoppgjør 2025',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expected =
+      'REGISTRY_UNINSTALL_KEY:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025';
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe(expected);
+    expect(profile.installer.uninstallCommand).toBe(expected);
+  });
+
   it('binds shared-runtime retention to both the normalized config and QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.EdgeWebView2Runtime',

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -361,6 +361,46 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.uninstallCommand).toBe(expected);
   });
 
+  it('binds the Visual Studio 2019 instance lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.VisualStudio.2019.BuildTools',
+      displayName: 'Visual Studio BuildTools 2019',
+      publisher: 'Microsoft',
+      version: '16.11.59',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet --wait --campaign "winget"',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Visual Studio BuildTools 2019',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedPath =
+      '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools';
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: expectedPath,
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          expectedPath,
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+  });
+
   it('binds shared-runtime retention to both the normalized config and QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.EdgeWebView2Runtime',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -41,7 +41,8 @@ function generateRegistryUninstallPackage(
   psadtConfig: unknown = {},
   packageDependencies: Array<Record<string, unknown>> = [],
   wingetId = 'IntuneGet.ContractTest',
-  uninstallDisplayName = displayName
+  uninstallDisplayName = displayName,
+  version = '1.0.0'
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -83,7 +84,7 @@ function generateRegistryUninstallPackage(
         INPUT_CALLBACK_URL: 'https://example.invalid/callback',
         INPUT_DISPLAY_NAME: displayName,
         INPUT_PUBLISHER: 'IntuneGet',
-        INPUT_VERSION: '1.0.0',
+        INPUT_VERSION: version,
         INPUT_WINGET_ID: wingetId,
         INPUT_INSTALLER_TYPE: installerType,
         INPUT_INSTALL_SCOPE: 'machine',
@@ -507,6 +508,67 @@ describe('PSADT vendor argument contract', () => {
       expect(uninstallFunction).not.toContain(
         'Remove-Item -LiteralPath $managedInstallDirectory'
       );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'resolves one validated package-version segment in a reviewed managed uninstaller',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Google Updater',
+        [],
+        {
+          reviewedManagedInstallDirectory:
+            '%ProgramFiles(x86)%\\Google\\GoogleUpdater',
+          reviewedManagedUninstall: {
+            executablePath:
+              '%ProgramFiles(x86)%\\Google\\GoogleUpdater\\<VERSION>\\updater.exe',
+            arguments: ['--uninstall', '--system'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Google.GoogleUpdater'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Google\\GoogleUpdater\\1.0.0\\updater.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$managedUninstallArguments = @('--uninstall', '--system')"
+      );
+      expect(uninstallFunction).not.toContain('<VERSION>');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects an unsafe package version used in a reviewed managed uninstaller path',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe Version App',
+          [],
+          {
+            reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
+            reviewedManagedUninstall: {
+              executablePath:
+                '%ProgramFiles%\\Example\\<VERSION>\\uninstall.exe',
+              arguments: ['/quiet'],
+              completionTimeoutMinutes: 5,
+            },
+          },
+          [],
+          'IntuneGet.UnsafeVersion',
+          'Unsafe Version App',
+          '..\\Windows'
+        )
+      ).toThrow('invalid version placeholder or package version');
     }
   );
 

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -235,6 +235,9 @@ export interface PSADTConfig {
   // Application adapters are the only trusted source for this value.
   reviewedManagedInstallDirectory?: string;
   reviewedManagedUninstall?: {
+    // A reviewed adapter may use one literal <VERSION> path segment. The
+    // packager replaces it with the validated package version before emitting
+    // the PSADT script; customer-controlled configuration cannot supply it.
     executablePath: string;
     arguments: string[];
     completionTimeoutMinutes: number;


### PR DESCRIPTION
## Summary
- treat Google Updater as a reviewed managed-directory lifecycle and use Google's documented versioned system-uninstall command
- validate the internal <VERSION> executable-path segment before emitting PSADT
- bind Maestro Årsoppgjør 2025 to the exact ProductCode inspected from its signed, hash-verified embedded MSI
- manage all supported Visual Studio generations and editions by their exact installation paths through Microsoft's setup.exe instance lifecycle
- apply every rule identically to QA and customer PSADT packages

## Verification
- 
pm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (147 passed)
- targeted ESLint passed
- git diff --check passed