### PR TITLE
Fix Visual Studio 2022 Build Tools instance root

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -334,6 +334,27 @@ describe('application packaging adapters', () => {
     ).toEqual(['/uninstall', '/quiet', '/norestart']);
     expect(
       applyApplicationPackagingAdapter(
+        'Microsoft.VisualStudio.2022.BuildTools',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.Professional',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -55,9 +55,10 @@ const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
 };
 
 const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
-  // Visual Studio 2022 and newer are 64-bit products whose documented default
-  // instance root is Program Files. The Visual Studio Installer itself remains
-  // a 32-bit shared component below Program Files (x86).
+  // Visual Studio 2022 and newer full IDE editions use Program Files. Build
+  // Tools 2022 remains below Program Files (x86), as documented by Microsoft's
+  // unattended Build Tools deployment example. The shared Visual Studio
+  // Installer also remains below Program Files (x86).
   'Microsoft.VisualStudio.BuildTools':
     '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
   'Microsoft.VisualStudio.Community':
@@ -75,7 +76,7 @@ const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
   'Microsoft.VisualStudio.2019.Professional':
     '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\Professional',
   'Microsoft.VisualStudio.2022.BuildTools':
-    '%ProgramFiles%\\Microsoft Visual Studio\\2022\\BuildTools',
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
   'Microsoft.VisualStudio.2022.Community':
     '%ProgramFiles%\\Microsoft Visual Studio\\2022\\Community',
   'Microsoft.VisualStudio.2022.Enterprise':

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -402,6 +402,46 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig).toMatchObject(expectedConfig);
   });
 
+  it('binds the Visual Studio 2022 Build Tools x86 instance root to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.VisualStudio.2022.BuildTools',
+      displayName: 'Visual Studio BuildTools 2022',
+      publisher: 'Microsoft',
+      version: '17.14.37',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet --wait --campaign "winget"',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Visual Studio BuildTools 2022',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedPath =
+      '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools';
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: expectedPath,
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          expectedPath,
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+  });
+
   it('binds shared-runtime retention to both the normalized config and QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.EdgeWebView2Runtime',


### PR DESCRIPTION
## Summary
- keep Visual Studio 2022 full IDE editions under Program Files
- restore the documented Visual Studio 2022 Build Tools instance root under Program Files (x86)
- cover the shared customer and QA package profile with focused regression tests

## Evidence
- failed isolated QA run 31953435331 created Visual Studio setup state but could not find the incorrectly asserted Program Files instance
- Microsoft documents the unattended 2022 Build Tools installation path as %ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools

## Verification
- npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (169 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check

Repository-wide npx tsc --noEmit remains blocked by existing unrelated test typing errors.