### PR TITLE
Activate the Insta360 lifecycle packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd67ec022c5edcd89b8d84edb958b4f1c494da5b5',
+  packagerCommit: 'f7c3ed00118ada623d70503009d1f72a164f1d95',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -274,6 +274,16 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // adds the vendor's /MULTIUSER switch for LocalSystem deployments.
     'Mega.MEGASync',
   ],
+  'f7c3ed00118ada623d70503009d1f72a164f1d95': [
+    // Preserve the still-unconsumed reviewed PDFsam and MEGAsync retries in
+    // this cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    // Link Controller's Inno uninstaller left its exact ARP key while the
+    // tray/background process family was still active. This release closes
+    // those reviewed processes through PSADT before vendor removal.
+    'Insta360.Link.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA package profiles to the reviewed Insta360 lifecycle adapter commit
- carry forward targeted retries for PDFsam and MEGAsync
- add Insta360 Link Controller as a targeted terminal retry

## Validation
- 122 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed