### PR TITLE
Fix targeted QA retry starvation

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -1057,6 +1057,68 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(candidateInserts[0]).toMatchObject({ winget_id: 'Supported.App' });
   });
 
+  it('does not stop before an older deployed terminal retry target is scanned', async () => {
+    const firstPage = [
+      ...['Recent.One', 'Recent.Two', 'Recent.Three'].map((wingetId, index) =>
+        profileCandidate({
+          id: `recent-stale-${index}`,
+          wingetId,
+          packagerCommit: '1'.repeat(40),
+          enqueuedAt: '2026-08-08T10:00:00.000Z',
+        })
+      ),
+      ...Array.from({ length: 997 }, (_, index) =>
+        profileCandidate({
+          id: `irrelevant-${String(997 - index).padStart(4, '0')}`,
+          wingetId: `Irrelevant.App.${index}`,
+          packagerCommit: '1'.repeat(40),
+          enqueuedAt: '2026-08-08T10:00:00.000Z',
+          profileKind: 'deployment-config',
+        })
+      ),
+    ];
+    const supportedApps = [
+      ...['Recent.One', 'Recent.Two', 'Recent.Three'].map((winget_id) => ({
+        winget_id,
+        name: winget_id,
+        publisher: 'Contoso',
+      })),
+      { winget_id: 'PDFsam.PDFsam', name: 'PDFsam', publisher: 'Sober Lemur' },
+    ];
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps,
+      deployedApps: supportedApps.map((app) => app.winget_id),
+      candidatePages: [
+        firstPage,
+        [
+          profileCandidate({
+            id: 'pdfsam-terminal-failure',
+            wingetId: 'PDFsam.PDFsam',
+            packagerCommit: '1'.repeat(40),
+            enqueuedAt: '2026-08-08T09:59:59.000Z',
+            status: 'failed',
+          }),
+        ],
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 4,
+      queued: 4,
+      toolchainBackfillCount: 3,
+      toolchainBackfillPagesScanned: 2,
+    });
+    expect(candidateInserts).toContainEqual(
+      expect.objectContaining({ winget_id: 'PDFsam.PDFsam' })
+    );
+  });
+
   it('prioritizes failed stale profiles before ordinary toolchain backfill', async () => {
     expect(prioritizeToolchainBackfill([
       {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -30,6 +30,7 @@ import {
 import {
   prioritizeToolchainBackfill,
   shouldRetryTerminalToolchainCandidate,
+  terminalToolchainRetryTargets,
   type QaToolchainBackfillCandidate,
 } from '@/lib/qa/toolchain-backfill';
 import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
@@ -107,6 +108,22 @@ async function findToolchainBackfillIds(
 ): Promise<{ ids: string[]; pagesScanned: number }> {
   const decidedIds = new Set<string>();
   const supportedStaleCandidates: QaToolchainBackfillCandidate[] = [];
+  const retryTargets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
+  let pendingTerminalRetryIds = new Set<string>();
+  if (retryTargets.length > 0) {
+    const { data: deployedRetryTargets, error: deployedRetryTargetsError } = await supabase
+      .from('upload_history')
+      .select('winget_id')
+      .in('winget_id', retryTargets);
+    if (deployedRetryTargetsError) {
+      throw new Error(
+        `Could not read deployed QA toolchain retry targets: ${deployedRetryTargetsError.message}`
+      );
+    }
+    pendingTerminalRetryIds = new Set(
+      (deployedRetryTargets || []).map((row) => row.winget_id.trim().toLowerCase())
+    );
+  }
   let cursor: { enqueuedAt: string; id: string } | null = null;
   let pagesScanned = 0;
 
@@ -135,8 +152,10 @@ async function findToolchainBackfillIds(
     const pageStaleRows: QaCandidateProfileRow[] = [];
     for (const row of rows) {
       const config = object(row.test_config);
-      if (config.profileKind !== 'catalog-default' || decidedIds.has(row.winget_id)) continue;
-      decidedIds.add(row.winget_id);
+      const normalizedWingetId = row.winget_id.trim().toLowerCase();
+      if (config.profileKind !== 'catalog-default' || decidedIds.has(normalizedWingetId)) continue;
+      decidedIds.add(normalizedWingetId);
+      pendingTerminalRetryIds.delete(normalizedWingetId);
       const validation = validateCurrentQaPackageProfile({
         testConfig: row.test_config,
         candidatePackageProfileSha256: row.package_profile_sha256,
@@ -216,7 +235,10 @@ async function findToolchainBackfillIds(
       }
     }
 
-    if (supportedStaleCandidates.length >= TOOLCHAIN_BACKFILL_BATCH_SIZE) {
+    if (
+      supportedStaleCandidates.length >= TOOLCHAIN_BACKFILL_BATCH_SIZE &&
+      pendingTerminalRetryIds.size === 0
+    ) {
       return {
         ids: prioritizeToolchainBackfill(supportedStaleCandidates).slice(
           0,

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { QA_PSADT_TOOLCHAIN } from './package-profile';
-import { shouldRetryTerminalToolchainCandidate } from './toolchain-backfill';
+import {
+  shouldRetryTerminalToolchainCandidate,
+  terminalToolchainRetryTargets,
+} from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('exposes a defensive copy of current terminal retry targets', () => {
+    const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
+    expect(targets).toEqual(expect.arrayContaining(['PDFsam.PDFsam', 'Mega.MEGASync']));
+
+    targets.length = 0;
+
+    expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
+      expect.arrayContaining(['PDFsam.PDFsam', 'Mega.MEGASync'])
+    );
+  });
+
   it('retries PDFsam once with its documented managed MSI command', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '404c9718a2c977722850bc9d70a02772a9bd1c7a',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -276,6 +276,10 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
   ],
 };
 
+export function terminalToolchainRetryTargets(packagerCommit: string): string[] {
+  return [...(TOOLCHAIN_TERMINAL_RETRY_TARGETS[packagerCommit] || [])];
+}
+
 export function shouldRetryTerminalToolchainCandidate(
   packagerCommit: string,
   candidate: Pick<QaToolchainBackfillCandidate, 'wingetId' | 'status'>


### PR DESCRIPTION
## Summary
- keep scanning historical catalog profiles until deployed terminal retry targets are encountered
- scope required retry scans to apps with durable tenant deployment demand
- normalize candidate IDs case-insensitively and preserve failure-first selection

## Verification
- 71 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed

The project-wide raw TypeScript check still reports pre-existing test-global/type errors outside this change; the Next.js preview build remains the release gate.