### PR TITLE
Keep quarantined QA installers terminal

### DIFF
--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -231,6 +231,55 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     ]);
   });
 
+  it('does not reactivate an installer source quarantined by dispatch preflight', async () => {
+    const input = demandInput();
+    const quarantineSummary =
+      'Installer source quarantined before QA: MANIFEST_CHANGED. The selected installer is stale.';
+    let candidateCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'qa_package_results') {
+          return { select: vi.fn(() => query({ data: null, error: null })) };
+        }
+        if (table !== 'qa_candidates') throw new Error(`Unexpected table: ${table}`);
+        candidateCall++;
+        if (candidateCall === 1) return query({ data: null, error: null });
+        if (candidateCall === 2) {
+          return {
+            insert: vi.fn(() => query({
+              data: null,
+              error: { message: 'duplicate', code: '23505' },
+            })),
+          };
+        }
+        if (candidateCall === 3) return query({ data: null, error: null });
+        if (candidateCall === 4) {
+          return {
+            select: vi.fn(() => query({
+              data: {
+                id: 'candidate-quarantined',
+                status: 'superseded',
+                priority: 500,
+                failure_summary: quarantineSummary,
+              },
+              error: null,
+            })),
+          };
+        }
+        throw new Error('Quarantined candidate must not be updated');
+      }),
+    };
+
+    const result = await ensureQaDemand(client as never, input);
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      candidateId: 'candidate-quarantined',
+      failureSummary: quarantineSummary,
+    });
+    expect(candidateCall).toBe(4);
+  });
+
   it('joins the active payload test when a concurrent insert wins the race', async () => {
     const input = demandInput();
     let candidateCall = 0;

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -20,6 +20,7 @@ import {
   getPackageEligibilityBlocks,
   PACKAGE_UNAVAILABLE_MESSAGE,
 } from '@/lib/package-eligibility';
+import { shouldReactivateSupersededCandidate } from '@/lib/qa/candidate-reactivation';
 
 export type QaDemandSource = 'customer' | 'auto_update' | 'managed' | 'operator';
 export type QaDemandState = 'passed' | 'failed' | 'waiting';
@@ -291,6 +292,19 @@ export async function ensureQaDemand(
       candidateId: existing.id,
       state: 'failed',
       failureSummary: existing.failure_summary || 'This app did not pass the isolated installation test.',
+    };
+  }
+
+  if (
+    existing.status === 'superseded' &&
+    !shouldReactivateSupersededCandidate(existing.status, existing.failure_summary)
+  ) {
+    return {
+      identity,
+      candidateId: existing.id,
+      state: 'failed',
+      failureSummary:
+        existing.failure_summary || 'This installer is no longer available for deployment.',
     };
   }
 


### PR DESCRIPTION
## Summary
- prevent customer-upload resume checks from reactivating exact installer payloads quarantined by dispatch preflight
- preserve the quarantine evidence so stale WinGet installer identities fail closed instead of looping in the queue
- add focused regression coverage for the resume-demand path

## Validation
- npm exec -- vitest run lib/qa/demand.test.ts app/api/cron/qa-resume/route.test.ts app/api/cron/qa-enqueue/route.test.ts
- npm exec -- eslint lib/qa/demand.ts lib/qa/demand.test.ts