### PR TITLE
Fail closed for undocumented EXE installers

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -823,6 +823,44 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(candidateInserts[0].package_profile_sha256).not.toBe('B'.repeat(64));
   });
 
+  it('supersedes a plain EXE with no declared silent install contract before dispatch', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      demandBackfillApps: ['Canon.GPCL6_V4_PrinterDriver_V21.00'],
+      supportedApps: [{
+        winget_id: 'Canon.GPCL6_V4_PrinterDriver_V21.00',
+        name: 'Canon PCL6 Driver',
+        publisher: 'Canon',
+        latest_version: '2.72',
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue({
+      status: 'resolved',
+      version: '2.72',
+      manifest: {
+        InstallerType: 'exe',
+        Installers: [{
+          Architecture: 'x64',
+          InstallerUrl: 'https://example.com/canon-driver.exe',
+          InstallerSha256: 'A'.repeat(64),
+          InstallerType: 'exe',
+        }],
+      },
+    });
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, alreadyKnown: 1 });
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({
+      winget_id: 'Canon.GPCL6_V4_PrinterDriver_V21.00',
+      status: 'superseded',
+      failure_summary: expect.stringContaining('explicit silent installer switches'),
+    });
+  });
+
   it('records a changed supported app failure and advances the completed comparison cursor', async () => {
     detectWingetChangesMock.mockResolvedValue({
       baseSha: 'a'.repeat(40),

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -825,7 +825,7 @@ export async function GET(request: Request) {
             const previousMatches = Boolean(previous);
             const now = new Date().toISOString();
             const initialStatus = !packagingContract.valid
-              ? 'failed'
+              ? 'superseded'
               : previousMatches
                 ? 'passed'
                 : 'queued';

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -889,6 +889,31 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('rejects a custom plain EXE without silent switches before creating a job', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          sourceType: 'custom',
+          installerSha256: '',
+          installCommand: 'setup.exe',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({ code: 'SILENT_INSTALL_UNAVAILABLE' });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
+  });
+
   it('treats a whitespace-only custom-app SHA256 as missing', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -45,6 +45,7 @@ import {
 import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { reconcileCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
+import { evaluatePackagingContract } from '@/lib/packaging-contract';
 import type { NormalizedInstaller } from '@/types/winget';
 import {
   getPackageEligibilityBlocks,
@@ -260,6 +261,26 @@ export async function POST(request: NextRequest) {
           },
           { status: 400 }
         );
+      }
+      if (item.sourceType === 'custom') {
+        const packagingContract = evaluatePackagingContract({
+          wingetId: item.wingetId,
+          installerType: item.installerType,
+          silentArgs: extractSilentSwitches(
+            item.installCommand,
+            item.installerType,
+            item.nestedInstallerType
+          ),
+          nestedInstallerType: item.nestedInstallerType,
+          nestedInstallerFiles: item.nestedInstallerPath ? [item.nestedInstallerPath] : [],
+        });
+        if (!packagingContract.valid) {
+          return NextResponse.json({
+            error: 'Installer validation blocked this deployment',
+            message: packagingContract.message,
+            code: 'SILENT_INSTALL_UNAVAILABLE',
+          }, { status: 400 });
+        }
       }
     }
 

--- a/components/CustomAppModal.tsx
+++ b/components/CustomAppModal.tsx
@@ -105,6 +105,9 @@ export function CustomAppModal({ onClose }: CustomAppModalProps) {
     if (iconUrl.trim() && !isValidIconUrl(iconUrl.trim())) {
       nextErrors.iconUrl = 'Must be a valid https:// URL';
     }
+    if (installerType === 'exe' && !silentSwitches.trim()) {
+      nextErrors.silentSwitches = 'Enter the vendor-documented silent switches';
+    }
     return nextErrors;
   };
 
@@ -364,22 +367,39 @@ export function CustomAppModal({ onClose }: CustomAppModalProps) {
 
             {/* Optional fields */}
             <div className="border-t border-overlay/10 pt-6 space-y-6">
-              <h3 className="text-sm font-semibold text-text-primary">Optional</h3>
+              <h3 className="text-sm font-semibold text-text-primary">Installer options</h3>
 
               {/* Silent Switches */}
               <div>
-                <label htmlFor="custom-app-silent-switches" className="block text-sm font-medium text-text-muted mb-2">Silent switches</label>
+                <label htmlFor="custom-app-silent-switches" className="block text-sm font-medium text-text-muted mb-2">
+                  Silent switches{installerType === 'exe' ? ' *' : ''}
+                </label>
                 <Input
                   id="custom-app-silent-switches"
                   type="text"
                   value={silentSwitches}
-                  onChange={(e) => setSilentSwitches(e.target.value)}
-                  placeholder={CUSTOM_SILENT_SWITCH_DEFAULTS[installerType]}
-                  className={cn(inputClassName, 'font-mono')}
+                  onChange={(e) => {
+                    setSilentSwitches(e.target.value);
+                    clearError('silentSwitches');
+                  }}
+                  placeholder={installerType === 'exe'
+                    ? 'Vendor-documented silent switches'
+                    : CUSTOM_SILENT_SWITCH_DEFAULTS[installerType]}
+                  aria-invalid={Boolean(errors.silentSwitches)}
+                  className={cn(
+                    inputClassName,
+                    'font-mono',
+                    errors.silentSwitches && 'border-red-500 focus:ring-red-500/20'
+                  )}
                 />
                 <p className="text-xs text-text-muted mt-1">
-                  Pre-filled with the default for the selected installer type.
+                  {installerType === 'exe'
+                    ? 'Required because plain EXE installers do not share one safe silent command.'
+                    : 'Pre-filled with the default for the selected installer type.'}
                 </p>
+                {errors.silentSwitches && (
+                  <p className="text-xs text-red-500 mt-1">{errors.silentSwitches}</p>
+                )}
               </div>
 
               {/* Uninstall Command */}

--- a/lib/__tests__/custom-app.test.ts
+++ b/lib/__tests__/custom-app.test.ts
@@ -22,6 +22,7 @@ function validInput(overrides: Partial<CustomAppInput> = {}): CustomAppInput {
     installerType: 'exe',
     architecture: 'x64',
     installScope: 'machine',
+    silentSwitches: '/vendor-silent',
     ...overrides,
   };
 }
@@ -128,17 +129,27 @@ describe('buildCustomAppCartItem', () => {
   });
 
   it('should apply per-type default silent switches to the install command', () => {
-    const exeItem = buildCustomAppCartItem(validInput({ installerType: 'exe' }));
-    expect(exeItem.installCommand).toBe(`"setup.exe" ${CUSTOM_SILENT_SWITCH_DEFAULTS.exe}`);
+    const exeItem = buildCustomAppCartItem(validInput({
+      installerType: 'exe',
+      silentSwitches: '/documented-quiet',
+    }));
+    expect(exeItem.installCommand).toBe('"setup.exe" /documented-quiet');
 
     const innoItem = buildCustomAppCartItem(
-      validInput({ installerType: 'inno', installerUrl: 'https://example.com/app-setup.exe' })
+      validInput({
+        installerType: 'inno',
+        installerUrl: 'https://example.com/app-setup.exe',
+        silentSwitches: '',
+      })
     );
     expect(innoItem.installCommand).toBe(
       `"app-setup.exe" ${CUSTOM_SILENT_SWITCH_DEFAULTS.inno}`
     );
 
-    const burnItem = buildCustomAppCartItem(validInput({ installerType: 'burn' }));
+    const burnItem = buildCustomAppCartItem(validInput({
+      installerType: 'burn',
+      silentSwitches: '',
+    }));
     expect(burnItem.installCommand).toBe(`"setup.exe" ${CUSTOM_SILENT_SWITCH_DEFAULTS.burn}`);
   });
 
@@ -203,6 +214,12 @@ describe('buildCustomAppCartItem', () => {
 
   it('should reject an invalid sha256', () => {
     expect(() => buildCustomAppCartItem(validInput({ sha256: 'xyz' }))).toThrow(/SHA256/);
+  });
+
+  it('should reject a custom plain EXE without vendor silent switches', () => {
+    expect(() => buildCustomAppCartItem(validInput({ silentSwitches: '' }))).toThrow(
+      /Silent switches are required/
+    );
   });
 
   it('should reject missing required fields', () => {

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -636,6 +636,7 @@ describe('generateInstallCommand', () => {
     const command = generateInstallCommand(installer);
 
     expect(command).toContain('"windows_64.exe"');
+    expect(command).not.toContain('/S');
   });
 
   it('should append .msi for extensionless MSI URLs', () => {

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -30,7 +30,7 @@ describe('normalizeInstaller', () => {
       sha256: 'abc123def456',
       type: 'exe',
       scope: undefined,
-      silentArgs: '/S',
+      silentArgs: '',
       productCode: undefined,
       packageFamilyName: undefined,
     });
@@ -85,7 +85,7 @@ describe('normalizeInstaller', () => {
     const result = normalizeInstaller(installer);
 
     expect(result.silentArgs).toBe(
-      '/S --lang=enUS --installpath="%PROGRAMFILES(X86)%\\Contoso"'
+      '--lang=enUS --installpath="%PROGRAMFILES(X86)%\\Contoso"'
     );
     expect(result.installLocationRequired).toBe(true);
     expect(result.defaultInstallLocation).toBe('%PROGRAMFILES(X86)%\\Contoso');
@@ -111,7 +111,7 @@ describe('normalizeInstaller', () => {
     expect(installer.InstallLocationRequired).toBe(true);
     expect(installer.DefaultInstallLocation).toBe('%PROGRAMFILES%\\Contoso');
     expect(normalizeInstaller(installer).silentArgs).toBe(
-      '/S --installpath="%PROGRAMFILES%\\Contoso"'
+      '--installpath="%PROGRAMFILES%\\Contoso"'
     );
   });
 
@@ -373,8 +373,8 @@ describe('normalizeInstaller', () => {
       expect(result.type).toBe('zip');
       expect(result.nestedInstallerType).toBe('exe');
       expect(result.nestedInstallerPath).toBe('paint.net.5.1.12.install.x64.exe');
-      // Default silent switch comes from the NESTED type, not zip
-      expect(result.silentArgs).toBe('/S');
+      // A nested plain EXE still requires declared vendor switches.
+      expect(result.silentArgs).toBe('');
     });
 
     it('should pick the nested-type default switch for zip with nested inno', () => {
@@ -422,7 +422,7 @@ describe('normalizeInstaller', () => {
 
       expect(result.nestedInstallerType).toBeUndefined();
       expect(result.nestedInstallerPath).toBeUndefined();
-      expect(result.silentArgs).toBe('/S');
+      expect(result.silentArgs).toBe('');
     });
 
     it('should yield undefined nestedInstallerPath for zip without NestedInstallerFiles', () => {

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -12,6 +12,7 @@ import {
   reconcileCatalogInstaller,
   selectTrustedCatalogInstaller,
 } from '@/lib/catalog-installer-reconciliation';
+import { InstallerPreflightError } from '@/lib/installer-preflight';
 import type { Win32CartItem } from '@/types/upload';
 import type { NormalizedInstaller } from '@/types/winget';
 
@@ -144,6 +145,35 @@ describe('catalog installer reconciliation', () => {
 
     expect(reconciled.item.installCommand).toBe('custom-install.exe /tenant-approved');
     expect(reconciled.item.uninstallCommand).toBe('custom-uninstall.exe /tenant-approved');
+  });
+
+  it('blocks an opaque EXE before a customer package can be created', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      ...operaInstallers[1],
+      silentArgs: '',
+    }]);
+
+    await expect(reconcileCatalogInstaller(operaItem({
+      wingetId: 'Contoso.OpaqueSetup',
+    }))).rejects.toMatchObject({
+      code: 'SILENT_INSTALL_UNAVAILABLE',
+      retryable: false,
+    } satisfies Partial<InstallerPreflightError>);
+  });
+
+  it('allows an explicit PSADT command for an otherwise opaque EXE', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      ...operaInstallers[1],
+      silentArgs: '',
+    }]);
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Contoso.OpaqueSetup',
+      psadtConfig: {
+        installCommand: 'setup.exe --quiet --norestart',
+      } as Win32CartItem['psadtConfig'],
+    }));
+
+    expect(reconciled.item.installCommand).toBe('setup.exe --quiet --norestart');
   });
 
   it('uses the reviewed vendor ARP identity for the Chrome EXE catalog package', async () => {

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -10,6 +10,7 @@ import {
   resolveApplicationInstallScope,
   resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
+import { evaluatePackagingContract } from '@/lib/packaging-contract';
 import { hashesEqual } from '@/lib/installer-download';
 import type { Win32CartItem } from '@/types/upload';
 import type { NormalizedInstaller, WingetScope } from '@/types/winget';
@@ -153,6 +154,21 @@ export async function reconcileCatalogInstaller(
 
   const customInstallCommand = item.psadtConfig?.installCommand?.trim();
   const customUninstallCommand = item.psadtConfig?.uninstallCommand?.trim();
+  const packagingContract = evaluatePackagingContract({
+    wingetId: item.wingetId,
+    installerType: installer.type,
+    silentArgs: customInstallCommand || installer.silentArgs || '',
+    nestedInstallerType: installer.nestedInstallerType,
+    nestedInstallerFiles: installer.nestedInstallerPath
+      ? [installer.nestedInstallerPath]
+      : undefined,
+  });
+  if (!packagingContract.valid) {
+    throw new InstallerPreflightError(
+      'SILENT_INSTALL_UNAVAILABLE',
+      packagingContract.message,
+    );
+  }
   const refreshedItem: Win32CartItem = {
     ...item,
     installScope,
@@ -199,6 +215,9 @@ async function healCatalogInstaller(
     InstallerUrl: value.url,
     InstallerSha256: value.sha256,
     InstallerType: value.type,
+    InstallerSwitches: value.silentArgs
+      ? { Silent: value.silentArgs }
+      : undefined,
     NestedInstallerType: value.nestedInstallerType,
     Scope: value.scope,
     InstallerSuccessCodes: value.installerSuccessCodes,

--- a/lib/custom-app.ts
+++ b/lib/custom-app.ts
@@ -33,7 +33,9 @@ export type CustomInstallerType = Extract<
 // Mirrors getDefaultSilentSwitch in lib/manifest-api.ts (not exported there),
 // limited to the installer types supported for custom apps.
 export const CUSTOM_SILENT_SWITCH_DEFAULTS: Record<CustomInstallerType, string> = {
-  exe: '/S',
+  // A direct EXE has no trustworthy universal unattended switch. Require the
+  // administrator to enter the vendor-documented command instead.
+  exe: '',
   msi: '/qn /norestart',
   inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
   nullsoft: '/S',
@@ -121,6 +123,9 @@ export function buildCustomAppCartItem(input: CustomAppInput): CustomAppCartItem
   }
   if (iconUrl && !isValidIconUrl(iconUrl)) {
     throw new Error('Icon URL must be a valid https URL');
+  }
+  if (input.installerType === 'exe' && !input.silentSwitches?.trim()) {
+    throw new Error('Silent switches are required for a custom EXE installer');
   }
 
   const wingetId = buildCustomWingetId(publisher, displayName);

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -494,7 +494,8 @@ function getDefaultSilentArgs(type: WingetInstallerType): string {
     msi: '/qn /norestart',
     msix: '',
     appx: '',
-    exe: '/S',
+    // Do not invent a vendor contract for an opaque EXE.
+    exe: '',
     inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -138,6 +138,18 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
   });
 
+  it('does not dispatch a custom plain EXE without silent switches', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(triggerPackagingWorkflow(workflowInputs({
+      silentSwitches: '',
+    }), config, { skipRunCapture: true })).rejects.toMatchObject({
+      code: 'silent-install-contract-missing',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('defaults to strict mode when no mode override is supplied', async () => {
     enforceInstallerPreflightMock.mockResolvedValueOnce({
       cacheKey: 'healthy-key',

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -11,6 +11,7 @@ import { reconcileCatalogInstaller } from './catalog-installer-reconciliation';
 import { enforceInstallerPreflight, InstallerPreflightError } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
 import { resolveApplicationUninstallCommand } from './packaging-adapters';
+import { assertPackagingContract } from './packaging-contract';
 import {
   normalizeQaWorkflowPackageInput,
 } from './qa/package-profile';
@@ -198,6 +199,16 @@ export async function triggerPackagingWorkflow(
     sourceType: effectiveInputs.sourceType,
   }, trustedInstallers);
   inputs = effectiveInputs;
+  // Final dispatch boundary: custom callers bypass catalog reconciliation, so
+  // they must still prove an unattended install contract before GitHub sees
+  // the installer URL or any tenant-scoped packaging request.
+  assertPackagingContract({
+    wingetId: inputs.wingetId,
+    installerType: inputs.installerType,
+    silentArgs: inputs.silentSwitches,
+    nestedInstallerType: inputs.nestedInstallerType,
+    nestedInstallerFiles: inputs.nestedInstallerPath ? [inputs.nestedInstallerPath] : [],
+  });
   const packageDependencies = inputs.sourceType === 'custom'
     ? []
     : await resolveWingetPackageDependencies({

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -742,7 +742,9 @@ function getDefaultSilentSwitch(installerType: WingetInstallerType): string {
     msi: '/qn /norestart',
     msix: '',
     appx: '',
-    exe: '/S',
+    // A generic EXE format says nothing about the vendor's unattended
+    // contract. WinGet manifests must declare switches explicitly.
+    exe: '',
     inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',

--- a/lib/msp/silent-switches.test.ts
+++ b/lib/msp/silent-switches.test.ts
@@ -33,6 +33,10 @@ describe('extractSilentSwitches', () => {
     )).toBe('/configure https://aka.ms/fhlwingetconfig');
   });
 
+  it('does not guess a universal switch for a plain EXE command', () => {
+    expect(extractSilentSwitches('"setup.exe"', 'exe')).toBe('');
+  });
+
   it('keeps MSI properties after removing the install action target', () => {
     expect(extractSilentSwitches(
       'msiexec.exe /i "agent.msi" /qn REBOOT=ReallySuppress ALLUSERS=1',

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -14,7 +14,7 @@ export function extractSilentSwitches(
   // Common silent switches by installer type
   const defaultSwitches: Record<string, string> = {
     msi: '/qn /norestart',
-    exe: '/S',
+    exe: '',
     inno: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
     nullsoft: '/S',
     wix: '/qn /norestart',
@@ -58,5 +58,5 @@ export function extractSilentSwitches(
     return cleaned;
   }
 
-  return defaultSwitches[effectiveType] ?? (sourceType === 'zip' ? '' : '/S');
+  return defaultSwitches[effectiveType] ?? '';
 }

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -720,6 +720,22 @@ function applicationPackagingAdapter(
   return undefined;
 }
 
+/**
+ * Return whether a reviewed application adapter supplies the install-side
+ * contract that an opaque EXE manifest does not. Uninstall-only and
+ * verification-only adapters deliberately do not qualify.
+ */
+export function hasReviewedApplicationInstallContract(wingetId: string): boolean {
+  const adapter = applicationPackagingAdapter(wingetId);
+  return Boolean(
+    adapter && (
+      adapter.reviewedInstallArguments?.some((argument) => argument.trim()) ||
+      adapter.reviewedInstallArgumentsOverride?.trim() ||
+      adapter.reviewedInstallShieldAdministrativeImage
+    )
+  );
+}
+
 export function resolveApplicationInstallScope(
   wingetId: string,
   requestedScope?: string | null

--- a/lib/packaging-contract.test.ts
+++ b/lib/packaging-contract.test.ts
@@ -2,6 +2,46 @@ import { describe, expect, it } from 'vitest';
 import { evaluatePackagingContract } from './packaging-contract';
 
 describe('evaluatePackagingContract', () => {
+  it('rejects a plain EXE when no unattended command is declared', () => {
+    const result = evaluatePackagingContract({
+      wingetId: 'Contoso.OpaqueSetup',
+      installerType: 'exe',
+      silentArgs: '',
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe('silent-install-contract-missing');
+  });
+
+  it('accepts a plain EXE with explicit vendor silent arguments', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Contoso.DocumentedSetup',
+      installerType: 'exe',
+      silentArgs: '--quiet --norestart',
+    }).valid).toBe(true);
+  });
+
+  it('accepts an EXE whose reviewed adapter supplies the install contract', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Bitvise.SSH.Client',
+      installerType: 'exe',
+      silentArgs: '',
+    }).valid).toBe(true);
+  });
+
+  it('rejects a nested plain EXE without silent arguments', () => {
+    const result = evaluatePackagingContract({
+      wingetId: 'Contoso.OpaqueArchive',
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerFiles: ['setup.exe'],
+      silentArgs: '',
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe('silent-install-contract-missing');
+  });
+
   it('recognizes complete Office Deployment Tool configuration arguments', () => {
     expect(evaluatePackagingContract({
       wingetId: 'Microsoft.Office',

--- a/lib/packaging-contract.ts
+++ b/lib/packaging-contract.ts
@@ -1,3 +1,5 @@
+import { hasReviewedApplicationInstallContract } from '@/lib/packaging-adapters';
+
 export type InstallerContractFamily =
   | 'msi'
   | 'msix'
@@ -17,6 +19,7 @@ export type PackagingContractResult =
       family: InstallerContractFamily;
       code:
         | 'unsupported-installer-type'
+        | 'silent-install-contract-missing'
         | 'archive-contract-incomplete'
         | 'required-argument-missing'
         | 'unsafe-argument-syntax';
@@ -100,8 +103,23 @@ export function evaluatePackagingContract(
     };
   }
 
+  const nestedType = input.nestedInstallerType?.trim().toLowerCase() || '';
+  const executesPlainExe = type === 'exe' || (type === 'zip' && nestedType === 'exe');
+  if (
+    executesPlainExe &&
+    !args &&
+    !hasReviewedApplicationInstallContract(input.wingetId)
+  ) {
+    return {
+      valid: false,
+      family,
+      code: 'silent-install-contract-missing',
+      message:
+        'A plain EXE package requires explicit silent installer switches or a reviewed application adapter.',
+    };
+  }
+
   if (family === 'archive') {
-    const nestedType = input.nestedInstallerType?.trim().toLowerCase() || '';
     const nestedFiles = (input.nestedInstallerFiles || []).filter((value) => value.trim());
     if (Boolean(nestedType) !== (nestedFiles.length > 0)) {
       return {

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -767,3 +767,22 @@ describe('unsupported dependency shape compatibility block contract', () => {
     expect(sql).toContain("'unsupported_dependency_shape'");
   });
 });
+
+describe('Canon printer driver managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818194500_block_canon_printer_driver_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the undocumented plain EXE lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Canon.GPCL6_V4_PrinterDriver_V21.00'");
+    expect(sql).toContain('d7f86d1703d858d6f7fe0308016a2134f05cc03e');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -152,7 +152,7 @@ describe('buildQaCatalogTestConfig', () => {
     });
 
     expect(config.silentArgs).toBe(
-      '/S --lang=enUS --installpath="%PROGRAMFILES(X86)%\\Battle.net"'
+      '--lang=enUS --installpath="%PROGRAMFILES(X86)%\\Battle.net"'
     );
   });
 

--- a/supabase/migrations/20260818194500_block_canon_printer_driver_unsupported_managed_install.sql
+++ b/supabase/migrations/20260818194500_block_canon_printer_driver_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- Canon's PCL6 V4 Driver 21.00 package is an opaque EXE whose WinGet
+-- manifest declares no Silent or SilentWithProgress switches. An isolated
+-- LocalSystem PSADT lifecycle run using the former generic /S fallback did
+-- not create an authoritative application registration, so deterministic
+-- install verification and removal are unavailable. Keep this driver out of
+-- automated deployment until Canon or WinGet publishes a reviewed unattended
+-- contract instead of guessing a vendor command on customer devices.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Canon.GPCL6_V4_PrinterDriver_V21.00',
+  'unsupported_managed_install',
+  'Canon PCL6 V4 Driver 21.00 is published as a plain EXE without silent switches. Isolated LocalSystem QA confirmed that the generic /S fallback does not produce a deterministic managed application identity for verification and removal.',
+  'https://github.com/microsoft/winget-pkgs/commit/d7f86d1703d858d6f7fe0308016a2134f05cc03e'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Canon.GPCL6_V4_PrinterDriver_V21.00';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Canon.GPCL6_V4_PrinterDriver_V21.00'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- stop inventing /S for opaque EXE manifests across QA and customer packaging
- require vendor-documented switches for custom EXEs while preserving reviewed app adapters
- retain silent switches during catalog cache healing and supersede unsupported QA candidates before VM dispatch
- permanently block the Canon PCL6 driver until a deterministic unattended lifecycle exists

## Verification
- 1,223 Vitest tests passed (full suite plus isolated rerun of one transient timeout)
- focused ESLint clean
- 
pm run build:ci passed
- git diff --check passed