### PR TITLE
Activate OpenWebStart uninstall fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '82958ac0c0b39e06af14a87b70319251604910f7',
+  packagerCommit: '11933b94c72275551a565bed7364ebb8616e4414',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -111,6 +111,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Build Tools 2022 remains below Program Files (x86), while the full 2022
   // IDE editions remain below Program Files. Preserve compatible passes.
   '1467e138d1e6f5f0cee3d8cda6f981c4d44f6b8f',
+  // OpenWebStart's install4j uninstall adapter changes only that app's failed
+  // lifecycle. Preserve compatible passes from the prior protected release.
+  '82958ac0c0b39e06af14a87b70319251604910f7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,7 @@ describe('QA toolchain targeted retries', () => {
       'IPEVO.Visualizer',
       'IPEVO.VisualizerLTSE',
       'Sonos.Controller',
+      'karakun.OpenWebStart',
     ]));
 
     targets.length = 0;
@@ -31,6 +32,7 @@ describe('QA toolchain targeted retries', () => {
         'IPEVO.Visualizer',
         'IPEVO.VisualizerLTSE',
         'Sonos.Controller',
+        'karakun.OpenWebStart',
       ])
     );
   });
@@ -296,6 +298,13 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries OpenWebStart once with its install4j unattended uninstaller', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'karakun.openwebstart', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -754,6 +754,34 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Microsoft.VisualStudio.2022.Enterprise',
     'Microsoft.VisualStudio.2022.Professional',
   ],
+  '11933b94c72275551a565bed7364ebb8616e4414': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    // Retry the exact failed OpenWebStart release once with install4j's
+    // documented unattended removal arguments.
+    'karakun.OpenWebStart',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate protected packager commit `11933b94c72275551a565bed7364ebb8616e4414`
- preserve compatible historical passes
- schedule one bounded OpenWebStart retry under the corrected shared adapter

## Verification
- `npx vitest run lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts lib/packaging-adapters.test.ts`
- `npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts`