### PR TITLE
Block unsupported DWG FastView managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -106,12 +106,6 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);
     expect(
-      applyApplicationPackagingAdapter(
-        'Gstarsoft.DWGFastView',
-        DEFAULT_PSADT_CONFIG
-      ).reviewedUninstallArguments
-    ).toEqual(['/s', '/uninstall']);
-    expect(
       applyApplicationPackagingAdapter('Google.GoogleDrive', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--silent', '--force_stop']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -306,16 +306,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/silent', 'forall'],
   },
   {
-    // DWG FastView registers setup.exe without a separate quiet uninstall
-    // command. Version 9.10's current WinGet manifest uses /s for unattended
-    // setup, while a /silent /uninstall trial left the exact
-    // DWGFastView_en_ww registration installed under SYSTEM. Pair the current
-    // silent switch with setup.exe's established /uninstall lifecycle on this
-    // exact package so QA and customer Intune packages exercise the same path.
-    wingetId: 'Gstarsoft.DWGFastView',
-    reviewedUninstallArguments: ['/s', '/uninstall'],
-  },
-  {
     // Dell Optimizer's registered InstallShield helper exits without removing
     // the product even with Dell's documented switches. Invoke the original,
     // hash-verified Dell Update Package instead; Dell documents the

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -473,6 +473,25 @@ describe('Lark EXE managed uninstall block migration contract', () => {
   });
 });
 
+describe('DWG FastView managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260816135000_block_dwgfastview_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unreliable vendor uninstaller across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Gstarsoft.DWGFastView'");
+    expect(sql).toContain('Gstarsoft.DWGFastView.installer.yaml');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260816135000_block_dwgfastview_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260816135000_block_dwgfastview_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- DWG FastView 9.10 supports unattended installation, but its registered
+-- setup.exe does not provide a reliable unattended removal lifecycle. Three
+-- isolated LocalSystem runs tried the bare registered command and the two
+-- plausible setup lifecycles (/silent /uninstall and /s /uninstall). Each
+-- remained installed through the bounded five-minute completion check, and
+-- independent detection still found the exact DWGFastView_en_ww registration.
+-- Keep this package out of customer packaging and QA until the vendor publishes
+-- a verified unattended uninstall contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Gstarsoft.DWGFastView',
+  'unsupported_managed_uninstall',
+  'DWG FastView supports unattended installation, but its registered Windows uninstaller does not currently provide a reliable unattended removal lifecycle. Isolated lifecycle QA confirmed that the exact application registration remained after each bounded removal attempt.',
+  'https://github.com/microsoft/winget-pkgs/blob/master/manifests/g/Gstarsoft/DWGFastView/9.10.0/Gstarsoft.DWGFastView.installer.yaml'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Gstarsoft.DWGFastView';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Gstarsoft.DWGFastView'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- remove ineffective DWG FastView uninstall guesses from the shared adapter
- block the package from customer packaging and QA after three bounded lifecycle failures
- clear catalog verification and supersede queued/failed candidates

## Evidence
- bare ARP command did not remove DWGFastView_en_ww
- /silent /uninstall did not remove it within 310 seconds
- /s /uninstall did not remove it within 310 seconds

## Verification
- 82 focused tests passed
- ESLint passed
- git diff --check passed