### PR TITLE
Block PotPlayer unsupported managed install

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -486,16 +486,6 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
-  it('uses PotPlayer\'s reviewed all-users NSIS command', () => {
-    const adapted = applyApplicationPackagingAdapter(
-      'Daum.PotPlayer',
-      DEFAULT_PSADT_CONFIG
-    );
-
-    expect(adapted.reviewedInstallArgumentsOverride).toBe('/S /allusers');
-    expect(adapted.reviewedUninstallArguments).toEqual([]);
-  });
-
   it('uses PTC Creo View Express documented MSI-forwarding syntax', () => {
     const adapted = applyApplicationPackagingAdapter(
       'PTC.CreoView.Express',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -228,15 +228,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/S /MULTIUSER',
   },
   {
-    // PotPlayer's NSIS package exposes a vendor-specific /allusers mode for
-    // managed deployment. Plain /S starts but does not complete reliably in a
-    // non-interactive LocalSystem session, leaving no application or ARP
-    // identity. Keep the all-users contract identical in QA and customer
-    // PSADT packages instead of relying on the generic NSIS default.
-    wingetId: 'Daum.PotPlayer',
-    reviewedInstallArgumentsOverride: '/S /allusers',
-  },
-  {
     // Google documents that Drive for desktop must be removed through its
     // versioned registered uninstaller with both --silent and --force_stop.
     // The latter is required whenever Drive is running; without it the helper

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -512,6 +512,27 @@ describe('3CX Phone System managed uninstall block migration contract', () => {
   });
 });
 
+describe('PotPlayer managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818183000_block_potplayer_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported PotPlayer LocalSystem install across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Daum.PotPlayer'");
+    expect(sql).toContain(
+      'https://learn.microsoft.com/en-us/answers/questions/991238/sccm-deployed-apps-failed-with-errors'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('Yandex Browser managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -391,30 +391,6 @@ describe('PSADT QA package identity', () => {
     );
   });
 
-  it('binds PotPlayer managed installs to the reviewed all-users command', () => {
-    const normalized = normalizeQaWorkflowPackageInput({
-      wingetId: 'Daum.PotPlayer',
-      displayName: 'PotPlayer',
-      publisher: 'Daum',
-      version: '26.07.01.0',
-      architecture: 'x64',
-      installerSha256: 'b'.repeat(64),
-      installerType: 'exe',
-      silentSwitches: '/S',
-      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:PotPlayer64:PotPlayer',
-      installScope: 'machine',
-      detectionRules: '[]',
-      psadtConfig: JSON.stringify({ detectionRules: [] }),
-    });
-    const profile = normalized.identity.profile as {
-      psadtConfig: { reviewedInstallArgumentsOverride?: string };
-    };
-
-    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
-      '/S /allusers'
-    );
-  });
-
   it('binds the Visual Studio 2019 instance lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2019.BuildTools',

--- a/supabase/migrations/20260818183000_block_potplayer_unsupported_managed_install.sql
+++ b/supabase/migrations/20260818183000_block_potplayer_unsupported_managed_install.sql
@@ -1,0 +1,39 @@
+-- PotPlayer 26.07.01.0 does not provide a deterministic unattended
+-- LocalSystem installation lifecycle. Two isolated PSADT runs used the exact
+-- current x64 payload and hash. The WinGet/NSIS /S command and the reviewed
+-- /S /allusers variant both launched successfully, then stopped producing
+-- installer activity without completing or registering an Apps & Features
+-- entry. A Microsoft deployment report independently describes PotPlayer
+-- succeeding under an interactive administrator while failing in the SYSTEM
+-- context used by managed deployment. Keep this package out of automated
+-- Intune packaging rather than publishing an unverified user-context workaround.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Daum.PotPlayer',
+  'unsupported_managed_install',
+  'PotPlayer 26.07.01.0 starts under LocalSystem but does not complete or register an application identity with either the WinGet silent command or the reviewed all-users variant. No deterministic unattended SYSTEM installation contract is available.',
+  'https://learn.microsoft.com/en-us/answers/questions/991238/sccm-deployed-apps-failed-with-errors'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Daum.PotPlayer';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Daum.PotPlayer'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
Two isolated LocalSystem PSADT lifecycle runs of Daum.PotPlayer 26.07.01.0 used the exact current x64 payload and hash. Both the WinGet NSIS /S command and the reviewed /S /allusers variant launched, then stalled without completing or registering an application identity.\n\nThis removes the ineffective adapter and blocks the unsupported managed install across customer packaging and QA.\n\nValidation: 149 focused Vitest tests, ESLint, and git diff --check.