### PR TITLE
Support Tor Browser managed folder lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -563,10 +563,15 @@ if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
         throw 'PSADT reviewedManagedInstallDirectory must be a string.'
     }
     $reviewedManagedInstallDirectory = ([string]$psadtConfig['reviewedManagedInstallDirectory']).Trim()
+    $isReviewedMachineManagedDirectory =
+        $reviewedManagedInstallDirectory -match '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$'
+    $isReviewedUserDesktopManagedDirectory =
+        $IsUserScope -and
+        $reviewedManagedInstallDirectory -match '^%USERPROFILE%\\Desktop\\[^*?"<>|\x00-\x1f]+$'
     if ($reviewedManagedInstallDirectory.Length -gt 260 -or
-        $reviewedManagedInstallDirectory -notmatch '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$' -or
+        -not ($isReviewedMachineManagedDirectory -or $isReviewedUserDesktopManagedDirectory) -or
         @($reviewedManagedInstallDirectory -split '\\') -contains '..') {
-        throw 'PSADT reviewedManagedInstallDirectory must be a safe path below Program Files or the reviewed SystemDrive SWSetup root.'
+        throw 'PSADT reviewedManagedInstallDirectory must be a safe machine path or a reviewed user Desktop path for a user-scope package.'
     }
 }
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -89,8 +89,18 @@ describe('application packaging adapters', () => {
     )).toBe('user');
     expect(resolveApplicationInstallScope('Rakuten.Viber', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' rakuten.viber ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope('TorProject.TorBrowser', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' torproject.torbrowser ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
+  });
+
+  it('models Tor Browser as the vendor-documented extracted user folder', () => {
+    expect(
+      applyApplicationPackagingAdapter('TorProject.TorBrowser', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
+    });
   });
 
   it('adds reviewed silent removal arguments for failing vendor lifecycles', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -142,6 +142,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Tor Browser's official Windows package is a user-scope NSIS extractor,
+    // not an ARP-registered application. Tor documents that the default
+    // installation is the user's Desktop\Tor Browser folder and that removal
+    // consists of deleting that folder. Model that exact extracted-directory
+    // lifecycle instead of waiting for an uninstall registry entry that the
+    // vendor intentionally does not create.
+    wingetId: 'TorProject.TorBrowser',
+    requiredInstallScope: 'user',
+    reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
+  },
+  {
     // Analog Devices documents this enterprise/server mode for silent SYSTEM
     // deployment. It prevents the MSI from extracting example data into the
     // LocalSystem AppData profile, which otherwise rolls back with exit 1603.

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -513,6 +513,25 @@ describe('DWG FastView managed uninstall block migration contract', () => {
   });
 });
 
+describe('Malwarebytes consumer managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260816193746_block_malwarebytes_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the interactive consumer removal flow across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Malwarebytes.Malwarebytes'");
+    expect(sql).toContain('31589300070683-Uninstall-Malwarebytes-for-Windows-and-Mac');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -402,6 +402,39 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig).toMatchObject(expectedConfig);
   });
 
+  it('binds the Tor Browser extracted-folder lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'TorProject.TorBrowser',
+      displayName: 'Tor Browser',
+      publisher: 'Tor Project',
+      version: '15.0.19',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Tor Browser',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
+    };
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.installer.installScope).toBe('user');
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\TorProject_TorBrowser',
+      }),
+    ]);
+  });
+
   it('binds the Visual Studio 2022 Build Tools x86 instance root to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2022.BuildTools',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -44,7 +44,8 @@ function generateRegistryUninstallPackage(
   uninstallDisplayName = displayName,
   version = '1.0.0',
   uninstallCommand = `REGISTRY_UNINSTALL:${uninstallDisplayName}`,
-  silentSwitches = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+  silentSwitches = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+  installScope: 'machine' | 'user' = 'machine'
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -89,7 +90,7 @@ function generateRegistryUninstallPackage(
         INPUT_VERSION: version,
         INPUT_WINGET_ID: wingetId,
         INPUT_INSTALLER_TYPE: installerType,
-        INPUT_INSTALL_SCOPE: 'machine',
+        INPUT_INSTALL_SCOPE: installScope,
         INPUT_SILENT_SWITCHES: silentSwitches,
         INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
         INPUT_PACKAGE_DEPENDENCIES: JSON.stringify(packageDependencies),
@@ -653,6 +654,55 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies and removes the reviewed Tor Browser user Desktop payload',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Tor Browser',
+        [],
+        { reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser' },
+        [],
+        'TorProject.TorBrowser',
+        'Tor Browser',
+        '15.0.19',
+        'REGISTRY_UNINSTALL:Tor Browser',
+        '/S',
+        'user'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%USERPROFILE%\\Desktop\\Tor Browser')"
+      );
+      expect(installFunction).toContain('Verified managed extracted payload');
+      expect(installFunction).not.toContain('Captured vendor uninstall entry');
+      expect(uninstallFunction).toContain('Remove-Item -LiteralPath $managedInstallDirectory');
+      expect(uninstallFunction).not.toContain('Waiting for vendor uninstall registration');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects a reviewed user Desktop directory for a machine-scope package',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe User Extractor',
+          [],
+          { reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Unsafe' }
+        )
+      ).toThrow('reviewed user Desktop path');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects an unsafe reviewed managed install directory',
     () => {
       expect(() =>
@@ -662,7 +712,7 @@ describe('PSADT vendor argument contract', () => {
           [],
           { reviewedManagedInstallDirectory: '%ProgramFiles%\\..\\Windows' }
         )
-      ).toThrow('must be a safe path below Program Files');
+      ).toThrow('must be a safe machine path');
       expect(() =>
         generateRegistryUninstallPackage(
           'exe',
@@ -670,7 +720,7 @@ describe('PSADT vendor argument contract', () => {
           [],
           { reviewedManagedInstallDirectory: '%SystemDrive%\\Windows' }
         )
-      ).toThrow('must be a safe path below Program Files');
+      ).toThrow('must be a safe machine path');
     }
   );
 

--- a/supabase/migrations/20260816193746_block_malwarebytes_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260816193746_block_malwarebytes_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- The Malwarebytes consumer package installs and registers successfully, but
+-- its current removal flow is interactive. Isolated LocalSystem QA invoked the
+-- exact registered uninstaller and waited through the bounded 310-second
+-- completion window; the exact ARP registration, services, and application
+-- remained. Malwarebytes documents an interactive multi-step uninstall and an
+-- interactive Support Tool cleanup, not a supported unattended consumer-app
+-- removal contract. Keep this consumer package out of automated Intune
+-- packaging until the vendor publishes a deterministic silent lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Malwarebytes.Malwarebytes',
+  'unsupported_managed_uninstall',
+  'The Malwarebytes consumer app installs silently, but its current vendor removal flow requires interaction and does not provide a reliable unattended Intune uninstall lifecycle.',
+  'https://help.malwarebytes.com/hc/en-us/articles/31589300070683-Uninstall-Malwarebytes-for-Windows-and-Mac'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Malwarebytes.Malwarebytes';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Malwarebytes.Malwarebytes'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- model Tor Browser as its documented user-scope extracted folder instead of an ARP-registered app
- verify and remove the exact Tor Browser folder across QA and customer packaging
- allow reviewed user Desktop managed directories only for user-scope packages
- block the Malwarebytes consumer package because its vendor removal flow remains interactive and the exact app registration survived the bounded uninstall lifecycle

## Evidence
- Tor's official WinGet manifest declares a user-scope Nullsoft package and Tor documents folder deletion as Windows removal
- Tor failed run 31965717549 extracted the payload but created no ARP entry
- Malwarebytes failed run 31967507271: install 0, detection 0, uninstall 60001 after 316 seconds, and post-uninstall detection still 0 (installed)
- Malwarebytes documents an interactive multi-step consumer uninstall and interactive Support Tool cleanup, not an unattended managed-removal contract

## Verification
- 278 focused adapter, profile, migration, generated-PSADT, and portable lifecycle tests passed
- touched TypeScript files pass ESLint
- generated PowerShell parses in the contract suite
- git diff --check