### PR TITLE
Activate headless Sonos extraction

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7c63f08735a32d428068d9e7fd467830096250a1',
+  packagerCommit: 'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -85,6 +85,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // adapter path. Preserve its passing result and every unrelated pass while
   // the Sonos-specific embedded-MSI lifecycle rolls out.
   '5569c16d136f464cbc014f40c70645414c601751',
+  // The headless-extraction correction changes only the reviewed Sonos
+  // adapter. Preserve Power Automate Desktop and all unrelated passing runs.
+  '7c63f08735a32d428068d9e7fd467830096250a1',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -583,6 +583,25 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // its exact product identity, and installs it through PSADT.
     'Sonos.Controller',
   ],
+  'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    // Retry Sonos with fully headless embedded-MSI extraction. The previous
+    // /qb path stalled under LocalSystem before the MSI could be installed.
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- promote the headless embedded-MSI packager commit
- retain the previous release as compatible for unrelated passing results
- carry unresolved terminal retries and retry Sonos on the corrected lifecycle

## Validation
- 155 QA profile, scheduler, and retry tests
- targeted ESLint
- git diff --check