### PR TITLE
Activate install4j uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'af4dfb94c9109ca598abc16a4b8cad57f6790066',
+  packagerCommit: '22b8e738d51a612f68b01c83b705d2dabc3bbcff',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -78,6 +78,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '461c2757292d3b7bcde33682d3f7b33e566b1fea',
   '02f93d590887282aca0037412c8786785ddc6486',
   'ca77e52dc65a404eb81679c5188378bf4d69a692',
+  'af4dfb94c9109ca598abc16a4b8cad57f6790066',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -12,8 +12,7 @@ describe('QA toolchain targeted retries', () => {
       'PDFsam.PDFsam',
       'Mega.MEGASync',
       'AOMEI.PartitionAssistant',
-      'Omnissa.HorizonClient',
-      'JetBrains.IntelliJIDEA.Ultimate',
+      'Ringler.SnapformViewer',
     ]));
 
     targets.length = 0;
@@ -23,8 +22,7 @@ describe('QA toolchain targeted retries', () => {
         'PDFsam.PDFsam',
         'Mega.MEGASync',
         'AOMEI.PartitionAssistant',
-        'Omnissa.HorizonClient',
-        'JetBrains.IntelliJIDEA.Ultimate',
+        'Ringler.SnapformViewer',
       ])
     );
   });
@@ -413,9 +411,13 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries Horizon Client after suppressing Burn uninstall restarts', () => {
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      'af4dfb94c9109ca598abc16a4b8cad57f6790066',
       { wingetId: 'OMNISSA.HORIZONCLIENT', status: 'failed' }
     )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'OMNISSA.HORIZONCLIENT', status: 'failed' }
+    )).toBe(false);
   });
 
   it('retries Ecosia once with Chromium silent removal', () => {
@@ -431,8 +433,19 @@ describe('QA toolchain targeted retries', () => {
 
   it('retries IntelliJ Ultimate with its exact named ARP key', () => {
     expect(shouldRetryTerminalToolchainCandidate(
+      'af4dfb94c9109ca598abc16a4b8cad57f6790066',
+      { wingetId: 'jetbrains.intellijidea.ultimate', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'jetbrains.intellijidea.ultimate', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Snapform Viewer with install4j unattended removal', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ringler.snapformviewer', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -471,6 +471,21 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // as the exact ARP registry key for QA and customer package lifecycle.
     'JetBrains.IntelliJIDEA.Ultimate',
   ],
+  '22b8e738d51a612f68b01c83b705d2dabc3bbcff': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    // install4j registers its canonical .install4j uninstaller without quiet
+    // arguments. The shared packager now applies its documented unattended mode.
+    'Ringler.SnapformViewer',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager revision 22b8e738d51a612f68b01c83b705d2dabc3bbcff
- preserve passes from the previous revision because this only repairs a previously failing install4j path
- retry Snapform Viewer once with documented unattended removal
- do not requeue IntelliJ or Horizon Client after their successful current-version tests

## Verification
- npm test -- lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (105 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check