### PR TITLE
Allow Acronis child-process removal to complete

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -112,6 +112,22 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('allows Acronis child-process removal to finish against the exact registration', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Acronis.CyberProtectHomeOffice',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      uninstallCompletionTimeoutMinutes: 10,
+    });
+
+    expect(
+      applyApplicationPackagingAdapter('Example.App', DEFAULT_PSADT_CONFIG)
+        .uninstallCompletionTimeoutMinutes
+    ).toBeUndefined();
+  });
+
   it('adds reviewed silent removal arguments for failing vendor lifecycles', () => {
     expect(
       applyApplicationPackagingAdapter('RARLab.WinRAR', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -178,6 +178,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/vADDLOCAL="ALL" /qn /norestart',
   },
   {
+    // Acronis' signed removal process returns before its child process removes
+    // the exact captured product registration. A five-minute generic wait can
+    // therefore report an uninstall failure even though the same QA lifecycle
+    // subsequently verifies the application as absent. Keep polling the exact
+    // registration longer for both QA and customer Intune removals.
+    wingetId: 'Acronis.CyberProtectHomeOffice',
+    uninstallCompletionTimeoutMinutes: 10,
+  },
+  {
     // Apryse documents -q as the unattended Windows uninstall switch for the
     // install4j-based Xodo/PDF Studio family. The registered Xodo PDF Reader
     // command omits it, which leaves the confirmation flow waiting in a


### PR DESCRIPTION
## Summary
- add a narrow 10-minute uninstall completion window for Acronis Cyber Protect Home Office
- keep exact-registration polling and the global five-minute default unchanged
- apply the adapter to both QA and customer Intune PSADT packages

## Evidence
- QA run 32183177035 installed and detected successfully
- the signed vendor uninstaller removed the exact captured registration shortly after the generic five-minute deadline
- removal verification succeeded even though the uninstall wrapper had already returned 60001

## Verification
- 93 focused adapter/package/scheduler tests passed
- full suite: 1,225 tests passed; one unrelated translation-provider timeout passed immediately when rerun in isolation
- production Next.js build passed