### PR TITLE
fix(packaging): close Bria before MSI lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -225,6 +225,10 @@ describe('application packaging adapters', () => {
         .processesToClose
     ).toEqual([{ name: 'Evernote', description: 'Evernote' }]);
     expect(
+      applyApplicationPackagingAdapter('Bria.Bria', DEFAULT_PSADT_CONFIG)
+        .processesToClose
+    ).toEqual([{ name: 'Bria', description: 'Bria' }]);
+    expect(
       applyApplicationPackagingAdapter('Insta360.Link.Controller', DEFAULT_PSADT_CONFIG)
         .processesToClose
     ).toEqual([

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -295,6 +295,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Bria keeps its desktop client running in the notification area when its
+    // window is closed. The MSI uninstall can then return 1603 and leave the
+    // exact product registration installed. CounterPath's removal guidance
+    // requires Bria to be exited first, so close only the reviewed Bria client
+    // through PSADT before install, upgrade, or uninstall.
+    wingetId: 'Bria.Bria',
+    requiredProcessesToClose: [
+      { name: 'Bria', description: 'Bria' },
+    ],
+  },
+  {
     // Link Controller remains active in the notification area after its UI is
     // closed, and its optional camera helper can hold the Inno installation
     // directory open. The silent uninstaller then exits without removing the


### PR DESCRIPTION
## Summary
- add a reviewed Bria process-close adapter shared by QA and customer PSADT packages
- prevent Bria's background client from blocking MSI removal with exit 1603
- cover the adapter with packaging contract tests

## Verification
- 125 focused packaging and PSADT contract tests passed
- ESLint passed
- git diff --check passed