### PR TITLE
Block unreliable GeForce NOW managed installs

### DIFF
--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -4,6 +4,7 @@ import type { Database } from '@/types/database';
 export type PackageEligibilityBlockCode =
   | 'vendor_retired'
   | 'upstream_removed'
+  | 'unsupported_managed_install'
   | 'unsupported_managed_uninstall';
 
 export interface PackageEligibilityBlock {

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -367,6 +367,27 @@ describe('AOMEI managed uninstall block migration contract', () => {
   });
 });
 
+describe('NVIDIA GeForce NOW managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260815063000_block_nvidia_geforce_now_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unreliable bootstrapper across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Nvidia.GeForceNow'");
+    expect(sql).toContain(
+      'https://github.com/microsoft/winget-pkgs/issues/56299'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260815063000_block_nvidia_geforce_now_managed_install.sql
+++ b/supabase/migrations/20260815063000_block_nvidia_geforce_now_managed_install.sql
@@ -1,0 +1,49 @@
+-- NVIDIA GeForce NOW's consumer bootstrapper does not expose a documented,
+-- deterministic enterprise installation contract. The current WinGet silent
+-- arguments ran for more than two minutes in isolated user-context lifecycle
+-- QA but returned without creating an installed-application registration or a
+-- detectable package. The upstream WinGet package issue records the same
+-- nondeterministic outcome on physical Windows systems. Do not let this app
+-- loop through QA or leave customer uploads waiting for a result that cannot
+-- establish a reliable managed lifecycle.
+
+alter table public.package_eligibility_blocks
+  drop constraint if exists package_eligibility_blocks_block_code_check;
+alter table public.package_eligibility_blocks
+  add constraint package_eligibility_blocks_block_code_check
+  check (block_code in (
+    'vendor_retired',
+    'upstream_removed',
+    'unsupported_managed_install',
+    'unsupported_managed_uninstall'
+  ));
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Nvidia.GeForceNow',
+  'unsupported_managed_install',
+  'NVIDIA GeForce NOW does not currently provide a reliable unattended managed-install contract. Isolated lifecycle QA and the open upstream WinGet package issue both show the bootstrapper can finish without registering an installed application.',
+  'https://github.com/microsoft/winget-pkgs/issues/56299'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Nvidia.GeForceNow';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Nvidia.GeForceNow'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- add a first-class unsupported_managed_install eligibility code
- block Nvidia.GeForceNow consistently across catalog, QA, and customer packaging
- supersede failed or queued candidates so the QA cohort can continue

## Evidence
- current isolated user-context PSADT lifecycle ran the vendor bootstrapper for 152 seconds but produced no installed-app registration or detection result
- Microsoft WinGet package issue #56299 documents the same nondeterministic missing-registration outcome

## Verification
- 45 targeted Vitest tests passed
- targeted ESLint passed