### PR TITLE
Honor reviewed installer scope in preflight

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -97,12 +97,51 @@ describe('installer dispatch preflight', () => {
 
   it('keeps user and machine health identities separate', () => {
     expect(createInstallerHealthKey(request)).toBe(
-      '327be777601869688f3f80fe55d2b1f7fe1da11fd7a7352d7c1f0328dfb589bb'
+      '3b7e40af357d2af41613cc5526ad84c5fbaa2d2ce127b6c88b66e014fce7f9bd'
     );
     expect(createInstallerHealthKey(request)).not.toBe(createInstallerHealthKey({
       ...request,
       installScope: 'user',
     }));
+  });
+
+  it('accepts Logitech Presentation user manifest bytes for reviewed SYSTEM execution', async () => {
+    const logitechRequest = {
+      ...request,
+      wingetId: 'Logitech.Presentation',
+      architecture: 'x86',
+      installerUrl: 'https://example.test/logitech-presentation.exe',
+      installerType: 'nullsoft',
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x86',
+      url: logitechRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'nullsoft',
+      scope: 'user',
+    }]);
+
+    await expect(enforceInstallerPreflight(logitechRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects an opposite manifest scope without a reviewed adapter', async () => {
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: request.installerUrl,
+      sha256: expectedSha256,
+      type: 'exe',
+      scope: 'user',
+    }]);
+
+    await expect(enforceInstallerPreflight(request)).rejects.toMatchObject({
+      code: 'MANIFEST_CHANGED',
+      retryable: false,
+    });
+    expect(hashRemoteInstallerMock).not.toHaveBeenCalled();
   });
 
   it('treats WinGet installer aliases as the same executable contract', async () => {

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -7,13 +7,14 @@ import {
   isLikelyMutableInstallerUrl,
 } from '@/lib/installer-download';
 import { normalizeQaInstallerType } from '@/lib/qa/candidate';
+import { resolveApplicationInstallerSelectionScope } from '@/lib/packaging-adapters';
 import type { NormalizedInstaller } from '@/types/winget';
 
 const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
 const HEALTHY_VERSIONED_TTL_MS = 6 * 60 * 60 * 1000;
 const ERROR_TTL_MS = 60 * 1000;
 const MANIFEST_CHANGED_TTL_MS = 6 * 60 * 60 * 1000;
-const PREFLIGHT_CACHE_SCHEMA_VERSION = '2';
+const PREFLIGHT_CACHE_SCHEMA_VERSION = '3';
 const LEASE_SECONDS = 240;
 const WAIT_FOR_CLAIM_MS = 240_000;
 const POLL_INTERVAL_MS = 1_500;
@@ -99,6 +100,10 @@ function isHostedRuntime(): boolean {
 }
 
 export function createInstallerHealthKey(input: InstallerPreflightRequest): string {
+  const executionScope = normalizedRequestedScope(input.installScope);
+  const manifestScope = executionScope
+    ? resolveApplicationInstallerSelectionScope(input.wingetId, executionScope)
+    : undefined;
   return createHash('sha256')
     .update([
       PREFLIGHT_CACHE_SCHEMA_VERSION,
@@ -106,11 +111,19 @@ export function createInstallerHealthKey(input: InstallerPreflightRequest): stri
       input.version.trim(),
       (input.architecture || 'x64').trim().toLowerCase(),
       normalizePreflightInstallerType(input.installerType),
-      (input.installScope || '').trim().toLowerCase(),
+      executionScope || '',
+      manifestScope || '',
       input.installerUrl.trim(),
       input.installerSha256.trim().toUpperCase(),
     ].join('\0'))
     .digest('hex');
+}
+
+function normalizedRequestedScope(
+  scope?: InstallerPreflightRequest['installScope']
+): 'machine' | 'user' | undefined {
+  const normalized = scope?.trim().toLowerCase();
+  return normalized === 'machine' || normalized === 'user' ? normalized : undefined;
 }
 
 function normalizePreflightInstallerType(type?: string): string {
@@ -238,7 +251,10 @@ function installerExistsInManifest(
   const expectedHash = input.installerSha256.toUpperCase();
   const requestedArchitecture = (input.architecture || 'x64').toLowerCase();
   const requestedType = normalizePreflightInstallerType(input.installerType);
-  const requestedScope = input.installScope?.toLowerCase();
+  const executionScope = normalizedRequestedScope(input.installScope);
+  const requestedScope = executionScope
+    ? resolveApplicationInstallerSelectionScope(input.wingetId, executionScope)
+    : undefined;
   const requestedUrl = (input.manifestInstallerUrl || input.installerUrl).trim();
 
   return installers.some((installer) => {


### PR DESCRIPTION
## Summary
- use the reviewed application installer-selection scope in shared preflight
- retain fail-closed scope matching for every unreviewed package
- rotate the health-cache schema so the corrected tuple is checked immediately

## Verification
- npm test (1234 passed)
- npm run lint
- npm run build:ci