### PR TITLE
Complete Dropbox unattended lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -103,8 +103,11 @@ describe('application packaging adapters', () => {
     ).toEqual(['--silent', '--force_stop']);
     expect(
       applyApplicationPackagingAdapter('Dropbox.Dropbox', DEFAULT_PSADT_CONFIG)
-        .processesToClose
-    ).toEqual([{ name: 'Dropbox', description: 'Dropbox' }]);
+    ).toMatchObject({
+      reviewedInstallArgumentsOverride: '/NOLAUNCH',
+      reviewedUninstallArguments: ['/S'],
+      processesToClose: [{ name: 'Dropbox', description: 'Dropbox' }],
+    });
     expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -150,13 +150,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--silent', '--force_stop'],
   },
   {
-    // Dropbox's support guidance requires every Dropbox desktop process to be
-    // quit before retrying a failed Windows uninstall. The enterprise offline
-    // installer can leave Dropbox running after installation, and its captured
-    // machine uninstaller otherwise returns asynchronously while the exact ARP
-    // registration remains. Close the reviewed desktop process through PSADT
-    // before both upgrade and Intune removal.
+    // Dropbox documents /NOLAUNCH for unattended enterprise installs that must
+    // not start the client. Its Windows support guidance also requires Dropbox
+    // processes to be closed before removal. The registered machine uninstaller
+    // needs NSIS /S in addition to its captured /InstallType:MACHINE argument;
+    // otherwise it returns while the exact ARP registration remains installed.
     wingetId: 'Dropbox.Dropbox',
+    reviewedInstallArgumentsOverride: '/NOLAUNCH',
+    reviewedUninstallArguments: ['/S'],
     requiredProcessesToClose: [
       { name: 'Dropbox', description: 'Dropbox' },
     ],


### PR DESCRIPTION
## Summary
- install Dropbox silently without launching the client
- append the unattended switch to the captured machine uninstaller
- keep the reviewed Dropbox process-close safeguard
- apply the same adapter to QA and customer Intune packages

## Evidence
- Dropbox support documents /NOLAUNCH for managed installs and requires Dropbox processes to be closed before uninstall
- the current QA run reproduced a 312-second registered-uninstaller timeout without /S

## Verification
- 150 focused tests passed
- focused lint passed