### PR TITLE
fix: block unsafe Firezone uninstall lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -302,6 +302,27 @@ describe('CapCut managed uninstall block migration contract', () => {
   });
 });
 
+describe('Firezone managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260814165000_block_firezone_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks Firezone consistently across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Firezone.Client.GUI'");
+    expect(sql).toContain(
+      'https://github.com/firezone/firezone/blob/gui-client-1.5.16/rust/gui-client/src-tauri/win_files/sparse-package.wxs'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260814165000_block_firezone_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260814165000_block_firezone_unsupported_managed_uninstall.sql
@@ -1,0 +1,36 @@
+-- Firezone Client GUI 1.5.16 installs successfully, but its signed vendor MSI
+-- fails its own deferred DeprovisionSparsePackage custom action during an
+-- unattended LocalSystem removal. Isolated lifecycle QA received MSI 1603 and
+-- confirmed that the exact ARP entry, service, and payload remained installed.
+-- Do not present the package as managed-removable until the vendor ships a
+-- verifiable unattended deprovision lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Firezone.Client.GUI',
+  'unsupported_managed_uninstall',
+  'Firezone installs silently, but its current signed MSI fails its sparse-package deprovision custom action during unattended LocalSystem removal and leaves the application installed.',
+  'https://github.com/firezone/firezone/blob/gui-client-1.5.16/rust/gui-client/src-tauri/win_files/sparse-package.wxs'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Firezone.Client.GUI';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Firezone.Client.GUI'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Firezone Client GUI from customer packaging and QA backfill while its vendor MSI cannot remove itself unattended
- mark the catalog entry unverified and supersede queued/failed QA candidates
- keep the public/customer reason generic while retaining operator evidence in the migration

## Evidence
Firezone 1.5.16 installed and detected successfully in isolated LocalSystem QA. Its signed MSI then returned 1603 from the vendor-authored deferred `DeprovisionSparsePackage` custom action and left the exact ARP entry, tunnel service, and payload installed. The action is wired with `Return=check` in Firezone's tagged source.

## Verification
- 39 migration and eligibility tests passed
- targeted ESLint passed
- `git diff --check` passed