### PR TITLE
Fix Sonos SYSTEM installs via embedded MSI

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -244,6 +244,35 @@ if ($psadtConfig.Contains('reviewedInstallArgumentsOverride') -and
     }
 }
 
+$reviewedInstallShieldMsiExtractionConfigured = $false
+$reviewedInstallShieldMsiExpectedFileName = ''
+if ($psadtConfig.Contains('reviewedInstallShieldMsiExtraction') -and
+    $null -ne $psadtConfig['reviewedInstallShieldMsiExtraction']) {
+    $rawInstallShieldMsiExtraction = $psadtConfig['reviewedInstallShieldMsiExtraction']
+    if ($rawInstallShieldMsiExtraction -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedInstallShieldMsiExtraction must be a JSON object.'
+    }
+    foreach ($installShieldExtractionKey in $rawInstallShieldMsiExtraction.Keys) {
+        if ([string]$installShieldExtractionKey -notin @('expectedMsiFileName')) {
+            throw "PSADT reviewedInstallShieldMsiExtraction contains an unsupported property: $installShieldExtractionKey"
+        }
+    }
+    if (-not $rawInstallShieldMsiExtraction.Contains('expectedMsiFileName') -or
+        $rawInstallShieldMsiExtraction['expectedMsiFileName'] -isnot [string]) {
+        throw 'PSADT reviewedInstallShieldMsiExtraction must include expectedMsiFileName as a string.'
+    }
+    $reviewedInstallShieldMsiExpectedFileName =
+        ([string]$rawInstallShieldMsiExtraction['expectedMsiFileName']).Trim()
+    if ([string]::IsNullOrWhiteSpace($reviewedInstallShieldMsiExpectedFileName) -or
+        $reviewedInstallShieldMsiExpectedFileName.Length -gt 128 -or
+        [System.IO.Path]::GetFileName($reviewedInstallShieldMsiExpectedFileName) -ne $reviewedInstallShieldMsiExpectedFileName -or
+        $reviewedInstallShieldMsiExpectedFileName -notmatch '^[A-Za-z0-9][A-Za-z0-9 ._()-]*\.msi$' -or
+        $reviewedInstallShieldMsiExpectedFileName.Contains('..')) {
+        throw 'PSADT reviewedInstallShieldMsiExtraction expectedMsiFileName must be a safe literal MSI filename.'
+    }
+    $reviewedInstallShieldMsiExtractionConfigured = $true
+}
+
 $reviewedUninstallArguments = @()
 if ($psadtConfig.Contains('reviewedUninstallArguments') -and
     $null -ne $psadtConfig['reviewedUninstallArguments']) {
@@ -966,6 +995,7 @@ $reviewedExactUninstallArgumentsLiteral = @(
 ) -join ', '
 $reviewedRegistryInstallEvidenceProviderPathEscaped = $reviewedRegistryInstallEvidenceProviderPath -replace "'", "''"
 $reviewedRegistryInstallEvidenceValueNameEscaped = $reviewedRegistryInstallEvidenceValueName -replace "'", "''"
+$reviewedInstallShieldMsiExpectedFileNameEscaped = $reviewedInstallShieldMsiExpectedFileName -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherSingleQuoteEscaped = $Publisher -replace "'", "''"
@@ -1243,6 +1273,20 @@ if ($reviewedRegistryInstallEvidenceConfigured) {
         throw 'PSADT reviewedRegistryInstallEvidence requires a machine-scope registry uninstall package.'
     }
     Write-Host "Using reviewed registry installation evidence: $reviewedRegistryInstallEvidenceKeyPath"
+}
+
+if ($reviewedInstallShieldMsiExtractionConfigured) {
+    if ($IsUserScope -or $installerTypeLower -ne 'exe' -or $fileExtension -ne '.exe') {
+        throw 'PSADT reviewedInstallShieldMsiExtraction requires a machine-scope EXE package.'
+    }
+    if (-not $useRegistryUninstall -or
+        $registryUninstallProductCode -notmatch '^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$') {
+        throw 'PSADT reviewedInstallShieldMsiExtraction requires an exact manifest MSI product code.'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
+        throw 'PSADT reviewedInstallShieldMsiExtraction cannot be combined with a custom install command.'
+    }
+    Write-Host "Using reviewed InstallShield embedded-MSI lifecycle: $reviewedInstallShieldMsiExpectedFileName"
 }
 
 if ($useRegistryUninstall) {
@@ -1972,8 +2016,56 @@ if ($removeExistingInstall) {
     )
 }
 
-# Generate install command - custom override takes precedence over installer type synthesis
-if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
+# Generate install command. Reviewed extraction adapters take precedence over
+# generic launcher synthesis; application adapters remove customer overrides.
+if ($reviewedInstallShieldMsiExtractionConfigured) {
+    $lines += @(
+        '    # Extract the reviewed embedded MSI in the target context; never run the vendor launcher as the installer.'
+        '    $embeddedMsiExtractDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_EmbeddedMsi_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
+        '    $null = New-Item -Path $embeddedMsiExtractDir -ItemType Directory -Force'
+        '    try {'
+        '        $embeddedMsiExtractArguments = ''/S /x /b"'' + $embeddedMsiExtractDir + ''" /v"/qb"'''
+        '        Write-ADTLogEntry -Message "Extracting reviewed embedded MSI to a bounded temporary directory." -Severity ''Info'' -Source ''Install-ADTDeployment'''
+        '        Start-ADTProcess -FilePath $installerPath -ArgumentList $embeddedMsiExtractArguments -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 5) -TimeoutAction Stop'
+        '        $embeddedMsiFiles = @(Get-ChildItem -LiteralPath $embeddedMsiExtractDir -Filter ''*.msi'' -File -Recurse -ErrorAction Stop)'
+        "        if (`$embeddedMsiFiles.Count -ne 1 -or `$embeddedMsiFiles[0].Name -ine '$reviewedInstallShieldMsiExpectedFileNameEscaped') {"
+        "            throw 'Reviewed InstallShield extraction did not produce exactly one $reviewedInstallShieldMsiExpectedFileNameEscaped file.'"
+        '        }'
+        '        $embeddedMsiPath = $embeddedMsiFiles[0].FullName'
+        "        `$expectedEmbeddedMsiProductCode = '$registryUninstallProductCode'"
+        '        $embeddedMsiInstaller = $null'
+        '        $embeddedMsiDatabase = $null'
+        '        $embeddedMsiView = $null'
+        '        $embeddedMsiRecord = $null'
+        '        try {'
+        '            $embeddedMsiInstaller = New-Object -ComObject WindowsInstaller.Installer'
+        '            $embeddedMsiDatabase = $embeddedMsiInstaller.GetType().InvokeMember(''OpenDatabase'', [System.Reflection.BindingFlags]::InvokeMethod, $null, $embeddedMsiInstaller, @($embeddedMsiPath, 0))'
+        '            $embeddedMsiView = $embeddedMsiDatabase.OpenView("SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = ''ProductCode''")'
+        '            [void]$embeddedMsiView.Execute()'
+        '            $embeddedMsiRecord = $embeddedMsiView.Fetch()'
+        '            $embeddedMsiProductCode = if ($embeddedMsiRecord) { [string]$embeddedMsiRecord.StringData(1) } else { $null }'
+        '        }'
+        '        finally {'
+        '            if ($embeddedMsiView) { try { [void]$embeddedMsiView.Close() } catch { } }'
+        '            foreach ($embeddedMsiComObject in @($embeddedMsiRecord, $embeddedMsiView, $embeddedMsiDatabase, $embeddedMsiInstaller)) {'
+        '                if ($embeddedMsiComObject -and [System.Runtime.InteropServices.Marshal]::IsComObject($embeddedMsiComObject)) {'
+        '                    [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($embeddedMsiComObject)'
+        '                }'
+        '            }'
+        '        }'
+        '        if (-not [string]::Equals($embeddedMsiProductCode, $expectedEmbeddedMsiProductCode, [System.StringComparison]::OrdinalIgnoreCase)) {'
+        '            throw "Extracted MSI product code [$embeddedMsiProductCode] does not match the manifest identity [$expectedEmbeddedMsiProductCode]."'
+        '        }'
+        '        Write-ADTLogEntry -Message "Validated the reviewed embedded MSI product identity; installing through PSADT." -Severity ''Info'' -Source ''Install-ADTDeployment'''
+        '        Start-ADTMsiProcess -Action ''Install'' -FilePath $embeddedMsiPath -AdditionalArgumentList ''REBOOT=ReallySuppress'''
+        '    }'
+        '    finally {'
+        '        if (Test-Path -LiteralPath $embeddedMsiExtractDir) {'
+        '            Remove-Item -LiteralPath $embeddedMsiExtractDir -Recurse -Force -ErrorAction SilentlyContinue'
+        '        }'
+        '    }'
+    )
+} elseif (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
     Write-Host "Using custom install command override from PSADT config"
     $lines += @(
         '    # Custom install command override (user-specified)'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -393,15 +393,17 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
-  it('uses the documented InstallShield forwarding form for Sonos', () => {
+  it('uses the reviewed embedded-MSI lifecycle for Sonos', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Sonos.Controller',
-      DEFAULT_PSADT_CONFIG
+      { ...DEFAULT_PSADT_CONFIG, installCommand: 'customer override' }
     );
 
-    expect(adapted.reviewedInstallArgumentsOverride).toBe(
-      '/s /v"/qn /norestart REBOOT=ReallySuppress"'
-    );
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+    expect(adapted.reviewedInstallShieldMsiExtraction).toEqual({
+      expectedMsiFileName: 'Sonos.msi',
+    });
+    expect(adapted.installCommand).toBeUndefined();
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
@@ -474,6 +476,9 @@ describe('application packaging adapters', () => {
         valueName: 'Release',
         minimumDword: 1,
       },
+      reviewedInstallShieldMsiExtraction: {
+        expectedMsiFileName: 'customer-controlled.msi',
+      },
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
       reviewedManagedInstallEvidenceFile: '%ProgramFiles%\\Example\\app.exe',
       reviewedManagedInstallCompletionProcess:
@@ -495,6 +500,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedRegistryInstallEvidence).toBeUndefined();
+    expect(adapted.reviewedInstallShieldMsiExtraction).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
     expect(adapted.reviewedManagedInstallEvidenceFile).toBeUndefined();
     expect(adapted.reviewedManagedInstallCompletionProcess).toBeUndefined();

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -7,6 +7,9 @@ interface ApplicationPackagingAdapter {
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
+  reviewedInstallShieldMsiExtraction?: Readonly<{
+    expectedMsiFileName: string;
+  }>;
   reviewedUninstallArguments?: readonly string[];
   reviewedUninstallProcessGuard?: Readonly<{
     processName: string;
@@ -141,15 +144,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
   },
   {
-    // Sonos ships a Basic MSI inside an InstallShield setup launcher. The
-    // current WinGet switches pass /quiet and /norestart as separate /V
-    // arguments, which the 90.0 launcher rejected with MSI 1619 under
-    // LocalSystem. Revenera documents a single quoted /v payload for reliably
-    // forwarding multiple MSI options through setup.exe. Use that exact form
-    // for both QA and customer Intune packages.
+    // Sonos' compressed InstallShield launcher does not reliably install in a
+    // non-interactive LocalSystem session. Extract its embedded MSI in the
+    // target context, validate the MSI against the manifest-owned product
+    // identity, and install that MSI through PSADT for both QA and customers.
     wingetId: 'Sonos.Controller',
-    reviewedInstallArgumentsOverride:
-      '/s /v"/qn /norestart REBOOT=ReallySuppress"',
+    reviewedInstallShieldMsiExtraction: {
+      expectedMsiFileName: 'Sonos.msi',
+    },
   },
   {
     // MEGA's installer source makes silent installs current-user by default.
@@ -736,6 +738,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedInstallArgumentsOverride &&
+      !config.reviewedInstallShieldMsiExtraction &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedRegistryInstallEvidence &&
@@ -751,6 +754,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedInstallArgumentsOverride: undefined,
+      reviewedInstallShieldMsiExtraction: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedRegistryInstallEvidence: undefined,
@@ -828,6 +832,12 @@ export function applyApplicationPackagingAdapter(
     processesToClose,
     reviewedInstallArguments,
     reviewedInstallArgumentsOverride,
+    installCommand: adapter.reviewedInstallShieldMsiExtraction
+      ? undefined
+      : config.installCommand,
+    reviewedInstallShieldMsiExtraction: adapter.reviewedInstallShieldMsiExtraction
+      ? { ...adapter.reviewedInstallShieldMsiExtraction }
+      : undefined,
     reviewedUninstallArguments,
     reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard
       ? { ...adapter.reviewedUninstallProcessGuard }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -872,6 +872,71 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'extracts and validates a reviewed InstallShield MSI instead of installing the launcher',
+    () => {
+      const productCode = '{6FB7DAEC-5DAD-491E-9951-4684423F291C}';
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Sonos',
+        [],
+        {
+          reviewedInstallShieldMsiExtraction: {
+            expectedMsiFileName: 'Sonos.msi',
+          },
+        },
+        [],
+        'Sonos.Controller',
+        'Sonos',
+        '90.0.77070',
+        `REGISTRY_UNINSTALL_PRODUCT:${productCode}:Sonos`,
+        '/S /V/quiet /V/norestart'
+      );
+
+      expect(generated).toContain(
+        '$embeddedMsiExtractArguments = \'/S /x /b"\' + $embeddedMsiExtractDir + \'" /v"/qb"\''
+      );
+      expect(generated).toContain(
+        "if ($embeddedMsiFiles.Count -ne 1 -or $embeddedMsiFiles[0].Name -ine 'Sonos.msi')"
+      );
+      expect(generated).toContain(
+        `$expectedEmbeddedMsiProductCode = '${productCode}'`
+      );
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath $embeddedMsiPath -AdditionalArgumentList 'REBOOT=ReallySuppress'"
+      );
+      expect(generated).toContain(
+        'Remove-Item -LiteralPath $embeddedMsiExtractDir -Recurse -Force'
+      );
+      expect(generated).not.toContain(
+        "-ArgumentList '/S /V/quiet /V/norestart' -WindowStyle Hidden"
+      );
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects unsafe or ambiguous reviewed InstallShield MSI extraction contracts',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage('exe', 'Unsafe Embedded MSI App', [], {
+          reviewedInstallShieldMsiExtraction: {
+            expectedMsiFileName: '..\\payload.msi',
+          },
+        })
+      ).toThrow('expectedMsiFileName must be a safe literal MSI filename');
+
+      expect(() =>
+        generateRegistryUninstallPackage('exe', 'Ambiguous Embedded MSI App', [], {
+          reviewedInstallShieldMsiExtraction: {
+            expectedMsiFileName: 'payload.msi',
+          },
+        })
+      ).toThrow('requires an exact manifest MSI product code');
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects an unbounded reviewed install argument surface',
     () => {
       expect(() => generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -204,6 +204,14 @@ export interface PSADTConfig {
   // adapters populate this field; customers cannot supply it directly.
   reviewedInstallArgumentsOverride?: string;
 
+  // Internal extraction contract for a reviewed InstallShield launcher whose
+  // embedded MSI is the only reliable LocalSystem deployment path. The
+  // generated package validates the exact MSI filename and its manifest-owned
+  // product code before installation. Customers cannot supply this directly.
+  reviewedInstallShieldMsiExtraction?: {
+    expectedMsiFileName: string;
+  };
+
   // Internal, reviewed vendor arguments appended to an exact registered
   // uninstaller. Application adapters populate this field; it is intentionally
   // not exposed as a customer-facing free-form command surface.
@@ -351,6 +359,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
   reviewedInstallArgumentsOverride: undefined,
+  reviewedInstallShieldMsiExtraction: undefined,
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,
 };


### PR DESCRIPTION
## Summary
- replace the unreliable Sonos InstallShield launcher install with a reviewed embedded-MSI lifecycle
- validate the extracted MSI filename and manifest product code before PSADT installation
- share the same adapter between QA and customer Intune packaging and clean temporary extraction data

## Validation
- 167 focused Vitest tests passed
- targeted ESLint passed
- PowerShell parser passed
- git diff --check passed