### PR TITLE
Activate corrected DWG FastView packaging release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4d9a1c9cae5383b6bf44f7501e4bb0dc157c7e3f',
+  packagerCommit: '02caa5a067569ad1d1e017fc6f52f3ee4e152120',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -99,6 +99,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // failed lifecycle. Preserve all compatible passes from the preceding
   // protected release while newly dispatched profiles use the exact pin.
   'f70f65692afddaf7b249cdacdcbacb356822f4f0',
+  // The current DWG FastView silent-token correction remains confined to its
+  // previously failing removal path. Preserve unrelated compatible passes.
+  '4d9a1c9cae5383b6bf44f7501e4bb0dc157c7e3f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -662,6 +662,26 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // exact failed version once through the shared QA/customer adapter.
     'Gstarsoft.DWGFastView',
   ],
+  '02caa5a067569ad1d1e017fc6f52f3ee4e152120': [
+    // Carry every unconsumed bounded lifecycle retry through the atomic pin
+    // rollout. Compatible passes are removed before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    // Give the exact failed DWG FastView version one final bounded retry with
+    // the current /s /uninstall shared QA/customer packaging adapter.
+    'Gstarsoft.DWGFastView',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- advance the protected QA/customer packager pin to 02caa5a
- preserve compatible passes from the previous release
- carry bounded retry targets, including DWG FastView's final corrected retry

## Verification
- 145 focused tests passed
- ESLint passed
- git diff --check passed