### PR TITLE
Fix DWG FastView unattended removal switch

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -110,7 +110,7 @@ describe('application packaging adapters', () => {
         'Gstarsoft.DWGFastView',
         DEFAULT_PSADT_CONFIG
       ).reviewedUninstallArguments
-    ).toEqual(['/silent', '/uninstall']);
+    ).toEqual(['/s', '/uninstall']);
     expect(
       applyApplicationPackagingAdapter('Google.GoogleDrive', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -307,13 +307,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // DWG FastView registers setup.exe without a separate quiet uninstall
-    // command. The vendor setup lifecycle requires both /silent and
-    // /uninstall; replaying the bare ARP command opens the removal UI and
-    // leaves the exact DWGFastView_en_ww registration installed under SYSTEM.
-    // Append the reviewed contract to the captured installation-specific path
-    // so QA and customer Intune packages share the same unattended removal.
+    // command. Version 9.10's current WinGet manifest uses /s for unattended
+    // setup, while a /silent /uninstall trial left the exact
+    // DWGFastView_en_ww registration installed under SYSTEM. Pair the current
+    // silent switch with setup.exe's established /uninstall lifecycle on this
+    // exact package so QA and customer Intune packages exercise the same path.
     wingetId: 'Gstarsoft.DWGFastView',
-    reviewedUninstallArguments: ['/silent', '/uninstall'],
+    reviewedUninstallArguments: ['/s', '/uninstall'],
   },
   {
     // Dell Optimizer's registered InstallShield helper exits without removing


### PR DESCRIPTION
## Summary
- use DWG FastView 9.10's current unattended setup token for removal
- retain the setup.exe uninstall lifecycle
- apply the same reviewed adapter to QA and customer packages

## Verification
- 85 focused tests passed
- ESLint passed
- git diff --check passed