### PR TITLE
Activate root-level install4j uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '81ad189d7e51026bd15681264f774f498429f526',
+  packagerCommit: 'f70f65692afddaf7b249cdacdcbacb356822f4f0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -91,6 +91,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The administrative-image correction changes only the reviewed Sonos
   // adapter. Preserve Mendeley Reference Manager and all unrelated passes.
   'e6dfe920d82e0b62c5d5e420fb603f61acdb5a42',
+  // Preserve compatible passing coverage from the prior protected release.
+  // The intervening changes repair reviewed failure paths while the exact
+  // current profile remains mandatory for newly dispatched candidates.
+  '81ad189d7e51026bd15681264f774f498429f526',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -622,6 +622,25 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // launcher and returned Windows Installer error 1605.
     'Sonos.Controller',
   ],
+  'f70f65692afddaf7b249cdacdcbacb356822f4f0': [
+    // Preserve every still-unconsumed reviewed lifecycle retry in this
+    // cumulative release. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    // Retry Snapform with root-level install4j uninstall.exe recognition and
+    // the framework's documented unattended removal arguments.
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA to protected packager commit f70f65692afddaf7b249cdacdcbacb356822f4f0
- retain compatible passing coverage from the prior protected release
- carry reviewed retries forward and requeue Snapform with the corrected install4j uninstall path

## Validation
- 156 package-profile, backfill, enqueue, and dispatch tests passed
- focused ESLint passed
- git diff --check passed