### PR TITLE
Activate hardened lifecycle packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '71ee706fe545cdcd8667545eb65e8ba62d82208c',
+  packagerCommit: '6af0cfac18f3c4653a69a01f41bc1170c1237807',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -128,6 +128,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // arguments contain a target-machine environment token. Preserve every
   // unrelated compatible pass from the prior protected release.
   'fbb4aa2eed6cc545ec343373dd8947d04463a4a1',
+  // The safe vendor-uninstall working directory changes only removal paths
+  // that did not already pass. Filename normalization and dispatch budgeting
+  // happen before execution, so preserve every compatible passing payload.
+  '71ee706fe545cdcd8667545eb65e8ba62d82208c',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -19,6 +19,11 @@ describe('QA toolchain targeted retries', () => {
       'Sonos.Controller',
       'karakun.OpenWebStart',
       'MSYS2.MSYS2',
+      'Insta360.Link.Controller',
+      'Logitech.SetPoint',
+      'Timely.Memory',
+      'Blizzard.BattleNet',
+      'DATEV.SicherheitspaketCompact',
     ]));
 
     targets.length = 0;
@@ -35,6 +40,11 @@ describe('QA toolchain targeted retries', () => {
         'Sonos.Controller',
         'karakun.OpenWebStart',
         'MSYS2.MSYS2',
+        'Insta360.Link.Controller',
+        'Logitech.SetPoint',
+        'Timely.Memory',
+        'Blizzard.BattleNet',
+        'DATEV.SicherheitspaketCompact',
       ])
     );
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -963,6 +963,43 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // payload with the inherited WinGet install-location contract.
     'Blizzard.BattleNet',
   ],
+  '6af0cfac18f3c4653a69a01f41bc1170c1237807': [
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    // These registered vendor uninstallers are retried from a safe PSADT
+    // working directory outside their own application trees.
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    // The installer executes from a version-shaped extensionless URL. Retry
+    // once with the corrected executable filename in QA and customer packages.
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    // DATEV did not reach GitHub because the old 60-second Vercel function
+    // window ended during exact installer preflight.
+    'DATEV.SicherheitspaketCompact',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- pin QA package profiles to the shared lifecycle fix from PR #599
- preserve compatible passing payloads
- carry only bounded affected retries, including DATEV, Timely, Insta360, SetPoint, and Battle.net

## Verification
- 148 focused QA profile, backfill, and enqueue tests passed
- ESLint and git diff checks passed