### PR TITLE
Activate Sonos InstallShield packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '25682a8899466dbfe72403556e854d7335e1ae8f',
+  packagerCommit: 'cfc6f269e1a818dd4a61b95121268f6991f78642',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -16,6 +16,7 @@ describe('QA toolchain targeted retries', () => {
       'Cisco.Jabber',
       'IPEVO.Visualizer',
       'IPEVO.VisualizerLTSE',
+      'Sonos.Controller',
     ]));
 
     targets.length = 0;
@@ -29,6 +30,7 @@ describe('QA toolchain targeted retries', () => {
         'Cisco.Jabber',
         'IPEVO.Visualizer',
         'IPEVO.VisualizerLTSE',
+        'Sonos.Controller',
       ])
     );
   });
@@ -469,6 +471,13 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'ipevo.visualizerltse', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries Sonos with its reviewed InstallShield silent argument payload', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'sonos.controller', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -522,6 +522,26 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // The shared packager now captures that one observed, version-agreeing identity.
     'IPEVO.VisualizerLTSE',
   ],
+  'cfc6f269e1a818dd4a61b95121268f6991f78642': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    // Sonos uses an InstallShield Basic MSI bootstrapper. The shared packager
+    // now sends one quoted /v payload so the embedded MSI receives /qn and the
+    // restart-suppression properties instead of returning MSI error 1619.
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
Pins QA to the reviewed Sonos InstallShield packager commit and schedules a targeted Sonos retry. The retry list remains cumulative so unconsumed reviewed lifecycle fixes are preserved.\n\nValidation:\n- 109 focused tests passed\n- ESLint passed for changed files\n- git diff --check passed