### PR TITLE
fix: preserve PDFsam retry on cumulative packager

### DIFF
--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -8,6 +8,10 @@ describe('QA toolchain targeted retries', () => {
       '404c9718a2c977722850bc9d70a02772a9bd1c7a',
       { wingetId: 'pdfsam.pdfsam', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'pdfsam.pdfsam', status: 'failed' }
+    )).toBe(true);
   });
 
   it('retries MEGAsync once with its reviewed all-users command', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -267,6 +267,9 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'PDFsam.PDFsam',
   ],
   'd67ec022c5edcd89b8d84edb958b4f1c494da5b5': [
+    // PDFsam's reviewed MSI command remains present in this cumulative
+    // packager release, so preserve its still-unconsumed bounded retry.
+    'PDFsam.PDFsam',
     // MEGAsync defaults silent NSIS installs to CurrentUser. This release
     // adds the vendor's /MULTIUSER switch for LocalSystem deployments.
     'Mega.MEGASync',


### PR DESCRIPTION
The MEGAsync packager is cumulative and still contains the reviewed PDFsam MSI fix. Carry PDFsam's unconsumed bounded terminal retry forward to the current pin so the fixed package is actually re-tested.

Verification:
- 46 focused retry-selection tests passed
- ESLint passed
- git diff --check passed