### PR TITLE
Fix Sonos InstallShield administrative image

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -244,33 +244,33 @@ if ($psadtConfig.Contains('reviewedInstallArgumentsOverride') -and
     }
 }
 
-$reviewedInstallShieldMsiExtractionConfigured = $false
+$reviewedInstallShieldAdministrativeImageConfigured = $false
 $reviewedInstallShieldMsiExpectedFileName = ''
-if ($psadtConfig.Contains('reviewedInstallShieldMsiExtraction') -and
-    $null -ne $psadtConfig['reviewedInstallShieldMsiExtraction']) {
-    $rawInstallShieldMsiExtraction = $psadtConfig['reviewedInstallShieldMsiExtraction']
-    if ($rawInstallShieldMsiExtraction -isnot [System.Collections.IDictionary]) {
-        throw 'PSADT reviewedInstallShieldMsiExtraction must be a JSON object.'
+if ($psadtConfig.Contains('reviewedInstallShieldAdministrativeImage') -and
+    $null -ne $psadtConfig['reviewedInstallShieldAdministrativeImage']) {
+    $rawInstallShieldAdministrativeImage = $psadtConfig['reviewedInstallShieldAdministrativeImage']
+    if ($rawInstallShieldAdministrativeImage -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedInstallShieldAdministrativeImage must be a JSON object.'
     }
-    foreach ($installShieldExtractionKey in $rawInstallShieldMsiExtraction.Keys) {
-        if ([string]$installShieldExtractionKey -notin @('expectedMsiFileName')) {
-            throw "PSADT reviewedInstallShieldMsiExtraction contains an unsupported property: $installShieldExtractionKey"
+    foreach ($installShieldAdministrativeImageKey in $rawInstallShieldAdministrativeImage.Keys) {
+        if ([string]$installShieldAdministrativeImageKey -notin @('expectedMsiFileName')) {
+            throw "PSADT reviewedInstallShieldAdministrativeImage contains an unsupported property: $installShieldAdministrativeImageKey"
         }
     }
-    if (-not $rawInstallShieldMsiExtraction.Contains('expectedMsiFileName') -or
-        $rawInstallShieldMsiExtraction['expectedMsiFileName'] -isnot [string]) {
-        throw 'PSADT reviewedInstallShieldMsiExtraction must include expectedMsiFileName as a string.'
+    if (-not $rawInstallShieldAdministrativeImage.Contains('expectedMsiFileName') -or
+        $rawInstallShieldAdministrativeImage['expectedMsiFileName'] -isnot [string]) {
+        throw 'PSADT reviewedInstallShieldAdministrativeImage must include expectedMsiFileName as a string.'
     }
     $reviewedInstallShieldMsiExpectedFileName =
-        ([string]$rawInstallShieldMsiExtraction['expectedMsiFileName']).Trim()
+        ([string]$rawInstallShieldAdministrativeImage['expectedMsiFileName']).Trim()
     if ([string]::IsNullOrWhiteSpace($reviewedInstallShieldMsiExpectedFileName) -or
         $reviewedInstallShieldMsiExpectedFileName.Length -gt 128 -or
         [System.IO.Path]::GetFileName($reviewedInstallShieldMsiExpectedFileName) -ne $reviewedInstallShieldMsiExpectedFileName -or
         $reviewedInstallShieldMsiExpectedFileName -notmatch '^[A-Za-z0-9][A-Za-z0-9 ._()-]*\.msi$' -or
         $reviewedInstallShieldMsiExpectedFileName.Contains('..')) {
-        throw 'PSADT reviewedInstallShieldMsiExtraction expectedMsiFileName must be a safe literal MSI filename.'
+        throw 'PSADT reviewedInstallShieldAdministrativeImage expectedMsiFileName must be a safe literal MSI filename.'
     }
-    $reviewedInstallShieldMsiExtractionConfigured = $true
+    $reviewedInstallShieldAdministrativeImageConfigured = $true
 }
 
 $reviewedUninstallArguments = @()
@@ -1275,18 +1275,18 @@ if ($reviewedRegistryInstallEvidenceConfigured) {
     Write-Host "Using reviewed registry installation evidence: $reviewedRegistryInstallEvidenceKeyPath"
 }
 
-if ($reviewedInstallShieldMsiExtractionConfigured) {
+if ($reviewedInstallShieldAdministrativeImageConfigured) {
     if ($IsUserScope -or $installerTypeLower -ne 'exe' -or $fileExtension -ne '.exe') {
-        throw 'PSADT reviewedInstallShieldMsiExtraction requires a machine-scope EXE package.'
+        throw 'PSADT reviewedInstallShieldAdministrativeImage requires a machine-scope EXE package.'
     }
     if (-not $useRegistryUninstall -or
         $registryUninstallProductCode -notmatch '^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$') {
-        throw 'PSADT reviewedInstallShieldMsiExtraction requires an exact manifest MSI product code.'
+        throw 'PSADT reviewedInstallShieldAdministrativeImage requires an exact manifest MSI product code.'
     }
     if (-not [string]::IsNullOrWhiteSpace($customInstallCommand)) {
-        throw 'PSADT reviewedInstallShieldMsiExtraction cannot be combined with a custom install command.'
+        throw 'PSADT reviewedInstallShieldAdministrativeImage cannot be combined with a custom install command.'
     }
-    Write-Host "Using reviewed InstallShield embedded-MSI lifecycle: $reviewedInstallShieldMsiExpectedFileName"
+    Write-Host "Using reviewed InstallShield administrative-image lifecycle: $reviewedInstallShieldMsiExpectedFileName"
 }
 
 if ($useRegistryUninstall) {
@@ -2016,21 +2016,22 @@ if ($removeExistingInstall) {
     )
 }
 
-# Generate install command. Reviewed extraction adapters take precedence over
-# generic launcher synthesis; application adapters remove customer overrides.
-if ($reviewedInstallShieldMsiExtractionConfigured) {
+# Generate install command. Reviewed administrative-image adapters take
+# precedence over generic launcher synthesis; application adapters remove
+# customer overrides.
+if ($reviewedInstallShieldAdministrativeImageConfigured) {
     $lines += @(
-        '    # Extract the reviewed embedded MSI in the target context; never run the vendor launcher as the installer.'
-        '    $embeddedMsiExtractDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_EmbeddedMsi_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
-        '    $null = New-Item -Path $embeddedMsiExtractDir -ItemType Directory -Force'
+        '    # Create the reviewed administrative image in the target context; never run the vendor launcher as the installer.'
+        '    $embeddedMsiAdminDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_AdminImage_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))'
+        '    $null = New-Item -Path $embeddedMsiAdminDir -ItemType Directory -Force'
         '    try {'
-        '        # /qn is required here because extraction runs as LocalSystem with no interactive MSI UI channel.'
-        '        $embeddedMsiExtractArguments = ''/S /x /b"'' + $embeddedMsiExtractDir + ''" /v"/qn"'''
-        '        Write-ADTLogEntry -Message "Extracting reviewed embedded MSI to a bounded temporary directory." -Severity ''Info'' -Source ''Install-ADTDeployment'''
-        '        Start-ADTProcess -FilePath $installerPath -ArgumentList $embeddedMsiExtractArguments -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 5) -TimeoutAction Stop'
-        '        $embeddedMsiFiles = @(Get-ChildItem -LiteralPath $embeddedMsiExtractDir -Filter ''*.msi'' -File -Recurse -ErrorAction Stop)'
+        '        # InstallShield /a creates an administrative image. /s and /qn keep both launcher and MSI UI headless under LocalSystem.'
+        '        $embeddedMsiAdminArguments = ''/a"'' + $embeddedMsiAdminDir + ''" /s /v"/qn TARGETDIR='' + $embeddedMsiAdminDir + '' REBOOT=ReallySuppress"'''
+        '        Write-ADTLogEntry -Message "Creating reviewed InstallShield administrative image in a bounded temporary directory." -Severity ''Info'' -Source ''Install-ADTDeployment'''
+        '        Start-ADTProcess -FilePath $installerPath -ArgumentList $embeddedMsiAdminArguments -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 5) -TimeoutAction Stop'
+        '        $embeddedMsiFiles = @(Get-ChildItem -LiteralPath $embeddedMsiAdminDir -Filter ''*.msi'' -File -Recurse -ErrorAction Stop)'
         "        if (`$embeddedMsiFiles.Count -ne 1 -or `$embeddedMsiFiles[0].Name -ine '$reviewedInstallShieldMsiExpectedFileNameEscaped') {"
-        "            throw 'Reviewed InstallShield extraction did not produce exactly one $reviewedInstallShieldMsiExpectedFileNameEscaped file.'"
+        "            throw 'Reviewed InstallShield administrative image did not produce exactly one $reviewedInstallShieldMsiExpectedFileNameEscaped file.'"
         '        }'
         '        $embeddedMsiPath = $embeddedMsiFiles[0].FullName'
         "        `$expectedEmbeddedMsiProductCode = '$registryUninstallProductCode'"
@@ -2055,14 +2056,14 @@ if ($reviewedInstallShieldMsiExtractionConfigured) {
         '            }'
         '        }'
         '        if (-not [string]::Equals($embeddedMsiProductCode, $expectedEmbeddedMsiProductCode, [System.StringComparison]::OrdinalIgnoreCase)) {'
-        '            throw "Extracted MSI product code [$embeddedMsiProductCode] does not match the manifest identity [$expectedEmbeddedMsiProductCode]."'
+        '            throw "Administrative-image MSI product code [$embeddedMsiProductCode] does not match the manifest identity [$expectedEmbeddedMsiProductCode]."'
         '        }'
-        '        Write-ADTLogEntry -Message "Validated the reviewed embedded MSI product identity; installing through PSADT." -Severity ''Info'' -Source ''Install-ADTDeployment'''
+        '        Write-ADTLogEntry -Message "Validated the reviewed administrative-image MSI product identity; installing through PSADT." -Severity ''Info'' -Source ''Install-ADTDeployment'''
         '        Start-ADTMsiProcess -Action ''Install'' -FilePath $embeddedMsiPath -AdditionalArgumentList ''REBOOT=ReallySuppress'''
         '    }'
         '    finally {'
-        '        if (Test-Path -LiteralPath $embeddedMsiExtractDir) {'
-        '            Remove-Item -LiteralPath $embeddedMsiExtractDir -Recurse -Force -ErrorAction SilentlyContinue'
+        '        if (Test-Path -LiteralPath $embeddedMsiAdminDir) {'
+        '            Remove-Item -LiteralPath $embeddedMsiAdminDir -Recurse -Force -ErrorAction SilentlyContinue'
         '        }'
         '    }'
     )

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -393,14 +393,14 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
-  it('uses the reviewed embedded-MSI lifecycle for Sonos', () => {
+  it('uses the reviewed InstallShield administrative-image lifecycle for Sonos', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Sonos.Controller',
       { ...DEFAULT_PSADT_CONFIG, installCommand: 'customer override' }
     );
 
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
-    expect(adapted.reviewedInstallShieldMsiExtraction).toEqual({
+    expect(adapted.reviewedInstallShieldAdministrativeImage).toEqual({
       expectedMsiFileName: 'Sonos.msi',
     });
     expect(adapted.installCommand).toBeUndefined();
@@ -476,7 +476,7 @@ describe('application packaging adapters', () => {
         valueName: 'Release',
         minimumDword: 1,
       },
-      reviewedInstallShieldMsiExtraction: {
+      reviewedInstallShieldAdministrativeImage: {
         expectedMsiFileName: 'customer-controlled.msi',
       },
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
@@ -500,7 +500,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedRegistryInstallEvidence).toBeUndefined();
-    expect(adapted.reviewedInstallShieldMsiExtraction).toBeUndefined();
+    expect(adapted.reviewedInstallShieldAdministrativeImage).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
     expect(adapted.reviewedManagedInstallEvidenceFile).toBeUndefined();
     expect(adapted.reviewedManagedInstallCompletionProcess).toBeUndefined();

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -7,7 +7,7 @@ interface ApplicationPackagingAdapter {
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
-  reviewedInstallShieldMsiExtraction?: Readonly<{
+  reviewedInstallShieldAdministrativeImage?: Readonly<{
     expectedMsiFileName: string;
   }>;
   reviewedUninstallArguments?: readonly string[];
@@ -145,11 +145,12 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // Sonos' compressed InstallShield launcher does not reliably install in a
-    // non-interactive LocalSystem session. Extract its embedded MSI in the
-    // target context, validate the MSI against the manifest-owned product
-    // identity, and install that MSI through PSADT for both QA and customers.
+    // non-interactive LocalSystem session. Create the vendor-supported
+    // administrative image in the target context, validate its MSI against the
+    // manifest-owned product identity, and install that MSI through PSADT for
+    // both QA and customers.
     wingetId: 'Sonos.Controller',
-    reviewedInstallShieldMsiExtraction: {
+    reviewedInstallShieldAdministrativeImage: {
       expectedMsiFileName: 'Sonos.msi',
     },
   },
@@ -738,7 +739,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedInstallArgumentsOverride &&
-      !config.reviewedInstallShieldMsiExtraction &&
+      !config.reviewedInstallShieldAdministrativeImage &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedRegistryInstallEvidence &&
@@ -754,7 +755,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedInstallArgumentsOverride: undefined,
-      reviewedInstallShieldMsiExtraction: undefined,
+      reviewedInstallShieldAdministrativeImage: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedRegistryInstallEvidence: undefined,
@@ -832,11 +833,12 @@ export function applyApplicationPackagingAdapter(
     processesToClose,
     reviewedInstallArguments,
     reviewedInstallArgumentsOverride,
-    installCommand: adapter.reviewedInstallShieldMsiExtraction
+    installCommand: adapter.reviewedInstallShieldAdministrativeImage
       ? undefined
       : config.installCommand,
-    reviewedInstallShieldMsiExtraction: adapter.reviewedInstallShieldMsiExtraction
-      ? { ...adapter.reviewedInstallShieldMsiExtraction }
+    reviewedInstallShieldAdministrativeImage:
+      adapter.reviewedInstallShieldAdministrativeImage
+      ? { ...adapter.reviewedInstallShieldAdministrativeImage }
       : undefined,
     reviewedUninstallArguments,
     reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -872,7 +872,7 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'extracts and validates a reviewed InstallShield MSI instead of installing the launcher',
+    'creates and validates a reviewed InstallShield administrative image instead of installing the launcher',
     () => {
       const productCode = '{6FB7DAEC-5DAD-491E-9951-4684423F291C}';
       const generated = generateRegistryUninstallPackage(
@@ -880,7 +880,7 @@ describe('PSADT vendor argument contract', () => {
         'Sonos',
         [],
         {
-          reviewedInstallShieldMsiExtraction: {
+          reviewedInstallShieldAdministrativeImage: {
             expectedMsiFileName: 'Sonos.msi',
           },
         },
@@ -893,9 +893,9 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(generated).toContain(
-        '$embeddedMsiExtractArguments = \'/S /x /b"\' + $embeddedMsiExtractDir + \'" /v"/qn"\''
+        '$embeddedMsiAdminArguments = \'/a"\' + $embeddedMsiAdminDir + \'" /s /v"/qn TARGETDIR=\' + $embeddedMsiAdminDir + \' REBOOT=ReallySuppress"\''
       );
-      expect(generated).not.toContain('/v"/qb"');
+      expect(generated).not.toContain(' /x ');
       expect(generated).toContain(
         "if ($embeddedMsiFiles.Count -ne 1 -or $embeddedMsiFiles[0].Name -ine 'Sonos.msi')"
       );
@@ -906,7 +906,7 @@ describe('PSADT vendor argument contract', () => {
         "Start-ADTMsiProcess -Action 'Install' -FilePath $embeddedMsiPath -AdditionalArgumentList 'REBOOT=ReallySuppress'"
       );
       expect(generated).toContain(
-        'Remove-Item -LiteralPath $embeddedMsiExtractDir -Recurse -Force'
+        'Remove-Item -LiteralPath $embeddedMsiAdminDir -Recurse -Force'
       );
       expect(generated).not.toContain(
         "-ArgumentList '/S /V/quiet /V/norestart' -WindowStyle Hidden"
@@ -916,11 +916,11 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'rejects unsafe or ambiguous reviewed InstallShield MSI extraction contracts',
+    'rejects unsafe or ambiguous reviewed InstallShield administrative-image contracts',
     () => {
       expect(() =>
         generateRegistryUninstallPackage('exe', 'Unsafe Embedded MSI App', [], {
-          reviewedInstallShieldMsiExtraction: {
+          reviewedInstallShieldAdministrativeImage: {
             expectedMsiFileName: '..\\payload.msi',
           },
         })
@@ -928,7 +928,7 @@ describe('PSADT vendor argument contract', () => {
 
       expect(() =>
         generateRegistryUninstallPackage('exe', 'Ambiguous Embedded MSI App', [], {
-          reviewedInstallShieldMsiExtraction: {
+          reviewedInstallShieldAdministrativeImage: {
             expectedMsiFileName: 'payload.msi',
           },
         })

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -204,11 +204,12 @@ export interface PSADTConfig {
   // adapters populate this field; customers cannot supply it directly.
   reviewedInstallArgumentsOverride?: string;
 
-  // Internal extraction contract for a reviewed InstallShield launcher whose
-  // embedded MSI is the only reliable LocalSystem deployment path. The
-  // generated package validates the exact MSI filename and its manifest-owned
-  // product code before installation. Customers cannot supply this directly.
-  reviewedInstallShieldMsiExtraction?: {
+  // Internal administrative-image contract for a reviewed InstallShield
+  // launcher whose embedded MSI is the only reliable LocalSystem deployment
+  // path. The generated package validates the exact MSI filename and its
+  // manifest-owned product code before installation. Customers cannot supply
+  // this directly.
+  reviewedInstallShieldAdministrativeImage?: {
     expectedMsiFileName: string;
   };
 
@@ -359,7 +360,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
   reviewedInstallArgumentsOverride: undefined,
-  reviewedInstallShieldMsiExtraction: undefined,
+  reviewedInstallShieldAdministrativeImage: undefined,
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,
 };


### PR DESCRIPTION
## Summary
- replace the obsolete InstallShield /x extraction assumption with the documented /a administrative-image mode
- keep the exact embedded MSI filename and ProductCode validation before PSADT installs it
- apply the same reviewed adapter to QA and customer Intune packages

## Validation
- 114 focused Vitest checks passed
- targeted ESLint passed
- PowerShell parser passed
- git diff --check passed