### PR TITLE
Block Wisenet WAVE unsupported managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -639,18 +639,6 @@ describe('application packaging adapters', () => {
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
-  it('closes the Wisenet WAVE desktop client before its Burn removal lifecycle', () => {
-    const adapted = applyApplicationPackagingAdapter(
-      'Hanwha.WisenetWAVEClient',
-      DEFAULT_PSADT_CONFIG
-    );
-
-    expect(adapted.processesToClose).toEqual([
-      { name: 'Wisenet WAVE', description: 'Wisenet WAVE Client' },
-    ]);
-    expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
-  });
-
   it('closes Greenshot before install and removal lifecycle actions', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Greenshot.Greenshot',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -605,17 +605,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // Wisenet WAVE starts its desktop client after a silent installation. The
-    // vendor documents that Windows client executable as `Wisenet WAVE.exe`,
-    // and its Burn uninstaller returns 1603 while the client remains in use.
-    // Close the client before managed lifecycle actions so unattended removal
-    // can delete the exact application registration under LocalSystem.
-    wingetId: 'Hanwha.WisenetWAVEClient',
-    requiredProcessesToClose: [
-      { name: 'Wisenet WAVE', description: 'Wisenet WAVE Client' },
-    ],
-  },
-  {
     wingetId: 'Greenshot.Greenshot',
     requiredProcessesToClose: [
       { name: 'Greenshot', description: 'Greenshot' },

--- a/supabase/migrations/20260816015000_block_wisenet_wave_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260816015000_block_wisenet_wave_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- Wisenet WAVE Client 6.0.5.41290 installs silently and is detected correctly,
+-- but its signed Burn uninstaller does not complete unattended LocalSystem
+-- removal. Isolated lifecycle QA tested the exact registered uninstaller and
+-- repeated the lifecycle after closing the vendor-documented `Wisenet WAVE`
+-- desktop process. Both profiles returned 1603, left the exact ARP entry in
+-- place after the bounded 311-second deadline, and remained independently
+-- detected. Hanwha documents Windows removal through its installer or the
+-- interactive Programs and Features flow, not a silent enterprise command.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Hanwha.WisenetWAVEClient',
+  'unsupported_managed_uninstall',
+  'Wisenet WAVE Client installs silently, but its current signed Burn uninstaller returns 1603 and leaves the application installed during unattended LocalSystem removal, including after the documented desktop process is closed. The vendor documents only interactive Windows removal.',
+  'https://support.hanwhavision.com/hc/en-us/articles/47257343139347-How-do-I-cleanly-uninstall-WAVE'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Hanwha.WisenetWAVEClient';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Hanwha.WisenetWAVEClient'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Hanwha.WisenetWAVEClient from customer packaging and QA backfills because its unattended removal contract is not reliable
- retire the unsuccessful process-close adapter
- invalidate existing curated verification and supersede obsolete failed or queued candidates

## Evidence
- installation and post-install detection pass under LocalSystem
- the exact registered Burn uninstaller returns 1603 and leaves the exact ARP entry after 311 seconds
- repeating the lifecycle after closing the vendor-documented Wisenet WAVE process fails identically
- independent post-removal detection still returns Detected
- Hanwha documents removal through its installer or interactive Windows Programs and Features flow

## Verification
- 216 focused tests passed
- focused ESLint passed
- git diff --check passed