### PR TITLE
Activate Sonos administrative-image packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42',
+  packagerCommit: '81ad189d7e51026bd15681264f774f498429f526',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -88,6 +88,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The headless-extraction correction changes only the reviewed Sonos
   // adapter. Preserve Power Automate Desktop and all unrelated passing runs.
   '7c63f08735a32d428068d9e7fd467830096250a1',
+  // The administrative-image correction changes only the reviewed Sonos
+  // adapter. Preserve Mendeley Reference Manager and all unrelated passes.
+  'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -35,13 +35,22 @@ describe('QA toolchain targeted retries', () => {
     );
   });
 
-  it('does not repeat the consumed .NET Framework retry in the Sonos release', () => {
+  it('does not repeat the consumed .NET Framework retry in the Sonos releases', () => {
     expect(terminalToolchainRetryTargets(
       '5569c16d136f464cbc014f40c70645414c601751'
     )).toContain('Microsoft.DotNet.Framework.Runtime');
     expect(terminalToolchainRetryTargets(
       QA_PSADT_TOOLCHAIN.packagerCommit
     )).not.toContain('Microsoft.DotNet.Framework.Runtime');
+  });
+
+  it('carries Sonos into the administrative-image retry after failed extraction', () => {
+    expect(terminalToolchainRetryTargets(
+      'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42'
+    )).toContain('Sonos.Controller');
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('Sonos.Controller');
   });
 
   it('retries PDFsam once with its documented managed MSI command', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -602,6 +602,26 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // /qb path stalled under LocalSystem before the MSI could be installed.
     'Sonos.Controller',
   ],
+  '81ad189d7e51026bd15681264f774f498429f526': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative packager release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    // Retry Sonos through the documented InstallShield administrative-image
+    // path. The previous /x command entered uninstall mode on the current
+    // launcher and returned Windows Installer error 1605.
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate shared packager commit 81ad189d7e51026bd15681264f774f498429f526
- preserve unaffected passing QA results from the prior release
- carry Sonos into the targeted retry set

## Validation
- 227 focused Vitest checks passed
- targeted ESLint passed
- git diff --check passed