### PR TITLE
Activate AOMEI unattended lifecycle toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '20e762d9c48a90881d9901c93d3f84f2d9474654',
+  packagerCommit: '719d7fd6db57ce5cbcecad528d53ae9c9088616f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -71,6 +71,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '77ed8d66246e8c7098f427e32d8488bc73f8eb3d',
   'c14531559086f83364ce69178369bf9462bcd872',
   '00fa68c7a24afe9db434cef87baa42455ed81fbb',
+  '20e762d9c48a90881d9901c93d3f84f2d9474654',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -8,12 +8,20 @@ import {
 describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
-    expect(targets).toEqual(expect.arrayContaining(['PDFsam.PDFsam', 'Mega.MEGASync']));
+    expect(targets).toEqual(expect.arrayContaining([
+      'PDFsam.PDFsam',
+      'Mega.MEGASync',
+      'AOMEI.PartitionAssistant',
+    ]));
 
     targets.length = 0;
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
-      expect.arrayContaining(['PDFsam.PDFsam', 'Mega.MEGASync'])
+      expect.arrayContaining([
+        'PDFsam.PDFsam',
+        'Mega.MEGASync',
+        'AOMEI.PartitionAssistant',
+      ])
     );
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -348,6 +348,21 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // to its captured machine uninstaller for a fully unattended lifecycle.
     'Dropbox.Dropbox',
   ],
+  '719d7fd6db57ce5cbcecad528d53ae9c9088616f': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    // Partition Assistant can keep its Inno uninstaller interactive while
+    // its desktop process is active. This release closes PartAssist through
+    // PSADT and supplies the complete unattended Inno removal contract.
+    'AOMEI.PartitionAssistant',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate the cumulative AOMEI packaging release for QA profile generation
- preserve compatible release history
- carry bounded retries forward and include AOMEI Partition Assistant

## Verification
- 153 focused tests pass
- focused ESLint passes