### PR TITLE
Block unsupported Insta360 managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -532,6 +532,26 @@ describe('Malwarebytes consumer managed uninstall block migration contract', () 
   });
 });
 
+describe('Insta360 Link Controller managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260817131620_block_insta360_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unreliable vendor removal flow across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Insta360.Link.Controller'");
+    expect(sql).toContain('controller-client-error/crash');
+    expect(sql).toContain('{C05A30CA-A10A-4553-9524-5B377F959166}_is1');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260817131620_block_insta360_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260817131620_block_insta360_unsupported_managed_uninstall.sql
@@ -1,0 +1,40 @@
+-- Insta360 Link Controller installs and registers successfully, but its exact
+-- Inno Setup uninstaller does not complete an unattended removal lifecycle.
+-- Two isolated LocalSystem runs used the framework-standard Inno silent flags,
+-- closed the known controller, virtual-camera, and driver processes, and ran
+-- the uninstaller from a safe working directory. Both runs left the exact
+-- {C05A30CA-A10A-4553-9524-5B377F959166}_is1 registration and application
+-- files after the bounded 311-second completion window. Insta360's current
+-- support material documents guided removal inside Link Controller, not a
+-- supported unattended enterprise uninstall contract. Keep this package out
+-- of automated Intune packaging until the vendor publishes one.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Insta360.Link.Controller',
+  'unsupported_managed_uninstall',
+  'Insta360 Link Controller installs silently, but its current vendor removal flow does not provide a reliable unattended Intune uninstall lifecycle.',
+  'https://onlinemanual.insta360.com/link/en-us/troubleshooting/controller-client-error/crash'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Insta360.Link.Controller';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Insta360.Link.Controller'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## What changed

- Add a shared `unsupported_managed_uninstall` eligibility block for `Insta360.Link.Controller`.
- Clear catalog verification and supersede queued or failed QA candidates for the unsupported lifecycle.
- Add a migration contract covering the exact app identity, reviewed ARP identity, and customer/QA effects.

## Why

Two isolated LocalSystem PSADT lifecycle tests installed and detected the app successfully, but the exact Inno uninstaller left the registered product and installed files after the bounded 311-second completion window. The second run used the corrected safe working directory and known process-close list, so another blind retry would not be justified. Current vendor documentation provides guided removal behavior but no deterministic unattended enterprise uninstall contract.

## Impact

QA and customer packaging will reject this app until a supported unattended uninstall contract is available, preventing a package with a known-broken Intune removal lifecycle from being shipped.

## Validation

- `npm test -- lib/qa/migration-contract.test.ts` (50 passed)
- `npm exec eslint -- lib/qa/migration-contract.test.ts`
- `git diff --check`