### PR TITLE
Activate exact non-MSI identity packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '94c8f81e38ac180048f86dbf2df7f987fa448676',
+  packagerCommit: 'af4dfb94c9109ca598abc16a4b8cad57f6790066',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -13,7 +13,7 @@ describe('QA toolchain targeted retries', () => {
       'Mega.MEGASync',
       'AOMEI.PartitionAssistant',
       'Omnissa.HorizonClient',
-      'Ecosia.EcosiaBrowser',
+      'JetBrains.IntelliJIDEA.Ultimate',
     ]));
 
     targets.length = 0;
@@ -24,7 +24,7 @@ describe('QA toolchain targeted retries', () => {
         'Mega.MEGASync',
         'AOMEI.PartitionAssistant',
         'Omnissa.HorizonClient',
-        'Ecosia.EcosiaBrowser',
+        'JetBrains.IntelliJIDEA.Ultimate',
       ])
     );
   });
@@ -420,8 +420,19 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Ecosia once with Chromium silent removal', () => {
     expect(shouldRetryTerminalToolchainCandidate(
+      '94c8f81e38ac180048f86dbf2df7f987fa448676',
+      { wingetId: 'ECOSIA.ECOSIABROWSER', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'ECOSIA.ECOSIABROWSER', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries IntelliJ Ultimate with its exact named ARP key', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'jetbrains.intellijidea.ultimate', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -455,6 +455,22 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // confirmation UI. This release appends --force-uninstall for one retry.
     'Ecosia.EcosiaBrowser',
   ],
+  'af4dfb94c9109ca598abc16a4b8cad57f6790066': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Omnissa.HorizonClient',
+    // IntelliJ publishes a stable, versioned non-MSI ProductCode. Preserve it
+    // as the exact ARP registry key for QA and customer package lifecycle.
+    'JetBrains.IntelliJIDEA.Ultimate',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA profiles to packager af4dfb94
- retry IntelliJ Ultimate once with its exact named ARP key
- retain unresolved targeted lifecycle retries without replaying repaired Ecosia

## Validation
- 131 focused tests passed
- ESLint passed