### PR TITLE
Activate Appx provisioning heartbeat release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '77735e28d450c6b1c4f14a9a667bc5336eeeb3ea',
+  packagerCommit: '7a8401469e353172b652259e731aa505cf8067bd',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -146,6 +146,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // non-interactive install path. Bria and 3CX are blocked at the shared
   // eligibility gate, so preserve every unrelated compatible passing result.
   '16a626f329d93d1e499c1db30a243d9dc18a2aa6',
+  // Appx provisioning heartbeats affect only machine-scoped packages whose
+  // servicing operation remained silent long enough to hit the QA stall
+  // detector. Preserve every previously passing package from this release.
+  '77735e28d450c6b1c4f14a9a667bc5336eeeb3ea',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -50,6 +50,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Ubuntu on the Appx provisioning heartbeat release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'canonical.ubuntu.2404', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '77735e28d450c6b1c4f14a9a667bc5336eeeb3ea',
+      { wingetId: 'Canonical.Ubuntu.2404', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1211,6 +1211,43 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  '7a8401469e353172b652259e731aa505cf8067bd': [
+    // Ubuntu completed provisioning but the old package emitted no log entry
+    // while Windows servicing was active, so QA terminated it as stalled.
+    // Retry it with the shared Appx provisioning heartbeat release.
+    'Canonical.Ubuntu.2404',
+    // Carry still-unconsumed bounded targets across the atomic pin rollout.
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '12831539c9dc30678c6f16367faab76820502d2a': [
     // CutePDF's registered unInstcpw helper requires its vendor-specific
     // /uninstall /s contract rather than the nested installer's Inno switches.


### PR DESCRIPTION
## Summary
- pin QA package generation to packager commit 7a8401469e353172b652259e731aa505cf8067bd
- preserve compatible historical passes from the prior release
- target Canonical Ubuntu 24.04 for a clean retry
- carry forward the remaining bounded retry set

## Verification
- 126 package-profile/backfill tests passed
- 47 dispatch/enqueue tests passed