### PR TITLE
Activate CutePDF packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '6af0cfac18f3c4653a69a01f41bc1170c1237807',
+  packagerCommit: '12831539c9dc30678c6f16367faab76820502d2a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -132,6 +132,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // that did not already pass. Filename normalization and dispatch budgeting
   // happen before execution, so preserve every compatible passing payload.
   '71ee706fe545cdcd8667545eb65e8ba62d82208c',
+  // CutePDF's vendor-specific removal correction affects only its previously
+  // failing unInstcpw helper. Preserve every unrelated compatible pass.
+  '6af0cfac18f3c4653a69a01f41bc1170c1237807',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries CutePDF once with its vendor-specific silent removal adapter', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'acrosoftware.cutepdfwriter', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '6af0cfac18f3c4653a69a01f41bc1170c1237807',
+      { wingetId: 'AcroSoftware.CutePDFWriter', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -963,6 +963,40 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // payload with the inherited WinGet install-location contract.
     'Blizzard.BattleNet',
   ],
+  '12831539c9dc30678c6f16367faab76820502d2a': [
+    // CutePDF's registered unInstcpw helper requires its vendor-specific
+    // /uninstall /s contract rather than the nested installer's Inno switches.
+    'AcroSoftware.CutePDFWriter',
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '6af0cfac18f3c4653a69a01f41bc1170c1237807': [
     // Carry still-unconsumed bounded retries across the atomic pin rollout.
     // Compatible passes are filtered before candidates are created.


### PR DESCRIPTION
Activates packager commit 12831539c9dc30678c6f16367faab76820502d2a for scheduler profile generation, preserves compatible prior passes, and targets the failed CutePDF candidate for one bounded retry.\n\nVerification: 149 focused QA profile, backfill, and enqueue tests passed; git diff --check passed.