### PR TITLE
Close Logitech SetPoint before uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -141,6 +141,14 @@ describe('application packaging adapters', () => {
       { name: 'Insta360LinkDriver', description: 'Insta360 Link driver' },
     ]);
     expect(
+      applyApplicationPackagingAdapter('Logitech.SetPoint', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([
+      { name: 'SetPoint', description: 'Logitech SetPoint' },
+      { name: 'SetPointII', description: 'Logitech SetPoint' },
+      { name: 'KHALMNPR', description: 'Logitech SetPoint device service' },
+    ]);
+    expect(
       applyApplicationPackagingAdapter('Opera.Opera', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [{ name: 'opera', description: 'Opera browser' }],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -172,6 +172,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Logitech's own removal guidance requires the SetPoint notification-area
+    // client to be exited first. Under non-interactive LocalSystem the generic
+    // NSIS /S uninstaller otherwise removes part of the product but leaves the
+    // SetPoint 6.90 ARP identity and payload behind. Close the reviewed SetPoint
+    // client family through PSADT before invoking the captured vendor removal.
+    wingetId: 'Logitech.SetPoint',
+    requiredProcessesToClose: [
+      { name: 'SetPoint', description: 'Logitech SetPoint' },
+      { name: 'SetPointII', description: 'Logitech SetPoint' },
+      { name: 'KHALMNPR', description: 'Logitech SetPoint device service' },
+    ],
+  },
+  {
     // AnyDesk's ARP entry can invoke its interactive removal path, which exits
     // without removing the product under Intune's non-interactive SYSTEM
     // context. AnyDesk documents this exact CLI contract for automated silent


### PR DESCRIPTION
## Summary
- add a shared Logitech SetPoint lifecycle adapter
- close the reviewed SetPoint process family through PSADT before vendor removal
- apply the same adapter to QA and customer package generation

## Evidence
- install and detection passed for 6.90.66
- generic NSIS removal left the SetPoint ARP identity and returned 60001 after 315 seconds
- Logitech's removal guidance requires exiting the SetPoint notification-area client first

## Validation
- 156 adapter and packager-contract tests passed
- focused ESLint passed
- git diff --check passed