### PR TITLE
Fix NVM managed deployment elevation

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -128,6 +128,29 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts NVM user manifest bytes for reviewed SYSTEM execution', async () => {
+    const nvmRequest = {
+      ...request,
+      wingetId: 'CoreyButler.NVMforWindows',
+      architecture: 'x86',
+      installerUrl: 'https://example.test/nvm-setup.exe',
+      installerType: 'inno',
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x86',
+      url: nvmRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'inno',
+      scope: 'user',
+    }]);
+
+    await expect(enforceInstallerPreflight(nvmRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
   it('still rejects an opposite manifest scope without a reviewed adapter', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -164,6 +164,36 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.item.installCommand).toBe('"logitech-presentation.exe" /S');
   });
 
+  it('selects NVM user bytes for reviewed LocalSystem execution', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x86',
+      url: 'https://example.test/nvm-setup.exe',
+      sha256,
+      type: 'inno',
+      scope: 'user',
+      silentArgs: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      productCode: '40078385-F676-4C61-9A9C-F9028599D6D3_is1',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'CoreyButler.NVMforWindows',
+      displayName: 'NVM for Windows',
+      version: '1.2.2',
+      architecture: 'x86',
+      installScope: 'user',
+      installerUrl: 'https://example.test/nvm-setup.exe',
+      installCommand: '"nvm-setup.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:40078385-F676-4C61-9A9C-F9028599D6D3_is1:NVM for Windows',
+    }));
+
+    expect(reconciled.item.installScope).toBe('machine');
+    expect(reconciled.item.installerUrl).toBe('https://example.test/nvm-setup.exe');
+    expect(reconciled.item.installCommand).toBe(
+      '"nvm-setup.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+    );
+  });
+
   it('preserves explicit PSADT command overrides', async () => {
     const reconciled = await reconcileCatalogInstaller(operaItem({
       psadtConfig: {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -119,6 +119,22 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('runs NVM for Windows elevated from a deterministic machine directory', () => {
+    expect(resolveApplicationInstallScope('CoreyButler.NVMforWindows', 'user')).toBe(
+      'machine'
+    );
+    expect(resolveApplicationInstallerSelectionScope(
+      'CoreyButler.NVMforWindows',
+      'machine'
+    )).toBe('user');
+    expect(
+      applyApplicationPackagingAdapter('CoreyButler.NVMforWindows', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedInstallArgumentsOverride:
+        '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="%ProgramFiles%\\nvm"',
+    });
+  });
+
   it('models Tor Browser as the vendor-documented extracted user folder', () => {
     expect(
       applyApplicationPackagingAdapter('TorProject.TorBrowser', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -332,6 +332,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/S /U:0 /A:0',
   },
   {
+    // WinGet publishes NVM for Windows as a user-scope Inno package whose own
+    // setup source requires administrative privileges and writes machine-wide
+    // environment values. A standard Intune user cannot satisfy the vendor's
+    // self-elevation prompt. Keep selecting the trusted user-scoped bytes, but
+    // execute the managed package as LocalSystem and place the payload in a
+    // deterministic machine directory instead of the SYSTEM profile.
+    wingetId: 'CoreyButler.NVMforWindows',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+    reviewedInstallArgumentsOverride:
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="%ProgramFiles%\\nvm"',
+  },
+  {
     // Logitech's own removal guidance requires the SetPoint notification-area
     // client to be exited first. Under non-interactive LocalSystem the generic
     // NSIS /S uninstaller otherwise removes part of the product but leaves the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -343,6 +343,39 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'CoreyButler.NVMforWindows',
+      displayName: 'NVM for Windows',
+      publisher: 'CoreyButler',
+      version: '1.2.2',
+      architecture: 'x86',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:40078385-F676-4C61-9A9C-F9028599D6D3_is1:NVM for Windows',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="%ProgramFiles%\\nvm"'
+    );
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\CoreyButler_NVMforWindows',
+      }),
+    ]);
+  });
+
   it('binds the reviewed Google Chrome EXE ARP identity to customer packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Google.Chrome.EXE',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1043,6 +1043,26 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'expands environment variables in a reviewed Inno install directory override',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'inno',
+        'NVM for Windows',
+        [],
+        {
+          reviewedInstallArgumentsOverride:
+            '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="%ProgramFiles%\\nvm"',
+        }
+      );
+
+      expect(generated).toContain(
+        "$effectiveInstallerArguments = [Environment]::ExpandEnvironmentVariables('/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR=\"%ProgramFiles%\\nvm\"')"
+      );
+      expect(generated).toContain('-ArgumentList $effectiveInstallerArguments');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'creates and validates a reviewed InstallShield administrative image instead of installing the launcher',
     () => {
       const productCode = '{6FB7DAEC-5DAD-491E-9951-4684423F291C}';


### PR DESCRIPTION
## What changed

- add a reviewed NVM for Windows packaging adapter
- keep selecting the hash-verified WinGet user-scope installer while running PSADT as LocalSystem
- install into a deterministic Program Files directory and emit machine-scope detection
- keep installer preflight, QA package identity, and customer package identity aligned

## Root cause

NVM's official Inno source requires administrative privileges and writes machine environment values, while the WinGet manifest labels the installer user-scope and self-elevating. A standard Intune user cannot satisfy that UAC elevation, so the unattended installer returned exit code 2.

## Impact

QA and customer Intune packages now use the same reviewed, unattended NVM lifecycle without weakening generic opposite-scope installer safeguards.

## Validation

- 1,239 Vitest tests passed
- ESLint passed
- Next.js production build passed