### PR TITLE
Block unsupported SetPoint managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -552,6 +552,26 @@ describe('Insta360 Link Controller managed uninstall block migration contract', 
   });
 });
 
+describe('Logitech SetPoint managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260817133612_block_setpoint_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the interactive legacy removal flow across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Logitech.SetPoint'");
+    expect(sql).toContain('360023237354-Unable-to-customize-my-mouse-or-keyboard-in-SetPoint');
+    expect(sql).toContain('exact sp6');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260817133612_block_setpoint_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260817133612_block_setpoint_unsupported_managed_uninstall.sql
@@ -1,0 +1,40 @@
+-- Logitech SetPoint installs and registers successfully, but the registered
+-- sp6 removal route does not provide a deterministic unattended lifecycle.
+-- Two isolated LocalSystem tests closed SetPoint, SetPointII, and KHALMNPR;
+-- the corrected retry also executed from a safe working directory outside the
+-- application tree. In both runs the vendor parent exited while the exact sp6
+-- registration remained through the bounded 310-second completion window.
+-- Logitech's SetPoint support material documents an interactive Programs and
+-- Features removal flow, not a supported silent enterprise uninstall command.
+-- Keep this legacy package out of automated Intune packaging until a verified
+-- unattended vendor contract becomes available.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Logitech.SetPoint',
+  'unsupported_managed_uninstall',
+  'Logitech SetPoint installs silently, but its current vendor removal flow does not provide a reliable unattended Intune uninstall lifecycle.',
+  'https://support.logi.com/hc/en-us/articles/360023237354-Unable-to-customize-my-mouse-or-keyboard-in-SetPoint'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Logitech.SetPoint';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Logitech.SetPoint'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Logitech SetPoint from automated customer packaging and QA because its registered `sp6` removal route does not complete unattended
- clear the catalog verification flag and supersede stale candidates
- add a migration contract test

## Evidence
- install and post-install detection both succeeded
- two isolated LocalSystem lifecycle attempts, including the safe working-directory retry, left the exact `sp6` registration after the bounded 310-second uninstall window
- Logitech’s SetPoint support material documents interactive Programs and Features removal, not a verified unattended enterprise uninstall contract

## Validation
- `npm test -- lib/qa/migration-contract.test.ts` (51 passed)
- `npm exec eslint -- lib/qa/migration-contract.test.ts`
- `git diff --check`