### PR TITLE
Fix Insta360 Link Controller uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -133,6 +133,14 @@ describe('application packaging adapters', () => {
         .processesToClose
     ).toEqual([{ name: 'Evernote', description: 'Evernote' }]);
     expect(
+      applyApplicationPackagingAdapter('Insta360.Link.Controller', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([
+      { name: 'Insta360 Link Controller', description: 'Insta360 Link Controller' },
+      { name: 'VirtualCameraService', description: 'Insta360 Virtual Camera' },
+      { name: 'Insta360LinkDriver', description: 'Insta360 Link driver' },
+    ]);
+    expect(
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -159,6 +159,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Link Controller remains active in the notification area after its UI is
+    // closed, and its optional camera helper can hold the Inno installation
+    // directory open. The silent uninstaller then exits without removing the
+    // exact ARP registration. Close only Insta360's reviewed process family
+    // through PSADT before invoking the captured vendor uninstaller.
+    wingetId: 'Insta360.Link.Controller',
+    requiredProcessesToClose: [
+      { name: 'Insta360 Link Controller', description: 'Insta360 Link Controller' },
+      { name: 'VirtualCameraService', description: 'Insta360 Virtual Camera' },
+      { name: 'Insta360LinkDriver', description: 'Insta360 Link driver' },
+    ],
+  },
+  {
     // AnyDesk's ARP entry can invoke its interactive removal path, which exits
     // without removing the product under Intune's non-interactive SYSTEM
     // context. AnyDesk documents this exact CLI contract for automated silent


### PR DESCRIPTION
## Summary
- close the reviewed Insta360 Link Controller process family through PSADT before vendor removal
- preserve the captured exact Inno registration as the authoritative uninstall completion signal
- apply the adapter to both QA-generated and customer-generated packages

## Evidence
The isolated QA run installed and detected version 2.2.4.14 successfully, but the silent Inno uninstaller left {C05A30CA-A10A-4553-9524-5B377F959166}_is1 registered for the full five-minute completion window while the application can remain active in the tray/background.

## Verification
- 98 packaging adapter and PSADT packager contract tests passed
- focused ESLint passed
- git diff --check passed