### PR TITLE
chore: activate PDFsam packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f50cead1fac963c257f01213718a14fd36987d2c',
+  packagerCommit: '404c9718a2c977722850bc9d70a02772a9bd1c7a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:


### PR DESCRIPTION
Pins QA package profiles to the reviewed PDFsam managed-install fix in packager commit 404c9718a2c977722850bc9d70a02772a9bd1c7a.

Verification:
- 95 focused QA profile/backfill tests passed
- ESLint passed
- git diff --check passed