### PR TITLE
Fix Logitech Presentation managed install scope

### DIFF
--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -135,6 +135,35 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.trustedInstallers).toBe(operaInstallers);
   });
 
+  it('selects Logitech Presentation user bytes for reviewed LocalSystem execution', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x86',
+      url: 'https://example.test/logitech-presentation.exe',
+      sha256,
+      type: 'nullsoft',
+      scope: 'user',
+      silentArgs: '/S',
+      productCode: 'LogiPresentation',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Logitech.Presentation',
+      displayName: 'Logitech Presentation',
+      version: '2.10.34',
+      architecture: 'x86',
+      installScope: 'user',
+      installerUrl: 'https://example.test/logitech-presentation.exe',
+      installCommand: '"logitech-presentation.exe" /S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:LogiPresentation:Logitech Presentation',
+    }));
+
+    expect(reconciled.item.installScope).toBe('machine');
+    expect(reconciled.item.installerUrl).toBe(
+      'https://example.test/logitech-presentation.exe'
+    );
+    expect(reconciled.item.installCommand).toBe('"logitech-presentation.exe" /S');
+  });
+
   it('preserves explicit PSADT command overrides', async () => {
     const reconciled = await reconcileCatalogInstaller(operaItem({
       psadtConfig: {

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -8,6 +8,7 @@ import {
 import { getLiveInstallers } from '@/lib/manifest-api';
 import {
   resolveApplicationInstallScope,
+  resolveApplicationInstallerSelectionScope,
   resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import { evaluatePackagingContract } from '@/lib/packaging-contract';
@@ -121,6 +122,10 @@ export async function reconcileCatalogInstaller(
   item: Win32CartItem,
 ): Promise<ReconciledCatalogInstaller> {
   const installScope = resolveApplicationInstallScope(item.wingetId, item.installScope);
+  const installerSelectionScope = resolveApplicationInstallerSelectionScope(
+    item.wingetId,
+    installScope,
+  );
   const trustedInstallers = await getLiveInstallers(item.wingetId, item.version);
   if (trustedInstallers.length === 0) {
     throw new InstallerPreflightError(
@@ -134,7 +139,7 @@ export async function reconcileCatalogInstaller(
     wingetId: item.wingetId,
     version: item.version,
     architecture: item.architecture,
-    installScope,
+    installScope: installerSelectionScope,
     installerUrl: item.installerUrl,
     installerSha256: item.installerSha256,
     localeCode: item.localeCode,
@@ -142,7 +147,7 @@ export async function reconcileCatalogInstaller(
   if (!installer) {
     throw new InstallerPreflightError(
       'INSTALL_SCOPE_UNAVAILABLE',
-      `WinGet does not publish a ${item.architecture || 'x64'} ${installScope}-scope installer for ${item.wingetId} ${item.version}`,
+      `WinGet does not publish a ${item.architecture || 'x64'} ${installerSelectionScope}-scope installer for ${item.wingetId} ${item.version}`,
     );
   }
   if (!installer.url?.trim() || !/^[A-Fa-f0-9]{64}$/.test(installer.sha256?.trim() || '')) {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationInstallerSelectionScope,
   resolveApplicationUninstallCommand,
 } from './packaging-adapters';
 
@@ -102,6 +103,20 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' torproject.torbrowser ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
+  });
+
+  it('runs Logitech Presentation elevated without weakening catalog scope matching', () => {
+    expect(resolveApplicationInstallScope('Logitech.Presentation', 'user')).toBe('machine');
+    expect(resolveApplicationInstallerSelectionScope(
+      'Logitech.Presentation',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallerSelectionScope('Example.App', 'machine')).toBe('machine');
+    expect(
+      applyApplicationPackagingAdapter('Logitech.Presentation', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedInstallArgumentsOverride: '/S /U:0 /A:0',
+    });
   });
 
   it('models Tor Browser as the vendor-documented extracted user folder', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -4,6 +4,7 @@ import type { WingetScope } from '@/types/winget';
 interface ApplicationPackagingAdapter {
   wingetId: string;
   requiredInstallScope?: WingetScope;
+  reviewedInstallerSelectionScope?: WingetScope;
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
@@ -317,6 +318,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       { name: 'VirtualCameraService', description: 'Insta360 Virtual Camera' },
       { name: 'Insta360LinkDriver', description: 'Insta360 Link driver' },
     ],
+  },
+  {
+    // Logitech publishes Presentation as a user-scope NSIS package, but the
+    // signed bootstrapper requests elevation even when /S is supplied. A
+    // standard Intune user therefore receives an unserviceable UAC credential
+    // prompt. Logitech documents the same binary for remote deployment with
+    // /S plus the update and analytics controls below. Select the published
+    // user-scoped binary while executing the managed package as LocalSystem.
+    wingetId: 'Logitech.Presentation',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+    reviewedInstallArgumentsOverride: '/S /U:0 /A:0',
   },
   {
     // Logitech's own removal guidance requires the SetPoint notification-area
@@ -742,6 +755,20 @@ export function resolveApplicationInstallScope(
 ): WingetScope {
   const requested = requestedScope?.trim().toLowerCase() === 'user' ? 'user' : 'machine';
   return applicationPackagingAdapter(wingetId)?.requiredInstallScope || requested;
+}
+
+/**
+ * Return the manifest scope used to select the trusted installer bytes. This
+ * normally matches the managed execution scope. A reviewed adapter may select
+ * a vendor-published user entry while still requiring LocalSystem execution;
+ * that exception is app-specific and cannot be supplied by customer input.
+ */
+export function resolveApplicationInstallerSelectionScope(
+  wingetId: string,
+  executionScope: WingetScope
+): WingetScope {
+  return applicationPackagingAdapter(wingetId)?.reviewedInstallerSelectionScope ||
+    executionScope;
 }
 
 const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -314,6 +314,35 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds Logitech Presentation remote deployment to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Logitech.Presentation',
+      displayName: 'Logitech Presentation',
+      publisher: 'Logitech',
+      version: '2.10.34',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:LogiPresentation:Logitech Presentation',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe('/S /U:0 /A:0');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Logitech_Presentation',
+      }),
+    ]);
+  });
+
   it('binds the reviewed Google Chrome EXE ARP identity to customer packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Google.Chrome.EXE',


### PR DESCRIPTION
## Summary
- execute Logitech Presentation as LocalSystem while selecting its trusted user-scoped WinGet installer
- apply Logitech's documented unattended deployment switches
- cover catalog reconciliation plus the shared customer and QA package identity

## Verification
- npm test (1231 passed)
- npm run lint
- npm run build:ci