### PR TITLE
Activate the Logitech lifecycle packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f7c3ed00118ada623d70503009d1f72a164f1d95',
+  packagerCommit: '0565fb456b7faf84cca56f2c988c99591015fe93',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -284,6 +284,17 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // those reviewed processes through PSADT before vendor removal.
     'Insta360.Link.Controller',
   ],
+  '0565fb456b7faf84cca56f2c988c99591015fe93': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    // SetPoint's NSIS removal left its ARP identity while the notification-area
+    // client family was active. This release closes those reviewed processes
+    // through PSADT before vendor removal.
+    'Logitech.SetPoint',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA profiles to the reviewed Logitech SetPoint lifecycle adapter commit
- preserve targeted retries for PDFsam, MEGAsync, and Insta360
- add Logitech SetPoint as a targeted terminal retry

## Validation
- 123 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed