### PR TITLE
fix: install MEGAsync for all users

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -286,6 +286,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('selects MEGAsync all-users mode for LocalSystem deployment', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Mega.MEGASync',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('/S /MULTIUSER');
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('replaces Bitvise generic switches with its documented unattended mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Bitvise.SSH.Client',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -133,6 +133,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
   },
   {
+    // MEGA's installer source makes silent installs current-user by default.
+    // Its reviewed /MULTIUSER option selects the AllUsers path required for
+    // non-interactive LocalSystem deployment and machine-wide detection.
+    wingetId: 'Mega.MEGASync',
+    reviewedInstallArgumentsOverride: '/S /MULTIUSER',
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.


### PR DESCRIPTION
MEGAsync's own NSIS source defaults silent installs to CurrentUser. The reviewed `/MULTIUSER` option selects its AllUsers path, which is required for LocalSystem Intune deployment and machine-wide detection.

This adapter is shared by customer and QA packaging.

Verification:
- 29 focused packaging adapter tests passed
- ESLint passed
- git diff --check passed