### PR TITLE
Activate Visual Studio Build Tools root fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f',
+  packagerCommit: '82958ac0c0b39e06af14a87b70319251604910f7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -108,6 +108,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Visual Studio's managed-directory correction affects only 64-bit 2022+
   // instances. Preserve unrelated compatible passes from this release.
   '7870c214b74ac666b16573ac42cbc9e65a3848e2',
+  // Build Tools 2022 remains below Program Files (x86), while the full 2022
+  // IDE editions remain below Program Files. Preserve compatible passes.
+  '1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -292,7 +292,7 @@ describe('QA toolchain targeted retries', () => {
     'Microsoft.VisualStudio.2022.Community',
     'Microsoft.VisualStudio.2022.Enterprise',
     'Microsoft.VisualStudio.2022.Professional',
-  ])('retries terminal %s through the corrected 64-bit instance root', (wingetId) => {
+  ])('retries terminal %s through the current reviewed instance root', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -727,6 +727,33 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Microsoft.VisualStudio.2022.Enterprise',
     'Microsoft.VisualStudio.2022.Professional',
   ],
+  '82958ac0c0b39e06af14a87b70319251604910f7': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    // Keep the Visual Studio retries bounded while correcting the 2022 Build
+    // Tools exception back to its documented Program Files (x86) root.
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate protected packager commit 82958ac0c0b39e06af14a87b70319251604910f7
- preserve compatible results from the previous release
- carry bounded terminal retry targets across the atomic QA/customer workflow pin rollout

## Verification
- npx vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts lib/packaging-adapters.test.ts (146 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check