### PR TITLE
Activate Dropbox lifecycle fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c14531559086f83364ce69178369bf9462bcd872',
+  packagerCommit: '00fa68c7a24afe9db434cef87baa42455ed81fbb',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -69,6 +69,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '34189c6876f0fe4539b971ba1b9e962ff66cd259',
   '0565fb456b7faf84cca56f2c988c99591015fe93',
   '77ed8d66246e8c7098f427e32d8488bc73f8eb3d',
+  'c14531559086f83364ce69178369bf9462bcd872',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -320,6 +320,20 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // the exact ARP product is removed under non-interactive LocalSystem.
     'Google.GoogleDrive',
   ],
+  '00fa68c7a24afe9db434cef87baa42455ed81fbb': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    // Dropbox's enterprise offline installer leaves the desktop process
+    // running, which blocks its captured machine uninstaller. This release
+    // closes the reviewed process through the shared PSADT lifecycle.
+    'Dropbox.Dropbox',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
Moves the protected QA profile to packager commit 00fa68c7a24afe9db434cef87baa42455ed81fbb and carries the bounded lifecycle retries forward, including Dropbox.