### PR TITLE
Activate Tor lifecycle packager release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'a48022baddf7b3f312541ef2e127220f508104a8',
+  packagerCommit: '91abb42cf1096de692500203fc7373ef6a25a3dd',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -120,6 +120,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The MSYS2 correction preserves the reviewed path allowlist and changes
   // only its previously failing removal path. Preserve all compatible passes.
   '0b562aa574144a19a6b4c5e6c3d3d7a4c241961f',
+  // Tor Browser's managed-directory adapter affects only its previously
+  // failing no-ARP lifecycle. Malwarebytes is blocked at the shared
+  // eligibility gate. Preserve every compatible pass from this release.
+  'a48022baddf7b3f312541ef2e127220f508104a8',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -840,6 +840,36 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // and the reviewed Qt Installer Framework removal arguments.
     'MSYS2.MSYS2',
   ],
+  '91abb42cf1096de692500203fc7373ef6a25a3dd': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    // Retry only the failed Tor lifecycle with its reviewed exact extracted
+    // user-folder verification and removal behavior.
+    'TorProject.TorBrowser',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate protected packager commit 91abb42cf1096de692500203fc7373ef6a25a3dd
- preserve compatible passes from the prior protected release
- schedule one bounded retry for Tor Browser with the reviewed managed-directory lifecycle
- retain prior unconsumed retry targets while pass filtering prevents duplicate successful apps

## Verification
- 117 package profile and toolchain backfill tests passed
- touched files pass ESLint
- git diff --check