### PR TITLE
Preserve AOMEI registered quiet uninstall contract

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -117,7 +117,7 @@ describe('application packaging adapters', () => {
       reviewedExactUninstall: {
         executablePath:
           '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-        arguments: ['/S'],
+        arguments: ['/SILENT'],
         completionTimeoutMinutes: 5,
       },
       processesToClose: [

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,10 +163,10 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // AOMEI's uninstaller uses its own /S unattended contract. Generic Inno
-    // switches leave the product registration behind even though the process
-    // returns. Close the reviewed desktop process through PSADT and execute
-    // the installed vendor uninstaller directly for QA and customer packages.
+    // AOMEI registers /SILENT as its quiet uninstall contract. Replacing it
+    // with generic Inno switches or NSIS-style /S leaves the product
+    // registration behind. Close the reviewed desktop process through PSADT
+    // and preserve the installed vendor command for QA and customer packages.
     wingetId: 'AOMEI.PartitionAssistant',
     requiredProcessesToClose: [
       { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
@@ -174,7 +174,7 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedExactUninstall: {
       executablePath:
         '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-      arguments: ['/S'],
+      arguments: ['/SILENT'],
       completionTimeoutMinutes: 5,
     },
   },

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -360,7 +360,7 @@ describe('PSADT vendor argument contract', () => {
           reviewedExactUninstall: {
             executablePath:
               '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-            arguments: ['/S'],
+            arguments: ['/SILENT'],
             completionTimeoutMinutes: 5,
           },
         },
@@ -376,13 +376,13 @@ describe('PSADT vendor argument contract', () => {
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe')"
       );
       expect(uninstallFunction).toContain(
-        "$registeredUninstallArguments = @('/S')"
+        "$registeredUninstallArguments = @('/SILENT')"
       );
       expect(uninstallFunction).toContain(
         "if (-not $useReviewedExactUninstall -and -not $isVivaldiUninstall"
       );
       expect(uninstallFunction).not.toContain(
-        "$registeredUninstallArguments = @('/S', '/VERYSILENT'"
+        "$registeredUninstallArguments = @('/SILENT', '/VERYSILENT'"
       );
     }
   );


### PR DESCRIPTION
## Summary
- preserve AOMEI's registered /SILENT uninstall argument verbatim
- keep the exact reviewed command authoritative under the shared PSADT generator
- update adapter and generated-package contract coverage

## Evidence
- generic Inno normalization and NSIS-style /S both returned while the exact AOMEI ARP registration remained
- the installed package registers /SILENT as its quiet uninstall contract

## Verification
- 151 focused tests passed
- focused ESLint passed

This shared adapter is consumed by both QA and customer Intune packaging.