### PR TITLE
Block unsupported Roblox managed lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -388,6 +388,27 @@ describe('NVIDIA GeForce NOW managed install block migration contract', () => {
   });
 });
 
+describe('Roblox managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260815151000_block_roblox_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unreliable lifecycle across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Roblox.Roblox'");
+    expect(sql).toContain(
+      'https://github.com/microsoft/winget-pkgs/pull/391567'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260815151000_block_roblox_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260815151000_block_roblox_unsupported_managed_uninstall.sql
@@ -1,0 +1,37 @@
+-- Roblox Player 0.726 installs its current WinGet bootstrapper and creates an
+-- Add/Remove Programs registration, but the vendor command returns exit code 7
+-- and does not publish a versioned managed-detection contract. Isolated
+-- LocalSystem lifecycle QA then invoked the exact registered uninstaller; the
+-- application registration and payload remained after the bounded completion
+-- deadline. Do not offer this package as a managed Intune application until
+-- Roblox publishes a verifiable unattended removal contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Roblox.Roblox',
+  'unsupported_managed_uninstall',
+  'Roblox Player installs silently, but its current bootstrapper does not expose a reliable managed lifecycle. Isolated LocalSystem QA invoked the exact registered uninstaller and confirmed that the application remained installed.',
+  'https://github.com/microsoft/winget-pkgs/pull/391567'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Roblox.Roblox';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Roblox.Roblox'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Roblox from automated Intune packaging until it exposes a verifiable unattended uninstall lifecycle
- remove the failed app from QA retries and catalog verification
- cover the shared customer and QA eligibility policy with a migration contract test

## Evidence
- isolated PSADT QA installed Roblox Player but the vendor installer returned 7
- exact registered uninstaller left the product registration and payload installed after the bounded deadline
- the upstream WinGet release supplies install switches but no managed uninstall contract and notes that the package does not write version information

## Validation
- npm test -- lib/qa/migration-contract.test.ts (43 passed)
- npx eslint lib/qa/migration-contract.test.ts
- git diff --check