### PR TITLE
fix: bind K-Lite family registry identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -22,15 +22,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
-  it('uses K-Lite Full\'s exact stable Inno registry key', () => {
+  it('uses the exact stable Inno registry key for every K-Lite edition', () => {
+    for (const edition of ['Basic', 'Standard', 'Full', 'Mega']) {
+      expect(resolveApplicationUninstallCommand(
+        `CodecGuide.K-LiteCodecPack.${edition}`,
+        `REGISTRY_UNINSTALL:K-Lite Codec Pack ${edition}`
+      )).toBe(
+        `REGISTRY_UNINSTALL_KEY:KLiteCodecPack_is1:K-Lite Codec Pack ${edition}`
+      );
+    }
     expect(resolveApplicationUninstallCommand(
-      'CodecGuide.K-LiteCodecPack.Full',
-      'REGISTRY_UNINSTALL:K-Lite Codec Pack Full'
-    )).toBe(
-      'REGISTRY_UNINSTALL_KEY:KLiteCodecPack_is1:K-Lite Codec Pack Full'
-    );
-    expect(resolveApplicationUninstallCommand(
-      'CodecGuide.K-LiteCodecPack.Full',
+      'CodecGuide.K-LiteCodecPack.Standard',
       'vendor-uninstall.exe --custom'
     )).toBe('vendor-uninstall.exe --custom');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -465,12 +465,28 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Google Chrome',
   },
   // K-Lite inserts the version between the family and edition in DisplayName
-  // (for example `K-Lite Codec Pack 19.9.0 Full`). Its Inno registry key is
-  // stable and edition-specific, so use that exact vendor identity instead of
-  // weakening the generic display-name matcher to a broad prefix search.
+  // (for example `K-Lite Codec Pack 19.9.0 Standard`). All four mutually
+  // exclusive editions use the same stable Inno registry key, so use that
+  // exact vendor identity instead of weakening the generic display-name
+  // matcher to a broad prefix search that also captures unrelated servicing.
+  'codecguide.k-litecodecpack.basic': {
+    generatedDisplayName: 'K-Lite Codec Pack Basic',
+    registeredDisplayName: 'K-Lite Codec Pack Basic',
+    registeredRegistryKey: 'KLiteCodecPack_is1',
+  },
+  'codecguide.k-litecodecpack.standard': {
+    generatedDisplayName: 'K-Lite Codec Pack Standard',
+    registeredDisplayName: 'K-Lite Codec Pack Standard',
+    registeredRegistryKey: 'KLiteCodecPack_is1',
+  },
   'codecguide.k-litecodecpack.full': {
     generatedDisplayName: 'K-Lite Codec Pack Full',
     registeredDisplayName: 'K-Lite Codec Pack Full',
+    registeredRegistryKey: 'KLiteCodecPack_is1',
+  },
+  'codecguide.k-litecodecpack.mega': {
+    generatedDisplayName: 'K-Lite Codec Pack Mega',
+    registeredDisplayName: 'K-Lite Codec Pack Mega',
     registeredRegistryKey: 'KLiteCodecPack_is1',
   },
   // Maestro's signed EXE wraps an MSI whose authoritative ProductCode is not


### PR DESCRIPTION
## Summary
- bind Basic, Standard, Full, and Mega to K-Lite's stable `KLiteCodecPack_is1` registry key
- avoid broad ARP-delta inference when Windows servicing changes unrelated registrations
- retain exact edition display names for evidence and removal

## Evidence
K-Lite Standard 19.9.0 installed successfully and registered `K-Lite Codec Pack 19.9.0 Standard`, but simultaneous Edge/WebView2 servicing produced multiple ARP changes. The generic selector correctly refused to guess. K-Lite's four mutually exclusive editions use the reviewed stable Inno key already proven for Full.

## Verification
- 147 focused packaging/QA/PSADT contract tests passed
- targeted ESLint passed
- `git diff --check` passed