### PR TITLE
Activate Autodesk Licensing lifecycle QA release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '12831539c9dc30678c6f16367faab76820502d2a',
+  packagerCommit: 'f426e369f2134ca5bb896170c9f7fd7e526c5916',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -135,6 +135,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // CutePDF's vendor-specific removal correction affects only its previously
   // failing unInstcpw helper. Preserve every unrelated compatible pass.
   '6af0cfac18f3c4653a69a01f41bc1170c1237807',
+  // Autodesk Licensing Service uses its dedicated payload and documented
+  // uninstaller instead of an ambiguous ARP delta. Preserve every unrelated
+  // compatible pass from the preceding protected release.
+  '12831539c9dc30678c6f16367faab76820502d2a',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Autodesk Licensing Service only on its dedicated lifecycle release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'autodesk.licensingservice', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '12831539c9dc30678c6f16367faab76820502d2a',
+      { wingetId: 'Autodesk.LicensingService', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries CutePDF once with its vendor-specific silent removal adapter', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -35,6 +46,7 @@ describe('QA toolchain targeted retries', () => {
       'Timely.Memory',
       'Blizzard.BattleNet',
       'DATEV.SicherheitspaketCompact',
+      'Autodesk.LicensingService',
     ]));
 
     targets.length = 0;
@@ -56,6 +68,7 @@ describe('QA toolchain targeted retries', () => {
         'Timely.Memory',
         'Blizzard.BattleNet',
         'DATEV.SicherheitspaketCompact',
+        'Autodesk.LicensingService',
       ])
     );
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -963,6 +963,42 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // payload with the inherited WinGet install-location contract.
     'Blizzard.BattleNet',
   ],
+  'f426e369f2134ca5bb896170c9f7fd7e526c5916': [
+    // Autodesk Licensing Service does not expose a product ARP identity. This
+    // release verifies its dedicated service payload and uses Autodesk's
+    // documented unattended uninstaller.
+    'Autodesk.LicensingService',
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- activate protected packager commit f426e369f2134ca5bb896170c9f7fd7e526c5916
- preserve compatible passes from the prior release
- target Autodesk Licensing Service for one corrected retry while carrying unresolved bounded retries

## Verification
- 123 focused release/profile tests passed
- ESLint passed
- git diff --check passed