### PR TITLE
Add VirusTotal security check to QA results and live pipeline

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -11,7 +11,9 @@ import {
   Monitor,
   Radio,
   Server,
+  ShieldAlert,
   ShieldCheck,
+  ShieldQuestion,
   XCircle,
 } from 'lucide-react';
 import { AppIcon } from '@/components/AppIcon';
@@ -29,7 +31,7 @@ import {
   getQaPhasePresentation,
 } from '@/lib/qa/presentation';
 import { cn } from '@/lib/utils';
-import type { QaLivePhase, QaLiveResponse } from '@/types/qa';
+import type { QaLivePhase, QaLiveResponse, QaVirusTotalStatus } from '@/types/qa';
 
 function healthTone(state: string): StatusTone {
   if (state === 'healthy' || state === 'testing') return 'success';
@@ -47,6 +49,7 @@ function schedulerIssueLabel(issue: QaLiveResponse['scheduler']['issue']): strin
 
 function QaPhaseLabel({ phase }: { phase: QaLivePhase }) {
   if (phase === 'queued') return <T>Queued</T>;
+  if (phase === 'scanning_installer') return <T>Checking installer reputation</T>;
   if (phase === 'preparing_package') return <T>Preparing package</T>;
   if (phase === 'restoring_vm') return <T>Restoring golden VM</T>;
   if (phase === 'installing') return <T>Installing</T>;
@@ -72,6 +75,34 @@ function QaResultStatus({ outcome }: { outcome: 'Passed' | 'Failed' }) {
       <T>{outcome}</T>
     </span>
   );
+}
+
+function QaVirusTotalCell({ status }: { status: QaVirusTotalStatus | null }) {
+  if (status === 'clean') {
+    return (
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs font-medium text-status-success">
+        <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <T>Clean</T>
+      </span>
+    );
+  }
+  if (status === 'flagged') {
+    return (
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs font-medium text-status-error">
+        <ShieldAlert className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <T>Flagged</T>
+      </span>
+    );
+  }
+  if (status === 'not_found') {
+    return (
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-text-muted">
+        <ShieldQuestion className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <T>Not analyzed</T>
+      </span>
+    );
+  }
+  return <span className="text-xs text-text-muted" aria-hidden="true">—</span>;
 }
 
 function resultEdgeClass(outcome: 'Passed' | 'Failed'): string {
@@ -515,7 +546,12 @@ function DashboardContent() {
                         {formatRelativeTime(item.testedAtUtc, data.serverTime) ?? <T>Test time unavailable</T>}
                       </span>
                     </span>
-                    <QaResultStatus outcome={item.outcome} />
+                    <span className="flex flex-col items-end gap-1">
+                      <QaResultStatus outcome={item.outcome} />
+                      {item.virusTotalStatus === 'clean' || item.virusTotalStatus === 'flagged' ? (
+                        <QaVirusTotalCell status={item.virusTotalStatus} />
+                      ) : null}
+                    </span>
                   </button>
                 ))}
               </div>
@@ -526,6 +562,7 @@ function DashboardContent() {
                     <tr>
                       <th className="px-6 py-3 font-medium"><T>Application</T></th>
                       <th className="px-3 py-3 font-medium"><T>Result</T></th>
+                      <th className="px-3 py-3 font-medium"><T>VirusTotal</T></th>
                       <th className="px-3 py-3 font-medium"><T>Duration</T></th>
                       <th className="px-6 py-3 font-medium"><T>Tested</T></th>
                     </tr>
@@ -560,6 +597,9 @@ function DashboardContent() {
                         </td>
                         <td className="px-3 py-3">
                           <QaResultStatus outcome={item.outcome} />
+                        </td>
+                        <td className="px-3 py-3">
+                          <QaVirusTotalCell status={item.virusTotalStatus} />
                         </td>
                         <td className="px-3 py-3 font-mono text-xs text-text-secondary">{formatQaDuration(item.durationSeconds)}</td>
                         <td className="whitespace-nowrap px-6 py-3 text-xs text-text-muted">

--- a/app/api/apps/[id]/qa/route.ts
+++ b/app/api/apps/[id]/qa/route.ts
@@ -64,6 +64,15 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       relevantEventCount: row.relevant_event_count,
       environment: row.environment,
       effectiveConfiguration: row.effective_configuration,
+      virusTotal: row.virustotal_status
+        ? {
+            status: row.virustotal_status,
+            malicious: row.virustotal_malicious ?? null,
+            suspicious: row.virustotal_suspicious ?? null,
+            totalEngines: row.virustotal_total_engines ?? null,
+            scannedAtUtc: row.virustotal_scanned_at_utc ?? null,
+          }
+        : null,
       package: {
         testLevel: row.test_level,
         profileSha256: row.package_profile_sha256,

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -11,7 +11,9 @@ import {
   PackageCheck,
   RefreshCw,
   Settings2,
+  ShieldAlert,
   ShieldCheck,
+  ShieldQuestion,
   TerminalSquare,
   XCircle,
 } from 'lucide-react';
@@ -33,6 +35,7 @@ import {
   type QaChangeSet,
   type QaPhaseResult,
   type QaPromptConfiguration,
+  type QaVirusTotalSummary,
 } from '@/types/qa';
 
 interface QaDetailsDialogProps {
@@ -201,6 +204,92 @@ function LifecycleCard({ name, result }: { name: string; result: QaPhaseResult |
   );
 }
 
+function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
+  const clean = virusTotal.status === 'clean';
+  const flagged = virusTotal.status === 'flagged';
+  const flaggedCount = (virusTotal.malicious ?? 0) + (virusTotal.suspicious ?? 0);
+  const totalEngines = virusTotal.totalEngines ?? 0;
+  const Icon = clean ? ShieldCheck : flagged ? ShieldAlert : ShieldQuestion;
+
+  return (
+    <section
+      aria-labelledby="qa-virustotal-heading"
+      className={cn(
+        'relative overflow-hidden rounded-2xl border p-5 sm:p-6',
+        clean && 'border-status-success/25 bg-gradient-to-br from-status-success/15 via-status-success/5 to-transparent',
+        flagged && 'border-status-error/25 bg-gradient-to-br from-status-error/15 via-status-error/5 to-transparent',
+        !clean && !flagged && 'border-overlay/10 bg-bg-elevated/40'
+      )}
+    >
+      <Icon
+        aria-hidden="true"
+        className={cn(
+          'pointer-events-none absolute -right-5 -top-5 h-32 w-32 opacity-[0.07]',
+          clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-muted'
+        )}
+      />
+      <div className="relative flex items-start gap-4">
+        <span
+          className={cn(
+            'flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ring-4',
+            clean && 'bg-status-success/15 text-status-success ring-status-success/10',
+            flagged && 'bg-status-error/15 text-status-error ring-status-error/10',
+            !clean && !flagged && 'bg-overlay/10 text-text-muted ring-overlay/5'
+          )}
+        >
+          <Icon className="h-6 w-6" aria-hidden="true" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p
+            className={cn(
+              'text-xs font-medium uppercase tracking-[0.16em]',
+              clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-muted'
+            )}
+          >
+            <T>VirusTotal security check</T>
+          </p>
+          <h3
+            id="qa-virustotal-heading"
+            className={cn(
+              'mt-1 text-lg font-semibold sm:text-xl',
+              clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-primary'
+            )}
+          >
+            {clean ? (
+              <T>No threats found</T>
+            ) : flagged ? (
+              <T><Var>{flaggedCount}</Var> of <Var>{totalEngines}</Var> security vendors flagged this installer</T>
+            ) : virusTotal.status === 'not_found' ? (
+              <T>No verdict available yet</T>
+            ) : (
+              <T>Security check unavailable</T>
+            )}
+          </h3>
+          <p className="mt-1.5 text-sm leading-6 text-text-secondary">
+            {clean ? (
+              <T><Var>{virusTotal.malicious ?? 0}</Var> of <Var>{totalEngines}</Var> security vendors flagged this installer when its verified hash was checked against the VirusTotal database.</T>
+            ) : flagged ? (
+              <T><Var>{virusTotal.malicious ?? 0}</Var> vendors rated it malicious and <Var>{virusTotal.suspicious ?? 0}</Var> suspicious. A small number of detections is often a false positive for installers — review the flagged engines on VirusTotal before drawing conclusions.</T>
+            ) : virusTotal.status === 'not_found' ? (
+              <T>This installer version is not in the VirusTotal database yet, so no reputation verdict is available.</T>
+            ) : virusTotal.status === 'skipped' ? (
+              <T>The VirusTotal lookup was not configured when this run executed.</T>
+            ) : (
+              <T>The VirusTotal lookup could not be completed for this run.</T>
+            )}
+          </p>
+          <p className="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
+            <span><T>Hash-only lookup — the installer is never uploaded</T></span>
+            {virusTotal.scannedAtUtc ? (
+              <span><T>Last analyzed <Var>{new Date(virusTotal.scannedAtUtc).toLocaleDateString()}</Var></T></span>
+            ) : null}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function DetailsSkeleton({ wingetId }: { wingetId: string }) {
   return (
     <div className="space-y-6" aria-label="Loading QA result">
@@ -325,6 +414,8 @@ export function QaDetailsDialog({
                   </SummaryItem>
                 </div>
               </section>
+
+              {data.virusTotal ? <VirusTotalBanner virusTotal={data.virusTotal} /> : null}
 
               {data.testedVersion !== catalogVersion ? (
                 <div className="flex gap-3 rounded-2xl border border-status-warning/20 bg-status-warning/10 p-4 text-sm leading-6 text-status-warning">

--- a/components/qa/QaLiveStepTimeline.tsx
+++ b/components/qa/QaLiveStepTimeline.tsx
@@ -9,6 +9,7 @@ import {
   RotateCcw,
   SearchCheck,
   Send,
+  ShieldCheck,
   Trash2,
   type LucideIcon,
 } from 'lucide-react';
@@ -26,6 +27,13 @@ interface TimelineStep {
 }
 
 const STEPS: TimelineStep[] = [
+  {
+    phase: 'scanning_installer',
+    label: 'Security scan',
+    description: 'Check the verified installer hash against the VirusTotal database.',
+    tasks: ['Query 70+ security vendors by SHA-256', 'Record the reputation verdict'],
+    Icon: ShieldCheck,
+  },
   {
     phase: 'preparing_package',
     label: 'Prepare the package',

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -396,7 +396,7 @@ export class SupabaseCatalogSource implements CatalogSource {
       const { data, error } = await supabase
         .from('qa_package_results')
         .select(
-          'package_profile_sha256, winget_id, display_name, publisher, tested_version, architecture, installer_sha256, outcome, tested_at_utc, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256'
+          'package_profile_sha256, winget_id, display_name, publisher, tested_version, architecture, installer_sha256, outcome, tested_at_utc, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256, virustotal_status, virustotal_malicious, virustotal_suspicious, virustotal_total_engines, virustotal_scanned_at_utc'
         )
         .eq('winget_id', wingetId)
         .eq('package_profile_sha256', packageProfileSha256.toUpperCase())
@@ -423,7 +423,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     const { data, error } = await supabase
       .from('qa_results')
       .select(
-        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, installer_sha256, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, synced_at, test_level, package_profile_sha256, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256'
+        'winget_id, display_name, publisher, tested_version, architecture, outcome, tested_at_utc, installer_sha256, overall_duration_seconds, installer_type, install_command, uninstall_command, detection, phase_results, changes, relevant_event_count, environment, effective_configuration, qa_schema_version, synced_at, test_level, package_profile_sha256, psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256, packager_commit, package_content_sha256, virustotal_status, virustotal_malicious, virustotal_suspicious, virustotal_total_engines, virustotal_scanned_at_utc'
       )
       .eq('winget_id', wingetId)
       .eq('test_level', 'psadt-package')

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -4,12 +4,12 @@ import { createServerClient } from '@/lib/supabase';
 import { QA_LIVE_FRAME_MAX_AGE_MS } from '@/lib/qa/constants';
 import { getQaPipelineControl, type QaPipelineControl } from '@/lib/qa/pipeline-control';
 import type { Json } from '@/types/database';
-import type { QaArchitecture, QaLiveActivity, QaLiveLog, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome } from '@/types/qa';
+import type { QaArchitecture, QaLiveActivity, QaLiveLog, QaLivePhase, QaLiveResponse, QaLiveUiConfiguration, QaOutcome, QaVirusTotalStatus } from '@/types/qa';
 
 const RUNNER_STALE_MS = 10 * 60 * 1000;
 const POLL_STALE_MS = 5 * 60 * 1000;
 export const QA_LIVE_RECENT_RESULT_COLUMNS =
-  'winget_id, package_profile_sha256, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds';
+  'winget_id, package_profile_sha256, tested_version, architecture, outcome, tested_at_utc, overall_duration_seconds, virustotal_status';
 
 interface CandidateRow {
   id: string;
@@ -56,6 +56,7 @@ interface ResultRow {
   outcome: string;
   tested_at_utc: string;
   overall_duration_seconds?: number | null;
+  virustotal_status?: string | null;
 }
 
 interface AppRow {
@@ -80,6 +81,7 @@ export interface QaLiveSnapshotInput {
 
 const VALID_PHASES = new Set<QaLivePhase>([
   'queued',
+  'scanning_installer',
   'preparing_package',
   'restoring_vm',
   'installing',
@@ -92,6 +94,12 @@ const LIVE_ACTIVITY_TARGET = /^(?:%(?:PROGRAMFILES|PROGRAMFILES\(X86\)|PROGRAMDA
 
 function architecture(value: string): QaArchitecture {
   return value === 'x86' || value === 'arm64' ? value : 'x64';
+}
+
+function virusTotalStatus(value: string | null | undefined): QaVirusTotalStatus | null {
+  return value === 'clean' || value === 'flagged' || value === 'not_found' || value === 'error' || value === 'skipped'
+    ? value
+    : null;
 }
 
 function latestRecentResultPerRelease(results: ResultRow[]): ResultRow[] {
@@ -377,6 +385,7 @@ export function buildQaLiveResponse(input: QaLiveSnapshotInput): QaLiveResponse 
       outcome: result.outcome === 'Passed' ? 'Passed' : ('Failed' as QaOutcome),
       testedAtUtc: result.tested_at_utc,
       durationSeconds: result.overall_duration_seconds ?? null,
+      virusTotalStatus: virusTotalStatus(result.virustotal_status),
     })),
   };
 }

--- a/lib/qa/presentation.test.ts
+++ b/lib/qa/presentation.test.ts
@@ -10,9 +10,18 @@ describe('QA presentation helpers', () => {
   it('maps an active phase to a compact step presentation', () => {
     expect(getQaPhasePresentation('installing')).toEqual({
       label: 'Installing',
-      step: 3,
-      totalSteps: 7,
-      progressPercent: 43,
+      step: 4,
+      totalSteps: 8,
+      progressPercent: 50,
+    });
+  });
+
+  it('presents the VirusTotal reputation lookup as the first execution step', () => {
+    expect(getQaPhasePresentation('scanning_installer')).toEqual({
+      label: 'Checking installer reputation',
+      step: 1,
+      totalSteps: 8,
+      progressPercent: 13,
     });
   });
 
@@ -20,7 +29,7 @@ describe('QA presentation helpers', () => {
     expect(getQaPhasePresentation('queued')).toEqual({
       label: 'Queued',
       step: 0,
-      totalSteps: 7,
+      totalSteps: 8,
       progressPercent: 0,
     });
   });

--- a/lib/qa/presentation.ts
+++ b/lib/qa/presentation.ts
@@ -1,6 +1,7 @@
 import type { QaLivePhase } from '@/types/qa';
 
 const QA_PHASES: Array<{ id: QaLivePhase; label: string }> = [
+  { id: 'scanning_installer', label: 'Checking installer reputation' },
   { id: 'preparing_package', label: 'Preparing package' },
   { id: 'restoring_vm', label: 'Restoring golden VM' },
   { id: 'installing', label: 'Installing' },

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -56,6 +56,8 @@ const QA_COLUMNS = [
   'relevant_event_count', 'environment', 'effective_configuration', 'qa_schema_version', 'synced_at',
   'test_level', 'package_profile_sha256', 'psadt_version', 'psadt_template_sha256',
   'psadt_config_sha256', 'detection_rules_sha256', 'packager_commit', 'package_content_sha256',
+  'virustotal_status', 'virustotal_malicious', 'virustotal_suspicious',
+  'virustotal_total_engines', 'virustotal_scanned_at_utc',
 ];
 
 /** Fetch every row of a table in pages (Supabase caps a single request at 1000). */
@@ -127,7 +129,9 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
         qa_schema_version INTEGER NOT NULL,
         synced_at TEXT NOT NULL, test_level TEXT NOT NULL, package_profile_sha256 TEXT,
         psadt_version TEXT, psadt_template_sha256 TEXT, psadt_config_sha256 TEXT,
-        detection_rules_sha256 TEXT, packager_commit TEXT, package_content_sha256 TEXT
+        detection_rules_sha256 TEXT, packager_commit TEXT, package_content_sha256 TEXT,
+        virustotal_status TEXT, virustotal_malicious INTEGER, virustotal_suspicious INTEGER,
+        virustotal_total_engines INTEGER, virustotal_scanned_at_utc TEXT
       );
     `);
 
@@ -157,13 +161,15 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
        uninstall_command, detection, phase_results, changes, relevant_event_count,
        environment, effective_configuration, qa_schema_version, synced_at, test_level, package_profile_sha256,
        psadt_version, psadt_template_sha256, psadt_config_sha256, detection_rules_sha256,
-       packager_commit, package_content_sha256)
+       packager_commit, package_content_sha256, virustotal_status, virustotal_malicious,
+       virustotal_suspicious, virustotal_total_engines, virustotal_scanned_at_utc)
       VALUES (@winget_id,@display_name,@publisher,@tested_version,@architecture,@outcome,@installer_sha256,
        @tested_at_utc,@overall_duration_seconds,@installer_type,@install_command,
        @uninstall_command,@detection,@phase_results,@changes,@relevant_event_count,
        @environment,@effective_configuration,@qa_schema_version,@synced_at,@test_level,@package_profile_sha256,
        @psadt_version,@psadt_template_sha256,@psadt_config_sha256,@detection_rules_sha256,
-       @packager_commit,@package_content_sha256)`);
+       @packager_commit,@package_content_sha256,@virustotal_status,@virustotal_malicious,
+       @virustotal_suspicious,@virustotal_total_engines,@virustotal_scanned_at_utc)`);
 
     const tx = db.transaction(() => {
       for (const a of curatedApps) {
@@ -230,6 +236,11 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           detection_rules_sha256: q.detection_rules_sha256 ?? null,
           packager_commit: q.packager_commit ?? null,
           package_content_sha256: q.package_content_sha256 ?? null,
+          virustotal_status: q.virustotal_status ?? null,
+          virustotal_malicious: q.virustotal_malicious ?? null,
+          virustotal_suspicious: q.virustotal_suspicious ?? null,
+          virustotal_total_engines: q.virustotal_total_engines ?? null,
+          virustotal_scanned_at_utc: q.virustotal_scanned_at_utc ?? null,
         });
       }
     });

--- a/supabase/migrations/20260815120000_qa_virustotal_verdict.sql
+++ b/supabase/migrations/20260815120000_qa_virustotal_verdict.sql
@@ -1,0 +1,158 @@
+-- Informational VirusTotal hash-lookup verdict for QA results. The verdict is
+-- produced on the QA host from the already-public installer SHA-256 before
+-- packaging; no file content is ever uploaded to VirusTotal and the verdict
+-- never gates the QA outcome. Absent columns mean the run predates the check.
+alter table public.qa_results
+  add column if not exists virustotal_status text,
+  add column if not exists virustotal_malicious integer,
+  add column if not exists virustotal_suspicious integer,
+  add column if not exists virustotal_total_engines integer,
+  add column if not exists virustotal_scanned_at_utc timestamptz;
+
+alter table public.qa_package_results
+  add column if not exists virustotal_status text,
+  add column if not exists virustotal_malicious integer,
+  add column if not exists virustotal_suspicious integer,
+  add column if not exists virustotal_total_engines integer,
+  add column if not exists virustotal_scanned_at_utc timestamptz;
+
+do $$
+declare
+  target text;
+begin
+  foreach target in array array['qa_results', 'qa_package_results'] loop
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = target || '_virustotal_status_check'
+        and conrelid = ('public.' || target)::regclass
+    ) then
+      execute format(
+        'alter table public.%I add constraint %I check (virustotal_status is null or virustotal_status in (%L, %L, %L, %L, %L))',
+        target, target || '_virustotal_status_check',
+        'clean', 'flagged', 'not_found', 'error', 'skipped'
+      );
+    end if;
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = target || '_virustotal_counts_check'
+        and conrelid = ('public.' || target)::regclass
+    ) then
+      execute format(
+        'alter table public.%I add constraint %I check (
+           coalesce(virustotal_malicious, 0) >= 0
+           and coalesce(virustotal_suspicious, 0) >= 0
+           and coalesce(virustotal_total_engines, 0) >= 0
+         )',
+        target, target || '_virustotal_counts_check'
+      );
+    end if;
+  end loop;
+end
+$$;
+
+-- Extend the synchronization wrapper so the verdict rides the existing result
+-- payload. The private metadata helper stays untouched; this wrapper keeps the
+-- exact package-detail enrichment from 20260812163353 and adds the VirusTotal
+-- columns for both the exact package rows and the canonical catalog rows.
+create or replace function public.sync_qa_results_v2(
+  p_secret text,
+  p_rows jsonb,
+  p_recipes jsonb,
+  p_allow_large_delete boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  sync_result jsonb;
+begin
+  sync_result := public.sync_qa_results_v2_metadata_only(
+    p_secret,
+    p_rows,
+    p_recipes,
+    p_allow_large_delete
+  );
+
+  update public.qa_package_results as package_result
+  set display_name = row_data.display_name,
+      publisher = row_data.publisher,
+      installer_type = row_data.installer_type,
+      install_command = row_data.install_command,
+      uninstall_command = row_data.uninstall_command,
+      detection = row_data.detection,
+      phase_results = row_data.phase_results,
+      changes = row_data.changes,
+      relevant_event_count = row_data.relevant_event_count,
+      environment = row_data.environment,
+      effective_configuration = row_data.effective_configuration,
+      qa_schema_version = row_data.qa_schema_version,
+      profile_kind = coalesce(nullif(row_data.profile_kind, ''), 'catalog-default'),
+      virustotal_status = row_data.virustotal_status,
+      virustotal_malicious = row_data.virustotal_malicious,
+      virustotal_suspicious = row_data.virustotal_suspicious,
+      virustotal_total_engines = row_data.virustotal_total_engines,
+      virustotal_scanned_at_utc = row_data.virustotal_scanned_at_utc
+  from pg_catalog.jsonb_to_recordset(p_rows) as row_data(
+    package_profile_sha256 text,
+    tested_at_utc timestamptz,
+    test_level text,
+    display_name text,
+    publisher text,
+    installer_type text,
+    install_command text,
+    uninstall_command text,
+    detection jsonb,
+    phase_results jsonb,
+    changes jsonb,
+    relevant_event_count integer,
+    environment jsonb,
+    effective_configuration jsonb,
+    qa_schema_version integer,
+    profile_kind text,
+    virustotal_status text,
+    virustotal_malicious integer,
+    virustotal_suspicious integer,
+    virustotal_total_engines integer,
+    virustotal_scanned_at_utc timestamptz
+  )
+  where row_data.test_level = 'psadt-package'
+    and upper(row_data.package_profile_sha256) = package_result.package_profile_sha256
+    and row_data.tested_at_utc >= package_result.tested_at_utc;
+
+  update public.qa_results as result
+  set virustotal_status = row_data.virustotal_status,
+      virustotal_malicious = row_data.virustotal_malicious,
+      virustotal_suspicious = row_data.virustotal_suspicious,
+      virustotal_total_engines = row_data.virustotal_total_engines,
+      virustotal_scanned_at_utc = row_data.virustotal_scanned_at_utc
+  from pg_catalog.jsonb_to_recordset(p_rows) as row_data(
+    winget_id text,
+    tested_at_utc timestamptz,
+    profile_kind text,
+    virustotal_status text,
+    virustotal_malicious integer,
+    virustotal_suspicious integer,
+    virustotal_total_engines integer,
+    virustotal_scanned_at_utc timestamptz
+  )
+  where coalesce(nullif(row_data.profile_kind, ''), 'catalog-default') = 'catalog-default'
+    and result.winget_id = row_data.winget_id
+    and row_data.tested_at_utc >= result.tested_at_utc;
+
+  return sync_result;
+end;
+$$;
+
+revoke all on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  from public, authenticated, service_role;
+grant execute on function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  to anon;
+
+comment on column public.qa_results.virustotal_status is
+  'Informational VirusTotal hash-lookup verdict: clean, flagged, not_found, error, or skipped. Hash-only lookup; never gates the QA outcome.';
+comment on column public.qa_package_results.virustotal_status is
+  'Informational VirusTotal hash-lookup verdict: clean, flagged, not_found, error, or skipped. Hash-only lookup; never gates the QA outcome.';

--- a/supabase/migrations/20260815130000_qa_scanning_installer_phase.sql
+++ b/supabase/migrations/20260815130000_qa_scanning_installer_phase.sql
@@ -1,0 +1,80 @@
+-- The VirusTotal reputation lookup is now a first-class live QA phase. It runs
+-- on the host between marking the candidate running and package preparation,
+-- so the public live timeline can show the security check as its own step.
+alter table public.qa_candidates
+  drop constraint if exists qa_candidates_phase_check;
+
+alter table public.qa_candidates
+  add constraint qa_candidates_phase_check check (
+    phase is null or phase in (
+      'queued',
+      'scanning_installer',
+      'preparing_package',
+      'restoring_vm',
+      'installing',
+      'detecting_install',
+      'uninstalling',
+      'verifying_removal',
+      'publishing'
+    )
+  );
+
+create or replace function public.publish_qa_candidate_phase(
+  p_secret text,
+  p_candidate_id uuid,
+  p_phase text,
+  p_observed_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  expected_secret_hash constant text := 'becb40ddd30dcf9fc45551f1ff4e515ea1512cb9692d977f44f0323a216d0921';
+  updated_count integer;
+begin
+  if encode(extensions.digest(coalesce(p_secret, ''), 'sha256'), 'hex') <> expected_secret_hash then
+    raise insufficient_privilege using message = 'Invalid QA synchronization credential';
+  end if;
+
+  if p_phase is null or p_phase not in (
+    'queued',
+    'scanning_installer',
+    'preparing_package',
+    'restoring_vm',
+    'installing',
+    'detecting_install',
+    'uninstalling',
+    'verifying_removal',
+    'publishing'
+  ) then
+    raise exception 'Invalid QA candidate phase';
+  end if;
+
+  if p_observed_at is null or p_observed_at > now() + interval '5 minutes' then
+    raise exception 'Invalid QA phase observation time';
+  end if;
+
+  update public.qa_candidates
+  set
+    phase_started_at = case
+      when phase is distinct from p_phase then p_observed_at
+      else phase_started_at
+    end,
+    phase = p_phase,
+    phase_updated_at = p_observed_at,
+    updated_at = greatest(updated_at, p_observed_at)
+  where id = p_candidate_id
+    and status in ('dispatched', 'running')
+    and (phase_updated_at is null or p_observed_at > phase_updated_at);
+
+  get diagnostics updated_count = row_count;
+  return updated_count = 1;
+end;
+$$;
+
+revoke all on function public.publish_qa_candidate_phase(text, uuid, text, timestamptz)
+  from public, authenticated, service_role;
+grant execute on function public.publish_qa_candidate_phase(text, uuid, text, timestamptz)
+  to anon;

--- a/types/database.ts
+++ b/types/database.ts
@@ -55,6 +55,11 @@ export interface Database {
           github_run_id: string | null;
           github_run_attempt: number | null;
           qa_schema_version: number;
+          virustotal_status: string | null;
+          virustotal_malicious: number | null;
+          virustotal_suspicious: number | null;
+          virustotal_total_engines: number | null;
+          virustotal_scanned_at_utc: string | null;
           synced_at: string;
         };
         Insert: {
@@ -88,6 +93,11 @@ export interface Database {
           github_run_id?: string | null;
           github_run_attempt?: number | null;
           qa_schema_version?: number;
+          virustotal_status?: string | null;
+          virustotal_malicious?: number | null;
+          virustotal_suspicious?: number | null;
+          virustotal_total_engines?: number | null;
+          virustotal_scanned_at_utc?: string | null;
           synced_at?: string;
         };
         Update: {
@@ -121,6 +131,11 @@ export interface Database {
           github_run_id?: string | null;
           github_run_attempt?: number | null;
           qa_schema_version?: number;
+          virustotal_status?: string | null;
+          virustotal_malicious?: number | null;
+          virustotal_suspicious?: number | null;
+          virustotal_total_engines?: number | null;
+          virustotal_scanned_at_utc?: string | null;
           synced_at?: string;
         };
         Relationships: GenericRelationship[];
@@ -255,6 +270,11 @@ export interface Database {
           package_content_sha256: string;
           github_run_id: string | null;
           github_run_url: string | null;
+          virustotal_status: string | null;
+          virustotal_malicious: number | null;
+          virustotal_suspicious: number | null;
+          virustotal_total_engines: number | null;
+          virustotal_scanned_at_utc: string | null;
           synced_at: string;
         };
         Insert: Omit<Database['public']['Tables']['qa_package_results']['Row'], 'synced_at'> & {

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -108,6 +108,7 @@ export interface QaLiveLog {
 
 export type QaLivePhase =
   | 'queued'
+  | 'scanning_installer'
   | 'preparing_package'
   | 'restoring_vm'
   | 'installing'
@@ -176,10 +177,22 @@ export interface QaLiveResponse {
     outcome: QaOutcome;
     testedAtUtc: string;
     durationSeconds: number | null;
+    virusTotalStatus: QaVirusTotalStatus | null;
   }>;
 }
 
 export type QaTestLevel = 'installer-preflight' | 'psadt-package';
+
+export type QaVirusTotalStatus = 'clean' | 'flagged' | 'not_found' | 'error' | 'skipped';
+
+/** Informational hash-only VirusTotal verdict; it never gates the QA outcome. */
+export interface QaVirusTotalSummary {
+  status: QaVirusTotalStatus;
+  malicious: number | null;
+  suspicious: number | null;
+  totalEngines: number | null;
+  scannedAtUtc: string | null;
+}
 
 /** Minimal database row used for card/list status badges. */
 export interface QaStatusRow {
@@ -227,6 +240,12 @@ export interface QaResultRow extends QaStatusRow {
   detection_rules_sha256: string | null;
   packager_commit: string | null;
   package_content_sha256: string | null;
+  /** Optional: absent from rows read out of pre-VirusTotal catalog snapshots. */
+  virustotal_status?: QaVirusTotalStatus | null;
+  virustotal_malicious?: number | null;
+  virustotal_suspicious?: number | null;
+  virustotal_total_engines?: number | null;
+  virustotal_scanned_at_utc?: string | null;
 }
 
 export interface QaStatus {
@@ -285,6 +304,7 @@ export interface QaDetailsResponse {
   relevantEventCount: number | null;
   environment: QaEnvironment | null;
   effectiveConfiguration: QaEffectiveConfiguration | null;
+  virusTotal: QaVirusTotalSummary | null;
   classification: QaClassification | null;
   package?: {
     testLevel: QaTestLevel;


### PR DESCRIPTION
The QA host checks each verified installer SHA-256 against the VirusTotal database (hash-only lookup, never uploading the file and never gating the QA outcome). The verdict flows through the sync RPC into qa_results and qa_package_results.

On the QA page this surfaces as:
- a new "Security scan" step in the live test-progress timeline (phase scanning_installer)
- a VirusTotal column in the recent-results table
- a prominent shield banner in the QA details dialog ("No threats found - 0 of N security vendors flagged this installer")

Both Supabase migrations are already applied to production, so this is backward-compatible to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)