### PR TITLE
Activate Acronis uninstall timeout adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '9205d51e3c693afe7fdd385572f181c4739d91c5',
+  packagerCommit: '78dfd1a4113805acbd03fe52ddfe6bc06d90544d',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -70,6 +70,7 @@ describe('QA toolchain targeted retries', () => {
       'DATEV.SicherheitspaketCompact',
       'Autodesk.LicensingService',
       'Daum.PotPlayer',
+      'Acronis.CyberProtectHomeOffice',
     ]));
 
     targets.length = 0;
@@ -93,6 +94,7 @@ describe('QA toolchain targeted retries', () => {
         'DATEV.SicherheitspaketCompact',
         'Autodesk.LicensingService',
         'Daum.PotPlayer',
+        'Acronis.CyberProtectHomeOffice',
       ])
     );
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1144,6 +1144,43 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  '78dfd1a4113805acbd03fe52ddfe6bc06d90544d': [
+    // Acronis removes its exact captured product registration asynchronously.
+    // Retry it once with the reviewed ten-minute completion window shared by
+    // QA and customer PSADT packages. Carry still-unconsumed bounded targets;
+    // compatible passes and eligibility-blocked apps are filtered upstream.
+    'Acronis.CyberProtectHomeOffice',
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- advance the protected QA/customer packager pin to the Acronis lifecycle fix
- retry Acronis once with the corrected profile
- preserve unconsumed bounded retry targets across the atomic rollout

## Verification
- 181 package-profile, retry-map, package-route, and scheduler tests passed
- QA remains paused until the website scheduler and workflow repository report the same commit