### PR TITLE
Activate Dropbox unattended lifecycle toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '00fa68c7a24afe9db434cef87baa42455ed81fbb',
+  packagerCommit: '20e762d9c48a90881d9901c93d3f84f2d9474654',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -70,6 +70,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '0565fb456b7faf84cca56f2c988c99591015fe93',
   '77ed8d66246e8c7098f427e32d8488bc73f8eb3d',
   'c14531559086f83364ce69178369bf9462bcd872',
+  '00fa68c7a24afe9db434cef87baa42455ed81fbb',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -334,6 +334,20 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // closes the reviewed process through the shared PSADT lifecycle.
     'Dropbox.Dropbox',
   ],
+  '20e762d9c48a90881d9901c93d3f84f2d9474654': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    // The previous Dropbox retry proved that closing the client alone is not
+    // enough. This release installs without launching Dropbox and appends /S
+    // to its captured machine uninstaller for a fully unattended lifecycle.
+    'Dropbox.Dropbox',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 20e762d9 for new QA and customer package profiles
- keep the prior release compatible for unaffected passing apps
- invalidate old Dropbox passes through the adapter-aware compatibility check

## Verification
- 81 focused tests passed
- focused lint passed