### PR TITLE
Close Core Temp before managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -639,6 +639,18 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
+  it('closes Core Temp before its driver-backed Inno removal lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'ALCPU.CoreTemp',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'Core Temp', description: 'Core Temp hardware monitor' },
+    ]);
+    expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
+  });
+
   it('closes Greenshot before install and removal lifecycle actions', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Greenshot.Greenshot',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -605,6 +605,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Core Temp loads a low-level monitoring driver, and lifecycle QA found its
+    // registered Inno removal still present after the unattended deadline.
+    // Close the well-known desktop process before invoking the uninstaller to
+    // remove the application-in-use blocker under LocalSystem.
+    wingetId: 'ALCPU.CoreTemp',
+    requiredProcessesToClose: [
+      { name: 'Core Temp', description: 'Core Temp hardware monitor' },
+    ],
+  },
+  {
     wingetId: 'Greenshot.Greenshot',
     requiredProcessesToClose: [
       { name: 'Greenshot', description: 'Greenshot' },


### PR DESCRIPTION
## Summary
- add an exact ALCPU.CoreTemp packaging adapter
- close the Core Temp desktop process before PSADT install/removal lifecycle actions
- apply the same adapter to QA and customer packages through the execution-profile hash

## Evidence
- install and detection passed under LocalSystem
- the registered Inno removal remained present for 310 seconds and returned 60001
- independent post-uninstall detection still found Core Temp
- Core Temp documents its low-level monitoring driver requirement

## Verification
- 168 focused adapter, profile, and PSADT packager tests passed
- focused ESLint passed
- git diff --check passed