### PR TITLE
Fix OpenWebStart unattended uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -114,6 +114,10 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['-q']);
     expect(
+      applyApplicationPackagingAdapter('karakun.OpenWebStart', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['-q', '-Dinstall4j.suppressUnattendedReboot=true']);
+    expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--force-uninstall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -167,6 +167,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-q'],
   },
   {
+    // OpenWebStart documents its Windows payload as an install4j application
+    // with a root-level uninstall.exe. The registered command is interactive,
+    // and the generic framework detector cannot infer install4j from WinGet's
+    // bare `-q` install switch. Append install4j's unattended removal contract
+    // to the exact captured product uninstaller for both QA and customers.
+    wingetId: 'karakun.OpenWebStart',
+    reviewedUninstallArguments: [
+      '-q',
+      '-Dinstall4j.suppressUnattendedReboot=true',
+    ],
+  },
+  {
     // Sonos' compressed InstallShield launcher does not reliably install in a
     // non-interactive LocalSystem session. Create the vendor-supported
     // administrative image in the target context, validate its MSI against the


### PR DESCRIPTION
## Summary
- append install4j unattended uninstall arguments for OpenWebStart
- keep the exact captured registration as the removal completion signal
- share the adapter between QA and customer Intune packaging

## Evidence
- OpenWebStart documents a root-level `uninstall.exe` and `.install4j` payload
- QA run 31958183650 installed and detected 1.14.0, then left the exact registration after the generic uninstall deadline

## Verification
- `npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts`
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`