### PR TITLE
Activate Autodesk ODIS packager release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '02f93d590887282aca0037412c8786785ddc6486',
+  packagerCommit: 'ca77e52dc65a404eb81679c5188378bf4d69a692',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -76,6 +76,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '6db4e201f11e49bceb4d2729a2bc77fb0e675e89',
   '0c2765c26b69619df8f581190f4e67d97d79b589',
   '461c2757292d3b7bcde33682d3f7b33e566b1fea',
+  '02f93d590887282aca0037412c8786785ddc6486',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -12,6 +12,9 @@ describe('QA toolchain targeted retries', () => {
       'PDFsam.PDFsam',
       'Mega.MEGASync',
       'AOMEI.PartitionAssistant',
+      'Omnissa.HorizonClient',
+      'Autodesk.NavisworksFreedom.2026',
+      'Autodesk.NavisworksFreedom.2027',
     ]));
 
     targets.length = 0;
@@ -21,6 +24,9 @@ describe('QA toolchain targeted retries', () => {
         'PDFsam.PDFsam',
         'Mega.MEGASync',
         'AOMEI.PartitionAssistant',
+        'Omnissa.HorizonClient',
+        'Autodesk.NavisworksFreedom.2026',
+        'Autodesk.NavisworksFreedom.2027',
       ])
     );
   });
@@ -411,6 +417,16 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'OMNISSA.HORIZONCLIENT', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it.each([
+    'Autodesk.NavisworksFreedom.2026',
+    'Autodesk.NavisworksFreedom.2027',
+  ])('retries %s with its reviewed ODIS lifecycle', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -421,6 +421,24 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // the complete unattended Burn lifecycle for QA and customer packages.
     'Omnissa.HorizonClient',
   ],
+  'ca77e52dc65a404eb81679c5188378bf4d69a692': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Omnissa.HorizonClient',
+    // Autodesk ODIS keeps working after its bootstrap process exits. These
+    // releases wait for the exact managed executable and ODIS completion,
+    // then use Autodesk's manifest-driven unattended uninstall lifecycle.
+    'Autodesk.NavisworksFreedom.2026',
+    'Autodesk.NavisworksFreedom.2027',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA profile generation to shared packager ca77e52
- preserve prior passing-profile compatibility
- schedule bounded fresh retries for Navisworks Freedom 2026/2027 and unresolved lifecycle targets
- retain the new fail-closed production scheduler release gate

## Validation
- 163 targeted Vitest tests passed
- ESLint passed
- git diff --check passed