### PR TITLE
Close Wisenet WAVE before managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -651,6 +651,18 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
+  it('closes the Wisenet WAVE desktop client before its Burn removal lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Hanwha.WisenetWAVEClient',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'Wisenet WAVE', description: 'Wisenet WAVE Client' },
+    ]);
+    expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
+  });
+
   it('closes Greenshot before install and removal lifecycle actions', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Greenshot.Greenshot',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -615,6 +615,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Wisenet WAVE starts its desktop client after a silent installation. The
+    // vendor documents that Windows client executable as `Wisenet WAVE.exe`,
+    // and its Burn uninstaller returns 1603 while the client remains in use.
+    // Close the client before managed lifecycle actions so unattended removal
+    // can delete the exact application registration under LocalSystem.
+    wingetId: 'Hanwha.WisenetWAVEClient',
+    requiredProcessesToClose: [
+      { name: 'Wisenet WAVE', description: 'Wisenet WAVE Client' },
+    ],
+  },
+  {
     wingetId: 'Greenshot.Greenshot',
     requiredProcessesToClose: [
       { name: 'Greenshot', description: 'Greenshot' },


### PR DESCRIPTION
## Summary
- add an exact shared packaging adapter for Hanwha.WisenetWAVEClient
- close the vendor-documented Wisenet WAVE client before managed lifecycle actions
- cover the effective process-close configuration with focused tests

## Evidence
- installation succeeded, but the Burn uninstaller returned 1603 and left the exact application registration after the 311-second deadline
- Hanwha documents the Windows client executable as Wisenet WAVE.exe

## Verification
- 169 focused tests passed
- focused ESLint passed
- git diff --check passed