### PR TITLE
Use reviewed Sonos InstallShield arguments

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -393,6 +393,18 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses the documented InstallShield forwarding form for Sonos', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Sonos.Controller',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/s /v"/qn /norestart REBOOT=ReallySuppress"'
+    );
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('selects MEGAsync all-users mode for LocalSystem deployment', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Mega.MEGASync',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -136,6 +136,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
   },
   {
+    // Sonos ships a Basic MSI inside an InstallShield setup launcher. The
+    // current WinGet switches pass /quiet and /norestart as separate /V
+    // arguments, which the 90.0 launcher rejected with MSI 1619 under
+    // LocalSystem. Revenera documents a single quoted /v payload for reliably
+    // forwarding multiple MSI options through setup.exe. Use that exact form
+    // for both QA and customer Intune packages.
+    wingetId: 'Sonos.Controller',
+    reviewedInstallArgumentsOverride:
+      '/s /v"/qn /norestart REBOOT=ReallySuppress"',
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.


### PR DESCRIPTION
## Summary
- override Sonos Controller's split MSI forwarding switches with Revenera's documented quoted InstallShield form
- apply the adapter through the shared configuration used by QA and customer Intune packaging
- cover the exact command with a focused regression test

## Evidence
- clean-VM PSADT returned MSI 1619 with the upstream split forwarding arguments
- the vendor wrapper created no install registration
- Revenera documents a single quoted /v payload when forwarding multiple MSI arguments

## Validation
- 126 focused tests passed
- ESLint passed for changed TypeScript files
- git diff --check