### PR TITLE
fix: prevent preflight retries blocking QA queue

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -91,6 +91,9 @@ function createSupabaseStub(
   const claimedIds: string[] = [];
   const claimAttemptIds: string[] = [];
   const rollbackIds: string[] = [];
+  const rollbackPayloads: Array<Record<string, unknown>> = [];
+  const terminalErrorIds: string[] = [];
+  const terminalErrorPayloads: Array<Record<string, unknown>> = [];
   const orFilters: string[] = [];
   const supersedePayloads: Array<Record<string, unknown>> = [];
   const queuePages = [queued, ...additionalPages];
@@ -164,9 +167,20 @@ function createSupabaseStub(
           }
 
           if (values.status === 'queued') {
+            rollbackPayloads.push(values);
             const builder = query({ data: null, error: null }) as Record<string, unknown>;
             builder.eq = vi.fn((column: string, value: string) => {
               if (column === 'id') rollbackIds.push(value);
+              return builder;
+            });
+            return builder;
+          }
+
+          if (values.status === 'error') {
+            terminalErrorPayloads.push(values);
+            const builder = query({ data: null, error: null }) as Record<string, unknown>;
+            builder.eq = vi.fn((column: string, value: string) => {
+              if (column === 'id') terminalErrorIds.push(value);
               return builder;
             });
             return builder;
@@ -184,6 +198,9 @@ function createSupabaseStub(
     claimedIds,
     claimAttemptIds,
     rollbackIds,
+    rollbackPayloads,
+    terminalErrorIds,
+    terminalErrorPayloads,
     orFilters,
   };
 }
@@ -402,6 +419,71 @@ describe('GET /api/cron/qa-dispatch', () => {
     await expect(GET(cronRequest())).rejects.toThrow('GitHub unavailable');
 
     expect(rollbackIds).toEqual([row.id]);
+  });
+
+  it('defers a retryable installer preflight and dispatches the next candidate', async () => {
+    const unavailable = candidate('catalog-default');
+    unavailable.id = testUuid(50);
+    const valid = candidate('catalog-default');
+    valid.id = testUuid(51);
+    const { client, claimedIds, rollbackIds, rollbackPayloads } = createSupabaseStub([
+      unavailable,
+      valid,
+    ]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock
+      .mockRejectedValueOnce(new InstallerPreflightError(
+        'PREFLIGHT_UNAVAILABLE',
+        'Installer download returned HTTP 403',
+        true,
+      ))
+      .mockResolvedValueOnce(undefined);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ dispatched: true, candidateId: valid.id });
+    expect(claimedIds).toEqual([unavailable.id, valid.id]);
+    expect(rollbackIds).toEqual([unavailable.id]);
+    expect(rollbackPayloads).toContainEqual(expect.objectContaining({
+      status: 'queued',
+      attempts: 1,
+      enqueued_at: expect.any(String),
+    }));
+  });
+
+  it('terminates an exhausted installer preflight retry and continues dispatching', async () => {
+    const unavailable = candidate('catalog-default');
+    unavailable.id = testUuid(52);
+    unavailable.attempts = 1;
+    const valid = candidate('catalog-default');
+    valid.id = testUuid(53);
+    const { client, claimedIds, terminalErrorIds, terminalErrorPayloads } = createSupabaseStub([
+      unavailable,
+      valid,
+    ]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock
+      .mockRejectedValueOnce(new InstallerPreflightError(
+        'PREFLIGHT_UNAVAILABLE',
+        'Installer download returned HTTP 403',
+        true,
+      ))
+      .mockResolvedValueOnce(undefined);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ dispatched: true, candidateId: valid.id });
+    expect(claimedIds).toEqual([unavailable.id, valid.id]);
+    expect(terminalErrorIds).toEqual([unavailable.id]);
+    expect(terminalErrorPayloads).toContainEqual(expect.objectContaining({
+      status: 'error',
+      attempts: 2,
+      finished_at: expect.any(String),
+    }));
   });
 
   it('supersedes an installer quarantined by the shared customer preflight', async () => {

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -95,6 +95,12 @@ export async function GET(request: Request) {
   let scanned = 0;
   let superseded = 0;
   let lastInstallerQuarantine: { candidateId: string; code: string } | null = null;
+  let lastInstallerUnavailable: {
+    candidateId: string;
+    code: string;
+    attempts: number;
+    exhausted: boolean;
+  } | null = null;
   const supersededAt = new Date().toISOString();
 
   for (let pageIndex = 0; pageIndex < MAX_QUEUE_SCAN_PAGES; pageIndex++) {
@@ -269,6 +275,53 @@ export async function GET(request: Request) {
           // high-priority candidate cannot starve unrelated applications.
           continue;
         }
+        if (error instanceof InstallerPreflightError && error.retryable) {
+          const deferredAt = new Date().toISOString();
+          const attempts = Number.isInteger(claimed.attempts)
+            ? claimed.attempts
+            : candidate.attempts + 1;
+          const exhausted = attempts >= MAX_ATTEMPTS;
+          const { error: deferError } = await supabase
+            .from('qa_candidates')
+            .update(exhausted
+              ? {
+                  status: 'error',
+                  attempts,
+                  finished_at: deferredAt,
+                  phase: null,
+                  phase_started_at: null,
+                  phase_updated_at: null,
+                  failure_summary:
+                    `The installer source remained unavailable after ${attempts} verification attempts. The app was not tested.`,
+                  updated_at: deferredAt,
+                }
+              : {
+                  status: 'queued',
+                  attempts,
+                  enqueued_at: deferredAt,
+                  dispatched_at: null,
+                  phase: null,
+                  phase_started_at: null,
+                  phase_updated_at: null,
+                  failure_summary:
+                    'The installer source is temporarily unavailable; retry scheduled behind other queued apps.',
+                  updated_at: deferredAt,
+                })
+            .eq('id', claimed.id)
+            .eq('status', 'dispatched');
+          if (deferError) throw deferError;
+          lastInstallerUnavailable = {
+            candidateId: claimed.id,
+            code: error.code,
+            attempts,
+            exhausted,
+          };
+          console.warn('QA installer preflight deferred', lastInstallerUnavailable);
+          // A transient publisher/CDN response must not block unrelated apps.
+          // Move the candidate behind the current queue (or terminate after the
+          // bounded retry limit) and continue within this dispatch tick.
+          continue;
+        }
         await supabase
           .from('qa_candidates')
           .update({
@@ -295,10 +348,13 @@ export async function GET(request: Request) {
     dispatched: false,
     reason: lastInstallerQuarantine
       ? 'installer_quarantined'
+      : lastInstallerUnavailable
+        ? 'installer_unavailable'
       : scanned >= QUEUE_SCAN_PAGE_SIZE * MAX_QUEUE_SCAN_PAGES
         ? 'scan_limit'
         : 'queue_empty',
     ...(lastInstallerQuarantine || {}),
+    ...(lastInstallerUnavailable || {}),
     reconciled,
     scanned,
     superseded,


### PR DESCRIPTION
Retryable installer-source failures currently reset attempts to zero, return the candidate to the head, throw a 500, and block every later app indefinitely. This change preserves attempts, moves the first retry behind the current queue, terminates after the bounded limit, continues scanning in the same dispatch tick, and adds a structured warning.

Verification:
- 15 focused dispatch tests passed, including defer-and-continue and exhaustion cases
- ESLint passed
- git diff --check passed