### PR TITLE
Fix Timely Memory uninstall identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -50,6 +50,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Timely Memory\'s published stable NSIS registry key', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Timely.Memory',
+      'REGISTRY_UNINSTALL:Memory'
+    )).toBe('REGISTRY_UNINSTALL_KEY:Memory:Memory');
+    expect(resolveApplicationUninstallCommand(
+      'timely.memory',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -540,6 +540,17 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Maestro Årsoppgjør 2025',
     registeredRegistryKey: '{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}',
   },
+  // Timely publishes the stable NSIS uninstall registry key as ProductCode
+  // `Memory`. It is not an MSI GUID, so the generic manifest conversion treats
+  // it as a display name and misses the vendor entry when background servicing
+  // changes unrelated ARP records at the same time. Bind the published key so
+  // install verification, the Intune marker, and removal all use one exact
+  // user-scoped identity.
+  'timely.memory': {
+    generatedDisplayName: 'Memory',
+    registeredDisplayName: 'Memory',
+    registeredRegistryKey: 'Memory',
+  },
 };
 
 export function resolveApplicationUninstallCommand(


### PR DESCRIPTION
## Summary
- bind Timely Memory to the stable NSIS uninstall key published by WinGet
- keep customer packaging and QA on the same exact registry identity
- add regression coverage for custom-command preservation

## Validation
- 150 focused packaging tests passed
- ESLint passed