### PR TITLE
Handle chained MSI identities for EXE wrappers

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2535,12 +2535,12 @@ if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
     # This is a packager-time decision. Do not emit $originalInstallerType into the
     # generated deployment script: that variable exists only in this generator and
     # StrictMode would turn the fallback check into a post-install 60001 failure.
-    if ($originalInstallerType -eq 'burn') {
+    if ($originalInstallerType -in @('burn', 'exe')) {
         $lines += @(
             '        if ($selectedApplications.Count -gt 1) {'
-            '            # A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
-            '            # Prefer the single non-MSI entry from the already identity-matched set; never widen'
-            '            # an ambiguous match to an unrelated uninstall entry.'
+            '            # A top-level executable wrapper and its chained MSI can intentionally share the same ARP display name.'
+            '            # Prefer the single visible non-MSI entry from the already identity-matched set; never widen'
+            '            # an ambiguous match to an unrelated uninstall entry or guess between multiple wrappers.'
             '            $bundleCandidates = @($selectedApplications | Where-Object {'
             '                $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
             '                $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
@@ -2908,6 +2908,22 @@ if ($useManagedDirectoryLifecycle) {
         '            $installedApps = $containsMatches'
         '        }'
         '    }'
+    )
+    if ($originalInstallerType -in @('burn', 'exe')) {
+        $lines += @(
+            '    if ($installedApps.Count -gt 1) {'
+            '        # Recover a missing marker only when one exact, visible top-level wrapper is distinguishable'
+            '        # from chained MSI registrations with the same display name. Multiple wrappers remain fail-closed.'
+            '        $topLevelWrapperMatches = @($installedApps | Where-Object {'
+            '            $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+            '            $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+            '            $isVisibleApplication -and -not $_.WindowsInstaller'
+            '        })'
+            '        if ($topLevelWrapperMatches.Count -eq 1) { $installedApps = $topLevelWrapperMatches }'
+            '    }'
+        )
+    }
+    $lines += @(
         '    if ($installedApps.Count -ne 1) {'
         '        throw "Could not find one unambiguous vendor uninstall registry entry for [$appName]. Found $($installedApps.Count); refusing broad removal."'
         '    }'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1640,29 +1640,38 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   });
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'narrows an ambiguous Burn display-name match to the single bundle entry',
+    'narrows an ambiguous executable-wrapper display-name match to the single top-level entry',
     () => {
-      const generated = generateRegistryUninstallPackage('burn', 'PreForm');
+      for (const installerType of ['burn', 'exe']) {
+        const generated = generateRegistryUninstallPackage(installerType, 'Wrapped App');
 
-      expect(generated).toContain('if ($selectedApplications.Count -gt 1)');
-      expect(generated).toContain(
-        '$bundleCandidates = @($selectedApplications | Where-Object {'
-      );
-      expect(generated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
-      expect(generated.indexOf('if ($selectedApplications.Count -gt 1)')).toBeLessThan(
-        generated.indexOf('if ($selectedApplications.Count -eq 1) { break }')
-      );
+        expect(generated).toContain('if ($selectedApplications.Count -gt 1)');
+        expect(generated).toContain(
+          '$bundleCandidates = @($selectedApplications | Where-Object {'
+        );
+        expect(generated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
+        expect(generated.indexOf('if ($selectedApplications.Count -gt 1)')).toBeLessThan(
+          generated.indexOf('if ($selectedApplications.Count -eq 1) { break }')
+        );
+        expect(generated).toContain(
+          '$topLevelWrapperMatches = @($installedApps | Where-Object {'
+        );
+        expect(generated).toContain(
+          'if ($topLevelWrapperMatches.Count -eq 1) { $installedApps = $topLevelWrapperMatches }'
+        );
+      }
     }
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'does not emit Burn-only duplicate-entry narrowing for non-Burn packages',
+    'does not emit executable-wrapper duplicate-entry narrowing for native installer packages',
     () => {
       const generated = generateRegistryUninstallPackage('inno', 'Example App');
 
       expect(generated).not.toContain(
-        'A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
+        'A top-level executable wrapper and its chained MSI can intentionally share the same ARP display name.'
       );
+      expect(generated).not.toContain('$topLevelWrapperMatches');
     }
   );
 
@@ -1679,7 +1688,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       );
       expect(burnGenerated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
       expect(burnGenerated).toContain(
-        'A Burn bundle and its chained MSI can intentionally share the same ARP display name.'
+        'A top-level executable wrapper and its chained MSI can intentionally share the same ARP display name.'
       );
     }
   );


### PR DESCRIPTION
## Summary
- treat plain EXE wrappers like Burn bundles when one visible non-MSI ARP entry is distinguishable from chained MSI entries
- apply the same bounded recovery when a legacy/missing marker requires uninstall lookup
- keep multiple-wrapper ambiguity fail-closed

## Evidence
- Acronis Cyber Protect Home Office changed four ARP entries; two matched its configured identity, causing install/uninstall exit 60001
- 83 test files / 1,225 tests passed
- production Next.js build and TypeScript passed