### PR TITLE
Activate version-suffixed ARP identity packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'cc143c874f2e84f06097cb199ad9998344040ded',
+  packagerCommit: '25682a8899466dbfe72403556e854d7335e1ae8f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -80,6 +80,7 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'ca77e52dc65a404eb81679c5188378bf4d69a692',
   'af4dfb94c9109ca598abc16a4b8cad57f6790066',
   '22b8e738d51a612f68b01c83b705d2dabc3bbcff',
+  'cc143c874f2e84f06097cb199ad9998344040ded',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -15,6 +15,7 @@ describe('QA toolchain targeted retries', () => {
       'Ringler.SnapformViewer',
       'Cisco.Jabber',
       'IPEVO.Visualizer',
+      'IPEVO.VisualizerLTSE',
     ]));
 
     targets.length = 0;
@@ -27,6 +28,7 @@ describe('QA toolchain targeted retries', () => {
         'Ringler.SnapformViewer',
         'Cisco.Jabber',
         'IPEVO.Visualizer',
+        'IPEVO.VisualizerLTSE',
       ])
     );
   });
@@ -460,6 +462,13 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries Visualizer LTSE with exact version-suffixed ARP identity matching', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ipevo.visualizerltse', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -504,6 +504,24 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Cisco.Jabber',
     'IPEVO.Visualizer',
   ],
+  '25682a8899466dbfe72403556e854d7335e1ae8f': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    // This MSI app appends the exact package version to its ARP display name.
+    // The shared packager now captures that one observed, version-agreeing identity.
+    'IPEVO.VisualizerLTSE',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## What changed

- makes packager commit `25682a8899466dbfe72403556e854d7335e1ae8f` the canonical QA and customer packaging release
- retains the prior packager as compatible for unaffected successful profiles
- carries forward unresolved lifecycle retries and adds a targeted retry for `IPEVO.VisualizerLTSE`

## Why

The shared packager now safely captures MSI registrations whose display name appends the exact requested package version. Activation must use that same immutable generator for QA and customer packages.

## Validation

- 135 focused package-profile, backfill, and scheduler tests
- ESLint on touched files
- `git diff --check`