### PR TITLE
Use Xodo's documented silent uninstall contract

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -110,6 +110,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['--silent', '--force_stop']);
     expect(
+      applyApplicationPackagingAdapter('Apryse.XodoPDFReader', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['-q']);
+    expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--force-uninstall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -154,6 +154,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
   },
   {
+    // Apryse documents -q as the unattended Windows uninstall switch for the
+    // install4j-based Xodo/PDF Studio family. The registered Xodo PDF Reader
+    // command omits it, which leaves the confirmation flow waiting in a
+    // non-interactive Intune session. Append the vendor's quiet contract to
+    // the exact captured product-specific uninstaller for QA and customers.
+    wingetId: 'Apryse.XodoPDFReader',
+    reviewedUninstallArguments: ['-q'],
+  },
+  {
     // Sonos' compressed InstallShield launcher does not reliably install in a
     // non-interactive LocalSystem session. Create the vendor-supported
     // administrative image in the target context, validate its MSI against the


### PR DESCRIPTION
## Summary
- append Apryse's documented -q switch to the exact captured Xodo PDF Reader uninstaller
- apply the same managed lifecycle to QA and customer Intune packages
- cover the reviewed adapter contract

## Evidence
- install and detection passed in QA run 31912104340
- the registered uninstaller left product 0810-2976-4416-1744 present for five minutes
- Apryse's official Windows deployment guidance documents uninstall.exe -q for unattended removal

## Verification
- 134 focused tests passed
- focused ESLint passed
- git diff --check passed