### PR TITLE
fix(packaging): block unsupported ExpressVPN installer

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -451,6 +451,27 @@ describe('Nmap managed install block migration contract', () => {
   });
 });
 
+describe('ExpressVPN managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818162500_block_expressvpn_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the undocumented ExpressVPN 14 installer across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'ExpressVPN.ExpressVPN'");
+    expect(sql).toContain(
+      'https://github.com/microsoft/winget-pkgs/pull/390529'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('Yandex Browser managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260818162500_block_expressvpn_unsupported_managed_install.sql
+++ b/supabase/migrations/20260818162500_block_expressvpn_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- ExpressVPN 14 changed from the previously published Burn installer to a
+-- generic EXE manifest with no InstallModes or silent switches. Microsoft
+-- WinGet validation explicitly reported those missing properties. Isolated
+-- PSADT lifecycle QA confirmed that the generic /S fallback exits with code 2
+-- and creates no installed-app registration. Do not guess an undocumented
+-- command for customer devices; block automated deployment until the vendor
+-- or WinGet publishes a verifiable unattended install contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'ExpressVPN.ExpressVPN',
+  'unsupported_managed_install',
+  'ExpressVPN 14 does not publish a verifiable unattended Windows install contract. Its current WinGet manifest omits InstallModes and silent switches, and isolated PSADT QA confirmed that the generic /S fallback exits with code 2 without installing the app.',
+  'https://github.com/microsoft/winget-pkgs/pull/390529'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'ExpressVPN.ExpressVPN';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'ExpressVPN.ExpressVPN'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- block ExpressVPN 14 from automated customer deployment and QA
- record the missing unattended install contract in the shared eligibility gate
- supersede the failed/queued ExpressVPN lifecycle instead of guessing undocumented switches

## Evidence
- current WinGet manifest omits InstallModes and silent switches
- WinGet validation flagged the missing switches in microsoft/winget-pkgs#390529
- isolated PSADT QA run 32158750169 returned exit 2 for /S and created no installed-app registration

## Verification
- 53 migration contract tests passed
- ESLint passed
- git diff --check passed