### PR TITLE
Fix PTC Creo View Express unattended packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -455,6 +455,18 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses PTC Creo View Express documented MSI-forwarding syntax', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'PTC.CreoView.Express',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/vADDLOCAL="ALL" /qn /norestart'
+    );
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('uses the reviewed InstallShield administrative-image lifecycle for Sonos', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Sonos.Controller',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -169,6 +169,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/qb /norestart CHECK_FOR_UPDATES=false DONATE_NOTIFICATION=false SKIPTHANKSPAGE=Yes',
   },
   {
+    // PTC's bootstrapper forwards MSI properties only when they immediately
+    // follow /v. The community manifest's separated `/v /quiet /norestart`
+    // command can install the payload but return an error before IntuneGet can
+    // verify it and write detection evidence. PTC documents ADDLOCAL="ALL"
+    // with /qn for a complete unattended Creo View Express installation.
+    wingetId: 'PTC.CreoView.Express',
+    reviewedInstallArgumentsOverride: '/vADDLOCAL="ALL" /qn /norestart',
+  },
+  {
     // Apryse documents -q as the unattended Windows uninstall switch for the
     // install4j-based Xodo/PDF Studio family. The registered Xodo PDF Reader
     // command omits it, which leaves the confirmation flow waiting in a


### PR DESCRIPTION
## Summary
- override the malformed WinGet bootstrapper switches with PTC's documented MSI-forwarding syntax
- apply the adapter to both QA and customer PSADT packages
- add focused adapter coverage

## Verification
- npm exec vitest -- run lib/packaging-adapters.test.ts
- npm exec eslint -- lib/packaging-adapters.ts lib/packaging-adapters.test.ts
- git diff --check