### PR TITLE
Bind reviewed MSI packaging identities exactly

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -42,12 +42,21 @@ describe('application packaging adapters', () => {
       'MaestroSoft.MaestroAarsoppgjoer.2025',
       'REGISTRY_UNINSTALL:Maestro Årsoppgjør 2025'
     )).toBe(
-      'REGISTRY_UNINSTALL_KEY:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025'
+      'REGISTRY_UNINSTALL_PRODUCT:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025'
     );
     expect(resolveApplicationUninstallCommand(
       'MaestroSoft.MaestroAarsoppgjoer.2025',
       'vendor-uninstall.exe --custom'
     )).toBe('vendor-uninstall.exe --custom');
+  });
+
+  it('uses PTC Creo View Express published MSI identity across prerequisite installs', () => {
+    expect(resolveApplicationUninstallCommand(
+      'PTC.CreoView.Express',
+      'REGISTRY_UNINSTALL:PTC Creo View Express'
+    )).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{6DE7DB1D-27F7-46A8-AE3A-D8C2BB62870B}:PTC Creo View Express'
+    );
   });
 
   it('uses Timely Memory\'s published stable NSIS registry key', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -746,6 +746,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Maestro Årsoppgjør 2025',
     registeredRegistryKey: '{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}',
   },
+  // Creo View Express installs several prerequisite products, and its ARP
+  // display name carries the embedded product release rather than WinGet's
+  // package version. WinGet publishes the main MSI ProductCode, so bind that
+  // immutable identity instead of selecting from multiple changed entries.
+  'ptc.creoview.express': {
+    generatedDisplayName: 'PTC Creo View Express',
+    registeredDisplayName: 'PTC Creo View Express',
+    registeredRegistryKey: '{6DE7DB1D-27F7-46A8-AE3A-D8C2BB62870B}',
+  },
   // Timely publishes the stable NSIS uninstall registry key as ProductCode
   // `Memory`. It is not an MSI GUID, so the generic manifest conversion treats
   // it as a display name and misses the vendor entry when background servicing
@@ -771,9 +780,14 @@ export function resolveApplicationUninstallCommand(
   if (!reviewed) return uninstallCommand;
   const expected = `REGISTRY_UNINSTALL:${reviewed.generatedDisplayName}`;
   if (uninstallCommand.trim() !== expected) return uninstallCommand;
-  return reviewed.registeredRegistryKey
-    ? `REGISTRY_UNINSTALL_KEY:${reviewed.registeredRegistryKey}:${reviewed.registeredDisplayName}`
-    : `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`;
+  if (!reviewed.registeredRegistryKey) {
+    return `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`;
+  }
+  const reviewedKey = reviewed.registeredRegistryKey;
+  const isMsiProductCode = /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$/.test(
+    reviewedKey
+  );
+  return `${isMsiProductCode ? 'REGISTRY_UNINSTALL_PRODUCT' : 'REGISTRY_UNINSTALL_KEY'}:${reviewedKey}:${reviewed.registeredDisplayName}`;
 }
 
 function normalizeProcessName(name: string): string {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -353,13 +353,42 @@ describe('PSADT QA package identity', () => {
       psadtConfig: JSON.stringify({ detectionRules: [] }),
     });
     const expected =
-      'REGISTRY_UNINSTALL_KEY:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025';
+      'REGISTRY_UNINSTALL_PRODUCT:{20C36C0E-AF6D-4C46-AA1C-39080889BE9F}:Maestro Årsoppgjør 2025';
     const profile = normalized.identity.profile as {
       installer: { uninstallCommand: string };
     };
 
     expect(normalized.uninstallCommand).toBe(expected);
     expect(profile.installer.uninstallCommand).toBe(expected);
+  });
+
+  it('binds PTC Creo View Express to its published MSI identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'PTC.CreoView.Express',
+      displayName: 'PTC Creo View Express',
+      publisher: 'PTC',
+      version: '20.0.0.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'zip',
+      silentSwitches: '/v /quiet /norestart',
+      uninstallCommand: 'REGISTRY_UNINSTALL:PTC Creo View Express',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expected =
+      'REGISTRY_UNINSTALL_PRODUCT:{6DE7DB1D-27F7-46A8-AE3A-D8C2BB62870B}:PTC Creo View Express';
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe(expected);
+    expect(profile.installer.uninstallCommand).toBe(expected);
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/vADDLOCAL="ALL" /qn /norestart'
+    );
   });
 
   it('binds the Visual Studio 2019 instance lifecycle to customer and QA packaging', () => {


### PR DESCRIPTION
## Summary
- bind PTC Creo View Express to WinGet's published main MSI ProductCode
- distinguish reviewed MSI ProductCodes from non-MSI registry keys
- fix the latent Maestro embedded-MSI marker to use the supported PRODUCT form
- verify customer and QA profiles carry identical lifecycle data

## Verification
- 92 focused tests passed
- targeted ESLint passed
- git diff --check