### PR TITLE
Activate PTC Creo View Express packaging fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '91abb42cf1096de692500203fc7373ef6a25a3dd',
+  packagerCommit: 'fec554c1bc7139ef1e7b489571a09f29760b06c0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -75,6 +75,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('retries PTC Creo View Express with the corrected MSI-forwarding command', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'ptc.creoview.express', status: 'failed' }
+    )).toBe(true);
+  });
+
   it('keeps the Office Deployment Tool managed lifecycle retry scoped to its release', () => {
     const wingetId = 'Microsoft.OfficeDeploymentTool';
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -870,6 +870,37 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // user-folder verification and removal behavior.
     'TorProject.TorBrowser',
   ],
+  'fec554c1bc7139ef1e7b489571a09f29760b06c0': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    // Retry the exact failed PTC payload once with the official MSI-forwarding
+    // command now shared by QA and customer PSADT packages.
+    'PTC.CreoView.Express',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA package generation to the merged PTC silent-install adapter
- carry pending bounded retries through the atomic rollout
- retry the exact failed PTC payload once

## Verification
- 153 focused tests passed
- targeted ESLint passed
- git diff --check