### PR TITLE
fix: make REAPER uninstall unattended

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -67,6 +67,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/S']);
     expect(
+      applyApplicationPackagingAdapter('Cockos.REAPER', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['/S']);
+    expect(
       applyApplicationPackagingAdapter('AnyDesk.AnyDesk', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'AnyDesk', description: 'AnyDesk' }],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,6 +163,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // REAPER registers an interactive uninstall command without a separate
+    // QuietUninstallString. Its vendor installer and uninstaller both accept
+    // the manifest's case-sensitive /S switch; without it, a SYSTEM removal
+    // waits behind the hidden uninstall wizard and leaves the ARP identity.
+    wingetId: 'Cockos.REAPER',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
   },


### PR DESCRIPTION
## Summary
- apply REAPER's case-sensitive `/S` switch to its registered uninstaller
- keep the behavior in the shared packaging adapter used by customer and QA packages
- cover the adapter with the focused lifecycle contract tests

## Evidence
REAPER 7.78 installed successfully, but its bare registered uninstall command waited behind the hidden vendor wizard and left the exact `REAPER` ARP identity until the 5-minute bounded timeout. WinGet's reviewed manifest declares `/S` for unattended execution, and the same switch makes the registered vendor uninstaller non-interactive.

## Verification
- 147 focused tests passed across packaging adapters, QA package profiles, and PSADT packager contracts
- targeted ESLint passed
- `git diff --check` passed