### PR TITLE
Fix MSYS2 managed lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -61,6 +61,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses MSYS2\'s registered product family instead of its catalog title', () => {
+    expect(resolveApplicationUninstallCommand(
+      'MSYS2.MSYS2',
+      'REGISTRY_UNINSTALL:MSYS2 Installer'
+    )).toBe('REGISTRY_UNINSTALL:MSYS2');
+    expect(resolveApplicationUninstallCommand(
+      'msys2.msys2',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
@@ -117,6 +128,15 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('karakun.OpenWebStart', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['-q', '-Dinstall4j.suppressUnattendedReboot=true']);
+    expect(
+      applyApplicationPackagingAdapter('MSYS2.MSYS2', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedExactUninstall: {
+        executablePath: 'C:\\msys64\\uninstall.exe',
+        arguments: ['pr', '--confirm-command'],
+        completionTimeoutMinutes: 5,
+      },
+    });
     expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -179,6 +179,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // The official MSYS2 installer always targets C:\msys64 for this WinGet
+    // profile and documents its Qt Installer Framework removal command. The
+    // catalog name (`MSYS2 Installer`) differs from the registered product
+    // (`MSYS2 <version>`), so capture that reviewed identity and use the
+    // vendor's exact headless uninstaller for QA and customer packages.
+    wingetId: 'MSYS2.MSYS2',
+    reviewedExactUninstall: {
+      executablePath: 'C:\\msys64\\uninstall.exe',
+      arguments: ['pr', '--confirm-command'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // Sonos' compressed InstallShield launcher does not reliably install in a
     // non-interactive LocalSystem session. Create the vendor-supported
     // administrative image in the target context, validate its MSI against the
@@ -725,6 +738,10 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'Memory',
     registeredDisplayName: 'Memory',
     registeredRegistryKey: 'Memory',
+  },
+  'msys2.msys2': {
+    generatedDisplayName: 'MSYS2 Installer',
+    registeredDisplayName: 'MSYS2',
   },
 };
 


### PR DESCRIPTION
## Summary
- map the WinGet catalog title `MSYS2 Installer` to the observed `MSYS2 <version>` product family
- invoke MSYS2's official headless removal command from the fixed WinGet install root
- share the exact lifecycle adapter between QA and customer Intune packaging

## Evidence
- failed QA run `31960587958`
- official MSYS2 installer README documents `C:\msys64\uninstall.exe pr --confirm-command`
- official package metadata declares the product display name `MSYS2`

## Verification
- `npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts`
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`