### PR TITLE
Fix exact non-MSI uninstall identities

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1120,10 +1120,10 @@ if ($installerTypeLower -eq 'portable' -or $isNestedPortable -or $isPlainPortabl
     $useRegistryUninstall = $true
     $registryUninstallProductCode = $Matches[1]
     $registryUninstallDisplayName = $Matches[2]
-} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_KEY:([A-Za-z0-9][A-Za-z0-9._{}+-]{0,255}):(.+)$') {
-    # Reviewed non-MSI installers can expose a stable, edition-specific ARP
-    # key even when their display name embeds the version. Reuse the existing
-    # exact PSChildName lifecycle rather than broadening name matching.
+} elseif ($uninstallCmd -match '^REGISTRY_UNINSTALL_KEY:((?:[A-Za-z0-9][A-Za-z0-9 ._{}()+-]{0,255}|\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}_[A-Za-z0-9._+-]{1,32})):(.+)$') {
+    # Non-MSI WinGet manifests can expose a stable, edition-specific ARP key,
+    # including keys with spaces or a version suffix. Reuse the existing exact
+    # PSChildName lifecycle rather than broadening name matching.
     $useRegistryUninstall = $true
     $registryUninstallProductCode = $Matches[1]
     $registryUninstallDisplayName = $Matches[2]

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -920,6 +920,42 @@ describe('generateUninstallCommand', () => {
     ).toBe('REGISTRY_UNINSTALL:Reader');
   });
 
+  it('should preserve a safe non-MSI ARP registry key as exact uninstall identity', () => {
+    const base: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/app.exe',
+      sha256: 'abc123',
+      type: 'nullsoft',
+    };
+
+    expect(
+      generateUninstallCommand(
+        { ...base, productCode: 'IntelliJ IDEA 2025.2.5' },
+        'IntelliJ IDEA Ultimate Edition'
+      )
+    ).toBe(
+      'REGISTRY_UNINSTALL_KEY:IntelliJ IDEA 2025.2.5:IntelliJ IDEA Ultimate Edition'
+    );
+    expect(
+      generateUninstallCommand(
+        {
+          ...base,
+          type: 'inno',
+          productCode: '{22222222-2222-2222-2222-222222222222}_is1',
+        },
+        'Inno App'
+      )
+    ).toBe(
+      'REGISTRY_UNINSTALL_KEY:{22222222-2222-2222-2222-222222222222}_is1:Inno App'
+    );
+    expect(
+      generateUninstallCommand(
+        { ...base, productCode: 'Unsafe\\Key:Value' },
+        'Unsafe App'
+      )
+    ).toBe('REGISTRY_UNINSTALL:Unsafe App');
+  });
+
   it('should delegate Inno uninstall to registry lookup when display name is provided', () => {
     const installer: NormalizedInstaller = {
       architecture: 'x64',

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -634,7 +634,7 @@ describe('normalizeManifestInstallers', () => {
     );
   });
 
-  it('does not replace an explicit non-GUID installer identity with an inherited product code', () => {
+  it('preserves an explicit non-GUID installer identity instead of replacing it', () => {
     const [installer] = normalizeManifestInstallers({
       InstallerType: 'inno',
       ProductCode: '{11111111-1111-1111-1111-111111111111}',
@@ -646,7 +646,29 @@ describe('normalizeManifestInstallers', () => {
       }],
     });
 
-    expect(installer.ProductCode).toBeUndefined();
+    expect(installer.ProductCode).toBe(
+      '{22222222-2222-2222-2222-222222222222}_is1'
+    );
+    expect(normalizeInstaller(installer).productCode).toBe(
+      '{22222222-2222-2222-2222-222222222222}_is1'
+    );
+  });
+
+  it('preserves a named non-MSI ARP key inherited from the manifest root', () => {
+    const [installer] = normalizeManifestInstallers({
+      InstallerType: 'nullsoft',
+      ProductCode: 'IntelliJ IDEA 2025.2.5',
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/idea.exe',
+        InstallerSha256: 'abc123',
+      }],
+    });
+
+    expect(installer.ProductCode).toBe('IntelliJ IDEA 2025.2.5');
+    expect(normalizeInstaller(installer).productCode).toBe(
+      'IntelliJ IDEA 2025.2.5'
+    );
   });
 
   it('inherits root nested installer semantics before normalization', () => {

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -470,6 +470,19 @@ function generateRegistryUninstallCommand(
     const canonicalProductCode = `{${productCodeMatch[1].toUpperCase()}}`;
     return `REGISTRY_UNINSTALL_PRODUCT:${canonicalProductCode}:${normalizedDisplayName}`;
   }
+  const exactRegistryKey = productCode?.trim();
+  const isSafeNamedKey = exactRegistryKey
+    ? /^[A-Za-z0-9][A-Za-z0-9 ._{}()+-]{0,255}$/.test(exactRegistryKey)
+    : false;
+  const isSafeInnoKey = exactRegistryKey
+    ? /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}_[A-Za-z0-9._+-]{1,32}$/.test(exactRegistryKey)
+    : false;
+  if (
+    exactRegistryKey &&
+    (isSafeNamedKey || isSafeInnoKey)
+  ) {
+    return `REGISTRY_UNINSTALL_KEY:${exactRegistryKey}:${normalizedDisplayName}`;
+  }
   return `REGISTRY_UNINSTALL:${normalizedDisplayName}`;
 }
 

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -18,20 +18,43 @@ import { getCatalogSource } from '@/lib/catalog';
 const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests';
 const GITHUB_API_BASE = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests';
 
-function normalizeProductCode(value: unknown): string | undefined {
+function normalizeProductCode(
+  value: unknown,
+  installerType?: unknown
+): string | undefined {
   if (typeof value !== 'string') return undefined;
-  const match = value.trim().match(
+  const candidate = value.trim();
+  const match = candidate.match(
     /^\{?([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})\}?$/
   );
-  return match ? `{${match[1].toUpperCase()}}` : undefined;
+  if (match) return `{${match[1].toUpperCase()}}`;
+
+  // WinGet's ProductCode is the ARP registry key, not necessarily an MSI GUID.
+  // NSIS/Inno/EXE packages commonly publish stable values such as
+  // "IntelliJ IDEA 2025.2.5" or "{GUID}_is1". Preserve a conservative registry
+  // key subset for non-MSI installers so packaging can use exact identity
+  // matching instead of a marketing display-name heuristic.
+  const normalizedType = typeof installerType === 'string'
+    ? installerType.toLowerCase()
+    : '';
+  if (normalizedType === 'msi' || normalizedType === 'wix') return undefined;
+  const isSafeNamedKey = /^[A-Za-z0-9][A-Za-z0-9 ._{}()+-]{0,255}$/.test(candidate);
+  const isSafeInnoKey = /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}_[A-Za-z0-9._+-]{1,32}$/.test(candidate);
+  return isSafeNamedKey || isSafeInnoKey
+    ? candidate
+    : undefined;
 }
 
-function appsAndFeaturesProductCode(value: unknown): string | undefined {
+function appsAndFeaturesProductCode(
+  value: unknown,
+  installerType?: unknown
+): string | undefined {
   if (!Array.isArray(value)) return undefined;
   for (const entry of value) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
     const productCode = normalizeProductCode(
-      (entry as Record<string, unknown>).ProductCode
+      (entry as Record<string, unknown>).ProductCode,
+      installerType
     );
     if (productCode) return productCode;
   }
@@ -455,8 +478,11 @@ function coerceInstallersArray(
     ),
     InstallerSuccessCodes: normalizeInstallerSuccessCodes(inst.InstallerSuccessCodes),
     ProductCode: explicitProductCode
-      ? normalizeProductCode(explicitProductCode)
-      : appsAndFeaturesProductCode(inst.AppsAndFeaturesEntries),
+      ? normalizeProductCode(explicitProductCode, inst.InstallerType || defaultType)
+      : appsAndFeaturesProductCode(
+          inst.AppsAndFeaturesEntries,
+          inst.InstallerType || defaultType
+        ),
     PackageFamilyName: inst.PackageFamilyName as string,
     UpgradeBehavior: inst.UpgradeBehavior as WingetInstaller['UpgradeBehavior'],
     Dependencies: inst.Dependencies as WingetInstaller['Dependencies'],
@@ -600,8 +626,8 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
   const defaultUpgrade = manifest.UpgradeBehavior as string;
   const defaultDependencies = manifest.Dependencies as WingetInstaller['Dependencies'];
   const defaultProductCode =
-    normalizeProductCode(manifest.ProductCode) ||
-    appsAndFeaturesProductCode(manifest.AppsAndFeaturesEntries);
+    normalizeProductCode(manifest.ProductCode, defaultType) ||
+    appsAndFeaturesProductCode(manifest.AppsAndFeaturesEntries, defaultType);
   const defaultPackageFamilyName = manifest.PackageFamilyName as string;
   const defaultSuccessCodes = normalizeInstallerSuccessCodes(manifest.InstallerSuccessCodes);
 
@@ -609,9 +635,13 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     const explicitInstallerProductCode = typeof installer.ProductCode === 'string'
       ? installer.ProductCode.trim()
       : '';
+    const effectiveInstallerType = (installer.InstallerType as string) || defaultType;
     const installerProductCode = explicitInstallerProductCode
-      ? normalizeProductCode(explicitInstallerProductCode)
-      : appsAndFeaturesProductCode(installer.AppsAndFeaturesEntries) || defaultProductCode;
+      ? normalizeProductCode(explicitInstallerProductCode, effectiveInstallerType)
+      : appsAndFeaturesProductCode(
+          installer.AppsAndFeaturesEntries,
+          effectiveInstallerType
+        ) || defaultProductCode;
 
     return ({
     Architecture: (installer.Architecture as WingetInstaller['Architecture']) || 'x64',
@@ -777,7 +807,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     ...(normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes)
       ? { installerSuccessCodes: normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) }
       : {}),
-    productCode: normalizeProductCode(installer.ProductCode),
+    productCode: normalizeProductCode(installer.ProductCode, installer.InstallerType),
     packageFamilyName: installer.PackageFamilyName,
     packageDependencies: packageDependencies.length > 0 ? packageDependencies : undefined,
     windowsFeatures: installer.Dependencies?.WindowsFeatures,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -42,7 +42,8 @@ function generateRegistryUninstallPackage(
   packageDependencies: Array<Record<string, unknown>> = [],
   wingetId = 'IntuneGet.ContractTest',
   uninstallDisplayName = displayName,
-  version = '1.0.0'
+  version = '1.0.0',
+  uninstallCommand = `REGISTRY_UNINSTALL:${uninstallDisplayName}`
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -91,7 +92,7 @@ function generateRegistryUninstallPackage(
         INPUT_SILENT_SWITCHES: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
         INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
         INPUT_PACKAGE_DEPENDENCIES: JSON.stringify(packageDependencies),
-        INPUT_UNINSTALL_COMMAND: `REGISTRY_UNINSTALL:${uninstallDisplayName}`,
+        INPUT_UNINSTALL_COMMAND: uninstallCommand,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: 'setup.exe',
         ...(packageDependencies.length > 0
@@ -917,7 +918,7 @@ describe('PSADT registry uninstall identity contract', () => {
 
   it('supports a reviewed exact non-MSI uninstall registry key', () => {
     expect(packager).toContain(
-      '^REGISTRY_UNINSTALL_KEY:([A-Za-z0-9][A-Za-z0-9._{}+-]{0,255}):(.+)$'
+      '^REGISTRY_UNINSTALL_KEY:((?:[A-Za-z0-9][A-Za-z0-9 ._{}()+-]{0,255}|'
     );
     expect(packager).toContain(
       "$uninstallCmd -match '^REGISTRY_UNINSTALL_(PRODUCT|KEY):'"
@@ -926,6 +927,31 @@ describe('PSADT registry uninstall identity contract', () => {
       '[string]$_.PSChildName -eq $configuredUninstallProductCode'
     );
   });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits a valid exact lifecycle for a named non-MSI ARP key',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'IntelliJ IDEA Ultimate Edition',
+        [],
+        {},
+        [],
+        'JetBrains.IntelliJIDEA.Ultimate',
+        'IntelliJ IDEA Ultimate Edition',
+        '2025.2.5',
+        'REGISTRY_UNINSTALL_KEY:IntelliJ IDEA 2025.2.5:IntelliJ IDEA Ultimate Edition'
+      );
+
+      expect(generated).toContain(
+        "$configuredUninstallProductCode = 'IntelliJ IDEA 2025.2.5'"
+      );
+      expect(generated).toContain(
+        'No captured entry; searching for manifest registry key: $configuredProductCode'
+      );
+    },
+    30_000
+  );
 
   it('selects one architecture-decorated ARP entry without accepting an ambiguous set', () => {
     expect(packager).toContain('$configuredUninstallComparableName = ((');

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -283,7 +283,7 @@ describe('buildQaCatalogTestConfig', () => {
         Architecture: 'x64',
         InstallerType: 'exe',
         AppsAndFeaturesEntries: [
-          { ProductCode: 'not-a-guid' },
+          { ProductCode: 'not\\a:guid' },
           { ProductCode: '{33333333-3333-3333-3333-333333333333}' },
         ],
       },
@@ -311,8 +311,39 @@ describe('buildQaCatalogTestConfig', () => {
       },
     });
 
-    expect(config.productCode).toBe('');
-    expect(config.uninstallCommand).toBe('REGISTRY_UNINSTALL:Contoso Inno App');
+    expect(config.productCode).toBe(
+      '{22222222-2222-2222-2222-222222222222}_is1'
+    );
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:{22222222-2222-2222-2222-222222222222}_is1:Contoso Inno App'
+    );
+  });
+
+  it('uses a root non-MSI ProductCode as the exact ARP lifecycle identity', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'JetBrains.IntelliJIDEA.Ultimate',
+        name: 'IntelliJ IDEA Ultimate Edition',
+        publisher: 'JetBrains',
+        version: '2025.2.5',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        ProductCode: 'IntelliJ IDEA 2025.2.5',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/idea.exe',
+        InstallerSha256: 'A'.repeat(64),
+        InstallerType: 'nullsoft',
+        Scope: 'machine',
+      },
+    });
+
+    expect(config.productCode).toBe('IntelliJ IDEA 2025.2.5');
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:IntelliJ IDEA 2025.2.5:IntelliJ IDEA Ultimate Edition'
+    );
   });
 
   it('inherits a root package family name for user-scoped MSIX handling', () => {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -51,12 +51,30 @@ function record(value: unknown): ManifestRecord {
     : {};
 }
 
-function appsAndFeaturesProductCode(installer: ManifestRecord): string {
+function registryProductCode(value: unknown, allowNonGuid: boolean): string {
+  const candidate = text(value);
+  const canonicalGuid = msiProductCode(candidate);
+  if (canonicalGuid) return canonicalGuid;
+  if (!allowNonGuid) return '';
+  const isSafeNamedKey = /^[A-Za-z0-9][A-Za-z0-9 ._{}()+-]{0,255}$/.test(candidate);
+  const isSafeInnoKey = /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}_[A-Za-z0-9._+-]{1,32}$/.test(candidate);
+  return isSafeNamedKey || isSafeInnoKey
+    ? candidate
+    : '';
+}
+
+function appsAndFeaturesProductCode(
+  installer: ManifestRecord,
+  allowNonGuid: boolean
+): string {
   const entries = Array.isArray(installer.AppsAndFeaturesEntries)
     ? installer.AppsAndFeaturesEntries
     : [];
   for (const entry of entries) {
-    const productCode = msiProductCode(record(entry).ProductCode);
+    const productCode = registryProductCode(
+      record(entry).ProductCode,
+      allowNonGuid
+    );
     if (productCode) return productCode;
   }
   return '';
@@ -124,12 +142,13 @@ export function buildQaCatalogTestConfig({
     : undefined;
   const rawScope = text(installer.Scope) || text(manifest.Scope);
   const scope: WingetScope = resolveApplicationInstallScope(app.wingetId, rawScope);
+  const allowNonGuidProductCode = !['msi', 'wix'].includes(sourceInstallerType);
   const explicitInstallerProductCode = text(installer.ProductCode);
   const productCode = explicitInstallerProductCode
-    ? msiProductCode(explicitInstallerProductCode)
-    : appsAndFeaturesProductCode(installer) ||
-      msiProductCode(manifest.ProductCode) ||
-      appsAndFeaturesProductCode(manifest);
+    ? registryProductCode(explicitInstallerProductCode, allowNonGuidProductCode)
+    : appsAndFeaturesProductCode(installer, allowNonGuidProductCode) ||
+      registryProductCode(manifest.ProductCode, allowNonGuidProductCode) ||
+      appsAndFeaturesProductCode(manifest, allowNonGuidProductCode);
   const packageFamilyName =
     text(installer.PackageFamilyName) || text(manifest.PackageFamilyName);
   const inheritedInstaller: WingetInstaller = {


### PR DESCRIPTION
## Summary
- preserve safe WinGet non-MSI ProductCode values as exact ARP registry keys
- emit and parse exact REGISTRY_UNINSTALL_KEY markers with named/versioned keys
- apply the same identity handling to QA and customer PSADT packaging

## Validation
- 238 focused tests passed
- ESLint passed for all changed TypeScript files
- generated PSADT lifecycle parses successfully for IntelliJ's exact ARP key