### PR TITLE
chore: activate reviewed lifecycle profile

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8ff0c569a8c7707726a9f5b47566cdf3087565af',
+  packagerCommit: '6bf25cb51650c925734b86ed5f818f8ea1bd86ec',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Updates the website and QA enqueue profile generator to the same reviewed packager commit already pinned by both QA and customer upload workflows: 6bf25cb51650c925734b86ed5f818f8ea1bd86ec.

Verification:
- package profile, enqueue, and toolchain backfill suites: 118 passed
- targeted ESLint passed
- git diff --check passed