### PR TITLE
Fix Autodesk ODIS packaging lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -473,6 +473,57 @@ if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
     }
 }
 
+$reviewedManagedInstallEvidenceFile = ''
+$reviewedManagedInstallCompletionProcess = ''
+$reviewedManagedInstallCompletionTimeoutMinutes = 0
+$hasManagedInstallCompletionContract =
+    ($psadtConfig.Contains('reviewedManagedInstallEvidenceFile') -and
+     $null -ne $psadtConfig['reviewedManagedInstallEvidenceFile']) -or
+    ($psadtConfig.Contains('reviewedManagedInstallCompletionProcess') -and
+     $null -ne $psadtConfig['reviewedManagedInstallCompletionProcess']) -or
+    ($psadtConfig.Contains('reviewedManagedInstallCompletionTimeoutMinutes') -and
+     $null -ne $psadtConfig['reviewedManagedInstallCompletionTimeoutMinutes'])
+if ($hasManagedInstallCompletionContract) {
+    if ([string]::IsNullOrWhiteSpace($reviewedManagedInstallDirectory)) {
+        throw 'PSADT reviewed managed install completion requires reviewedManagedInstallDirectory.'
+    }
+    if ($psadtConfig['reviewedManagedInstallEvidenceFile'] -isnot [string]) {
+        throw 'PSADT reviewedManagedInstallEvidenceFile must be a string.'
+    }
+    $reviewedManagedInstallEvidenceFile = ([string]$psadtConfig['reviewedManagedInstallEvidenceFile']).Trim()
+    if ($reviewedManagedInstallEvidenceFile.Length -gt 260 -or
+        $reviewedManagedInstallEvidenceFile -notmatch '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$' -or
+        @($reviewedManagedInstallEvidenceFile -split '\\') -contains '..' -or
+        -not $reviewedManagedInstallEvidenceFile.StartsWith(
+            $reviewedManagedInstallDirectory.TrimEnd('\') + '\',
+            [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw 'PSADT reviewedManagedInstallEvidenceFile must be a safe file below reviewedManagedInstallDirectory.'
+    }
+    if ($psadtConfig.Contains('reviewedManagedInstallCompletionProcess') -and
+        $null -ne $psadtConfig['reviewedManagedInstallCompletionProcess']) {
+        if ($psadtConfig['reviewedManagedInstallCompletionProcess'] -isnot [string]) {
+            throw 'PSADT reviewedManagedInstallCompletionProcess must be a string.'
+        }
+        $reviewedManagedInstallCompletionProcess = ([string]$psadtConfig['reviewedManagedInstallCompletionProcess']).Trim()
+        if ($reviewedManagedInstallCompletionProcess.Length -gt 260 -or
+            $reviewedManagedInstallCompletionProcess -notmatch '^%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\[^*?"<>|\x00-\x1f]+\.exe$' -or
+            @($reviewedManagedInstallCompletionProcess -split '\\') -contains '..') {
+            throw 'PSADT reviewedManagedInstallCompletionProcess must be a safe executable below a Program Files environment variable.'
+        }
+    }
+    $rawManagedInstallCompletionTimeoutMinutes = $psadtConfig['reviewedManagedInstallCompletionTimeoutMinutes']
+    if (($rawManagedInstallCompletionTimeoutMinutes -isnot [byte] -and
+         $rawManagedInstallCompletionTimeoutMinutes -isnot [int16] -and
+         $rawManagedInstallCompletionTimeoutMinutes -isnot [int32] -and
+         $rawManagedInstallCompletionTimeoutMinutes -isnot [int64]) -or
+        [int]$rawManagedInstallCompletionTimeoutMinutes -lt 1 -or
+        [int]$rawManagedInstallCompletionTimeoutMinutes -gt 60) {
+        throw 'PSADT reviewedManagedInstallCompletionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+    $reviewedManagedInstallCompletionTimeoutMinutes = [int]$rawManagedInstallCompletionTimeoutMinutes
+}
+
 $reviewedManagedUninstallConfigured = $false
 $reviewedManagedUninstallExecutable = ''
 $reviewedManagedUninstallArguments = @()
@@ -835,6 +886,8 @@ $versionSingleQuoteEscaped = $Version -replace "'", "''"
 $uninstallCmd = [string]$UninstallCommand
 $uninstallCmdSingleQuoteEscaped = $uninstallCmd -replace "'", "''"
 $reviewedManagedInstallDirectoryEscaped = $reviewedManagedInstallDirectory -replace "'", "''"
+$reviewedManagedInstallEvidenceFileEscaped = $reviewedManagedInstallEvidenceFile -replace "'", "''"
+$reviewedManagedInstallCompletionProcessEscaped = $reviewedManagedInstallCompletionProcess -replace "'", "''"
 $reviewedManagedUninstallExecutableEscaped = $reviewedManagedUninstallExecutable -replace "'", "''"
 $reviewedManagedUninstallArgumentsLiteral = @(
     $reviewedManagedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
@@ -2121,18 +2174,46 @@ $lines += @(
 )
 
 if ($useManagedDirectoryLifecycle) {
-    $lines += @(
-        ''
-        "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')"
-        '    if (-not (Test-Path -LiteralPath $managedInstallDirectory -PathType Container)) {'
-        '        throw "The reviewed managed install directory was not created: $managedInstallDirectory"'
-        '    }'
-        '    $managedPayloadFile = Get-ChildItem -LiteralPath $managedInstallDirectory -File -Recurse -ErrorAction Stop | Select-Object -First 1'
-        '    if (-not $managedPayloadFile) {'
-        '        throw "The reviewed managed install directory contains no payload files: $managedInstallDirectory"'
-        '    }'
-        '    Write-ADTLogEntry -Message "Verified managed extracted payload at [$managedInstallDirectory]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
-    )
+    $lines += @('', "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')")
+    if ($hasManagedInstallCompletionContract) {
+        $lines += @(
+            "    `$managedInstallEvidenceFile = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallEvidenceFileEscaped')"
+            "    `$managedInstallCompletionProcess = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallCompletionProcessEscaped')"
+            "    `$managedInstallDeadline = [DateTime]::UtcNow.AddMinutes($reviewedManagedInstallCompletionTimeoutMinutes)"
+            '    $managedInstallReadyObservations = 0'
+            '    do {'
+            '        $managedInstallEvidenceReady = Test-Path -LiteralPath $managedInstallEvidenceFile -PathType Leaf'
+            '        $managedInstallProcessActive = $false'
+            '        if (-not [string]::IsNullOrWhiteSpace($managedInstallCompletionProcess)) {'
+            '            $managedInstallProcessActive = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {'
+            '                [string]::Equals([string]$_.ExecutablePath, $managedInstallCompletionProcess, [System.StringComparison]::OrdinalIgnoreCase)'
+            '            }).Count -gt 0'
+            '        }'
+            '        if ($managedInstallEvidenceReady -and -not $managedInstallProcessActive) {'
+            '            $managedInstallReadyObservations++'
+            '        } else {'
+            '            $managedInstallReadyObservations = 0'
+            '        }'
+            '        if ($managedInstallReadyObservations -ge 2) { break }'
+            '        Start-Sleep -Seconds 5'
+            '    } while ([DateTime]::UtcNow -lt $managedInstallDeadline)'
+            '    if ($managedInstallReadyObservations -lt 2) {'
+            '        throw "The reviewed managed installation did not reach stable completion before the deadline: $managedInstallEvidenceFile"'
+            '    }'
+            '    Write-ADTLogEntry -Message "Verified stable managed installation evidence at [$managedInstallEvidenceFile]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+        )
+    } else {
+        $lines += @(
+            '    if (-not (Test-Path -LiteralPath $managedInstallDirectory -PathType Container)) {'
+            '        throw "The reviewed managed install directory was not created: $managedInstallDirectory"'
+            '    }'
+            '    $managedPayloadFile = Get-ChildItem -LiteralPath $managedInstallDirectory -File -Recurse -ErrorAction Stop | Select-Object -First 1'
+            '    if (-not $managedPayloadFile) {'
+            '        throw "The reviewed managed install directory contains no payload files: $managedInstallDirectory"'
+            '    }'
+            '    Write-ADTLogEntry -Message "Verified managed extracted payload at [$managedInstallDirectory]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+        )
+    }
 }
 
 # Optional post-install verification (opt-in via PSADT config)

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -207,6 +207,55 @@ describe('application packaging adapters', () => {
         .reviewedManagedInstallDirectory
     ).toBe('%SystemDrive%\\SWSetup\\HPImageAssistant');
     expect(
+      applyApplicationPackagingAdapter(
+        'Autodesk.NavisworksFreedom.2026',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026\\Roamer.exe',
+      reviewedManagedInstallCompletionProcess:
+        '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 15,
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+        arguments: [
+          '-i',
+          'uninstall',
+          '--silent',
+          '--trigger_point',
+          'system',
+          '-m',
+          '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\bundleManifest.xml',
+          '-x',
+          '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\SetupRes\\manifest.xsd',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
+        'autodesk.navisworksfreedom.2027',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2027',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2027\\Roamer.exe',
+      reviewedManagedInstallCompletionProcess:
+        '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 15,
+      reviewedManagedUninstall: {
+        arguments: expect.arrayContaining([
+          '%ProgramData%\\Autodesk\\ODIS\\metadata\\{52AC45A2-3099-370C-8394-8B347967768B}\\bundleManifest.xml',
+        ]),
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
       applyApplicationPackagingAdapter('Google.GoogleUpdater', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedManagedInstallDirectory:
@@ -389,6 +438,10 @@ describe('application packaging adapters', () => {
       reviewedMultiProductInstallDisplayNamePrefixes: ['Anything'],
       reviewedMultiProductInstallMinimumCount: 2,
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
+      reviewedManagedInstallEvidenceFile: '%ProgramFiles%\\Example\\app.exe',
+      reviewedManagedInstallCompletionProcess:
+        '%ProgramFiles%\\Example\\installer.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 5,
       reviewedManagedUninstall: {
         executablePath: '%ProgramFiles%\\Example\\uninstall.exe',
         arguments: ['/quiet'],
@@ -405,6 +458,9 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
+    expect(adapted.reviewedManagedInstallEvidenceFile).toBeUndefined();
+    expect(adapted.reviewedManagedInstallCompletionProcess).toBeUndefined();
+    expect(adapted.reviewedManagedInstallCompletionTimeoutMinutes).toBeUndefined();
     expect(adapted.reviewedManagedUninstall).toBeUndefined();
     expect(adapted.reviewedExactUninstall).toBeUndefined();
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -16,6 +16,9 @@ interface ApplicationPackagingAdapter {
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedManagedInstallDirectory?: string;
+  reviewedManagedInstallEvidenceFile?: string;
+  reviewedManagedInstallCompletionProcess?: string;
+  reviewedManagedInstallCompletionTimeoutMinutes?: number;
   reviewedManagedUninstall?: Readonly<{
     executablePath: string;
     arguments: readonly string[];
@@ -351,6 +354,63 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant',
   },
   {
+    // Navisworks Freedom 2026 is installed by Autodesk ODIS. The bootstrapper
+    // changes multiple Autodesk registrations, so a generic ARP capture cannot
+    // identify the product safely. Autodesk documents the ODIS manifest-based
+    // uninstall workflow, and this product GUID is also the exact GUID in the
+    // vendor installer URL published by WinGet.
+    wingetId: 'Autodesk.NavisworksFreedom.2026',
+    reviewedManagedInstallDirectory:
+      '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026\\Roamer.exe',
+    reviewedManagedInstallCompletionProcess:
+      '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 15,
+    reviewedManagedUninstall: {
+      executablePath: '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      arguments: [
+        '-i',
+        'uninstall',
+        '--silent',
+        '--trigger_point',
+        'system',
+        '-m',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\bundleManifest.xml',
+        '-x',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\SetupRes\\manifest.xsd',
+      ],
+      completionTimeoutMinutes: 15,
+    },
+  },
+  {
+    // Navisworks Freedom 2027 uses the same documented ODIS lifecycle with a
+    // release-specific manifest GUID from Autodesk's WinGet installer URL.
+    wingetId: 'Autodesk.NavisworksFreedom.2027',
+    reviewedManagedInstallDirectory:
+      '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2027',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2027\\Roamer.exe',
+    reviewedManagedInstallCompletionProcess:
+      '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 15,
+    reviewedManagedUninstall: {
+      executablePath: '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      arguments: [
+        '-i',
+        'uninstall',
+        '--silent',
+        '--trigger_point',
+        'system',
+        '-m',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{52AC45A2-3099-370C-8394-8B347967768B}\\bundleManifest.xml',
+        '-x',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{52AC45A2-3099-370C-8394-8B347967768B}\\SetupRes\\manifest.xsd',
+      ],
+      completionTimeoutMinutes: 15,
+    },
+  },
+  {
     // Google Updater is a shared system updater, not a conventional ARP app.
     // Its enterprise installer can update an existing registration without
     // creating a new uninstall entry, so ARP delta capture is not a reliable
@@ -642,6 +702,9 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedUninstallProcessGuard &&
       !config.reviewedManagedInstallDirectory &&
+      !config.reviewedManagedInstallEvidenceFile &&
+      !config.reviewedManagedInstallCompletionProcess &&
+      !config.reviewedManagedInstallCompletionTimeoutMinutes &&
       !config.reviewedManagedUninstall &&
       !config.reviewedExactUninstall
     ) return config;
@@ -653,6 +716,9 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedUninstallProcessGuard: undefined,
       reviewedManagedInstallDirectory: undefined,
+      reviewedManagedInstallEvidenceFile: undefined,
+      reviewedManagedInstallCompletionProcess: undefined,
+      reviewedManagedInstallCompletionTimeoutMinutes: undefined,
       reviewedManagedUninstall: undefined,
       reviewedExactUninstall: undefined,
     };
@@ -733,6 +799,12 @@ export function applyApplicationPackagingAdapter(
       adapter.preserveVendorInstallationOnUninstall || undefined,
     reviewedManagedInstallDirectory:
       adapter.reviewedManagedInstallDirectory || undefined,
+    reviewedManagedInstallEvidenceFile:
+      adapter.reviewedManagedInstallEvidenceFile || undefined,
+    reviewedManagedInstallCompletionProcess:
+      adapter.reviewedManagedInstallCompletionProcess || undefined,
+    reviewedManagedInstallCompletionTimeoutMinutes:
+      adapter.reviewedManagedInstallCompletionTimeoutMinutes,
     reviewedManagedUninstall: adapter.reviewedManagedUninstall
       ? {
           executablePath: adapter.reviewedManagedUninstall.executablePath,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -555,6 +555,81 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses the exact Autodesk ODIS manifest lifecycle for Navisworks Freedom',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Autodesk Create Installer',
+        [],
+        {
+          reviewedManagedInstallDirectory:
+            '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026',
+          reviewedManagedInstallEvidenceFile:
+            '%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026\\Roamer.exe',
+          reviewedManagedInstallCompletionProcess:
+            '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+          reviewedManagedInstallCompletionTimeoutMinutes: 15,
+          reviewedManagedUninstall: {
+            executablePath:
+              '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+            arguments: [
+              '-i',
+              'uninstall',
+              '--silent',
+              '--trigger_point',
+              'system',
+              '-m',
+              '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\bundleManifest.xml',
+              '-x',
+              '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\SetupRes\\manifest.xsd',
+            ],
+            completionTimeoutMinutes: 15,
+          },
+        },
+        [],
+        'Autodesk.NavisworksFreedom.2026'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026')"
+      );
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramW6432%\\Autodesk\\Navisworks Freedom 2026\\Roamer.exe')"
+      );
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe')"
+      );
+      expect(installFunction).toContain(
+        '$managedInstallReadyObservations -ge 2'
+      );
+      expect(installFunction).toContain(
+        '$managedInstallDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(installFunction).not.toContain('Captured vendor uninstall entry');
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$managedUninstallArguments = @('-i', 'uninstall', '--silent', '--trigger_point', 'system', '-m', '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\bundleManifest.xml', '-x', '%ProgramData%\\Autodesk\\ODIS\\metadata\\{BE06C262-73A9-3C2F-8982-C105E1EE9A34}\\SetupRes\\manifest.xsd')"
+      );
+      expect(uninstallFunction).toContain(
+        '$managedUninstallDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(uninstallFunction).not.toContain(
+        'Remove-Item -LiteralPath $managedInstallDirectory'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'resolves one validated package-version segment in a reviewed managed uninstaller',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -234,6 +234,9 @@ export interface PSADTConfig {
   // verifies this exact directory after install and removes it on uninstall.
   // Application adapters are the only trusted source for this value.
   reviewedManagedInstallDirectory?: string;
+  reviewedManagedInstallEvidenceFile?: string;
+  reviewedManagedInstallCompletionProcess?: string;
+  reviewedManagedInstallCompletionTimeoutMinutes?: number;
   reviewedManagedUninstall?: {
     // A reviewed adapter may use one literal <VERSION> path segment. The
     // packager replaces it with the validated package version before emitting


### PR DESCRIPTION
## Summary
- add exact Autodesk ODIS managed lifecycle adapters for Navisworks Freedom 2026 and 2027
- wait for stable Roamer.exe evidence and the ODIS installer process to finish before writing detection
- uninstall with Autodesk's exact product bundle manifest instead of ambiguous ARP entries

## Validation
- 184 targeted Vitest tests passed
- ESLint passed for changed TypeScript files
- PowerShell parser passed
- git diff --check passed