### PR TITLE
chore(qa): activate Bria process lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f426e369f2134ca5bb896170c9f7fd7e526c5916',
+  packagerCommit: '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -139,6 +139,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // uninstaller instead of an ambiguous ARP delta. Preserve every unrelated
   // compatible pass from the preceding protected release.
   '12831539c9dc30678c6f16367faab76820502d2a',
+  // Bria's process-close adapter affects only its previously failing MSI
+  // removal path. Preserve every unrelated compatible passing result.
+  'f426e369f2134ca5bb896170c9f7fd7e526c5916',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Bria only after the reviewed process-close lifecycle release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'bria.bria', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f426e369f2134ca5bb896170c9f7fd7e526c5916',
+      { wingetId: 'Bria.Bria', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Autodesk Licensing Service only on its dedicated lifecycle release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -47,6 +58,7 @@ describe('QA toolchain targeted retries', () => {
       'Blizzard.BattleNet',
       'DATEV.SicherheitspaketCompact',
       'Autodesk.LicensingService',
+      'Bria.Bria',
     ]));
 
     targets.length = 0;
@@ -69,6 +81,7 @@ describe('QA toolchain targeted retries', () => {
         'Blizzard.BattleNet',
         'DATEV.SicherheitspaketCompact',
         'Autodesk.LicensingService',
+        'Bria.Bria',
       ])
     );
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -999,6 +999,42 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  '16a626f329d93d1e499c1db30a243d9dc18a2aa6': [
+    // Bria keeps its desktop client running in the notification area. This
+    // release closes that reviewed process before invoking the MSI lifecycle.
+    'Bria.Bria',
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes are filtered before candidates are created.
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- activate packager commit 16a626f329d93d1e499c1db30a243d9dc18a2aa6
- preserve compatible passes from the prior release
- carry bounded retries forward and target Bria's failed MSI lifecycle

## Verification
- 160 focused profile, backfill, and adapter tests passed
- ESLint passed
- git diff --check passed