### PR TITLE
Fail closed on stale QA scheduler releases

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -82,6 +82,7 @@ function createSupabaseStub(
   additionalPages: Array<Array<ReturnType<typeof candidate>>> = [],
   options: {
     paused?: boolean;
+    requiredPackagerCommit?: string | null;
     claimNullIds?: string[];
     claimErrorById?: Record<string, { message: string; code?: string }>;
     supersedeError?: { message: string; code?: string };
@@ -107,6 +108,9 @@ function createSupabaseStub(
           data: {
             paused: options.paused === true,
             reason: options.paused ? 'Golden VM maintenance' : null,
+            required_packager_commit: options.requiredPackagerCommit ?? null,
+            scheduler_packager_commit: null,
+            scheduler_seen_at: null,
             updated_at: '2026-08-11T12:00:00.000Z',
           },
           error: null,
@@ -236,6 +240,25 @@ describe('GET /api/cron/qa-dispatch', () => {
       dispatched: false,
       reason: 'maintenance_paused',
       maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile or dispatch when production serves the wrong packager release', async () => {
+    const row = candidate('catalog-default');
+    const { client, claimedIds } = createSupabaseStub([row], [], {
+      requiredPackagerCommit: 'F'.repeat(40),
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      success: true,
+      dispatched: false,
+      reason: 'packager_release_pending',
     });
     expect(claimedIds).toEqual([]);
     expect(dispatchQaCandidateMock).not.toHaveBeenCalled();

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { dispatchQaCandidate } from '@/lib/qa/dispatch';
-import { validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
-import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
+import { QA_PSADT_TOOLCHAIN, validateCurrentQaPackageProfile } from '@/lib/qa/package-profile';
+import { getQaPipelineControl, isQaPackagerReleaseReady } from '@/lib/qa/pipeline-control';
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
 import { InstallerPreflightError } from '@/lib/installer-preflight';
 import { isQaRunnerArchitectureSupported } from '@/lib/qa/candidate';
@@ -54,6 +54,13 @@ export async function GET(request: Request) {
       reason: 'maintenance_paused',
       maintenanceReason: control.reason,
       pausedAt: control.updatedAt,
+    });
+  }
+  if (!isQaPackagerReleaseReady(control, QA_PSADT_TOOLCHAIN.packagerCommit)) {
+    return NextResponse.json({
+      success: true,
+      dispatched: false,
+      reason: 'packager_release_pending',
     });
   }
   const now = new Date();

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -72,6 +72,7 @@ function query(result: QueryResult) {
 
 function createSupabaseStub(options: {
   paused?: boolean;
+  requiredPackagerCommit?: string | null;
   coverage?: number;
   coverageError?: string;
   supportedApps?: Array<Record<string, unknown>>;
@@ -88,6 +89,7 @@ function createSupabaseStub(options: {
   const cursorUpdates: Array<Record<string, unknown>> = [];
   const candidateInserts: Array<Record<string, unknown>> = [];
   const compatibilityBlocks: Array<Record<string, unknown>> = [];
+  const pipelineControlUpdates: Array<Record<string, unknown>> = [];
   const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
   let candidatePageIndex = 0;
 
@@ -104,14 +106,22 @@ function createSupabaseStub(options: {
     }),
     from: vi.fn((table: string) => {
       if (table === 'qa_pipeline_control') {
-        return query({
+        const builder = query({
           data: {
             paused: options.paused === true,
             reason: options.paused ? 'Golden VM maintenance' : null,
+            required_packager_commit: options.requiredPackagerCommit ?? null,
+            scheduler_packager_commit: null,
+            scheduler_seen_at: null,
             updated_at: '2026-08-11T12:00:00.000Z',
           },
           error: null,
         });
+        builder.update = vi.fn((values: Record<string, unknown>) => {
+          pipelineControlUpdates.push(values);
+          return query({ data: null, error: null });
+        });
+        return builder;
       }
       if (table === 'qa_poll_runs') {
         return {
@@ -208,6 +218,7 @@ function createSupabaseStub(options: {
     cursorUpdates,
     candidateInserts,
     compatibilityBlocks,
+    pipelineControlUpdates,
     rpcCalls,
   };
 }
@@ -347,7 +358,8 @@ describe('GET /api/cron/qa-enqueue', () => {
   });
 
   it('does not poll or mutate the queue while maintenance is paused', async () => {
-    const { client, pollRunInserts, candidateInserts } = createSupabaseStub({ paused: true });
+    const { client, pollRunInserts, candidateInserts, pipelineControlUpdates } =
+      createSupabaseStub({ paused: true });
     createServerClientMock.mockReturnValue(client);
 
     const response = await GET(cronRequest());
@@ -359,6 +371,31 @@ describe('GET /api/cron/qa-enqueue', () => {
       paused: true,
       reason: 'maintenance_paused',
       maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(pollRunInserts).toHaveLength(0);
+    expect(candidateInserts).toHaveLength(0);
+    expect(detectWingetChangesMock).not.toHaveBeenCalled();
+    expect(pipelineControlUpdates).toEqual([
+      expect.objectContaining({
+        scheduler_packager_commit: QA_PSADT_TOOLCHAIN.packagerCommit,
+        scheduler_seen_at: expect.any(String),
+      }),
+    ]);
+  });
+
+  it('does not poll or mutate the queue when production serves the wrong packager release', async () => {
+    const { client, pollRunInserts, candidateInserts } = createSupabaseStub({
+      requiredPackagerCommit: 'F'.repeat(40),
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      success: true,
+      paused: true,
+      reason: 'packager_release_pending',
     });
     expect(pollRunInserts).toHaveLength(0);
     expect(candidateInserts).toHaveLength(0);

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -33,7 +33,11 @@ import {
   terminalToolchainRetryTargets,
   type QaToolchainBackfillCandidate,
 } from '@/lib/qa/toolchain-backfill';
-import { getQaPipelineControl } from '@/lib/qa/pipeline-control';
+import {
+  getQaPipelineControl,
+  isQaPackagerReleaseReady,
+  recordQaSchedulerHeartbeat,
+} from '@/lib/qa/pipeline-control';
 import { detectWingetChanges } from '@/lib/qa/winget-changes';
 import {
   createWingetManifestClient,
@@ -360,6 +364,11 @@ export async function GET(request: Request) {
 
   try {
     supabase = createServerClient();
+    await recordQaSchedulerHeartbeat(
+      supabase,
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      startedAt
+    );
     const control = await getQaPipelineControl(supabase);
     if (control.paused) {
       return NextResponse.json({
@@ -368,6 +377,13 @@ export async function GET(request: Request) {
         reason: 'maintenance_paused',
         maintenanceReason: control.reason,
         pausedAt: control.updatedAt,
+      });
+    }
+    if (!isQaPackagerReleaseReady(control, QA_PSADT_TOOLCHAIN.packagerCommit)) {
+      return NextResponse.json({
+        success: true,
+        paused: true,
+        reason: 'packager_release_pending',
       });
     }
     const { data: pollRun, error: pollRunError } = await supabase

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -402,6 +402,9 @@ describe('buildQaLiveResponse', () => {
         paused: true,
         reason:
           'Testing is temporarily paused for maintenance · Coordinating protected QA and customer packager pins for commit 1b130924ecc68909d6bb15f8cdf295944255a2f9.',
+        requiredPackagerCommit: null,
+        schedulerPackagerCommit: null,
+        schedulerSeenAt: null,
         updatedAt: '2026-08-11T12:04:00.000Z',
       },
     });

--- a/lib/qa/pipeline-control.ts
+++ b/lib/qa/pipeline-control.ts
@@ -3,7 +3,35 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 export interface QaPipelineControl {
   paused: boolean;
   reason: string | null;
+  requiredPackagerCommit: string | null;
+  schedulerPackagerCommit: string | null;
+  schedulerSeenAt: string | null;
   updatedAt: string;
+}
+
+export function isQaPackagerReleaseReady(
+  control: QaPipelineControl,
+  packagerCommit: string
+): boolean {
+  return !control.requiredPackagerCommit ||
+    control.requiredPackagerCommit.toLowerCase() === packagerCommit.trim().toLowerCase();
+}
+
+export async function recordQaSchedulerHeartbeat(
+  supabase: SupabaseClient,
+  packagerCommit: string,
+  observedAt: string
+): Promise<void> {
+  const { error } = await supabase
+    .from('qa_pipeline_control')
+    .update({
+      scheduler_packager_commit: packagerCommit,
+      scheduler_seen_at: observedAt,
+    })
+    .eq('id', 'global');
+  if (error) {
+    throw new Error(`Could not record the QA scheduler release heartbeat: ${error.message}`);
+  }
 }
 
 /**
@@ -16,7 +44,9 @@ export async function getQaPipelineControl(
 ): Promise<QaPipelineControl> {
   const { data, error } = await supabase
     .from('qa_pipeline_control')
-    .select('paused, reason, updated_at')
+    .select(
+      'paused, reason, required_packager_commit, scheduler_packager_commit, scheduler_seen_at, updated_at'
+    )
     .eq('id', 'global')
     .maybeSingle();
 
@@ -32,6 +62,18 @@ export async function getQaPipelineControl(
     reason: typeof data.reason === 'string' && data.reason.trim()
       ? data.reason.trim()
       : null,
+    requiredPackagerCommit:
+      typeof data.required_packager_commit === 'string' && data.required_packager_commit.trim()
+        ? data.required_packager_commit.trim()
+        : null,
+    schedulerPackagerCommit:
+      typeof data.scheduler_packager_commit === 'string' && data.scheduler_packager_commit.trim()
+        ? data.scheduler_packager_commit.trim()
+        : null,
+    schedulerSeenAt:
+      typeof data.scheduler_seen_at === 'string' && data.scheduler_seen_at.trim()
+        ? data.scheduler_seen_at.trim()
+        : null,
     updatedAt: data.updated_at,
   };
 }

--- a/supabase/migrations/20260815062000_qa_scheduler_packager_release_gate.sql
+++ b/supabase/migrations/20260815062000_qa_scheduler_packager_release_gate.sql
@@ -1,0 +1,21 @@
+-- Make scheduler rollouts observable and fail closed when production has not
+-- yet picked up the packager revision selected by the operator.
+alter table public.qa_pipeline_control
+  add column if not exists required_packager_commit text,
+  add column if not exists scheduler_packager_commit text,
+  add column if not exists scheduler_seen_at timestamptz;
+
+alter table public.qa_pipeline_control
+  drop constraint if exists qa_pipeline_control_required_packager_commit_format,
+  add constraint qa_pipeline_control_required_packager_commit_format
+    check (required_packager_commit is null or required_packager_commit ~ '^[0-9a-f]{40}$'),
+  drop constraint if exists qa_pipeline_control_scheduler_packager_commit_format,
+  add constraint qa_pipeline_control_scheduler_packager_commit_format
+    check (scheduler_packager_commit is null or scheduler_packager_commit ~ '^[0-9a-f]{40}$');
+
+comment on column public.qa_pipeline_control.required_packager_commit is
+  'Packager revision that production enqueue and dispatch code must match before mutating the queue.';
+comment on column public.qa_pipeline_control.scheduler_packager_commit is
+  'Packager revision most recently reported by the production enqueue scheduler.';
+comment on column public.qa_pipeline_control.scheduler_seen_at is
+  'Timestamp of the most recent production enqueue scheduler heartbeat.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -318,6 +318,9 @@ export interface Database {
           id: string;
           paused: boolean;
           reason: string | null;
+          required_packager_commit: string | null;
+          scheduler_packager_commit: string | null;
+          scheduler_seen_at: string | null;
           updated_at: string;
           updated_by: string | null;
         };
@@ -325,6 +328,9 @@ export interface Database {
           id: string;
           paused?: boolean;
           reason?: string | null;
+          required_packager_commit?: string | null;
+          scheduler_packager_commit?: string | null;
+          scheduler_seen_at?: string | null;
           updated_at?: string;
           updated_by?: string | null;
         };


### PR DESCRIPTION
## Summary
- record the packager revision served by the production enqueue scheduler even while QA is paused
- gate enqueue and dispatch against the operator-required packager revision
- add private control columns and database constraints for release observability
- keep public QA maintenance messaging free of internal revision details

## Validation
- 104 targeted Vitest tests passed
- ESLint passed
- git diff --check passed
- additive Supabase migration applied with the pipeline paused