### PR TITLE
Block unsupported 3CX managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -493,6 +493,25 @@ describe('Bria managed uninstall block migration contract', () => {
   });
 });
 
+describe('3CX Phone System managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818171800_block_3cx_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported 3CX removal lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'3CX.PhoneSystem'");
+    expect(sql).toContain('https://www.3cx.com/docs/upgrading-pbx/');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('Yandex Browser managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260818171800_block_3cx_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260818171800_block_3cx_unsupported_managed_uninstall.sql
@@ -1,0 +1,40 @@
+-- 3CX Phone System 20 installs silently and registers successfully, but its
+-- registered vendor uninstaller does not provide a deterministic unattended
+-- lifecycle. Isolated LocalSystem PSADT QA launched the exact registered
+-- command and kept checking the exact 3CX registration after its parent
+-- process exited. The registration remained through the bounded 310-second
+-- completion window and removal verification. Current 3CX guidance requires
+-- a backup and an administrator-driven uninstall during upgrades; it does not
+-- publish a supported unattended removal contract for this server product.
+-- Keep it out of automated Intune packaging rather than guessing destructive
+-- service, database, or data-removal behavior on customer systems.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  '3CX.PhoneSystem',
+  'unsupported_managed_uninstall',
+  '3CX Phone System installs silently, but its registered removal command exits without removing the exact application registration. Current vendor guidance does not publish a deterministic unattended uninstall contract for this server product.',
+  'https://www.3cx.com/docs/upgrading-pbx/'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = '3CX.PhoneSystem';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = '3CX.PhoneSystem'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
3CX Phone System installs and detects under LocalSystem, but its exact registered uninstaller exits while the registration remains through the bounded 310-second completion window and removal verification. Current vendor upgrade guidance requires an administrator-driven backup and uninstall and provides no deterministic unattended removal contract. This migration blocks customer packaging and repeated QA for that unsafe lifecycle. Verified with 55 migration contract tests and git diff --check.