### PR TITLE
Block unsupported Yandex managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -430,6 +430,27 @@ describe('Sonos Controller managed install block migration contract', () => {
   });
 });
 
+describe('Yandex Browser managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260815204500_block_yandex_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the interactive Yandex uninstaller across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Yandex.Browser'");
+    expect(sql).toContain(
+      'https://browser.yandex.com/help/en/about/install'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260815204500_block_yandex_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260815204500_block_yandex_unsupported_managed_uninstall.sql
@@ -1,0 +1,37 @@
+-- The current Yandex Browser WinGet manifest supports unattended installation,
+-- but does not publish an unattended uninstall contract. Isolated user-context
+-- lifecycle QA confirmed that the registered vendor uninstaller remains
+-- interactive: the parent command did not remove YandexBrowser within the
+-- bounded five-minute window and independent detection still found the app.
+-- Keep the same unsupported lifecycle out of customer packaging and QA until
+-- Yandex documents a reliable unattended Windows uninstall command.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Yandex.Browser',
+  'unsupported_managed_uninstall',
+  'Yandex Browser supports unattended installation, but its Windows uninstaller currently requires user interaction. Isolated lifecycle QA confirmed that the registered vendor uninstall command did not remove the application or its exact uninstall registration.',
+  'https://browser.yandex.com/help/en/about/install'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Yandex.Browser';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Yandex.Browser'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Yandex Browser from customer packaging and QA while its Windows uninstaller requires interaction
- remove any queued or failed Yandex candidates from the active QA queue
- add a migration contract test for the shared eligibility rule

## Evidence
- QA run 31906633860 installed and detected version 26.6.4.760 successfully
- the registered uninstaller did not remove the exact YandexBrowser registration within five minutes
- independent post-uninstall detection still found the application
- the current WinGet manifest publishes unattended install switches but no unattended uninstall switch
- Yandex's official Windows removal documentation describes an interactive flow

## Verification
- 45 migration contract tests passed