### PR TITLE
Activate Acronis eligibility release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '78dfd1a4113805acbd03fe52ddfe6bc06d90544d',
+  packagerCommit: '77735e28d450c6b1c4f14a9a667bc5336eeeb3ea',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1176,6 +1176,41 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  '77735e28d450c6b1c4f14a9a667bc5336eeeb3ea': [
+    // Carry still-unconsumed bounded targets through the Acronis eligibility
+    // release. The blocked Acronis package is intentionally absent and is
+    // also filtered by the shared eligibility policy before enqueue.
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- pin QA package profiles to the protected Acronis eligibility release
- carry forward only still-eligible bounded retry targets
- keep the blocked Acronis consumer package out of terminal retry scheduling

## Verification
- 181 focused QA scheduler and package-profile tests passed