### PR TITLE
Fix MSYS2 registry-driven silent uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -130,13 +130,8 @@ describe('application packaging adapters', () => {
     ).toEqual(['-q', '-Dinstall4j.suppressUnattendedReboot=true']);
     expect(
       applyApplicationPackagingAdapter('MSYS2.MSYS2', DEFAULT_PSADT_CONFIG)
-    ).toMatchObject({
-      reviewedExactUninstall: {
-        executablePath: 'C:\\msys64\\uninstall.exe',
-        arguments: ['pr', '--confirm-command'],
-        completionTimeoutMinutes: 5,
-      },
-    });
+        .reviewedUninstallArguments
+    ).toEqual(['pr', '--confirm-command']);
     expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -183,13 +183,11 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // profile and documents its Qt Installer Framework removal command. The
     // catalog name (`MSYS2 Installer`) differs from the registered product
     // (`MSYS2 <version>`), so capture that reviewed identity and use the
-    // vendor's exact headless uninstaller for QA and customer packages.
+    // vendor's headless arguments with the registry-discovered uninstaller for
+    // QA and customer packages. Keeping path discovery registry-owned avoids
+    // weakening the reviewed exact-path allowlist for root-level executables.
     wingetId: 'MSYS2.MSYS2',
-    reviewedExactUninstall: {
-      executablePath: 'C:\\msys64\\uninstall.exe',
-      arguments: ['pr', '--confirm-command'],
-      completionTimeoutMinutes: 5,
-    },
+    reviewedUninstallArguments: ['pr', '--confirm-command'],
   },
   {
     // Sonos' compressed InstallShield launcher does not reliably install in a


### PR DESCRIPTION
Uses the reviewed MSYS2 registered-product identity and appends the vendor's official headless arguments to the registry-discovered uninstaller. This preserves the exact-path security allowlist and applies to both QA and customer PSADT packages.\n\nVerified: 232 focused tests passed.