### PR TITLE
Activate PotPlayer managed install adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
+  packagerCommit: 'ca46c0860496e13b91842f7106f45505441dc44d',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -142,6 +142,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Bria's process-close adapter affects only its previously failing MSI
   // removal path. Preserve every unrelated compatible passing result.
   'f426e369f2134ca5bb896170c9f7fd7e526c5916',
+  // PotPlayer's all-users NSIS adapter affects only its previously failing
+  // non-interactive install path. Bria and 3CX are blocked at the shared
+  // eligibility gate, so preserve every unrelated compatible passing result.
+  '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,14 +6,25 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Bria only after the reviewed process-close lifecycle release', () => {
+  it('does not carry blocked Bria into the PotPlayer release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'bria.bria', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
+      { wingetId: 'Bria.Bria', status: 'failed' }
+    )).toBe(true);
+  });
+
+  it('retries PotPlayer only on its reviewed all-users release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'daum.potplayer', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'f426e369f2134ca5bb896170c9f7fd7e526c5916',
-      { wingetId: 'Bria.Bria', status: 'failed' }
+      '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
+      { wingetId: 'Daum.PotPlayer', status: 'failed' }
     )).toBe(false);
   });
 
@@ -58,7 +69,7 @@ describe('QA toolchain targeted retries', () => {
       'Blizzard.BattleNet',
       'DATEV.SicherheitspaketCompact',
       'Autodesk.LicensingService',
-      'Bria.Bria',
+      'Daum.PotPlayer',
     ]));
 
     targets.length = 0;
@@ -81,7 +92,7 @@ describe('QA toolchain targeted retries', () => {
         'Blizzard.BattleNet',
         'DATEV.SicherheitspaketCompact',
         'Autodesk.LicensingService',
-        'Bria.Bria',
+        'Daum.PotPlayer',
       ])
     );
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1035,6 +1035,43 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  'ca46c0860496e13b91842f7106f45505441dc44d': [
+    // Retry only the failed PotPlayer payload with its reviewed all-users
+    // NSIS install contract shared by QA and customer PSADT packages.
+    'Daum.PotPlayer',
+    // Carry still-unconsumed bounded retries across the atomic pin rollout.
+    // Compatible passes and eligibility-blocked apps are filtered before
+    // candidates are created.
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- pin QA and customer PSADT packaging to the reviewed PotPlayer adapter commit
- preserve compatible historical passes
- schedule one bounded retry for the failed PotPlayer payload
- stop carrying the now-blocked Bria retry

## Verification
- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts
- npm test -- app/api/cron/qa-enqueue/route.test.ts lib/qa/demand.test.ts
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check