### PR TITLE
chore: activate MEGAsync packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '404c9718a2c977722850bc9d70a02772a9bd1c7a',
+  packagerCommit: 'd67ec022c5edcd89b8d84edb958b4f1c494da5b5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -5,8 +5,15 @@ import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
 describe('QA toolchain targeted retries', () => {
   it('retries PDFsam once with its documented managed MSI command', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '404c9718a2c977722850bc9d70a02772a9bd1c7a',
       { wingetId: 'pdfsam.pdfsam', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries MEGAsync once with its reviewed all-users command', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'mega.megasync', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -266,6 +266,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // replaces it with the vendor-documented managed MSI property set.
     'PDFsam.PDFsam',
   ],
+  'd67ec022c5edcd89b8d84edb958b4f1c494da5b5': [
+    // MEGAsync defaults silent NSIS installs to CurrentUser. This release
+    // adds the vendor's /MULTIUSER switch for LocalSystem deployments.
+    'Mega.MEGASync',
+  ],
 };
 
 export function shouldRetryTerminalToolchainCandidate(


### PR DESCRIPTION
Pins QA profile generation to packager `d67ec022c5edcd89b8d84edb958b4f1c494da5b5` and allows exactly one terminal-failure retry for MEGAsync on that release.

Verification:
- 97 focused profile/backfill tests passed
- ESLint passed
- git diff --check passed