### PR TITLE
Block unsupported Lark EXE managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -451,6 +451,28 @@ describe('Yandex Browser managed uninstall block migration contract', () => {
   });
 });
 
+describe('Lark EXE managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260815235000_block_lark_exe_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the interactive Lark EXE while preserving the enterprise MSI route', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'ByteDance.Lark'");
+    expect(sql).toContain('ByteDance.Lark.MSI');
+    expect(sql).toContain(
+      'https://www.larksuite.com/hc/en-US/articles/360048487868-deploy-lark-by-using-microsoft-installer'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260815235000_block_lark_exe_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260815235000_block_lark_exe_unsupported_managed_uninstall.sql
@@ -1,0 +1,36 @@
+-- Lark's user-scoped EXE manifest supports unattended installation, but does
+-- not publish an unattended uninstall contract. Isolated lifecycle QA confirmed
+-- that the registered vendor uninstaller stayed interactive for more than five
+-- minutes and independent detection still found the application. Lark publishes
+-- a separate enterprise MSI package, so keep the EXE package out of customer
+-- packaging and QA rather than guessing an undocumented removal switch.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'ByteDance.Lark',
+  'unsupported_managed_uninstall',
+  'The user-scoped Lark EXE supports unattended installation but not a reliable unattended uninstall. Use the separate ByteDance.Lark.MSI enterprise package for managed deployment.',
+  'https://www.larksuite.com/hc/en-US/articles/360048487868-deploy-lark-by-using-microsoft-installer'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'ByteDance.Lark';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment. Use ByteDance.Lark.MSI instead.',
+    updated_at = now()
+where winget_id = 'ByteDance.Lark'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block the user-scoped ByteDance.Lark EXE from managed customer packaging and QA
- preserve the supported enterprise path through ByteDance.Lark.MSI
- supersede obsolete failed or queued EXE candidates

## Evidence
- isolated PSADT install and detection passed
- registered vendor uninstaller remained interactive for 310 seconds and returned 60001
- independent post-uninstall detection still found Lark
- Lark documents a separate Microsoft Installer deployment route

## Verification
- 46 migration contract tests passed
- focused ESLint passed
- git diff --check passed