### PR TITLE
Combine AOMEI quiet uninstall switches

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -117,7 +117,7 @@ describe('application packaging adapters', () => {
       reviewedExactUninstall: {
         executablePath:
           '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-        arguments: ['/SILENT'],
+        arguments: ['/SILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-'],
         completionTimeoutMinutes: 5,
       },
       processesToClose: [

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -163,10 +163,10 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // AOMEI registers /SILENT as its quiet uninstall contract. Replacing it
-    // with generic Inno switches or NSIS-style /S leaves the product
-    // registration behind. Close the reviewed desktop process through PSADT
-    // and preserve the installed vendor command for QA and customer packages.
+    // AOMEI registers /SILENT as its quiet uninstall contract, but its custom
+    // prompts still require Inno message-box and restart suppression under
+    // SYSTEM. Preserve /SILENT and add the companion unattended switches; the
+    // generic normalization path must not replace the registered quiet mode.
     wingetId: 'AOMEI.PartitionAssistant',
     requiredProcessesToClose: [
       { name: 'PartAssist', description: 'AOMEI Partition Assistant' },
@@ -174,7 +174,7 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedExactUninstall: {
       executablePath:
         '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-      arguments: ['/SILENT'],
+      arguments: ['/SILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-'],
       completionTimeoutMinutes: 5,
     },
   },

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -360,7 +360,12 @@ describe('PSADT vendor argument contract', () => {
           reviewedExactUninstall: {
             executablePath:
               '%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe',
-            arguments: ['/SILENT'],
+            arguments: [
+              '/SILENT',
+              '/SUPPRESSMSGBOXES',
+              '/NORESTART',
+              '/SP-',
+            ],
             completionTimeoutMinutes: 5,
           },
         },
@@ -376,13 +381,13 @@ describe('PSADT vendor argument contract', () => {
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\AOMEI Partition Assistant\\unins000.exe')"
       );
       expect(uninstallFunction).toContain(
-        "$registeredUninstallArguments = @('/SILENT')"
+        "$registeredUninstallArguments = @('/SILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-')"
       );
       expect(uninstallFunction).toContain(
         "if (-not $useReviewedExactUninstall -and -not $isVivaldiUninstall"
       );
       expect(uninstallFunction).not.toContain(
-        "$registeredUninstallArguments = @('/SILENT', '/VERYSILENT'"
+        "$registeredUninstallArguments = @('/SILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-', '/VERYSILENT'"
       );
     }
   );


### PR DESCRIPTION
## Summary
- preserve AOMEI's registered /SILENT mode
- add Inno message-box, restart, and startup-prompt suppression to the exact reviewed command
- keep generic normalization from replacing the vendor quiet mode

## Evidence
- generic Inno switches without /SILENT left the exact product registration installed
- /S left the exact product registration installed
- /SILENT alone also left the exact product registration installed for the full bounded completion window

## Verification
- 151 focused tests passed
- focused ESLint passed

The shared adapter is consumed by both QA and customer Intune packaging.