### PR TITLE
Fix Ecosia silent uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -102,6 +102,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['--silent', '--force_stop']);
     expect(
+      applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['--force-uninstall']);
+    expect(
       applyApplicationPackagingAdapter('Dropbox.Dropbox', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedInstallArgumentsOverride: '/NOLAUNCH',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -153,6 +153,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['--silent', '--force_stop'],
   },
   {
+    // Ecosia Browser uses Chromium's setup.exe lifecycle. Its captured ARP
+    // command contains --uninstall but omits --force-uninstall, so setup opens
+    // the confirmation UI and cannot complete in a non-interactive Intune
+    // session. Chromium defines --force-uninstall as the silent removal switch;
+    // append it to the exact captured per-user command for QA and customers.
+    wingetId: 'Ecosia.EcosiaBrowser',
+    reviewedUninstallArguments: ['--force-uninstall'],
+  },
+  {
     // Dropbox documents /NOLAUNCH for unattended enterprise installs that must
     // not start the client. Its Windows support guidance also requires Dropbox
     // processes to be closed before removal. The registered machine uninstaller


### PR DESCRIPTION
## Summary
- append Chromium's documented --force-uninstall switch to Ecosia's captured ARP command
- keep the adapter shared by QA and customer Intune packages
- cover the application adapter with a regression test

## Evidence
- Ecosia 148.1.7778.12 installed successfully but its unforced ARP command waited five minutes and left the exact registration behind
- Chromium defines --force-uninstall as the non-interactive removal switch

## Validation
- 
pm test -- lib/packaging-adapters.test.ts lib/qa/psadt-packager-contract.test.ts (101 passed)