### PR TITLE
Activate required install-location packager

### DIFF
--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -716,6 +716,23 @@ describe('current catalog QA package validation', () => {
     ).toEqual({ valid: false, reason: 'compatible-zero-day-deferral-changed' });
   });
 
+  it('retests a prior profile that needs target-machine install-location expansion', () => {
+    const legacyIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        silentArgs: '/S --installpath="%PROGRAMFILES(X86)%\\Contoso"',
+      }),
+      'fbb4aa2eed6cc545ec343373dd8947d04463a4a1'
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(candidateFromIdentity(legacyIdentity))
+    ).toEqual({
+      valid: false,
+      reason: 'compatible-install-location-expansion-changed',
+    });
+  });
+
   it('reuses the same deployment execution profile across an unrelated packager release', () => {
     const currentIdentity = buildQaPackageIdentity({
       ...input,

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'fbb4aa2eed6cc545ec343373dd8947d04463a4a1',
+  packagerCommit: '71ee706fe545cdcd8667545eb65e8ba62d82208c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -124,6 +124,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // failing no-ARP lifecycle. Malwarebytes is blocked at the shared
   // eligibility gate. Preserve every compatible pass from this release.
   'a48022baddf7b3f312541ef2e127220f508104a8',
+  // Required WinGet install-location handling changes only profiles whose
+  // arguments contain a target-machine environment token. Preserve every
+  // unrelated compatible pass from the prior protected release.
+  'fbb4aa2eed6cc545ec343373dd8947d04463a4a1',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 
@@ -316,6 +320,8 @@ function passingProfileCompatibilityReason(
 
   const psadtConfig = record(profile.psadtConfig);
   if (!psadtConfig) return 'compatible-profile-invalid';
+  const installer = record(profile.installer);
+  if (!installer) return 'compatible-profile-invalid';
   const configuredProcesses = Array.isArray(psadtConfig.processesToClose)
     ? psadtConfig.processesToClose
     : [];
@@ -339,6 +345,16 @@ function passingProfileCompatibilityReason(
       psadtConfig.deferDays === 0
     ) {
       return 'compatible-zero-day-deferral-changed';
+    }
+
+    // 71ee706 expands WinGet install-location environment variables inside
+    // the target VM. A prior pass without such a token cannot exercise this
+    // branch and remains compatible.
+    if (
+      release === '71ee706fe545cdcd8667545eb65e8ba62d82208c' &&
+      /%[A-Za-z][A-Za-z0-9()_]*%/.test(textValue(installer.silentArgs))
+    ) {
+      return 'compatible-install-location-expansion-changed';
     }
   }
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -82,6 +82,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('retries Battle.net with its required WinGet install location', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'blizzard.battlenet', status: 'failed' }
+    )).toBe(true);
+  });
+
   it('keeps the Office Deployment Tool managed lifecycle retry scoped to its release', () => {
     const wingetId = 'Microsoft.OfficeDeploymentTool';
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -931,6 +931,38 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // Retry the exact PTC payload with the published main MSI ProductCode.
     'PTC.CreoView.Express',
   ],
+  '71ee706fe545cdcd8667545eb65e8ba62d82208c': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    // Battle.net declares InstallLocationRequired. Retry its exact failed
+    // payload with the inherited WinGet install-location contract.
+    'Blizzard.BattleNet',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate protected packager commit 71ee706fe545cdcd8667545eb65e8ba62d82208c
- preserve unrelated compatible passes from the previous release
- require retesting only profiles with target-machine environment tokens

## Verification
- 57 package-profile tests passed
- targeted ESLint passed