### PR TITLE
Block Core Temp unsupported managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -639,18 +639,6 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
-  it('closes Core Temp before its driver-backed Inno removal lifecycle', () => {
-    const adapted = applyApplicationPackagingAdapter(
-      'ALCPU.CoreTemp',
-      DEFAULT_PSADT_CONFIG
-    );
-
-    expect(adapted.processesToClose).toEqual([
-      { name: 'Core Temp', description: 'Core Temp hardware monitor' },
-    ]);
-    expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
-  });
-
   it('closes the Wisenet WAVE desktop client before its Burn removal lifecycle', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Hanwha.WisenetWAVEClient',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -605,16 +605,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // Core Temp loads a low-level monitoring driver, and lifecycle QA found its
-    // registered Inno removal still present after the unattended deadline.
-    // Close the well-known desktop process before invoking the uninstaller to
-    // remove the application-in-use blocker under LocalSystem.
-    wingetId: 'ALCPU.CoreTemp',
-    requiredProcessesToClose: [
-      { name: 'Core Temp', description: 'Core Temp hardware monitor' },
-    ],
-  },
-  {
     // Wisenet WAVE starts its desktop client after a silent installation. The
     // vendor documents that Windows client executable as `Wisenet WAVE.exe`,
     // and its Burn uninstaller returns 1603 while the client remains in use.

--- a/supabase/migrations/20260816012500_block_coretemp_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260816012500_block_coretemp_unsupported_managed_uninstall.sql
@@ -1,0 +1,39 @@
+-- Core Temp 1.20.1 installs silently and is detected correctly, but its
+-- registered Inno uninstaller does not complete an unattended LocalSystem
+-- removal. Isolated lifecycle QA first tested the complete quiet Inno switch
+-- set, then repeated the lifecycle after closing the vendor-documented desktop
+-- process. Both profiles left the exact ARP entry installed after the bounded
+-- 310-second deadline. ALCPU only documents interactive removal through
+-- Programs and Features, while its hardware driver can remain loaded until it
+-- is explicitly stopped or Windows restarts. Do not offer this as a managed
+-- application until the vendor publishes a verifiable unattended lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'ALCPU.CoreTemp',
+  'unsupported_managed_uninstall',
+  'Core Temp installs silently, but its current Inno uninstaller does not remove the application during an unattended LocalSystem lifecycle, including after the desktop process is closed. The vendor documents only interactive removal and the application remains detected after the bounded completion deadline.',
+  'https://www.alcpu.com/forums/viewtopic.php?p=8987'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'ALCPU.CoreTemp';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'ALCPU.CoreTemp'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block ALCPU.CoreTemp from customer packaging and QA backfills because its unattended removal contract is not reliable
- retire the unsuccessful process-close adapter
- invalidate any existing curated verification and supersede obsolete failed or queued candidates

## Evidence
- install and post-install detection passed under LocalSystem
- the full quiet Inno switch profile left the exact ARP entry after 310 seconds
- a second profile closed the documented Core Temp desktop process and failed identically
- independent post-removal detection still returned Detected
- ALCPU documents interactive removal through Programs and Features and notes that its driver can require explicit stop or restart

## Verification
- 217 focused tests passed
- focused ESLint passed
- git diff --check passed