### PR TITLE
Activate AOMEI exact uninstall toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '719d7fd6db57ce5cbcecad528d53ae9c9088616f',
+  packagerCommit: '6db4e201f11e49bceb4d2729a2bc77fb0e675e89',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -72,6 +72,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'c14531559086f83364ce69178369bf9462bcd872',
   '00fa68c7a24afe9db434cef87baa42455ed81fbb',
   '20e762d9c48a90881d9901c93d3f84f2d9474654',
+  '719d7fd6db57ce5cbcecad528d53ae9c9088616f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -363,6 +363,20 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // PSADT and supplies the complete unattended Inno removal contract.
     'AOMEI.PartitionAssistant',
   ],
+  '6db4e201f11e49bceb4d2729a2bc77fb0e675e89': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    // AOMEI uses /S rather than generic Inno switches. The exact reviewed
+    // vendor command is now authoritative in QA and customer packages.
+    'AOMEI.PartitionAssistant',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 6db4e201f11e49bceb4d2729a2bc77fb0e675e89`n- retain the prior release in compatible history
- carry cumulative terminal retries while targeting AOMEI's corrected vendor contract

## Verification
- 98 focused tests passed
- focused ESLint passed