### PR TITLE
Block packaging when VirusTotal reports a malicious installer verdict

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -94,6 +94,14 @@ function QaVirusTotalCell({ status }: { status: QaVirusTotalStatus | null }) {
       </span>
     );
   }
+  if (status === 'suspicious') {
+    return (
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs font-medium text-status-warning">
+        <ShieldAlert className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <T>Suspicious</T>
+      </span>
+    );
+  }
   if (status === 'not_found') {
     return (
       <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-text-muted">
@@ -548,7 +556,9 @@ function DashboardContent() {
                     </span>
                     <span className="flex flex-col items-end gap-1">
                       <QaResultStatus outcome={item.outcome} />
-                      {item.virusTotalStatus === 'clean' || item.virusTotalStatus === 'flagged' ? (
+                      {item.virusTotalStatus === 'clean' ||
+                      item.virusTotalStatus === 'flagged' ||
+                      item.virusTotalStatus === 'suspicious' ? (
                         <QaVirusTotalCell status={item.virusTotalStatus} />
                       ) : null}
                     </span>

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -207,9 +207,10 @@ function LifecycleCard({ name, result }: { name: string; result: QaPhaseResult |
 function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
   const clean = virusTotal.status === 'clean';
   const flagged = virusTotal.status === 'flagged';
-  const flaggedCount = (virusTotal.malicious ?? 0) + (virusTotal.suspicious ?? 0);
+  const suspicious = virusTotal.status === 'suspicious';
   const totalEngines = virusTotal.totalEngines ?? 0;
-  const Icon = clean ? ShieldCheck : flagged ? ShieldAlert : ShieldQuestion;
+  const Icon = clean ? ShieldCheck : flagged || suspicious ? ShieldAlert : ShieldQuestion;
+  const neutral = !clean && !flagged && !suspicious;
 
   return (
     <section
@@ -218,14 +219,15 @@ function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
         'relative overflow-hidden rounded-2xl border p-5 sm:p-6',
         clean && 'border-status-success/25 bg-gradient-to-br from-status-success/15 via-status-success/5 to-transparent',
         flagged && 'border-status-error/25 bg-gradient-to-br from-status-error/15 via-status-error/5 to-transparent',
-        !clean && !flagged && 'border-overlay/10 bg-bg-elevated/40'
+        suspicious && 'border-status-warning/25 bg-gradient-to-br from-status-warning/15 via-status-warning/5 to-transparent',
+        neutral && 'border-overlay/10 bg-bg-elevated/40'
       )}
     >
       <Icon
         aria-hidden="true"
         className={cn(
           'pointer-events-none absolute -right-5 -top-5 h-32 w-32 opacity-[0.07]',
-          clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-muted'
+          clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-muted'
         )}
       />
       <div className="relative flex items-start gap-4">
@@ -234,7 +236,8 @@ function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
             'flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ring-4',
             clean && 'bg-status-success/15 text-status-success ring-status-success/10',
             flagged && 'bg-status-error/15 text-status-error ring-status-error/10',
-            !clean && !flagged && 'bg-overlay/10 text-text-muted ring-overlay/5'
+            suspicious && 'bg-status-warning/15 text-status-warning ring-status-warning/10',
+            neutral && 'bg-overlay/10 text-text-muted ring-overlay/5'
           )}
         >
           <Icon className="h-6 w-6" aria-hidden="true" />
@@ -243,7 +246,7 @@ function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
           <p
             className={cn(
               'text-xs font-medium uppercase tracking-[0.16em]',
-              clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-muted'
+              clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-muted'
             )}
           >
             <T>VirusTotal security check</T>
@@ -252,13 +255,15 @@ function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
             id="qa-virustotal-heading"
             className={cn(
               'mt-1 text-lg font-semibold sm:text-xl',
-              clean ? 'text-status-success' : flagged ? 'text-status-error' : 'text-text-primary'
+              clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-primary'
             )}
           >
             {clean ? (
               <T>No threats found</T>
             ) : flagged ? (
-              <T><Var>{flaggedCount}</Var> of <Var>{totalEngines}</Var> security vendors flagged this installer</T>
+              <T><Var>{virusTotal.malicious ?? 0}</Var> of <Var>{totalEngines}</Var> security vendors flagged this installer as malicious</T>
+            ) : suspicious ? (
+              <T><Var>{virusTotal.suspicious ?? 0}</Var> of <Var>{totalEngines}</Var> security vendors rated this installer suspicious</T>
             ) : virusTotal.status === 'not_found' ? (
               <T>No verdict available yet</T>
             ) : (
@@ -269,7 +274,9 @@ function VirusTotalBanner({ virusTotal }: { virusTotal: QaVirusTotalSummary }) {
             {clean ? (
               <T><Var>{virusTotal.malicious ?? 0}</Var> of <Var>{totalEngines}</Var> security vendors flagged this installer when its verified hash was checked against the VirusTotal database.</T>
             ) : flagged ? (
-              <T><Var>{virusTotal.malicious ?? 0}</Var> vendors rated it malicious and <Var>{virusTotal.suspicious ?? 0}</Var> suspicious. A small number of detections is often a false positive for installers — review the flagged engines on VirusTotal before drawing conclusions.</T>
+              <T>Packaging of this version is blocked until the finding is reviewed. <Var>{virusTotal.malicious ?? 0}</Var> vendors rated it malicious and <Var>{virusTotal.suspicious ?? 0}</Var> suspicious; earlier versions with a clean verdict remain available.</T>
+            ) : suspicious ? (
+              <T>No vendor rated it malicious, so this version is not blocked. Suspicious verdicts are heuristic and often false positives — review the engines on VirusTotal if in doubt.</T>
             ) : virusTotal.status === 'not_found' ? (
               <T>This installer version is not in the VirusTotal database yet, so no reputation verdict is available.</T>
             ) : virusTotal.status === 'skipped' ? (

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -43,7 +43,10 @@ interface TriggerResult {
   error?: string;
   skipped?: boolean;
   skipReason?: string;
-  code?: 'QA_FAILED_CURRENT_VERSION' | 'QA_NOT_PASSED_CURRENT_VERSION';
+  code?:
+    | 'QA_FAILED_CURRENT_VERSION'
+    | 'QA_NOT_PASSED_CURRENT_VERSION'
+    | 'QA_SECURITY_FLAGGED_CURRENT_VERSION';
 }
 
 export interface UpdateInfo {

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/supabase', () => ({
         packageEqMock(...args);
         return builder;
       });
+      builder.gte = vi.fn(() => builder);
       builder.order = vi.fn(() => builder);
       builder.limit = vi.fn(() => builder);
       builder.maybeSingle = getPackageResultMock;
@@ -26,7 +27,7 @@ vi.mock('@/lib/supabase', () => ({
   }),
 }));
 
-import { enforceQaGate, QaGateError, QaGateNotPassedError } from './gate';
+import { enforceQaGate, QaGateError, QaGateNotPassedError, QaSecurityGateError } from './gate';
 
 const installerSha256 = 'A'.repeat(64);
 const packageProfileSha256 = 'B'.repeat(64);
@@ -132,6 +133,66 @@ describe('enforceQaGate', () => {
         requirePassed: true,
       })
     ).rejects.toBeInstanceOf(QaGateNotPassedError);
+  });
+
+  it('blocks packaging when VirusTotal reported a malicious verdict for the exact installer', async () => {
+    getPackageResultMock.mockResolvedValueOnce({
+      data: { virustotal_malicious: 1, virustotal_total_engines: 72 },
+      error: null,
+    });
+    await expect(
+      enforceQaGate({
+        wingetId: 'OpenJS.NodeJS',
+        version: '26.7.0',
+        architecture: 'x64',
+        installerSha256,
+        packageProfileSha256,
+        requirePassed: true,
+      })
+    ).rejects.toBeInstanceOf(QaSecurityGateError);
+  });
+
+  it('does not allow a manual QA override to bypass the security gate', async () => {
+    getPackageResultMock.mockResolvedValueOnce({
+      data: { virustotal_malicious: 4, virustotal_total_engines: 70 },
+      error: null,
+    });
+    await expect(
+      enforceQaGate({
+        wingetId: 'OpenJS.NodeJS',
+        version: '26.7.0',
+        architecture: 'x64',
+        installerSha256,
+        qaOverride: true,
+      })
+    ).rejects.toBeInstanceOf(QaSecurityGateError);
+  });
+
+  it('blocks a flagged current version even when its installation test passed', async () => {
+    getQaResultMock.mockResolvedValue({
+      ...failedRow,
+      outcome: 'Passed',
+      virustotal_status: 'flagged',
+      virustotal_malicious: 2,
+      virustotal_total_engines: 72,
+    });
+    await expect(
+      enforceQaGate({ wingetId: 'OpenJS.NodeJS', version: '26.7.0', architecture: 'x64' })
+    ).rejects.toBeInstanceOf(QaSecurityGateError);
+  });
+
+  it('does not block on suspicious-only or missing VirusTotal verdicts', async () => {
+    getQaResultMock.mockResolvedValue({
+      ...failedRow,
+      outcome: 'Passed',
+      virustotal_status: 'suspicious',
+      virustotal_malicious: 0,
+      virustotal_suspicious: 3,
+      virustotal_total_engines: 72,
+    });
+    await expect(
+      enforceQaGate({ wingetId: 'OpenJS.NodeJS', version: '26.7.0', architecture: 'x64' })
+    ).resolves.toBeUndefined();
   });
 
   it('does not allow a manual override to bypass strict automatic QA', async () => {

--- a/lib/qa/gate.ts
+++ b/lib/qa/gate.ts
@@ -48,13 +48,39 @@ export class QaGateNotPassedError extends Error {
   }
 }
 
-export type AnyQaGateError = QaGateError | QaGateNotPassedError;
+export class QaSecurityGateError extends Error {
+  readonly code = 'QA_SECURITY_FLAGGED_CURRENT_VERSION' as const;
+
+  constructor(
+    readonly details: {
+      wingetId: string;
+      version: string;
+      architecture: string;
+      malicious: number;
+      totalEngines: number | null;
+    }
+  ) {
+    super(
+      `VirusTotal reported ${details.malicious} malicious verdict${details.malicious === 1 ? '' : 's'} for the ${details.wingetId} ${details.version} (${details.architecture}) installer`
+    );
+    this.name = 'QaSecurityGateError';
+  }
+}
+
+export type AnyQaGateError = QaGateError | QaGateNotPassedError | QaSecurityGateError;
 
 export function isQaGateError(error: unknown): error is AnyQaGateError {
-  return error instanceof QaGateError || error instanceof QaGateNotPassedError;
+  return (
+    error instanceof QaGateError ||
+    error instanceof QaGateNotPassedError ||
+    error instanceof QaSecurityGateError
+  );
 }
 
 export function describeQaGateError(error: AnyQaGateError): string {
+  if (error instanceof QaSecurityGateError) {
+    return `${error.message}. Packaging is blocked for this version until the finding is reviewed. Earlier versions with a clean verdict remain available.`;
+  }
   if (error instanceof QaGateNotPassedError) {
     return `${error.message}. Automatic deployment will resume after the installation test passes.`;
   }
@@ -77,11 +103,43 @@ export async function enforceQaGate(input: {
   qaOverride?: boolean;
   sourceType?: 'winget' | 'custom';
 }): Promise<void> {
-  if (input.sourceType === 'custom' || (!input.requirePassed && input.qaOverride)) return;
+  if (input.sourceType === 'custom') return;
 
   const architecture = (input.architecture || 'x64').toLowerCase();
   const installerSha256 = input.installerSha256?.trim().toUpperCase() || '';
   const packageProfileSha256 = input.packageProfileSha256?.trim().toUpperCase() || '';
+
+  // Security gate: a malicious VirusTotal verdict for this exact installer
+  // blocks packaging even when the installability gate is overridden.
+  if (installerSha256) {
+    const { data: securityRow, error: securityError } = await createServerClient()
+      .from('qa_package_results')
+      .select('virustotal_malicious, virustotal_total_engines')
+      .eq('winget_id', input.wingetId)
+      .eq('tested_version', input.version)
+      .eq('architecture', architecture)
+      .eq('installer_sha256', installerSha256)
+      .gte('virustotal_malicious', 1)
+      .order('tested_at_utc', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (securityError) {
+      throw new Error(`Could not read the installer security verdict: ${securityError.message}`);
+    }
+    const malicious = (securityRow?.virustotal_malicious as number | null) ?? 0;
+    if (malicious >= 1) {
+      throw new QaSecurityGateError({
+        wingetId: input.wingetId,
+        version: input.version,
+        architecture,
+        malicious,
+        totalEngines: (securityRow?.virustotal_total_engines as number | null) ?? null,
+      });
+    }
+  }
+
+  if (!input.requirePassed && input.qaOverride) return;
+
   const { data: passedRow, error: passedError } = installerSha256
     ? await createServerClient()
         .from('qa_package_results')
@@ -113,13 +171,24 @@ export async function enforceQaGate(input: {
 
   if (
     !row ||
-    row.outcome !== 'Failed' ||
     row.tested_version !== input.version ||
     (input.architecture && row.architecture.toLowerCase() !== input.architecture.toLowerCase()) ||
     row.test_level !== 'psadt-package'
   ) {
     return;
   }
+
+  if ((row.virustotal_malicious ?? 0) >= 1) {
+    throw new QaSecurityGateError({
+      wingetId: row.winget_id,
+      version: row.tested_version,
+      architecture: row.architecture,
+      malicious: row.virustotal_malicious ?? 0,
+      totalEngines: row.virustotal_total_engines ?? null,
+    });
+  }
+
+  if (row.outcome !== 'Failed') return;
 
   throw new QaGateError({
     wingetId: row.winget_id,

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -97,7 +97,12 @@ function architecture(value: string): QaArchitecture {
 }
 
 function virusTotalStatus(value: string | null | undefined): QaVirusTotalStatus | null {
-  return value === 'clean' || value === 'flagged' || value === 'not_found' || value === 'error' || value === 'skipped'
+  return value === 'clean' ||
+    value === 'suspicious' ||
+    value === 'flagged' ||
+    value === 'not_found' ||
+    value === 'error' ||
+    value === 'skipped'
     ? value
     : null;
 }

--- a/supabase/migrations/20260815150000_qa_virustotal_suspicious_status.sql
+++ b/supabase/migrations/20260815150000_qa_virustotal_suspicious_status.sql
@@ -1,0 +1,21 @@
+-- Split heuristic "suspicious" verdicts from confirmed "flagged" (malicious)
+-- verdicts. A flagged status now always means at least one vendor rated the
+-- installer malicious, which is what blocks packaging; suspicious-only
+-- verdicts remain informational warnings.
+alter table public.qa_results
+  drop constraint if exists qa_results_virustotal_status_check;
+alter table public.qa_results
+  add constraint qa_results_virustotal_status_check check (
+    virustotal_status is null or virustotal_status in (
+      'clean', 'suspicious', 'flagged', 'not_found', 'error', 'skipped'
+    )
+  );
+
+alter table public.qa_package_results
+  drop constraint if exists qa_package_results_virustotal_status_check;
+alter table public.qa_package_results
+  add constraint qa_package_results_virustotal_status_check check (
+    virustotal_status is null or virustotal_status in (
+      'clean', 'suspicious', 'flagged', 'not_found', 'error', 'skipped'
+    )
+  );

--- a/types/qa.ts
+++ b/types/qa.ts
@@ -183,7 +183,7 @@ export interface QaLiveResponse {
 
 export type QaTestLevel = 'installer-preflight' | 'psadt-package';
 
-export type QaVirusTotalStatus = 'clean' | 'flagged' | 'not_found' | 'error' | 'skipped';
+export type QaVirusTotalStatus = 'clean' | 'suspicious' | 'flagged' | 'not_found' | 'error' | 'skipped';
 
 /** Informational hash-only VirusTotal verdict; it never gates the QA outcome. */
 export interface QaVirusTotalSummary {

--- a/types/update-policies.ts
+++ b/types/update-policies.ts
@@ -213,7 +213,10 @@ export interface TriggerUpdateResponse {
     tenant_id: string;
     success: boolean;
     skipped?: boolean;
-    code?: 'QA_FAILED_CURRENT_VERSION' | 'QA_NOT_PASSED_CURRENT_VERSION';
+    code?:
+      | 'QA_FAILED_CURRENT_VERSION'
+      | 'QA_NOT_PASSED_CURRENT_VERSION'
+      | 'QA_SECURITY_FLAGGED_CURRENT_VERSION';
     packaging_job_id?: string;
     error?: string;
   }[];


### PR DESCRIPTION
Enforces the security policy for VirusTotal findings:

- enforceQaGate throws a new QaSecurityGateError when the exact installer has a malicious verdict in qa_package_results (or the canonical current-version row), blocking packaging and automatic updates. A manual QA override does not bypass the security gate.
- Heuristic-only detections get a distinct "suspicious" status: amber shield warning in the QA UI, no blocking.
- The flagged details banner now states that packaging of the version is blocked pending review.

The status constraint migration is already applied to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)