### PR TITLE
Activate Sonos embedded MSI lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '5569c16d136f464cbc014f40c70645414c601751',
+  packagerCommit: '7c63f08735a32d428068d9e7fd467830096250a1',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -81,6 +81,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   'af4dfb94c9109ca598abc16a4b8cad57f6790066',
   '22b8e738d51a612f68b01c83b705d2dabc3bbcff',
   'cc143c874f2e84f06097cb199ad9998344040ded',
+  // The .NET Framework registry-evidence release changed only its reviewed
+  // adapter path. Preserve its passing result and every unrelated pass while
+  // the Sonos-specific embedded-MSI lifecycle rolls out.
+  '5569c16d136f464cbc014f40c70645414c601751',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,7 +17,6 @@ describe('QA toolchain targeted retries', () => {
       'IPEVO.Visualizer',
       'IPEVO.VisualizerLTSE',
       'Sonos.Controller',
-      'Microsoft.DotNet.Framework.Runtime',
     ]));
 
     targets.length = 0;
@@ -32,9 +31,17 @@ describe('QA toolchain targeted retries', () => {
         'IPEVO.Visualizer',
         'IPEVO.VisualizerLTSE',
         'Sonos.Controller',
-        'Microsoft.DotNet.Framework.Runtime',
       ])
     );
+  });
+
+  it('does not repeat the consumed .NET Framework retry in the Sonos release', () => {
+    expect(terminalToolchainRetryTargets(
+      '5569c16d136f464cbc014f40c70645414c601751'
+    )).toContain('Microsoft.DotNet.Framework.Runtime');
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).not.toContain('Microsoft.DotNet.Framework.Runtime');
   });
 
   it('retries PDFsam once with its documented managed MSI command', () => {
@@ -476,18 +483,22 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
-  it('retries Sonos with its reviewed InstallShield silent argument payload', () => {
+  it('retries Sonos with its reviewed embedded-MSI lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'sonos.controller', status: 'failed' }
     )).toBe(true);
   });
 
-  it('retries .NET Framework with its reviewed Microsoft registry evidence', () => {
+  it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '5569c16d136f464cbc014f40c70645414c601751',
+      { wingetId: 'microsoft.dotnet.framework.runtime', status: 'failed' }
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'microsoft.dotnet.framework.runtime', status: 'failed' }
-    )).toBe(true);
+    )).toBe(false);
   });
 
   it.each([

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -563,6 +563,26 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // shared Windows runtime when IntuneGet relinquishes its marker.
     'Microsoft.DotNet.Framework.Runtime',
   ],
+  '7c63f08735a32d428068d9e7fd467830096250a1': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    // Sonos' native launcher cannot install silently as LocalSystem. This
+    // release extracts its embedded MSI inside the target context, validates
+    // its exact product identity, and installs it through PSADT.
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 7c63f08735a32d428068d9e7fd467830096250a1
- preserve compatible passes from the .NET registry-evidence release
- carry unresolved targeted retries while avoiding a duplicate .NET Framework replay

## Validation
- 155 focused tests passed
- targeted ESLint passed
- git diff --check passed