### PR TITLE
Activate Google Drive packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '77ed8d66246e8c7098f427e32d8488bc73f8eb3d',
+  packagerCommit: 'c14531559086f83364ce69178369bf9462bcd872',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -68,6 +68,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '9f3105f568ec221fb672a53f1dbafdf01cd2e8b5',
   '34189c6876f0fe4539b971ba1b9e962ff66cd259',
   '0565fb456b7faf84cca56f2c988c99591015fe93',
+  '77ed8d66246e8c7098f427e32d8488bc73f8eb3d',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -307,6 +307,19 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // depend on ambiguous display-name matching.
     'Timely.Memory',
   ],
+  'c14531559086f83364ce69178369bf9462bcd872': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    // Google Drive launches its versioned uninstaller asynchronously. This
+    // release appends Google's documented --silent --force_stop contract so
+    // the exact ARP product is removed under non-interactive LocalSystem.
+    'Google.GoogleDrive',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
Moves the current protected QA profile to packager commit c14531559086f83364ce69178369bf9462bcd872 and carries the bounded lifecycle retries forward, including Google Drive.