### PR TITLE
Fix .NET Framework runtime lifecycle detection

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -420,6 +420,70 @@ if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
     $reviewedMultiProductInstallMinimumCount = [int]$rawMultiProductMinimumCount
 }
 
+$reviewedRegistryInstallEvidenceConfigured = $false
+$reviewedRegistryInstallEvidenceKeyPath = ''
+$reviewedRegistryInstallEvidenceProviderPath = ''
+$reviewedRegistryInstallEvidenceValueName = ''
+$reviewedRegistryInstallEvidenceMinimumDword = [uint64]0
+if ($psadtConfig.Contains('reviewedRegistryInstallEvidence') -and
+    $null -ne $psadtConfig['reviewedRegistryInstallEvidence']) {
+    $rawRegistryEvidence = $psadtConfig['reviewedRegistryInstallEvidence']
+    if ($rawRegistryEvidence -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedRegistryInstallEvidence must be a JSON object.'
+    }
+
+    $allowedRegistryEvidenceKeys = @('keyPath', 'valueName', 'minimumDword')
+    foreach ($registryEvidenceKey in @($rawRegistryEvidence.Keys)) {
+        if ([string]$registryEvidenceKey -notin $allowedRegistryEvidenceKeys) {
+            throw "PSADT reviewedRegistryInstallEvidence contains an unsupported property: $registryEvidenceKey"
+        }
+    }
+    foreach ($requiredRegistryEvidenceKey in $allowedRegistryEvidenceKeys) {
+        if (-not $rawRegistryEvidence.Contains($requiredRegistryEvidenceKey)) {
+            throw "PSADT reviewedRegistryInstallEvidence must include $requiredRegistryEvidenceKey."
+        }
+    }
+    if ($rawRegistryEvidence['keyPath'] -isnot [string] -or
+        $rawRegistryEvidence['valueName'] -isnot [string]) {
+        throw 'PSADT reviewedRegistryInstallEvidence keyPath and valueName must be strings.'
+    }
+
+    $reviewedRegistryInstallEvidenceKeyPath = ([string]$rawRegistryEvidence['keyPath']).Trim()
+    if ($reviewedRegistryInstallEvidenceKeyPath.Length -gt 260 -or
+        $reviewedRegistryInstallEvidenceKeyPath -notmatch '^HKLM:\\SOFTWARE\\[^\\/*?"<>|\x00-\x1F\x7F]+(?:\\[^\\/*?"<>|\x00-\x1F\x7F]+)*$' -or
+        @($reviewedRegistryInstallEvidenceKeyPath -split '\\') -contains '..') {
+        throw 'PSADT reviewedRegistryInstallEvidence keyPath must be a safe literal path below HKLM:\SOFTWARE.'
+    }
+    $reviewedRegistryInstallEvidenceValueName = ([string]$rawRegistryEvidence['valueName']).Trim()
+    if ([string]::IsNullOrWhiteSpace($reviewedRegistryInstallEvidenceValueName) -or
+        $reviewedRegistryInstallEvidenceValueName.Length -gt 128 -or
+        [regex]::IsMatch($reviewedRegistryInstallEvidenceValueName, '[\\/*?"<>|\x00-\x1F\x7F]')) {
+        throw 'PSADT reviewedRegistryInstallEvidence valueName must be a safe bounded literal name.'
+    }
+
+    $rawRegistryMinimumDword = $rawRegistryEvidence['minimumDword']
+    if (($rawRegistryMinimumDword -isnot [byte] -and
+         $rawRegistryMinimumDword -isnot [uint16] -and
+         $rawRegistryMinimumDword -isnot [int16] -and
+         $rawRegistryMinimumDword -isnot [uint32] -and
+         $rawRegistryMinimumDword -isnot [int32] -and
+         $rawRegistryMinimumDword -isnot [uint64] -and
+         $rawRegistryMinimumDword -isnot [int64]) -or
+        [int64]$rawRegistryMinimumDword -lt 1 -or
+        [uint64]$rawRegistryMinimumDword -gt [uint32]::MaxValue) {
+        throw 'PSADT reviewedRegistryInstallEvidence minimumDword must be an integer from 1 to 4294967295.'
+    }
+    $reviewedRegistryInstallEvidenceMinimumDword = [uint64]$rawRegistryMinimumDword
+    $reviewedRegistryInstallEvidenceProviderPath =
+        'Registry::HKEY_LOCAL_MACHINE\' + $reviewedRegistryInstallEvidenceKeyPath.Substring('HKLM:\'.Length)
+    $reviewedRegistryInstallEvidenceConfigured = $true
+}
+
+if ($reviewedRegistryInstallEvidenceConfigured -and
+    $reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
+    throw 'PSADT reviewed registry and multi-product install evidence cannot be combined.'
+}
+
 $uninstallCompletionTimeoutMinutes = 5
 if ($psadtConfig.Contains('uninstallCompletionTimeoutMinutes') -and
     $null -ne $psadtConfig['uninstallCompletionTimeoutMinutes']) {
@@ -458,6 +522,10 @@ function Get-StrictPSADTBoolean {
 $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
     -Config $psadtConfig `
     -Name 'preserveVendorInstallationOnUninstall'
+if ($reviewedRegistryInstallEvidenceConfigured -and
+    -not $preserveVendorInstallationOnUninstall) {
+    throw 'PSADT reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall.'
+}
 
 $reviewedManagedInstallDirectory = ''
 if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
@@ -896,6 +964,8 @@ $reviewedExactUninstallExecutableEscaped = $reviewedExactUninstallExecutable -re
 $reviewedExactUninstallArgumentsLiteral = @(
     $reviewedExactUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
+$reviewedRegistryInstallEvidenceProviderPathEscaped = $reviewedRegistryInstallEvidenceProviderPath -replace "'", "''"
+$reviewedRegistryInstallEvidenceValueNameEscaped = $reviewedRegistryInstallEvidenceValueName -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
@@ -1166,6 +1236,13 @@ if ($useManagedDirectoryLifecycle) {
     # Never let unrelated background servicing become the captured identity.
     $useRegistryUninstall = $false
     Write-Host "Using reviewed managed-directory lifecycle: $reviewedManagedInstallDirectory"
+}
+
+if ($reviewedRegistryInstallEvidenceConfigured) {
+    if (-not $useRegistryUninstall -or $IsUserScope) {
+        throw 'PSADT reviewedRegistryInstallEvidence requires a machine-scope registry uninstall package.'
+    }
+    Write-Host "Using reviewed registry installation evidence: $reviewedRegistryInstallEvidenceKeyPath"
 }
 
 if ($useRegistryUninstall) {
@@ -1844,7 +1921,25 @@ $lines += @(
 )
 $lines += $dependencyInstallLines
 
-if ($useRegistryUninstall) {
+if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
+    $lines += @(
+        '    # Verify the adapter-reviewed Windows runtime signal instead of guessing an ARP identity.'
+        '    $capturedUninstallKey = $null'
+        '    $capturedUninstallName = $null'
+        '    $reviewedRegistryInstallationVerified = $false'
+        '    function Test-IntuneGetReviewedRegistryInstallEvidence {'
+        '        try {'
+        "            `$evidenceKey = Get-Item -LiteralPath '$reviewedRegistryInstallEvidenceProviderPathEscaped' -ErrorAction Stop"
+        "            if (`$evidenceKey.GetValueKind('$reviewedRegistryInstallEvidenceValueNameEscaped') -ne [Microsoft.Win32.RegistryValueKind]::DWord) { return `$false }"
+        "            `$evidenceValue = `$evidenceKey.GetValue('$reviewedRegistryInstallEvidenceValueNameEscaped', `$null)"
+        "            return `$null -ne `$evidenceValue -and [uint64]`$evidenceValue -ge [uint64]$reviewedRegistryInstallEvidenceMinimumDword"
+        '        } catch {'
+        '            return $false'
+        '        }'
+        '    }'
+        ''
+    )
+} elseif ($useRegistryUninstall) {
     $lines += @(
         '    # Snapshot uninstall entries so the exact vendor entry created or updated by this installer can be reused later.'
         '    $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
@@ -2219,7 +2314,23 @@ if ($useManagedDirectoryLifecycle) {
 # Optional post-install verification (opt-in via PSADT config)
 # Throwing here routes through the standard catch -> Close-ADTSession error exit,
 # and the detection marker write below is skipped because it never runs
-if ($useRegistryUninstall) {
+if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
+    $lines += @(
+        '    # Wait briefly for the documented Windows runtime registry signal to become visible.'
+        '    foreach ($verificationAttempt in 1..30) {'
+        '        if (Test-IntuneGetReviewedRegistryInstallEvidence) {'
+        '            $reviewedRegistryInstallationVerified = $true'
+        '            break'
+        '        }'
+        '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'
+        '    }'
+        '    if (-not $reviewedRegistryInstallationVerified) {'
+        "        throw 'Reviewed registry install verification failed: expected a DWORD value of at least $reviewedRegistryInstallEvidenceMinimumDword.'"
+        '    }'
+        "    Write-ADTLogEntry -Message 'Verified reviewed Windows runtime registry evidence.' -Severity 'Success' -Source 'Install-ADTDeployment'"
+        ''
+    )
+} elseif ($useRegistryUninstall) {
     $lines += @(
         '    # Capture the registry uninstall entry created or version-updated by this installer.'
         '    # Manifest identity is a preference; the observed ARP delta is authoritative when metadata is stale.'
@@ -2408,7 +2519,16 @@ if ($useRegistryUninstall) {
 if ($verifyInstall) {
     Write-Host "Post-install verification enabled"
     if ($useRegistryUninstall) {
-        if ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
+        if ($reviewedRegistryInstallEvidenceConfigured) {
+            $lines += @(
+                ''
+                '    ## Recheck the exact adapter-reviewed Windows runtime evidence.'
+                '    if (-not (Test-IntuneGetReviewedRegistryInstallEvidence)) {'
+                '        throw "Post-install verification failed: the reviewed Windows runtime registry evidence was not found."'
+                '    }'
+                "    Write-ADTLogEntry -Message 'Post-install verification passed for reviewed Windows runtime registry evidence' -Source 'Install-ADTDeployment'"
+            )
+        } elseif ($reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
             $lines += @(
                 ''
                 '    ## Verify the reviewed multi-product bundle evidence established above.'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -447,12 +447,33 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('uses Microsoft registry evidence for the shared .NET Framework runtime', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.DotNet.Framework.Runtime',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedRegistryInstallEvidence: {
+        keyPath: 'HKLM:\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full',
+        valueName: 'Release',
+        minimumDword: 533320,
+      },
+    });
+  });
+
   it('does not accept shared-runtime retention from customer-controlled config', () => {
     const adapted = applyApplicationPackagingAdapter('Example.App', {
       ...DEFAULT_PSADT_CONFIG,
       preserveVendorInstallationOnUninstall: true,
       reviewedMultiProductInstallDisplayNamePrefixes: ['Anything'],
       reviewedMultiProductInstallMinimumCount: 2,
+      reviewedRegistryInstallEvidence: {
+        keyPath: 'HKLM:\\SOFTWARE\\Example',
+        valueName: 'Release',
+        minimumDword: 1,
+      },
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
       reviewedManagedInstallEvidenceFile: '%ProgramFiles%\\Example\\app.exe',
       reviewedManagedInstallCompletionProcess:
@@ -473,6 +494,7 @@ describe('application packaging adapters', () => {
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
+    expect(adapted.reviewedRegistryInstallEvidence).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
     expect(adapted.reviewedManagedInstallEvidenceFile).toBeUndefined();
     expect(adapted.reviewedManagedInstallCompletionProcess).toBeUndefined();

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -31,6 +31,11 @@ interface ApplicationPackagingAdapter {
   }>;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
   reviewedMultiProductInstallMinimumCount?: number;
+  reviewedRegistryInstallEvidence?: Readonly<{
+    keyPath: string;
+    valueName: string;
+    minimumDword: number;
+  }>;
 }
 
 const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
@@ -497,6 +502,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     preserveVendorInstallationOnUninstall: true,
   },
   {
+    // .NET Framework 4.8.1 is a shared Windows runtime and does not expose one
+    // dependable ARP identity. Microsoft documents the Full\Release DWORD as
+    // the authoritative version signal; 533320 is the minimum for 4.8.1.
+    // Keep the runtime during Intune removal and remove only our marker.
+    wingetId: 'Microsoft.DotNet.Framework.Runtime',
+    preserveVendorInstallationOnUninstall: true,
+    reviewedRegistryInstallEvidence: {
+      keyPath: 'HKLM:\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full',
+      valueName: 'Release',
+      minimumDword: 533320,
+    },
+  },
+  {
     // VisualCppRedist AIO is intentionally a bundle of independently registered
     // Visual C++ runtimes. Version 104+ creates several unified ARP entries, so
     // no single vendor identity represents the package. These runtimes are also
@@ -720,6 +738,7 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedInstallArgumentsOverride &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
+      !config.reviewedRegistryInstallEvidence &&
       !config.reviewedUninstallProcessGuard &&
       !config.reviewedManagedInstallDirectory &&
       !config.reviewedManagedInstallEvidenceFile &&
@@ -734,6 +753,7 @@ export function applyApplicationPackagingAdapter(
       reviewedInstallArgumentsOverride: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
+      reviewedRegistryInstallEvidence: undefined,
       reviewedUninstallProcessGuard: undefined,
       reviewedManagedInstallDirectory: undefined,
       reviewedManagedInstallEvidenceFile: undefined,
@@ -844,5 +864,8 @@ export function applyApplicationPackagingAdapter(
     reviewedMultiProductInstallDisplayNamePrefixes,
     reviewedMultiProductInstallMinimumCount:
       adapter.reviewedMultiProductInstallMinimumCount,
+    reviewedRegistryInstallEvidence: adapter.reviewedRegistryInstallEvidence
+      ? { ...adapter.reviewedRegistryInstallEvidence }
+      : undefined,
   };
 }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -427,6 +427,43 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.preserveVendorInstallationOnUninstall).toBe(true);
   });
 
+  it('binds reviewed .NET Framework registry evidence to the QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.DotNet.Framework.Runtime',
+      displayName: 'Microsoft .NET Framework Runtime 4.8.1',
+      publisher: 'Microsoft',
+      version: '4.8.1',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/passive /AcceptEULA /norestart',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL:Microsoft .NET Framework Runtime 4.8.1',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedEvidence = {
+      keyPath: 'HKLM:\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full',
+      valueName: 'Release',
+      minimumDword: 533320,
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        preserveVendorInstallationOnUninstall?: boolean;
+        reviewedRegistryInstallEvidence?: typeof expectedEvidence;
+      };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedRegistryInstallEvidence: expectedEvidence,
+    });
+    expect(profile.psadtConfig.reviewedRegistryInstallEvidence).toEqual(
+      expectedEvidence
+    );
+  });
+
   it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -298,6 +298,103 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies .NET Framework with the reviewed Microsoft registry signal',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Microsoft .NET Framework Runtime 4.8.1',
+        [],
+        {
+          verifyInstall: true,
+          preserveVendorInstallationOnUninstall: true,
+          reviewedRegistryInstallEvidence: {
+            keyPath:
+              'HKLM:\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full',
+            valueName: 'Release',
+            minimumDword: 533320,
+          },
+        },
+        [],
+        'Microsoft.DotNet.Framework.Runtime'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "Get-Item -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full'"
+      );
+      expect(installFunction).toContain(
+        "GetValueKind('Release') -ne [Microsoft.Win32.RegistryValueKind]::DWord"
+      );
+      expect(installFunction).toContain(
+        '[uint64]$evidenceValue -ge [uint64]533320'
+      );
+      expect(installFunction).toContain(
+        'Post-install verification passed for reviewed Windows runtime registry evidence'
+      );
+      expect(installFunction).not.toContain('$preInstallApplications');
+      expect(installFunction).not.toContain(
+        'Could not select one vendor uninstall entry'
+      );
+      expect(uninstallFunction).toContain(
+        'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
+      );
+      expect(uninstallFunction).not.toContain(
+        'Could not find one unambiguous vendor uninstall'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects unsafe reviewed registry install evidence',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe Registry Evidence',
+          [],
+          {
+            preserveVendorInstallationOnUninstall: true,
+            reviewedRegistryInstallEvidence: {
+              keyPath: 'HKLM:\\SOFTWARE\\..\\Secrets',
+              valueName: 'Release',
+              minimumDword: 1,
+            },
+          }
+        )
+      ).toThrow('keyPath must be a safe literal path below HKLM:\\SOFTWARE');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'requires shared-runtime retention for reviewed registry evidence',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe Registry Lifecycle',
+          [],
+          {
+            reviewedRegistryInstallEvidence: {
+              keyPath: 'HKLM:\\SOFTWARE\\Microsoft\\Example',
+              valueName: 'Release',
+              minimumDword: 1,
+            },
+          }
+        )
+      ).toThrow(
+        'reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects malformed reviewed multi-product evidence',
     () => {
       expect(() =>

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -262,6 +262,15 @@ export interface PSADTConfig {
   reviewedMultiProductInstallDisplayNamePrefixes?: string[];
   reviewedMultiProductInstallMinimumCount?: number;
 
+  // Internal install-evidence contract for reviewed Windows runtimes whose
+  // authoritative presence signal is a fixed registry value rather than one
+  // Add/Remove Programs entry. Application adapters are the only source.
+  reviewedRegistryInstallEvidence?: {
+    keyPath: string;
+    valueName: string;
+    minimumDword: number;
+  };
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.


### PR DESCRIPTION
## Summary
- add an adapter-only registry evidence contract for Windows runtimes without one reliable ARP identity
- verify Microsoft .NET Framework 4.8.1 through the documented HKLM Full\\Release DWORD threshold
- retain the shared runtime on Intune uninstall while removing the IntuneGet marker
- bind the behavior into QA profile identity and strip customer-supplied internal evidence

## Validation
- 165 focused Vitest tests passed
- targeted ESLint passed
- generated PSADT script parses successfully in contract tests