### PR TITLE
Activate MSYS2 lifecycle fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '11933b94c72275551a565bed7364ebb8616e4414',
+  packagerCommit: '0b562aa574144a19a6b4c5e6c3d3d7a4c241961f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -114,6 +114,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // OpenWebStart's install4j uninstall adapter changes only that app's failed
   // lifecycle. Preserve compatible passes from the prior protected release.
   '82958ac0c0b39e06af14a87b70319251604910f7',
+  // MSYS2's reviewed identity and official CLI removal affect only its failed
+  // lifecycle. Preserve compatible passes from the prior protected release.
+  '11933b94c72275551a565bed7364ebb8616e4414',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -18,6 +18,7 @@ describe('QA toolchain targeted retries', () => {
       'IPEVO.VisualizerLTSE',
       'Sonos.Controller',
       'karakun.OpenWebStart',
+      'MSYS2.MSYS2',
     ]));
 
     targets.length = 0;
@@ -33,6 +34,7 @@ describe('QA toolchain targeted retries', () => {
         'IPEVO.VisualizerLTSE',
         'Sonos.Controller',
         'karakun.OpenWebStart',
+        'MSYS2.MSYS2',
       ])
     );
   });
@@ -305,6 +307,13 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'karakun.openwebstart', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries MSYS2 once with its reviewed product identity and uninstaller', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'msys2.msys2', status: 'failed' }
     )).toBe(true);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -782,6 +782,35 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // documented unattended removal arguments.
     'karakun.OpenWebStart',
   ],
+  '0b562aa574144a19a6b4c5e6c3d3d7a4c241961f': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    // Retry the exact failed MSYS2 release once with its reviewed registration
+    // identity and official Qt Installer Framework removal command.
+    'MSYS2.MSYS2',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate protected packager commit `0b562aa574144a19a6b4c5e6c3d3d7a4c241961f`
- preserve compatible historical passes
- schedule one bounded MSYS2 retry with the corrected shared lifecycle

## Verification
- `npx vitest run lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts lib/packaging-adapters.test.ts`
- `npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts`