### PR TITLE
Activate MSYS2 registry uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0b562aa574144a19a6b4c5e6c3d3d7a4c241961f',
+  packagerCommit: 'a48022baddf7b3f312541ef2e127220f508104a8',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -117,6 +117,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // MSYS2's reviewed identity and official CLI removal affect only its failed
   // lifecycle. Preserve compatible passes from the prior protected release.
   '11933b94c72275551a565bed7364ebb8616e4414',
+  // The MSYS2 correction preserves the reviewed path allowlist and changes
+  // only its previously failing removal path. Preserve all compatible passes.
+  '0b562aa574144a19a6b4c5e6c3d3d7a4c241961f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -811,6 +811,35 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // identity and official Qt Installer Framework removal command.
     'MSYS2.MSYS2',
   ],
+  'a48022baddf7b3f312541ef2e127220f508104a8': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    // Retry the preparation failure once with registry-owned path discovery
+    // and the reviewed Qt Installer Framework removal arguments.
+    'MSYS2.MSYS2',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
Pins QA profiles to protected packager commit a48022baddf7b3f312541ef2e127220f508104a8, preserves compatible prior passes, and carries bounded terminal retries including MSYS2.\n\nVerified: 116 focused tests passed.