### PR TITLE
chore: activate K-Lite family profile

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '39d78bece22095fc77c4bc68fa7a790ec92aa31b',
+  packagerCommit: 'f50cead1fac963c257f01213718a14fd36987d2c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Pin the QA profile generator to the reviewed K-Lite family registry-identity commit. Verified with 118 focused tests, targeted ESLint, and diff checks.