### PR TITLE
Route UHK Agent through its supported user scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -68,6 +68,14 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Makeblock.xToolStudio', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' makeblock.xtoolstudio ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope(
+      'UltimateGadgetLaboratories.UHKAgent',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      ' ultimategadgetlaboratories.uhkagent ',
+      undefined
+    )).toBe('user');
     expect(resolveApplicationInstallScope('Rakuten.Viber', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' rakuten.viber ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -118,6 +118,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // UHK Agent is built with Electron Builder's assisted NSIS profile
+    // (oneClick: false) without perMachine. Electron Builder defaults that
+    // profile to per-user installation. WinGet currently omits Scope, so the
+    // generic machine default installs below LocalSystem's LocalAppData and
+    // registers an unusable systemprofile uninstaller. Keep QA and customer
+    // Intune packages in the intended signed-in user context instead.
+    wingetId: 'UltimateGadgetLaboratories.UHKAgent',
+    requiredInstallScope: 'user',
+  },
+  {
     // Viber's MSI is declared machine-scope by WinGet, but its Directory
     // table targets LocalAppData. Under LocalSystem that resolves to the
     // system profile and the vendor's VerifyInstalledFiles action rolls the


### PR DESCRIPTION
## Summary
- classify UHK Agent's Electron Builder assisted NSIS package as user-scoped
- keep QA and customer Intune packaging out of the LocalSystem profile
- cover normalized and case-insensitive scope resolution

## Evidence
- upstream config sets oneClick=false without perMachine
- Electron Builder documents perMachine=false as the default
- QA installed under systemprofile and registered an unavailable LocalAppData uninstaller

## Verification
- 93 focused tests passed
- focused ESLint passed
- git diff --check passed