### PR TITLE
Activate AOMEI combined quiet toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0c2765c26b69619df8f581190f4e67d97d79b589',
+  packagerCommit: '461c2757292d3b7bcde33682d3f7b33e566b1fea',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -74,6 +74,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '20e762d9c48a90881d9901c93d3f84f2d9474654',
   '719d7fd6db57ce5cbcecad528d53ae9c9088616f',
   '6db4e201f11e49bceb4d2729a2bc77fb0e675e89',
+  '0c2765c26b69619df8f581190f4e67d97d79b589',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -391,6 +391,20 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // command guard after both generic Inno switches and /S proved no-ops.
     'AOMEI.PartitionAssistant',
   ],
+  '461c2757292d3b7bcde33682d3f7b33e566b1fea': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    // AOMEI's exact vendor command now preserves /SILENT while suppressing
+    // custom message boxes, restarts, and the startup prompt under SYSTEM.
+    'AOMEI.PartitionAssistant',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 461c2757292d3b7bcde33682d3f7b33e566b1fea`n- retain the preceding release in compatible history
- carry cumulative targeted retries with AOMEI's combined registered quiet command

## Verification
- 98 focused tests passed
- focused ESLint passed