### PR TITLE
Add managed PotPlayer install adapter

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -486,6 +486,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses PotPlayer\'s reviewed all-users NSIS command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Daum.PotPlayer',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('/S /allusers');
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('uses PTC Creo View Express documented MSI-forwarding syntax', () => {
     const adapted = applyApplicationPackagingAdapter(
       'PTC.CreoView.Express',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -228,6 +228,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/S /MULTIUSER',
   },
   {
+    // PotPlayer's NSIS package exposes a vendor-specific /allusers mode for
+    // managed deployment. Plain /S starts but does not complete reliably in a
+    // non-interactive LocalSystem session, leaving no application or ARP
+    // identity. Keep the all-users contract identical in QA and customer
+    // PSADT packages instead of relying on the generic NSIS default.
+    wingetId: 'Daum.PotPlayer',
+    reviewedInstallArgumentsOverride: '/S /allusers',
+  },
+  {
     // Google documents that Drive for desktop must be removed through its
     // versioned registered uninstaller with both --silent and --force_stop.
     // The latter is required whenever Drive is running; without it the helper

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -391,6 +391,30 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds PotPlayer managed installs to the reviewed all-users command', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Daum.PotPlayer',
+      displayName: 'PotPlayer',
+      publisher: 'Daum',
+      version: '26.07.01.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:PotPlayer64:PotPlayer',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/S /allusers'
+    );
+  });
+
   it('binds the Visual Studio 2019 instance lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2019.BuildTools',


### PR DESCRIPTION
## Summary
- bind Daum.PotPlayer to its all-users NSIS install command
- apply the same reviewed adapter to QA and customer PSADT packages
- cover adapter and package-profile normalization

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- npm test -- lib/qa/psadt-packager-contract.test.ts
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check