### PR TITLE
Fix Dropbox uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -102,6 +102,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['--silent', '--force_stop']);
     expect(
+      applyApplicationPackagingAdapter('Dropbox.Dropbox', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([{ name: 'Dropbox', description: 'Dropbox' }]);
+    expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedExactUninstall: {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -150,6 +150,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--silent', '--force_stop'],
   },
   {
+    // Dropbox's support guidance requires every Dropbox desktop process to be
+    // quit before retrying a failed Windows uninstall. The enterprise offline
+    // installer can leave Dropbox running after installation, and its captured
+    // machine uninstaller otherwise returns asynchronously while the exact ARP
+    // registration remains. Close the reviewed desktop process through PSADT
+    // before both upgrade and Intune removal.
+    wingetId: 'Dropbox.Dropbox',
+    requiredProcessesToClose: [
+      { name: 'Dropbox', description: 'Dropbox' },
+    ],
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.


### PR DESCRIPTION
Closes the Dropbox desktop process through the shared PSADT lifecycle before invoking the captured machine uninstaller, as required by Dropbox's uninstall guidance. This applies to both QA and customer Intune packages and includes focused regression coverage.