### PR TITLE
Block unsupported Nmap managed install

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -430,6 +430,27 @@ describe('Sonos Controller managed install block migration contract', () => {
   });
 });
 
+describe('Nmap managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260816183000_block_nmap_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported Nmap installer across catalog, customer packaging, and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Insecure.Nmap'");
+    expect(sql).toContain(
+      'https://github.com/microsoft/winget-pkgs/issues/341747'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('Yandex Browser managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260816183000_block_nmap_unsupported_managed_install.sql
+++ b/supabase/migrations/20260816183000_block_nmap_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- The only published Insecure.Nmap WinGet manifest is the obsolete 7.80
+-- user-scope installer. Isolated lifecycle QA confirmed that its advertised
+-- silent switch does not complete a managed install or create an unambiguous
+-- installed-app registration. The open WinGet update for the maintained Nmap
+-- release is explicitly blocked as Interactive-Only-Installer. Do not offer
+-- this package for customer deployment or repeatedly consume the QA VM until
+-- a verifiable unattended installer contract becomes available.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Insecure.Nmap',
+  'unsupported_managed_install',
+  'The published Nmap package does not provide a verifiable unattended managed-install contract. QA of WinGet version 7.80 returned 60001 and created no unambiguous installed-app registration; the maintained-version WinGet request is classified as interactive-only.',
+  'https://github.com/microsoft/winget-pkgs/issues/341747'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Insecure.Nmap';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Insecure.Nmap'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block the legacy Nmap package from customer packaging and QA
- document the failed unattended lifecycle and the upstream interactive-only classification
- add a migration contract regression test

## Verification
- `npx vitest run lib/qa/migration-contract.test.ts`
- `npx eslint lib/qa/migration-contract.test.ts`
- repository pre-push lint hook