### PR TITLE
Activate Visual Studio install path fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7870c214b74ac666b16573ac42cbc9e65a3848e2',
+  packagerCommit: '1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -105,6 +105,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Removing the ineffective DWG FastView adapter affects only an app now
   // blocked at the shared eligibility gate. Preserve every compatible pass.
   '02caa5a067569ad1d1e017fc6f52f3ee4e152120',
+  // Visual Studio's managed-directory correction affects only 64-bit 2022+
+  // instances. Preserve unrelated compatible passes from this release.
+  '7870c214b74ac666b16573ac42cbc9e65a3848e2',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -71,10 +71,8 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
-  it.each([
-    'Microsoft.OfficeDeploymentTool',
-    'Microsoft.VisualStudio.BuildTools',
-  ])('keeps the managed lifecycle retry scoped to its release for %s', (wingetId) => {
+  it('keeps the Office Deployment Tool managed lifecycle retry scoped to its release', () => {
+    const wingetId = 'Microsoft.OfficeDeploymentTool';
     expect(shouldRetryTerminalToolchainCandidate(
       '2e68a941d3410e4eb7c6ed1e73fbc0eff290c807',
       { wingetId, status: 'failed' }
@@ -266,17 +264,10 @@ describe('QA toolchain targeted retries', () => {
   });
 
   it.each([
-    'Microsoft.VisualStudio.Community',
-    'Microsoft.VisualStudio.Enterprise',
-    'Microsoft.VisualStudio.Professional',
     'Microsoft.VisualStudio.2019.BuildTools',
     'Microsoft.VisualStudio.2019.Community',
     'Microsoft.VisualStudio.2019.Enterprise',
     'Microsoft.VisualStudio.2019.Professional',
-    'Microsoft.VisualStudio.2022.BuildTools',
-    'Microsoft.VisualStudio.2022.Community',
-    'Microsoft.VisualStudio.2022.Enterprise',
-    'Microsoft.VisualStudio.2022.Professional',
     'Mozilla.Firefox.de',
   ])(
     'keeps the terminal %s retry scoped to its historical toolchain release',
@@ -291,6 +282,22 @@ describe('QA toolchain targeted retries', () => {
       )).toBe(false);
     }
   );
+
+  it.each([
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+  ])('retries terminal %s through the corrected 64-bit instance root', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+  });
 
   it('keeps the VirtualBox retry scoped to its historical toolchain release', () => {
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -700,6 +700,33 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'IPEVO.VisualizerLTSE',
     'Sonos.Controller',
   ],
+  '1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f': [
+    // Carry every still-unconsumed bounded retry across the atomic pin
+    // rollout. Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    // Visual Studio 2022 and newer install 64-bit instances below Program
+    // Files. Retry terminal outcomes through the corrected shared adapter.
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- advance the protected QA/customer packager pin to 1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f`n- preserve unrelated compatible passing coverage
- replay failed Visual Studio 2022+ family candidates against the corrected 64-bit instance root

## Verification
- 
pm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts lib/qa/psadt-packager-contract.test.ts (228 passed)