### PR TITLE
Block unsupported Bria managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -472,6 +472,27 @@ describe('ExpressVPN managed install block migration contract', () => {
   });
 });
 
+describe('Bria managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818165200_block_bria_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported Bria removal lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Bria.Bria'");
+    expect(sql).toContain(
+      'https://support.counterpath.com/hc/how-to-fully-uninstall-bria'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('Yandex Browser managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260818165200_block_bria_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260818165200_block_bria_unsupported_managed_uninstall.sql
@@ -1,0 +1,39 @@
+-- Bria 6.8.7.1 installs silently as LocalSystem and registers the expected
+-- product code, but the exact MSI uninstall is not a reliable unattended
+-- lifecycle. Two isolated PSADT runs closed the Bria background process,
+-- invoked that product code, returned MSI exit 1603, and still detected the
+-- installed registration after the removal settle window. CounterPath's
+-- current support material documents uninstalling through the operating
+-- system, but it does not publish a supported unattended removal contract.
+-- Do not guess vendor properties on customer devices; keep this version out
+-- of automated Intune packaging until a verifiable vendor contract exists.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Bria.Bria',
+  'unsupported_managed_uninstall',
+  'Bria installs silently, but two isolated PSADT lifecycle tests confirmed that its exact MSI product-code removal returns 1603 and leaves the application registered. The vendor does not publish a supported unattended removal contract.',
+  'https://support.counterpath.com/hc/how-to-fully-uninstall-bria'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Bria.Bria';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Bria.Bria'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
Bria installs and detects successfully, but two isolated LocalSystem PSADT runs closed the background process, invoked the exact MSI product code, returned 1603, and left the application registered. The vendor publishes only an interactive OS removal flow. This migration blocks automated customer packaging and future QA until a supported unattended removal contract exists. Verified with 54 migration contract tests and git diff --check.