### PR TITLE
Fix Visual Studio managed install roots

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -290,14 +290,14 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedManagedInstallDirectory:
-        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+        '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
       reviewedManagedUninstall: {
         executablePath:
           '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
         arguments: [
           'uninstall',
           '--installPath',
-          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+          '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
           '--quiet',
           '--norestart',
         ],
@@ -339,14 +339,14 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedManagedInstallDirectory:
-        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+        '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Professional',
       reviewedManagedUninstall: {
         executablePath:
           '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
         arguments: [
           'uninstall',
           '--installPath',
-          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+          '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Professional',
           '--quiet',
           '--norestart',
         ],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -55,14 +55,17 @@ const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
 };
 
 const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
+  // Visual Studio 2022 and newer are 64-bit products whose documented default
+  // instance root is Program Files. The Visual Studio Installer itself remains
+  // a 32-bit shared component below Program Files (x86).
   'Microsoft.VisualStudio.BuildTools':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+    '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
   'Microsoft.VisualStudio.Community':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Community',
+    '%ProgramFiles%\\Microsoft Visual Studio\\18\\Community',
   'Microsoft.VisualStudio.Enterprise':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Enterprise',
+    '%ProgramFiles%\\Microsoft Visual Studio\\18\\Enterprise',
   'Microsoft.VisualStudio.Professional':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\Professional',
+    '%ProgramFiles%\\Microsoft Visual Studio\\18\\Professional',
   'Microsoft.VisualStudio.2019.BuildTools':
     '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools',
   'Microsoft.VisualStudio.2019.Community':
@@ -72,13 +75,13 @@ const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
   'Microsoft.VisualStudio.2019.Professional':
     '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\Professional',
   'Microsoft.VisualStudio.2022.BuildTools':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
+    '%ProgramFiles%\\Microsoft Visual Studio\\2022\\BuildTools',
   'Microsoft.VisualStudio.2022.Community':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Community',
+    '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Community',
   'Microsoft.VisualStudio.2022.Enterprise':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise',
+    '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Enterprise',
   'Microsoft.VisualStudio.2022.Professional':
-    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\Professional',
+    '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Professional',
 } as const;
 
 const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -683,14 +683,14 @@ describe('PSADT vendor argument contract', () => {
         [],
         {
           reviewedManagedInstallDirectory:
-            '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+            '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
           reviewedManagedUninstall: {
             executablePath:
               '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
             arguments: [
               'uninstall',
               '--installPath',
-              '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools',
+              '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
               '--quiet',
               '--norestart',
             ],
@@ -709,7 +709,7 @@ describe('PSADT vendor argument contract', () => {
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe')"
       );
       expect(uninstallFunction).toContain(
-        "$managedUninstallArguments = @('uninstall', '--installPath', '%ProgramFiles(x86)%\\Microsoft Visual Studio\\18\\BuildTools', '--quiet', '--norestart')"
+        "$managedUninstallArguments = @('uninstall', '--installPath', '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools', '--quiet', '--norestart')"
       );
       expect(uninstallFunction).toContain(
         '$managedUninstallDeadline = [DateTime]::UtcNow.AddMinutes(15)'


### PR DESCRIPTION
## Summary
- use the documented 64-bit Program Files instance root for Visual Studio 2022 and version 18
- retain the shared Visual Studio Installer executable under Program Files (x86)
- update adapter and generated-packager contract coverage

## Evidence
The isolated Enterprise 2022 QA run installed files below %ProgramFiles%\\Microsoft Visual Studio\\2022\\Enterprise, while the previous adapter checked %ProgramFiles(x86)% and produced a false install failure plus ineffective cleanup.

## Verification
- 
pm test -- lib/packaging-adapters.test.ts lib/qa/psadt-packager-contract.test.ts (115 passed)
- pre-commit lint passed