### PR TITLE
Fix Autodesk Licensing Service package lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2802,6 +2802,14 @@ if ($reviewedExactUninstallConfigured) {
 if ($useManagedDirectoryLifecycle) {
     Write-Host 'Using reviewed managed-directory removal'
     $lines += @('', "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')")
+    if ($hasManagedInstallCompletionContract) {
+        $lines += @(
+            "    `$managedInstallEvidenceFile = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallEvidenceFileEscaped')"
+            '    $managedUninstallCompletionTarget = $managedInstallEvidenceFile'
+        )
+    } else {
+        $lines += '    $managedUninstallCompletionTarget = $managedInstallDirectory'
+    }
     if ($reviewedManagedUninstallConfigured) {
         $lines += @(
             "    `$managedUninstallExecutable = [Environment]::ExpandEnvironmentVariables('$reviewedManagedUninstallExecutableEscaped')"
@@ -2813,13 +2821,13 @@ if ($useManagedDirectoryLifecycle) {
             '        Write-ADTLogEntry -Message "Starting reviewed managed uninstaller [$managedUninstallExecutable]." -Source ''Uninstall-ADTDeployment'''
             '        $null = Start-ADTProcess -FilePath $managedUninstallExecutable -ArgumentList $managedUninstallArguments -WindowStyle Hidden -NoWait -PassThru'
             "        `$managedUninstallDeadline = [DateTime]::UtcNow.AddMinutes($reviewedManagedUninstallTimeoutMinutes)"
-            '        while ((Test-Path -LiteralPath $managedInstallDirectory) -and [DateTime]::UtcNow -lt $managedUninstallDeadline) {'
+            '        while ((Test-Path -LiteralPath $managedUninstallCompletionTarget) -and [DateTime]::UtcNow -lt $managedUninstallDeadline) {'
             '            Start-Sleep -Seconds 5'
             '        }'
-            '        if (Test-Path -LiteralPath $managedInstallDirectory) {'
-            '            throw "The reviewed managed uninstaller did not remove [$managedInstallDirectory] before the completion deadline."'
+            '        if (Test-Path -LiteralPath $managedUninstallCompletionTarget) {'
+            '            throw "The reviewed managed uninstaller did not remove [$managedUninstallCompletionTarget] before the completion deadline."'
             '        }'
-            '        Write-ADTLogEntry -Message "Reviewed managed uninstall completed for [$managedInstallDirectory]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+            '        Write-ADTLogEntry -Message "Reviewed managed uninstall completed for [$managedUninstallCompletionTarget]." -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
             '    } else {'
             '        Write-ADTLogEntry -Message "Managed installation was already absent: $managedInstallDirectory" -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
             '    }'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -262,6 +262,24 @@ describe('application packaging adapters', () => {
     ).toBe('%SystemDrive%\\SWSetup\\HPImageAssistant');
     expect(
       applyApplicationPackagingAdapter(
+        'Autodesk.LicensingService',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 5,
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+        arguments: ['--mode', 'unattended'],
+        completionTimeoutMinutes: 5,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Autodesk.NavisworksFreedom.2026',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -448,6 +448,24 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant',
   },
   {
+    // Autodesk documents Desktop Licensing Service as a shared component that
+    // does not appear in Programs and Features. Verify its dedicated payload
+    // instead of trying to select one of the unrelated Autodesk ARP changes,
+    // and use the vendor's documented unattended uninstaller during removal.
+    wingetId: 'Autodesk.LicensingService',
+    reviewedManagedInstallDirectory:
+      '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 5,
+    reviewedManagedUninstall: {
+      executablePath:
+        '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+      arguments: ['--mode', 'unattended'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // Navisworks Freedom 2026 is installed by Autodesk ODIS. The bootstrapper
     // changes multiple Autodesk registrations, so a generic ARP capture cannot
     // identify the product safely. Autodesk documents the ODIS manifest-based

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -807,6 +807,56 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses Autodesk Licensing Service dedicated evidence and unattended removal',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Autodesk Licensing Service',
+        [],
+        {
+          reviewedManagedInstallDirectory:
+            '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing',
+          reviewedManagedInstallEvidenceFile:
+            '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+          reviewedManagedInstallCompletionTimeoutMinutes: 5,
+          reviewedManagedUninstall: {
+            executablePath:
+              '%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe',
+            arguments: ['--mode', 'unattended'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Autodesk.LicensingService'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Common Files\\Autodesk Shared\\AdskLicensing\\uninstall.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$managedUninstallArguments = @('--mode', 'unattended')"
+      );
+      expect(uninstallFunction).toContain(
+        '$managedUninstallCompletionTarget = $managedInstallEvidenceFile'
+      );
+      expect(uninstallFunction).toContain(
+        'while ((Test-Path -LiteralPath $managedUninstallCompletionTarget)'
+      );
+      expect(uninstallFunction).not.toContain(
+        'while ((Test-Path -LiteralPath $managedInstallDirectory)'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'uses the exact Autodesk ODIS manifest lifecycle for Navisworks Freedom',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- add an exact managed lifecycle adapter for Autodesk Licensing Service
- verify Autodesk's dedicated service payload instead of ambiguous ARP changes
- use the documented unattended uninstaller and verify evidence-file removal

## Verification
- 231 focused Vitest tests passed
- ESLint passed for changed TypeScript files
- git diff --check passed

The repository-wide TypeScript command continues to report existing test-global and fixture type errors outside this change.