### PR TITLE
Activate DWG FastView lifecycle packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f70f65692afddaf7b249cdacdcbacb356822f4f0',
+  packagerCommit: '4d9a1c9cae5383b6bf44f7501e4bb0dc157c7e3f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -95,6 +95,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The intervening changes repair reviewed failure paths while the exact
   // current profile remains mandatory for newly dispatched candidates.
   '81ad189d7e51026bd15681264f774f498429f526',
+  // DWG FastView's reviewed silent-removal adapter changes only that vendor's
+  // failed lifecycle. Preserve all compatible passes from the preceding
+  // protected release while newly dispatched profiles use the exact pin.
+  'f70f65692afddaf7b249cdacdcbacb356822f4f0',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -641,6 +641,27 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'IPEVO.VisualizerLTSE',
     'Sonos.Controller',
   ],
+  '4d9a1c9cae5383b6bf44f7501e4bb0dc157c7e3f': [
+    // Preserve every still-unconsumed reviewed lifecycle retry across the
+    // atomic pin change. Compatible passes are filtered before enqueue.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    // The registered DWG FastView setup command is interactive unless the
+    // vendor's reviewed /silent /uninstall contract is appended. Retry the
+    // exact failed version once through the shared QA/customer adapter.
+    'Gstarsoft.DWGFastView',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
Pins QA and customer package generation to the reviewed DWG FastView lifecycle release, preserves compatible historical passes, and schedules one bounded retry of the failed version. Verification: 145 focused tests passed, targeted lint passed, and diff validation passed.