### PR TITLE
Fix required WinGet install locations

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2080,7 +2080,7 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
         "    Start-ADTProcess -FilePath `"`$env:SystemRoot\System32\cmd.exe`" -ArgumentList '/c $customInstallCommandEscaped' -WorkingDirectory `$adtSession.DirFiles -WindowStyle Hidden"
     )
 } else {
-    $installerArgumentList = "'$silentSwitchesEscaped'"
+    $effectiveInstallerArgumentsEscaped = $silentSwitchesEscaped
     if ($installerTypeLower -eq 'inno') {
         $innoSwitches = $effectiveSilentSwitches.Trim()
         if ($innoSwitches -notmatch '(?i)(^|\s)/SP-(\s|$)') { $innoSwitches = "$innoSwitches /SP-".Trim() }
@@ -2090,15 +2090,28 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
         # User-provided switches remain byte-for-byte authoritative apart from the
         # idempotent /SP- safety switch and PowerShell single-quote encoding.
         $innoSwitchesEscaped = $innoSwitches -replace "'", "''"
-        $installerArgumentList = "'$innoSwitchesEscaped'"
+        $effectiveInstallerArgumentsEscaped = $innoSwitchesEscaped
+    }
+    $installerArgumentList = "'$effectiveInstallerArgumentsEscaped'"
+    if ($effectiveInstallerArgumentsEscaped -match '%[A-Za-z][A-Za-z0-9()_]*%') {
+        $lines += "    `$effectiveInstallerArguments = [Environment]::ExpandEnvironmentVariables('$effectiveInstallerArgumentsEscaped')"
+        $installerArgumentList = '$effectiveInstallerArguments'
     }
     switch ($installerTypeLower) {
         { $_ -in 'msi', 'wix' } {
             $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
             if ($msiProperties) {
-                $lines += @(
-                    "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList '$msiProperties'"
-                )
+                $msiPropertiesEscaped = $msiProperties -replace "'", "''"
+                if ($msiPropertiesEscaped -match '%[A-Za-z][A-Za-z0-9()_]*%') {
+                    $lines += @(
+                        "    `$effectiveMsiProperties = [Environment]::ExpandEnvironmentVariables('$msiPropertiesEscaped')"
+                        "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList `$effectiveMsiProperties"
+                    )
+                } else {
+                    $lines += @(
+                        "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList '$msiPropertiesEscaped'"
+                    )
+                }
             } else {
                 $lines += @(
                     "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped'"

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -68,6 +68,53 @@ describe('normalizeInstaller', () => {
     expect(result.silentArgs).toBe('/S /passive');
   });
 
+  it('substitutes a required default install location into the vendor switch', () => {
+    const installer: WingetInstaller = {
+      Architecture: 'x86',
+      InstallerUrl: 'https://example.com/bootstrapper.exe',
+      InstallerSha256: 'abc123',
+      InstallerType: 'exe',
+      InstallLocationRequired: true,
+      DefaultInstallLocation: '%PROGRAMFILES(X86)%\\Contoso',
+      InstallerSwitches: {
+        Custom: '--lang=enUS',
+        InstallLocation: '--installpath="<INSTALLPATH>"',
+      },
+    };
+
+    const result = normalizeInstaller(installer);
+
+    expect(result.silentArgs).toBe(
+      '/S --lang=enUS --installpath="%PROGRAMFILES(X86)%\\Contoso"'
+    );
+    expect(result.installLocationRequired).toBe(true);
+    expect(result.defaultInstallLocation).toBe('%PROGRAMFILES(X86)%\\Contoso');
+  });
+
+  it('inherits required install-location metadata from the manifest root', () => {
+    const [installer] = normalizeManifestInstallers({
+      InstallerType: 'exe',
+      InstallLocationRequired: true,
+      InstallerSwitches: {
+        InstallLocation: '--installpath="<INSTALLPATH>"',
+      },
+      InstallationMetadata: {
+        DefaultInstallLocation: '%PROGRAMFILES%\\Contoso',
+      },
+      Installers: [{
+        Architecture: 'x64',
+        InstallerUrl: 'https://example.com/bootstrapper.exe',
+        InstallerSha256: 'abc123',
+      }],
+    });
+
+    expect(installer.InstallLocationRequired).toBe(true);
+    expect(installer.DefaultInstallLocation).toBe('%PROGRAMFILES%\\Contoso');
+    expect(normalizeInstaller(installer).silentArgs).toBe(
+      '/S --installpath="%PROGRAMFILES%\\Contoso"'
+    );
+  });
+
   it('should include scope when provided', () => {
     const installer: WingetInstaller = {
       Architecture: 'x64',

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -476,6 +476,11 @@ function coerceInstallersArray(
       defaultSilentArgs ? { Silent: defaultSilentArgs } : undefined,
       inst.InstallerSwitches
     ),
+    InstallLocationRequired: inst.InstallLocationRequired === true,
+    DefaultInstallLocation:
+      typeof inst.DefaultInstallLocation === 'string'
+        ? inst.DefaultInstallLocation.trim() || undefined
+        : defaultInstallLocation(inst.InstallationMetadata),
     InstallerSuccessCodes: normalizeInstallerSuccessCodes(inst.InstallerSuccessCodes),
     ProductCode: explicitProductCode
       ? normalizeProductCode(explicitProductCode, inst.InstallerType || defaultType)
@@ -611,6 +616,14 @@ function mergeInstallerSwitches(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function defaultInstallLocation(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const candidate = (value as Record<string, unknown>).DefaultInstallLocation;
+  if (typeof candidate !== 'string') return undefined;
+  const normalized = candidate.trim();
+  return normalized || undefined;
+}
+
 export function normalizeManifestInstallers(manifest: Record<string, unknown>): WingetInstaller[] {
   const rawInstallers = (manifest.Installers as Array<Record<string, unknown>>) || [];
 
@@ -630,6 +643,8 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     appsAndFeaturesProductCode(manifest.AppsAndFeaturesEntries, defaultType);
   const defaultPackageFamilyName = manifest.PackageFamilyName as string;
   const defaultSuccessCodes = normalizeInstallerSuccessCodes(manifest.InstallerSuccessCodes);
+  const defaultInstallLocationRequired = manifest.InstallLocationRequired === true;
+  const inheritedDefaultInstallLocation = defaultInstallLocation(manifest.InstallationMetadata);
 
   return rawInstallers.map((installer) => {
     const explicitInstallerProductCode = typeof installer.ProductCode === 'string'
@@ -663,6 +678,12 @@ export function normalizeManifestInstallers(manifest: Record<string, unknown>): 
     // WinGet inherits installer switches per field. An installer-level Custom
     // value must not discard a root-level Silent value (Vivaldi is one example).
     InstallerSwitches: mergeInstallerSwitches(defaultSwitches, installer.InstallerSwitches),
+    InstallLocationRequired:
+      typeof installer.InstallLocationRequired === 'boolean'
+        ? installer.InstallLocationRequired
+        : defaultInstallLocationRequired,
+    DefaultInstallLocation:
+      defaultInstallLocation(installer.InstallationMetadata) || inheritedDefaultInstallLocation,
     InstallerSuccessCodes:
       normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) || defaultSuccessCodes,
     // A non-empty installer-level ProductCode is authoritative. If it is an
@@ -759,6 +780,20 @@ function appendCustomSwitch(silentArgs: string, custom: string | undefined): str
   return silentArgs ? `${silentArgs} ${newTokens.join(' ')}` : newTokens.join(' ');
 }
 
+function appendRequiredInstallLocation(
+  silentArgs: string,
+  installer: WingetInstaller
+): string {
+  if (!installer.InstallLocationRequired) return silentArgs;
+
+  const switchTemplate = installer.InstallerSwitches?.InstallLocation?.trim();
+  const installLocation = installer.DefaultInstallLocation?.trim();
+  if (!switchTemplate || !installLocation) return silentArgs;
+
+  const locationSwitch = switchTemplate.replace(/<INSTALLPATH>/gi, installLocation);
+  return silentArgs ? `${silentArgs} ${locationSwitch}` : locationSwitch;
+}
+
 /**
  * Normalize installer to standard format
  */
@@ -781,6 +816,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
   }
 
   silentArgs = appendCustomSwitch(silentArgs, installer.InstallerSwitches?.Custom);
+  silentArgs = appendRequiredInstallLocation(silentArgs, installer);
 
   // Map manifest package dependencies (PascalCase) to the normalized shape
   const rawDependencies = installer.Dependencies?.PackageDependencies;
@@ -804,6 +840,12 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
     scope: installer.Scope,
     elevationRequirement: installer.ElevationRequirement,
     silentArgs,
+    ...(installer.InstallLocationRequired !== undefined
+      ? { installLocationRequired: installer.InstallLocationRequired }
+      : {}),
+    ...(installer.DefaultInstallLocation
+      ? { defaultInstallLocation: installer.DefaultInstallLocation }
+      : {}),
     ...(normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes)
       ? { installerSuccessCodes: normalizeInstallerSuccessCodes(installer.InstallerSuccessCodes) }
       : {}),

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -17,6 +17,8 @@ export interface WingetInstallerCandidate {
     Upgrade?: string;
     Custom?: string;
   };
+  InstallLocationRequired?: boolean;
+  DefaultInstallLocation?: string;
   AppsAndFeaturesEntries?: Array<{ ProductCode?: string }>;
 }
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -149,7 +149,14 @@ describe('PSADT Inno packaging contract', () => {
 
     expect(innoBlock).not.toContain('/LOG=');
     expect(innoBlock).not.toContain('IntuneGet-Inno-Install.log');
-    expect(innoBlock).toContain("$installerArgumentList = \"'$innoSwitchesEscaped'\"");
+    expect(innoBlock).toContain('$effectiveInstallerArgumentsEscaped = $innoSwitchesEscaped');
+  });
+
+  it('expands target-machine environment variables in vendor install arguments', () => {
+    expect(packager).toContain(
+      "`$effectiveInstallerArguments = [Environment]::ExpandEnvironmentVariables('$effectiveInstallerArgumentsEscaped')"
+    );
+    expect(packager).toContain("$effectiveInstallerArgumentsEscaped -match '%[A-Za-z][A-Za-z0-9()_]*%'");
   });
 
   it('keeps the startup-prompt suppression idempotent without format-string expansion', () => {
@@ -166,6 +173,35 @@ describe('PSADT Inno packaging contract', () => {
 });
 
 describe('PSADT vendor argument contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'expands required WinGet install locations on the target machine',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Battle.net Setup',
+        [],
+        {},
+        [],
+        'Blizzard.BattleNet',
+        'Battle.net',
+        '1.19.3.3219',
+        'REGISTRY_UNINSTALL_KEY:Battle.net:Battle.net',
+        '/S --lang=enUS --installpath="%PROGRAMFILES(X86)%\\Battle.net"'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "$effectiveInstallerArguments = [Environment]::ExpandEnvironmentVariables('/S --lang=enUS --installpath=\"%PROGRAMFILES(X86)%\\Battle.net\"')"
+      );
+      expect(installFunction).toContain(
+        'Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\setup.exe" -ArgumentList $effectiveInstallerArguments'
+      );
+    }
+  );
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'runs root-level install4j uninstallers unattended when the manifest identifies the framework',
     () => {

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -124,6 +124,38 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.silentArgs).toBe('/ROOT /CURRENTUSER');
   });
 
+  it('includes a required WinGet install location in the shared QA package arguments', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Blizzard.BattleNet',
+        name: 'Battle.net Setup',
+        publisher: 'Blizzard',
+        version: '1.19.3.3219',
+      },
+      manifest: {
+        InstallerType: 'exe',
+        Scope: 'machine',
+        InstallLocationRequired: true,
+        InstallerSwitches: {
+          Custom: '--lang=enUS',
+          InstallLocation: '--installpath="<INSTALLPATH>"',
+        },
+        InstallationMetadata: {
+          DefaultInstallLocation: '%PROGRAMFILES(X86)%\\Battle.net',
+        },
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'exe',
+        ProductCode: 'Battle.net',
+      },
+    });
+
+    expect(config.silentArgs).toBe(
+      '/S --lang=enUS --installpath="%PROGRAMFILES(X86)%\\Battle.net"'
+    );
+  });
+
   it('preserves Vivaldi-style root silent and installer custom switches', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -163,6 +163,16 @@ export function buildQaCatalogTestConfig({
     })),
     Scope: scope,
     InstallerSwitches: normalizeInstallerSwitches(effectiveSwitches),
+    InstallLocationRequired:
+      typeof installer.InstallLocationRequired === 'boolean'
+        ? installer.InstallLocationRequired
+        : manifest.InstallLocationRequired === true,
+    DefaultInstallLocation:
+      text(installer.DefaultInstallLocation) ||
+      text(record(installer.InstallationMetadata).DefaultInstallLocation) ||
+      text(manifest.DefaultInstallLocation) ||
+      text(record(manifest.InstallationMetadata).DefaultInstallLocation) ||
+      undefined,
     InstallerSuccessCodes: normalizeSuccessCodes(
       installer.InstallerSuccessCodes ?? manifest.InstallerSuccessCodes
     ),

--- a/types/winget.ts
+++ b/types/winget.ts
@@ -38,6 +38,8 @@ export interface WingetInstaller {
   Scope?: WingetScope;
   ElevationRequirement?: WingetElevationRequirement;
   InstallerSwitches?: WingetInstallerSwitches;
+  InstallLocationRequired?: boolean;
+  DefaultInstallLocation?: string;
   InstallerSuccessCodes?: number[];
   ProductCode?: string;
   PackageFamilyName?: string;
@@ -181,6 +183,8 @@ export interface NormalizedInstaller {
   scope?: WingetScope;
   elevationRequirement?: WingetElevationRequirement;
   silentArgs?: string;
+  installLocationRequired?: boolean;
+  defaultInstallLocation?: string;
   installerSuccessCodes?: number[];
   productCode?: string;
   packageFamilyName?: string;


### PR DESCRIPTION
## Summary
- inherit WinGet install-location metadata into selected installers
- append required install-location switches to QA and customer package arguments
- expand target-machine environment variables inside generated PSADT packages
- add Battle.net-style regression coverage and generated PowerShell parsing

## Verification
- 188 focused tests passed
- targeted ESLint passed
- generated PSADT deployment script parses in PowerShell