### PR TITLE
Activate Burn restart suppression toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '461c2757292d3b7bcde33682d3f7b33e566b1fea',
+  packagerCommit: '02f93d590887282aca0037412c8786785ddc6486',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -75,6 +75,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '719d7fd6db57ce5cbcecad528d53ae9c9088616f',
   '6db4e201f11e49bceb4d2729a2bc77fb0e675e89',
   '0c2765c26b69619df8f581190f4e67d97d79b589',
+  '461c2757292d3b7bcde33682d3f7b33e566b1fea',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -407,6 +407,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Horizon Client after suppressing Burn uninstall restarts', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'OMNISSA.HORIZONCLIENT', status: 'failed' }
+    )).toBe(true);
+  });
+
   it('still rebuilds a non-terminal stale candidate', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -405,6 +405,22 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // custom message boxes, restarts, and the startup prompt under SYSTEM.
     'AOMEI.PartitionAssistant',
   ],
+  '02f93d590887282aca0037412c8786785ddc6486': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    // Horizon Client's registered Burn helper omitted restart suppression and
+    // shut down the device during removal. The shared packager now guarantees
+    // the complete unattended Burn lifecycle for QA and customer packages.
+    'Omnissa.HorizonClient',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA and customer-demand packaging to the Burn restart-suppression packager
- retain compatibility with prior successful profiles
- carry unfinished targeted retries forward and add one bounded Horizon Client retry

## Verification
- 124 targeted tests passed
- ESLint passed
- git diff --check passed