### PR TITLE
chore: activate REAPER lifecycle profile

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '6bf25cb51650c925734b86ed5f818f8ea1bd86ec',
+  packagerCommit: '39d78bece22095fc77c4bc68fa7a790ec92aa31b',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Pin the QA package-profile generator to the reviewed packager commit containing the REAPER silent-uninstall adapter. Verified with 118 focused tests, targeted ESLint, and diff checks.