### PR TITLE
Fix AOMEI exact unattended uninstall contract

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2698,7 +2698,7 @@ if ($useManagedDirectoryLifecycle) {
             '            }'
             '        }'
             '    }'
-            '    if (-not $isVivaldiUninstall -and (Split-Path -Leaf $registeredUninstallFile) -ine ''msiexec.exe'' -and $registeredInstallerType -eq ''inno'') {'
+            '    if (-not $useReviewedExactUninstall -and -not $isVivaldiUninstall -and (Split-Path -Leaf $registeredUninstallFile) -ine ''msiexec.exe'' -and $registeredInstallerType -eq ''inno'') {'
             '        # Inno''s registered QuietUninstallString is not consistently fully unattended.'
             '        # Normalize weak /SILENT registrations to the vendor-documented, message-box-free'
             '        # switches so SYSTEM deployments cannot wait behind an invisible prompt.'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -114,12 +114,12 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
-      reviewedUninstallArguments: [
-        '/VERYSILENT',
-        '/SUPPRESSMSGBOXES',
-        '/NORESTART',
-        '/SP-',
-      ],
+      reviewedExactUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
+        arguments: ['/S'],
+        completionTimeoutMinutes: 5,
+      },
       processesToClose: [
         { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
       ],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,20 +163,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // AOMEI's Inno uninstaller can remain interactive, or return before the
-    // product is removed, while Partition Assistant is still running. Close
-    // the reviewed desktop process through PSADT and enforce Inno's complete
-    // unattended removal contract for both QA and customer Intune packages.
+    // AOMEI's uninstaller uses its own /S unattended contract. Generic Inno
+    // switches leave the product registration behind even though the process
+    // returns. Close the reviewed desktop process through PSADT and execute
+    // the installed vendor uninstaller directly for QA and customer packages.
     wingetId: 'AOMEI.PartitionAssistant',
     requiredProcessesToClose: [
       { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
     ],
-    reviewedUninstallArguments: [
-      '/VERYSILENT',
-      '/SUPPRESSMSGBOXES',
-      '/NORESTART',
-      '/SP-',
-    ],
+    reviewedExactUninstall: {
+      executablePath:
+        '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
+      arguments: ['/S'],
+      completionTimeoutMinutes: 5,
+    },
   },
   {
     // Bitvise uses its own unattended switch rather than the generic /S that

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -350,6 +350,44 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps an exact vendor uninstall contract authoritative for Inno packages',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'AOMEI Partition Assistant',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath:
+              '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
+            arguments: ['/S'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'AOMEI.PartitionAssistant'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallArguments = @('/S')"
+      );
+      expect(uninstallFunction).toContain(
+        "if (-not $useReviewedExactUninstall -and -not $isVivaldiUninstall"
+      );
+      expect(uninstallFunction).not.toContain(
+        "$registeredUninstallArguments = @('/S', '/VERYSILENT'"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'uses the hash-verified packaged installer for a reviewed vendor removal lifecycle',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- use AOMEI's reviewed installed uninstaller with its vendor-specific /S contract
- prevent generic Inno normalization from mutating reviewed exact uninstall commands
- cover the adapter and generated PSADT contract with focused tests

## Verification
- 151 focused Vitest checks passed
- focused ESLint passed

This shared packaging change applies to both QA packages and customer Intune packages.