### PR TITLE
fix: retry PDFsam on reviewed packager

### DIFF
--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -3,6 +3,13 @@ import { QA_PSADT_TOOLCHAIN } from './package-profile';
 import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries PDFsam once with its documented managed MSI command', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'pdfsam.pdfsam', status: 'failed' }
+    )).toBe(true);
+  });
+
   it.each([
     'Microsoft.OfficeDeploymentTool',
     'Microsoft.VisualStudio.BuildTools',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -261,6 +261,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Adobe.CreativeCloud',
     'Elgato.StreamDeck',
   ],
+  '404c9718a2c977722850bc9d70a02772a9bd1c7a': [
+    // PDFsam's WinGet /quiet command stalled under LocalSystem. This release
+    // replaces it with the vendor-documented managed MSI property set.
+    'PDFsam.PDFsam',
+  ],
 };
 
 export function shouldRetryTerminalToolchainCandidate(


### PR DESCRIPTION
Adds one bounded terminal-failure replay for PDFsam on packager commit 404c9718a2c977722850bc9d70a02772a9bd1c7a. Unrelated historical failures remain excluded.

Verification:
- 45 focused retry-selection tests passed
- ESLint passed
- git diff --check passed