### PR TITLE
fix: use PDFsam managed MSI arguments

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -274,6 +274,18 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses PDFsam\'s documented managed MSI command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'PDFsam.PDFsam',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes'
+    );
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('replaces Bitvise generic switches with its documented unattended mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Bitvise.SSH.Client',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -124,6 +124,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
+    // PDFsam documents this exact MSI command for managed Windows deployment.
+    // WinGet currently publishes /quiet with only SKIPTHANKSPAGE, which can
+    // leave the WiX install inactive under non-interactive LocalSystem. Keep
+    // the vendor's full property set in both customer and QA packages.
+    wingetId: 'PDFsam.PDFsam',
+    reviewedInstallArgumentsOverride:
+      '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.


### PR DESCRIPTION
## Summary
- replace the incomplete WinGet silent switch for PDFsam with the vendor-documented managed MSI command
- disable update checks and donation notifications during managed installation
- cover the shared adapter with a focused regression test

## Evidence
- signed PDFsam 6.0.5 MSI hash matches the WinGet manifest
- MSI properties default CHECK_FOR_UPDATES and DONATE_NOTIFICATION to true
- PDFsam's official deployment documentation specifies: /qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes

## Verification
- npm test -- lib/packaging-adapters.test.ts (28 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts
- git diff --check