### PR TITLE
Activate .NET Framework registry evidence

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'cfc6f269e1a818dd4a61b95121268f6991f78642',
+  packagerCommit: '5569c16d136f464cbc014f40c70645414c601751',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,7 @@ describe('QA toolchain targeted retries', () => {
       'IPEVO.Visualizer',
       'IPEVO.VisualizerLTSE',
       'Sonos.Controller',
+      'Microsoft.DotNet.Framework.Runtime',
     ]));
 
     targets.length = 0;
@@ -31,6 +32,7 @@ describe('QA toolchain targeted retries', () => {
         'IPEVO.Visualizer',
         'IPEVO.VisualizerLTSE',
         'Sonos.Controller',
+        'Microsoft.DotNet.Framework.Runtime',
       ])
     );
   });
@@ -478,6 +480,13 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'sonos.controller', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries .NET Framework with its reviewed Microsoft registry evidence', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'microsoft.dotnet.framework.runtime', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -542,6 +542,27 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // restart-suppression properties instead of returning MSI error 1619.
     'Sonos.Controller',
   ],
+  '5569c16d136f464cbc014f40c70645414c601751': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    // .NET Framework has no single dependable ARP identity. This release
+    // verifies Microsoft's documented Full\Release DWORD and retains the
+    // shared Windows runtime when IntuneGet relinquishes its marker.
+    'Microsoft.DotNet.Framework.Runtime',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 5569c16d136f464cbc014f40c70645414c601751
- carry forward unconsumed bounded retries
- add one targeted retry for Microsoft.DotNet.Framework.Runtime

## Validation
- 143 focused tests passed
- targeted ESLint passed