### PR TITLE
Block unsupported Battle.net managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -572,6 +572,26 @@ describe('Logitech SetPoint managed uninstall block migration contract', () => {
   });
 });
 
+describe('Battle.net managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260817145500_block_battlenet_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the interactive vendor removal flow across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Blizzard.BattleNet'");
+    expect(sql).toContain('us.support.blizzard.com/en/article/30304');
+    expect(sql).toContain('exact Battle.net registration');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('QA package result duration migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260817145500_block_battlenet_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260817145500_block_battlenet_unsupported_managed_uninstall.sql
@@ -1,0 +1,41 @@
+-- Battle.net installs and registers successfully, but the vendor removal route
+-- does not provide a deterministic unattended lifecycle. The isolated
+-- LocalSystem test invoked the exact Battle.net ARP command from a safe working
+-- directory and waited through the bounded 310-second completion window; the
+-- vendor command returned while the exact Battle.net registration remained.
+-- Blizzard's support material documents an interactive Programs and Features
+-- removal flow, followed by manual folder cleanup when required. It does not
+-- publish a supported silent enterprise uninstall contract. Manual deletion is
+-- unsafe for managed deployment because the launcher can own customer game
+-- locations and shared Battle.net data. Keep the app out of automated Intune
+-- packaging until Blizzard provides a verified unattended removal contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Blizzard.BattleNet',
+  'unsupported_managed_uninstall',
+  'Battle.net installs silently, but its current vendor removal flow does not provide a reliable unattended Intune uninstall lifecycle.',
+  'https://us.support.blizzard.com/en/article/30304'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Blizzard.BattleNet';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Blizzard.BattleNet'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block Battle.net at the shared package eligibility gate because its vendor removal flow is interactive and left the exact ARP registration after the bounded LocalSystem uninstall window
- keep the app out of both customer packaging and QA until Blizzard publishes a verified unattended uninstall contract
- supersede queued/failed candidates and clear catalog verification

## Validation
- npm exec -- vitest run lib/qa/migration-contract.test.ts (52 passed)
- git diff --check