### PR TITLE
Activate Ecosia lifecycle without duplicate QA

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -1134,6 +1134,43 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(candidateInserts[0]).toMatchObject({ winget_id: 'Supported.App' });
   });
 
+  it('does not rebuild a stale queued duplicate when its exact profile already passed', async () => {
+    const staleCandidate = profileCandidate({
+      id: 'covered-queued-duplicate',
+      wingetId: 'Covered.App',
+      packagerCommit: 'ca77e52dc65a404eb81679c5188378bf4d69a692',
+      enqueuedAt: '2026-08-15T07:20:00.000Z',
+      status: 'queued',
+    });
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [
+        { winget_id: 'Covered.App', name: 'Covered', publisher: 'Contoso' },
+      ],
+      deployedApps: ['Covered.App'],
+      candidatePages: [[staleCandidate]],
+      packageResults: [
+        {
+          winget_id: 'Covered.App',
+          tested_version: staleCandidate.version,
+          architecture: staleCandidate.architecture,
+          installer_sha256: staleCandidate.installer_sha256,
+          outcome: 'Passed',
+          tested_at_utc: '2026-08-15T07:10:00.000Z',
+          package_profile_sha256: staleCandidate.package_profile_sha256,
+        },
+      ],
+    });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ queued: 0, toolchainBackfillCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(resolveManifestMock).not.toHaveBeenCalled();
+  });
+
   it('does not stop before an older deployed terminal retry target is scanned', async () => {
     const firstPage = [
       ...['Recent.One', 'Recent.Two', 'Recent.Three'].map((wingetId, index) =>

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -88,6 +88,32 @@ interface QaCandidateProfileRow {
   priority: number;
 }
 
+interface QaPackagePassRow {
+  winget_id: string;
+  tested_version: string;
+  architecture: string;
+  installer_sha256: string | null;
+  outcome: string;
+  package_profile_sha256: string | null;
+}
+
+function packagePassKey(value: {
+  winget_id: string;
+  tested_version?: string;
+  version?: string;
+  architecture: string;
+  installer_sha256: string | null;
+  package_profile_sha256: string | null;
+}): string {
+  return [
+    value.winget_id.trim().toLowerCase(),
+    (value.tested_version || value.version || '').trim().toLowerCase(),
+    value.architecture.trim().toLowerCase(),
+    (value.installer_sha256 || '').trim().toUpperCase(),
+    (value.package_profile_sha256 || '').trim().toUpperCase(),
+  ].join('|');
+}
+
 function object(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -153,7 +179,7 @@ async function findToolchainBackfillIds(
     const rows = (data || []) as QaCandidateProfileRow[];
     pagesScanned++;
 
-    const pageStaleRows: QaCandidateProfileRow[] = [];
+    let pageStaleRows: QaCandidateProfileRow[] = [];
     for (const row of rows) {
       const config = object(row.test_config);
       const normalizedWingetId = row.winget_id.trim().toLowerCase();
@@ -193,6 +219,37 @@ async function findToolchainBackfillIds(
       ) {
         pageStaleRows.push(row);
       }
+    }
+
+    if (pageStaleRows.length > 0) {
+      // A queued or superseded duplicate can be newer than a genuine pass and
+      // would otherwise hide that reusable evidence during a toolchain rollout.
+      // Match the immutable payload and old execution profile, then run the
+      // normal release-aware compatibility check before scheduling any rebuild.
+      const { data: priorPasses, error: priorPassesError } = await supabase
+        .from('qa_package_results')
+        .select(
+          'winget_id, tested_version, architecture, installer_sha256, outcome, package_profile_sha256'
+        )
+        .in('winget_id', pageStaleRows.map((row) => row.winget_id))
+        .eq('outcome', 'Passed');
+      if (priorPassesError) {
+        throw new Error(`Could not read prior QA toolchain passes: ${priorPassesError.message}`);
+      }
+      const passedProfiles = new Set(
+        ((priorPasses || []) as QaPackagePassRow[]).map(packagePassKey)
+      );
+      pageStaleRows = pageStaleRows.filter((row) => {
+        if (!passedProfiles.has(packagePassKey(row))) return true;
+        return !validateCompatiblePassedCatalogQaProfile({
+          testConfig: row.test_config,
+          candidatePackageProfileSha256: row.package_profile_sha256,
+          candidateWingetId: row.winget_id,
+          candidateVersion: row.version,
+          candidateArchitecture: row.architecture,
+          candidateInstallerSha256: row.installer_sha256,
+        }).valid;
+      });
     }
 
     if (pageStaleRows.length > 0) {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 import {
   buildQaPackageIdentity,
   buildQaPackageIdentityFromWorkflowInput,
@@ -652,6 +653,24 @@ describe('current catalog QA package validation', () => {
     expect(
       validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
     ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
+  });
+
+  it('reuses an adapted pass when a later release leaves its behavior unchanged', () => {
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        wingetId: 'Google.GoogleDrive',
+        psadtConfig: applyApplicationPackagingAdapter(
+          'Google.GoogleDrive',
+          DEFAULT_PSADT_CONFIG
+        ),
+      }),
+      'ca77e52dc65a404eb81679c5188378bf4d69a692'
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toMatchObject({ valid: true });
   });
 
   it('normalizes case and whitespace on both sides of candidate bindings', () => {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ca77e52dc65a404eb81679c5188378bf4d69a692',
+  packagerCommit: '94c8f81e38ac180048f86dbf2df7f987fa448676',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -77,6 +77,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '0c2765c26b69619df8f581190f4e67d97d79b589',
   '461c2757292d3b7bcde33682d3f7b33e566b1fea',
   '02f93d590887282aca0037412c8786785ddc6486',
+  'ca77e52dc65a404eb81679c5188378bf4d69a692',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 
@@ -532,7 +533,7 @@ export function validateCompatiblePassedCatalogQaProfile(
   }
   const typedPsadtConfig = psadtConfig as unknown as PSADTConfig;
   const adapted = applyApplicationPackagingAdapter(wingetId, typedPsadtConfig);
-  if (adapted !== typedPsadtConfig) {
+  if (canonicalQaJson(adapted) !== canonicalQaJson(typedPsadtConfig)) {
     return { valid: false, reason: 'compatible-application-adapter-changed' };
   }
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -13,8 +13,7 @@ describe('QA toolchain targeted retries', () => {
       'Mega.MEGASync',
       'AOMEI.PartitionAssistant',
       'Omnissa.HorizonClient',
-      'Autodesk.NavisworksFreedom.2026',
-      'Autodesk.NavisworksFreedom.2027',
+      'Ecosia.EcosiaBrowser',
     ]));
 
     targets.length = 0;
@@ -25,8 +24,7 @@ describe('QA toolchain targeted retries', () => {
         'Mega.MEGASync',
         'AOMEI.PartitionAssistant',
         'Omnissa.HorizonClient',
-        'Autodesk.NavisworksFreedom.2026',
-        'Autodesk.NavisworksFreedom.2027',
+        'Ecosia.EcosiaBrowser',
       ])
     );
   });
@@ -420,14 +418,25 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('retries Ecosia once with Chromium silent removal', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ECOSIA.ECOSIABROWSER', status: 'failed' }
+    )).toBe(true);
+  });
+
   it.each([
     'Autodesk.NavisworksFreedom.2026',
     'Autodesk.NavisworksFreedom.2027',
   ])('retries %s with its reviewed ODIS lifecycle', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      'ca77e52dc65a404eb81679c5188378bf4d69a692',
       { wingetId, status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(false);
   });
 
   it('still rebuilds a non-terminal stale candidate', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -439,6 +439,22 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Autodesk.NavisworksFreedom.2026',
     'Autodesk.NavisworksFreedom.2027',
   ],
+  '94c8f81e38ac180048f86dbf2df7f987fa448676': [
+    // Preserve unresolved, customer-deployed lifecycle retries through the
+    // cumulative rollout. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Omnissa.HorizonClient',
+    // Ecosia's captured Chromium command omitted the switch that suppresses
+    // confirmation UI. This release appends --force-uninstall for one retry.
+    'Ecosia.EcosiaBrowser',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 94c8f81e38ac180048f86dbf2df7f987fa448676
- retry Ecosia and preserve unresolved customer-deployed lifecycle targets
- stop queued/superseded duplicates from hiding an exact compatible pass
- compare application adapters by canonical behavior so unchanged adapters are not retested after unrelated releases

## Validation
- 130 focused scheduler/profile tests passed
- focused ESLint passed