### PR TITLE
Activate MSI uninstall path fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '22b8e738d51a612f68b01c83b705d2dabc3bbcff',
+  packagerCommit: 'cc143c874f2e84f06097cb199ad9998344040ded',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -79,6 +79,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   '02f93d590887282aca0037412c8786785ddc6486',
   'ca77e52dc65a404eb81679c5188378bf4d69a692',
   'af4dfb94c9109ca598abc16a4b8cad57f6790066',
+  '22b8e738d51a612f68b01c83b705d2dabc3bbcff',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -13,6 +13,8 @@ describe('QA toolchain targeted retries', () => {
       'Mega.MEGASync',
       'AOMEI.PartitionAssistant',
       'Ringler.SnapformViewer',
+      'Cisco.Jabber',
+      'IPEVO.Visualizer',
     ]));
 
     targets.length = 0;
@@ -23,6 +25,8 @@ describe('QA toolchain targeted retries', () => {
         'Mega.MEGASync',
         'AOMEI.PartitionAssistant',
         'Ringler.SnapformViewer',
+        'Cisco.Jabber',
+        'IPEVO.Visualizer',
       ])
     );
   });
@@ -446,6 +450,16 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'ringler.snapformviewer', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it.each([
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+  ])('retries %s after bypassing empty EXE path parsing for exact MSI removal', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -486,6 +486,24 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // arguments. The shared packager now applies its documented unattended mode.
     'Ringler.SnapformViewer',
   ],
+  'cc143c874f2e84f06097cb199ad9998344040ded': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    // These MSI packages registered an authoritative ProductCode while their
+    // parsed executable uninstall path was empty. The shared packager now
+    // reaches the MSI branch before attempting any EXE path normalization.
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin the QA and customer PSADT toolchain to the MSI-safe shared packager
- retain compatible passes from the preceding release because the change only affects a previously failing uninstall path
- target Cisco Jabber, IPEVO Visualizer, and the outstanding Snapform lifecycle for one controlled retry

## Validation
- 134 focused QA profile, scheduler, and retry tests pass
- ESLint passes for all touched files
- git diff --check passes