### PR TITLE
Activate DWG FastView safety-block release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '02caa5a067569ad1d1e017fc6f52f3ee4e152120',
+  packagerCommit: '7870c214b74ac666b16573ac42cbc9e65a3848e2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -102,6 +102,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The current DWG FastView silent-token correction remains confined to its
   // previously failing removal path. Preserve unrelated compatible passes.
   '4d9a1c9cae5383b6bf44f7501e4bb0dc157c7e3f',
+  // Removing the ineffective DWG FastView adapter affects only an app now
+  // blocked at the shared eligibility gate. Preserve every compatible pass.
+  '02caa5a067569ad1d1e017fc6f52f3ee4e152120',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -682,6 +682,24 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // the current /s /uninstall shared QA/customer packaging adapter.
     'Gstarsoft.DWGFastView',
   ],
+  '7870c214b74ac666b16573ac42cbc9e65a3848e2': [
+    // Carry the still-unconsumed bounded lifecycle retries through the atomic
+    // pin rollout. DWG FastView is intentionally absent because the shared
+    // eligibility gate now blocks its unsupported managed uninstall.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- advance the protected QA/customer packager pin to 7870c214
- preserve compatible passing coverage
- carry remaining bounded retries while intentionally excluding blocked DWG FastView

## Verification
- 192 focused tests passed
- ESLint passed
- git diff --check passed