### PR TITLE
Block unsupported Acronis managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -112,19 +112,12 @@ describe('application packaging adapters', () => {
     });
   });
 
-  it('allows Acronis child-process removal to finish against the exact registration', () => {
+  it('does not extend the blocked Acronis managed-uninstall lifecycle', () => {
     expect(
       applyApplicationPackagingAdapter(
         'Acronis.CyberProtectHomeOffice',
         DEFAULT_PSADT_CONFIG
-      )
-    ).toMatchObject({
-      uninstallCompletionTimeoutMinutes: 10,
-    });
-
-    expect(
-      applyApplicationPackagingAdapter('Example.App', DEFAULT_PSADT_CONFIG)
-        .uninstallCompletionTimeoutMinutes
+      ).uninstallCompletionTimeoutMinutes
     ).toBeUndefined();
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -178,15 +178,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/vADDLOCAL="ALL" /qn /norestart',
   },
   {
-    // Acronis' signed removal process returns before its child process removes
-    // the exact captured product registration. A five-minute generic wait can
-    // therefore report an uninstall failure even though the same QA lifecycle
-    // subsequently verifies the application as absent. Keep polling the exact
-    // registration longer for both QA and customer Intune removals.
-    wingetId: 'Acronis.CyberProtectHomeOffice',
-    uninstallCompletionTimeoutMinutes: 10,
-  },
-  {
     // Apryse documents -q as the unattended Windows uninstall switch for the
     // install4j-based Xodo/PDF Studio family. The registered Xodo PDF Reader
     // command omits it, which leaves the confirmation flow waiting in a

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -493,6 +493,27 @@ describe('Bria managed uninstall block migration contract', () => {
   });
 });
 
+describe('Acronis managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260818213904_block_acronis_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported Acronis removal lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Acronis.CyberProtectHomeOffice'");
+    expect(sql).toContain(
+      'https://dl.acronis.com/u/pdf/ATI2026_userguidewindows_en-US.pdf'
+    );
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('3CX Phone System managed uninstall block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -70,8 +70,8 @@ describe('QA toolchain targeted retries', () => {
       'DATEV.SicherheitspaketCompact',
       'Autodesk.LicensingService',
       'Daum.PotPlayer',
-      'Acronis.CyberProtectHomeOffice',
     ]));
+    expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
 
     targets.length = 0;
 
@@ -94,9 +94,11 @@ describe('QA toolchain targeted retries', () => {
         'DATEV.SicherheitspaketCompact',
         'Autodesk.LicensingService',
         'Daum.PotPlayer',
-        'Acronis.CyberProtectHomeOffice',
       ])
     );
+    expect(
+      terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
+    ).not.toContain('Acronis.CyberProtectHomeOffice');
   });
 
   it('does not repeat the consumed .NET Framework retry in the Sonos releases', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1108,11 +1108,9 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'DATEV.SicherheitspaketCompact',
   ],
   '9205d51e3c693afe7fdd385572f181c4739d91c5': [
-    // Retry the exact Acronis payload once with the bounded top-level EXE
-    // wrapper selector shared by QA and customer PSADT packages. Carry the
-    // still-unconsumed prior repair targets through the atomic pin rollout;
-    // compatible passes and eligibility-blocked apps are filtered upstream.
-    'Acronis.CyberProtectHomeOffice',
+    // Carry the still-unconsumed prior repair targets through the atomic pin
+    // rollout; compatible passes and eligibility-blocked apps are filtered
+    // upstream.
     'Daum.PotPlayer',
     'Autodesk.LicensingService',
     'AcroSoftware.CutePDFWriter',
@@ -1145,11 +1143,8 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'DATEV.SicherheitspaketCompact',
   ],
   '78dfd1a4113805acbd03fe52ddfe6bc06d90544d': [
-    // Acronis removes its exact captured product registration asynchronously.
-    // Retry it once with the reviewed ten-minute completion window shared by
-    // QA and customer PSADT packages. Carry still-unconsumed bounded targets;
-    // compatible passes and eligibility-blocked apps are filtered upstream.
-    'Acronis.CyberProtectHomeOffice',
+    // Carry still-unconsumed bounded targets; compatible passes and
+    // eligibility-blocked apps are filtered upstream.
     'Daum.PotPlayer',
     'Autodesk.LicensingService',
     'AcroSoftware.CutePDFWriter',

--- a/supabase/migrations/20260818213904_block_acronis_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260818213904_block_acronis_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- Acronis Cyber Protect Home Office installs and registers successfully, but
+-- the exact registered vendor removal command did not remove registration
+-- {53A765B1-E86A-4058-A02E-3738B282CEE9}Visible in either the standard bounded
+-- lifecycle or a second isolated LocalSystem run with a ten-minute completion
+-- window. Acronis' current Windows guide documents an interactive uninstall,
+-- including an on-screen storage decision and a possible restart, rather than
+-- an unattended enterprise removal contract. Keep this consumer package out
+-- of automated Intune packaging until the vendor publishes a supported one.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Acronis.CyberProtectHomeOffice',
+  'unsupported_managed_uninstall',
+  'Acronis Cyber Protect Home Office installs silently, but its current vendor removal flow does not provide a reliable unattended Intune uninstall lifecycle.',
+  'https://dl.acronis.com/u/pdf/ATI2026_userguidewindows_en-US.pdf'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Acronis.CyberProtectHomeOffice';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Acronis.CyberProtectHomeOffice'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- remove the ineffective Acronis 10-minute uninstall timeout adapter
- block Acronis Cyber Protect Home Office when a reliable unattended uninstall lifecycle is required
- clear catalog verification and stop retrying failed Acronis candidates
- document the current Acronis Windows removal guidance as the primary source

## Evidence
- isolated QA run 32186728693 installed and detected successfully
- exact vendor registration remained after the registered removal command and a 10-minute completion window
- current Acronis documentation requires an interactive flow and may require a restart

## Verification
- 163 focused tests passed
- 1,226 full tests passed
- npm run build:ci passed