### PR TITLE
Fix AOMEI unattended uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -109,6 +109,22 @@ describe('application packaging adapters', () => {
       processesToClose: [{ name: 'Dropbox', description: 'Dropbox' }],
     });
     expect(
+      applyApplicationPackagingAdapter(
+        'AOMEI.PartitionAssistant',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedUninstallArguments: [
+        '/VERYSILENT',
+        '/SUPPRESSMSGBOXES',
+        '/NORESTART',
+        '/SP-',
+      ],
+      processesToClose: [
+        { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
+      ],
+    });
+    expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedExactUninstall: {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,6 +163,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // AOMEI's Inno uninstaller can remain interactive, or return before the
+    // product is removed, while Partition Assistant is still running. Close
+    // the reviewed desktop process through PSADT and enforce Inno's complete
+    // unattended removal contract for both QA and customer Intune packages.
+    wingetId: 'AOMEI.PartitionAssistant',
+    requiredProcessesToClose: [
+      { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
+    ],
+    reviewedUninstallArguments: [
+      '/VERYSILENT',
+      '/SUPPRESSMSGBOXES',
+      '/NORESTART',
+      '/SP-',
+    ],
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.


### PR DESCRIPTION
## Summary
- close AOMEI Partition Assistant through PSADT before lifecycle operations
- enforce the complete unattended Inno removal arguments
- apply the same adapter to QA and customer Intune packages

## Verification
- 150 focused packaging/profile contract tests pass
- focused ESLint passes