### PR TITLE
Fix QA portable installer lifecycle

### DIFF
--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -116,7 +116,8 @@ describe('QA candidate normalization', () => {
     expect(normalizeQaInstallerType('inno', 'exe')).toBe('exe');
     expect(normalizeQaInstallerType('nullsoft', 'exe')).toBe('exe');
     expect(normalizeQaInstallerType('wix', 'exe')).toBe('msi');
-    expect(normalizeQaInstallerType('portable', 'exe')).toBe('exe');
+    expect(normalizeQaInstallerType('portable', 'exe')).toBe('portable');
+    expect(normalizeQaInstallerType(null, 'portable')).toBe('portable');
   });
 
   it('gives extensionless executable URLs a runnable filename', () => {

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -142,16 +142,17 @@ export function normalizeInstallerSha256(value?: string | null): string {
 export function normalizeQaInstallerType(
   wingetType?: string | null,
   recipeType: string = 'exe'
-): 'exe' | 'msi' | 'msix' | 'appx' | 'zip' {
+): 'exe' | 'msi' | 'msix' | 'appx' | 'zip' | 'portable' {
   const normalized = wingetType?.trim().toLowerCase();
   if (normalized === 'wix' || normalized === 'msi') return 'msi';
   if (['inno', 'nullsoft', 'burn', 'exe'].includes(normalized || '')) return 'exe';
   if (normalized === 'msix') return 'msix';
   if (normalized === 'appx') return 'appx';
   if (normalized === 'zip') return 'zip';
+  if (normalized === 'portable') return 'portable';
   const fallback = recipeType.trim().toLowerCase();
-  return ['exe', 'msi', 'msix', 'appx', 'zip'].includes(fallback)
-    ? (fallback as 'exe' | 'msi' | 'msix' | 'appx' | 'zip')
+  return ['exe', 'msi', 'msix', 'appx', 'zip', 'portable'].includes(fallback)
+    ? (fallback as 'exe' | 'msi' | 'msix' | 'appx' | 'zip' | 'portable')
     : 'exe';
 }
 


### PR DESCRIPTION
## Summary
- preserve WinGet portable installer types in QA candidate normalization
- allow portable recipe fallbacks to use the shared portable folder lifecycle
- cover the exact normalization regression exposed by Tor Browser

## Verification
- npm test -- lib/qa/candidate.test.ts lib/qa/test-config.test.ts packager/tests/psadt-nested-portable.test.ts (87 passed)
- npx eslint lib/qa/candidate.ts lib/qa/candidate.test.ts
- git diff --check

The repository-wide TypeScript check still reports unrelated pre-existing test typing errors; the touched files pass focused tests and lint.