### PR TITLE
Prefer enterprise installers for machine packaging

### DIFF
--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -90,6 +90,41 @@ describe('catalog installer reconciliation', () => {
     })).toBeNull();
   });
 
+  it('prefers an enterprise MSI over a per-user bootstrapper for machine packaging', () => {
+    const ringCentralInstallers: NormalizedInstaller[] = [
+      {
+        architecture: 'x64',
+        url: 'https://example.test/ringcentral-user.exe',
+        sha256: 'A'.repeat(64),
+        type: 'nullsoft',
+        scope: 'machine',
+        silentArgs: '/S',
+      },
+      {
+        architecture: 'x64',
+        url: 'https://example.test/ringcentral-admin.msi',
+        sha256: 'B'.repeat(64),
+        type: 'wix',
+        scope: 'machine',
+        silentArgs: '/qn /norestart',
+        productCode: '{1DE15838-06D0-4C9D-B513-F86B806149D5}',
+      },
+    ];
+
+    const selected = selectTrustedCatalogInstaller(ringCentralInstallers, {
+      wingetId: 'RingCentral.RingCentralTeamsDesktopPlugin',
+      version: '26.2.20-build.233',
+      architecture: 'x64',
+      installScope: 'machine',
+      installerUrl: ringCentralInstallers[0].url,
+      installerSha256: ringCentralInstallers[0].sha256,
+    });
+
+    expect(selected?.type).toBe('wix');
+    expect(selected?.url).toBe('https://example.test/ringcentral-admin.msi');
+    expect(selected?.productCode).toBe('{1DE15838-06D0-4C9D-B513-F86B806149D5}');
+  });
+
   it('rebuilds a stale cart command from the trusted machine manifest entry', async () => {
     const reconciled = await reconcileCatalogInstaller(operaItem());
 

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -34,6 +34,24 @@ function normalized(value?: string | null): string {
   return value?.trim().toLowerCase() || '';
 }
 
+function preferEnterpriseMachineInstaller(
+  installers: NormalizedInstaller[],
+  installScope: WingetScope,
+): NormalizedInstaller[] {
+  if (installScope !== 'machine') return installers;
+
+  const enterpriseInstallers = installers.filter((installer) => {
+    const effectiveType = normalized(
+      installer.type === 'zip' && installer.nestedInstallerType
+        ? installer.nestedInstallerType
+        : installer.type,
+    );
+    return effectiveType === 'msi' || effectiveType === 'wix';
+  });
+
+  return enterpriseInstallers.length > 0 ? enterpriseInstallers : installers;
+}
+
 function selectPreferredIdentity(
   installers: NormalizedInstaller[],
   input: TrustedCatalogInstallerRequest,
@@ -83,13 +101,19 @@ export function selectTrustedCatalogInstaller(
     (installer) => normalized(installer.scope) === input.installScope
   );
   if (exactScope.length > 0) {
-    return selectPreferredIdentity(exactScope, input);
+    return selectPreferredIdentity(
+      preferEnterpriseMachineInstaller(exactScope, input.installScope),
+      input,
+    );
   }
 
   const unspecifiedScope = architectureCandidates.filter(
     (installer) => !installer.scope?.trim()
   );
-  return selectPreferredIdentity(unspecifiedScope, input);
+  return selectPreferredIdentity(
+    preferEnterpriseMachineInstaller(unspecifiedScope, input.installScope),
+    input,
+  );
 }
 
 export async function reconcileCatalogInstaller(

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -55,6 +55,29 @@ describe('QA candidate normalization', () => {
     expect(selectWingetInstaller(scopedInstallers, 'x64')?.InstallerUrl).toContain('all-users');
   });
 
+  it('prefers an admin MSI over a bootstrapper for machine-scope QA', () => {
+    const ringCentralInstallers = [
+      {
+        Architecture: 'x64',
+        Scope: 'machine',
+        InstallerType: 'nullsoft',
+        InstallerUrl: 'https://example.test/ringcentral-user.exe',
+      },
+      {
+        Architecture: 'x64',
+        Scope: 'machine',
+        InstallerType: 'wix',
+        InstallerUrl: 'https://example.test/ringcentral-admin.msi',
+        ProductCode: '{1DE15838-06D0-4C9D-B513-F86B806149D5}',
+      },
+    ];
+
+    expect(selectQaVmInstaller(ringCentralInstallers)?.installer.InstallerType).toBe('wix');
+    expect(selectWingetInstaller(ringCentralInstallers, 'x64')?.InstallerType).toBe('wix');
+    expect(selectWingetInstaller(ringCentralInstallers, 'x64', 'machine')?.InstallerType)
+      .toBe('wix');
+  });
+
   it('falls back to user scope when no machine or unspecified-scope installer exists', () => {
     const userInstaller = {
       Architecture: 'x64',

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -37,23 +37,52 @@ function preferredScopeInstaller(
   installers: WingetInstallerCandidate[],
   requestedScope?: 'machine' | 'user'
 ): WingetInstallerCandidate | null {
+  const preferEnterpriseMachineInstaller = (
+    candidates: WingetInstallerCandidate[],
+    machineScope: boolean,
+  ): WingetInstallerCandidate | null => {
+    if (!machineScope) return candidates[0] || null;
+
+    const enterpriseInstaller = candidates.find((installer) => {
+      const sourceType = installer.InstallerType?.trim().toLowerCase();
+      const effectiveType = sourceType === 'zip'
+        ? installer.NestedInstallerType?.trim().toLowerCase()
+        : sourceType;
+      return effectiveType === 'msi' || effectiveType === 'wix';
+    });
+    return enterpriseInstaller || candidates[0] || null;
+  };
+
   if (requestedScope) {
-    return (
-      installers.find(
-        (installer) => installer.Scope?.trim().toLowerCase() === requestedScope
-      ) ||
-      installers.find((installer) => !installer.Scope?.trim()) ||
-      null
+    const exactScope = installers.filter(
+      (installer) => installer.Scope?.trim().toLowerCase() === requestedScope
+    );
+    if (exactScope.length > 0) {
+      return preferEnterpriseMachineInstaller(exactScope, requestedScope === 'machine');
+    }
+
+    const unspecifiedScope = installers.filter((installer) => !installer.Scope?.trim());
+    return preferEnterpriseMachineInstaller(
+      unspecifiedScope,
+      requestedScope === 'machine',
     );
   }
 
-  return (
-    installers.find((installer) => installer.Scope?.trim().toLowerCase() === 'machine') ||
-    installers.find((installer) => !installer.Scope?.trim()) ||
-    installers.find((installer) => installer.Scope?.trim().toLowerCase() === 'user') ||
-    installers[0] ||
-    null
+  const machineScope = installers.filter(
+    (installer) => installer.Scope?.trim().toLowerCase() === 'machine'
   );
+  if (machineScope.length > 0) {
+    return preferEnterpriseMachineInstaller(machineScope, true);
+  }
+
+  const unspecifiedScope = installers.filter((installer) => !installer.Scope?.trim());
+  if (unspecifiedScope.length > 0) {
+    return preferEnterpriseMachineInstaller(unspecifiedScope, true);
+  }
+
+  return installers.find(
+    (installer) => installer.Scope?.trim().toLowerCase() === 'user'
+  ) || installers[0] || null;
 }
 
 export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 'arm64' {


### PR DESCRIPTION
## Summary
- prefer MSI/WiX installer variants when WinGet publishes multiple matching machine-scope installers
- apply the same deterministic selection in customer packaging and QA candidate creation
- preserve existing architecture, scope, locale, and current-identity behavior when no enterprise installer is available

## Root cause
RingCentral publishes both an x64 Nullsoft bootstrapper and an x64 admin MSI. The old first-match behavior selected the bootstrapper, which registered an uninstaller inside the LocalSystem profile but did not leave the executable present. The admin MSI provides an exact product code and a deterministic managed lifecycle.

## Verification
- 81 focused tests passed across selector, QA enqueue, GitHub Actions, and package route suites
- affected-file ESLint passed
- git diff --check passed