### PR TITLE
Fix Logitech G HUB PSADT lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -244,6 +244,21 @@ if ($psadtConfig.Contains('reviewedInstallArgumentsOverride') -and
     }
 }
 
+$reviewedInstallCompletionTimeoutMinutes = 0
+if ($psadtConfig.Contains('reviewedInstallCompletionTimeoutMinutes') -and
+    $null -ne $psadtConfig['reviewedInstallCompletionTimeoutMinutes']) {
+    $rawReviewedInstallCompletionTimeoutMinutes = $psadtConfig['reviewedInstallCompletionTimeoutMinutes']
+    if ($rawReviewedInstallCompletionTimeoutMinutes -isnot [int] -and
+        $rawReviewedInstallCompletionTimeoutMinutes -isnot [long]) {
+        throw 'PSADT reviewedInstallCompletionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+    $reviewedInstallCompletionTimeoutMinutes = [int]$rawReviewedInstallCompletionTimeoutMinutes
+    if ($reviewedInstallCompletionTimeoutMinutes -lt 1 -or
+        $reviewedInstallCompletionTimeoutMinutes -gt 60) {
+        throw 'PSADT reviewedInstallCompletionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+}
+
 $reviewedInstallShieldAdministrativeImageConfigured = $false
 $reviewedInstallShieldMsiExpectedFileName = ''
 if ($psadtConfig.Contains('reviewedInstallShieldAdministrativeImage') -and
@@ -2409,9 +2424,35 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                     '    }'
                 )
             } else {
-                $lines += @(
-                    "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
-                )
+                if ($reviewedInstallCompletionTimeoutMinutes -gt 0) {
+                    $lines += @(
+                        "    `$installerPath = Join-Path `$adtSession.DirFiles '$installerFileNameSingleQuoteEscaped'"
+                        "    `$installDeadline = [DateTime]::UtcNow.AddMinutes($reviewedInstallCompletionTimeoutMinutes)"
+                        '    $installHandle = Start-ADTProcess -FilePath $installerPath -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
+                        '    $nextInstallProgressLog = [DateTime]::UtcNow'
+                        '    while (-not $installHandle.Task.IsCompleted) {'
+                        '        if ([DateTime]::UtcNow -ge $installDeadline) {'
+                        "            throw 'The reviewed vendor installer did not complete within $reviewedInstallCompletionTimeoutMinutes minutes.'"
+                        '        }'
+                        '        if ([DateTime]::UtcNow -ge $nextInstallProgressLog) {'
+                        '            Write-ADTLogEntry -Message "The reviewed vendor installer is still working." -Source ''Install-ADTDeployment'''
+                        '            $nextInstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)'
+                        '        }'
+                        '        Start-Sleep -Seconds 5'
+                        '    }'
+                        '    $installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+                        '    if ($installProcessExitCode -in @(1641, 3010)) {'
+                        '        $script:InstallRebootExitCode = 3010'
+                        '        Write-ADTLogEntry -Message "The reviewed vendor installer requested a reboot with exit code [$installProcessExitCode]." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+                        '    } elseif ($installProcessExitCode -ne 0) {'
+                        '        throw "The reviewed vendor installer exited with code [$installProcessExitCode]."'
+                        '    }'
+                    )
+                } else {
+                    $lines += @(
+                        "    Start-ADTProcess -FilePath `"`$(`$adtSession.DirFiles)\$installerFileName`" -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
+                    )
+                }
             }
         }
     }

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -624,6 +624,7 @@ describe('application packaging adapters', () => {
       reviewedInstallShieldAdministrativeImage: {
         expectedMsiFileName: 'customer-controlled.msi',
       },
+      reviewedInstallCompletionTimeoutMinutes: 30,
       reviewedManagedInstallDirectory: '%ProgramFiles%\\Example',
       reviewedManagedInstallEvidenceFile: '%ProgramFiles%\\Example\\app.exe',
       reviewedManagedInstallCompletionProcess:
@@ -646,6 +647,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedRegistryInstallEvidence).toBeUndefined();
     expect(adapted.reviewedInstallShieldAdministrativeImage).toBeUndefined();
+    expect(adapted.reviewedInstallCompletionTimeoutMinutes).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();
     expect(adapted.reviewedManagedInstallEvidenceFile).toBeUndefined();
     expect(adapted.reviewedManagedInstallCompletionProcess).toBeUndefined();
@@ -686,6 +688,29 @@ describe('application packaging adapters', () => {
     });
 
     expect(adapted.reviewedUninstallArguments).toEqual(['/s', '--custom']);
+  });
+
+  it('binds the reviewed Logitech G HUB install and removal lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'logitech.ghub',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.processesToClose).toEqual([
+      { name: 'lghub', description: 'Logitech G HUB' },
+      { name: 'lghub_agent', description: 'Logitech G HUB Agent' },
+      { name: 'lghub_updater', description: 'Logitech G HUB Updater' },
+      {
+        name: 'lghub_software_manager',
+        description: 'Logitech G HUB Software Manager',
+      },
+    ]);
+    expect(adapted.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(adapted.reviewedExactUninstall).toEqual({
+      executablePath: '%ProgramFiles%\\LGHUB\\lghub_updater.exe',
+      arguments: ['--uninstall', '--full'],
+      completionTimeoutMinutes: 10,
+    });
   });
 
   it('preserves customer Opera process settings while enforcing the exact reviewed removal contract', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -8,6 +8,7 @@ interface ApplicationPackagingAdapter {
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
+  reviewedInstallCompletionTimeoutMinutes?: number;
   reviewedInstallShieldAdministrativeImage?: Readonly<{
     expectedMsiFileName: string;
   }>;
@@ -343,6 +344,29 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'user',
     reviewedInstallArgumentsOverride:
       '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="%ProgramFiles%\\nvm"',
+  },
+  {
+    // G HUB's evergreen bootstrapper can spend several minutes installing
+    // child packages after its silent launcher starts. Keep PSADT alive and
+    // observable for that reviewed window instead of treating the quiet
+    // bootstrapper as stalled. Logitech's registered software-manager command
+    // is interactive and does not remove the product under LocalSystem; close
+    // the documented G HUB process family and invoke the installed updater's
+    // full unattended removal contract while retaining the exact ARP identity
+    // as the authoritative completion signal.
+    wingetId: 'Logitech.GHUB',
+    requiredProcessesToClose: [
+      { name: 'lghub', description: 'Logitech G HUB' },
+      { name: 'lghub_agent', description: 'Logitech G HUB Agent' },
+      { name: 'lghub_updater', description: 'Logitech G HUB Updater' },
+      { name: 'lghub_software_manager', description: 'Logitech G HUB Software Manager' },
+    ],
+    reviewedInstallCompletionTimeoutMinutes: 15,
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles%\\LGHUB\\lghub_updater.exe',
+      arguments: ['--uninstall', '--full'],
+      completionTimeoutMinutes: 10,
+    },
   },
   {
     // Logitech's own removal guidance requires the SetPoint notification-area
@@ -757,6 +781,7 @@ export function hasReviewedApplicationInstallContract(wingetId: string): boolean
     adapter && (
       adapter.reviewedInstallArguments?.some((argument) => argument.trim()) ||
       adapter.reviewedInstallArgumentsOverride?.trim() ||
+      adapter.reviewedInstallCompletionTimeoutMinutes ||
       adapter.reviewedInstallShieldAdministrativeImage
     )
   );
@@ -908,6 +933,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedInstallArgumentsOverride &&
+      !config.reviewedInstallCompletionTimeoutMinutes &&
       !config.reviewedInstallShieldAdministrativeImage &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
@@ -924,6 +950,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedInstallArgumentsOverride: undefined,
+      reviewedInstallCompletionTimeoutMinutes: undefined,
       reviewedInstallShieldAdministrativeImage: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
@@ -1002,6 +1029,8 @@ export function applyApplicationPackagingAdapter(
     processesToClose,
     reviewedInstallArguments,
     reviewedInstallArgumentsOverride,
+    reviewedInstallCompletionTimeoutMinutes:
+      adapter.reviewedInstallCompletionTimeoutMinutes,
     installCommand: adapter.reviewedInstallShieldAdministrativeImage
       ? undefined
       : config.installCommand,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -343,6 +343,47 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds the reviewed Logitech G HUB lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Logitech.GHUB',
+      displayName: 'Logitech G HUB',
+      publisher: 'Logitech',
+      version: '2026.4.919028',
+      architecture: 'x64',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Logitech G HUB',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        processesToClose: Array<{ name: string }>;
+        reviewedInstallCompletionTimeoutMinutes?: number;
+        reviewedExactUninstall?: {
+          executablePath: string;
+          arguments: string[];
+          completionTimeoutMinutes: number;
+        };
+      };
+    };
+
+    expect(profile.psadtConfig.processesToClose.map(({ name }) => name)).toEqual([
+      'lghub',
+      'lghub_agent',
+      'lghub_updater',
+      'lghub_software_manager',
+    ]);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.psadtConfig.reviewedExactUninstall).toEqual({
+      executablePath: '%ProgramFiles%\\LGHUB\\lghub_updater.exe',
+      arguments: ['--uninstall', '--full'],
+      completionTimeoutMinutes: 10,
+    });
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1841,6 +1841,55 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps the reviewed Logitech G HUB bootstrapper observable and removes it silently',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Logitech G HUB',
+        [],
+        {
+          processesToClose: [
+            { name: 'lghub', description: 'Logitech G HUB' },
+            { name: 'lghub_agent', description: 'Logitech G HUB Agent' },
+            { name: 'lghub_updater', description: 'Logitech G HUB Updater' },
+            {
+              name: 'lghub_software_manager',
+              description: 'Logitech G HUB Software Manager',
+            },
+          ],
+          reviewedInstallCompletionTimeoutMinutes: 15,
+          reviewedExactUninstall: {
+            executablePath: '%ProgramFiles%\\LGHUB\\lghub_updater.exe',
+            arguments: ['--uninstall', '--full'],
+            completionTimeoutMinutes: 10,
+          },
+        },
+        [],
+        'Logitech.GHUB',
+        'Logitech G HUB',
+        '2026.4.919028',
+        'REGISTRY_UNINSTALL:Logitech G HUB',
+        '--silent'
+      );
+
+      expect(generated).toContain(
+        'Start-ADTProcess -FilePath $installerPath -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
+      );
+      expect(generated).toContain(
+        'Write-ADTLogEntry -Message "The reviewed vendor installer is still working."'
+      );
+      expect(generated).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\LGHUB\\lghub_updater.exe')"
+      );
+      expect(generated).toContain(
+        "$registeredUninstallArguments = @('--uninstall', '--full')"
+      );
+      expect(generated).toContain('$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 10 }');
+      expect(generated).toContain("@{ Name = 'lghub'; Description = 'Logitech G HUB' }");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'emits one valid force-countdown parameter set and never combines it with Silent',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -204,6 +204,12 @@ export interface PSADTConfig {
   // adapters populate this field; customers cannot supply it directly.
   reviewedInstallArgumentsOverride?: string;
 
+  // Internal completion window for a reviewed silent bootstrapper that keeps
+  // working without producing console output. The generated PSADT package
+  // emits bounded progress heartbeats while it waits, so QA and Intune use the
+  // same observable install lifecycle. Customers cannot supply this directly.
+  reviewedInstallCompletionTimeoutMinutes?: number;
+
   // Internal administrative-image contract for a reviewed InstallShield
   // launcher whose embedded MSI is the only reliable LocalSystem deployment
   // path. The generated package validates the exact MSI filename and its
@@ -360,6 +366,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
   reviewedInstallArgumentsOverride: undefined,
+  reviewedInstallCompletionTimeoutMinutes: undefined,
   reviewedInstallShieldAdministrativeImage: undefined,
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,


### PR DESCRIPTION
## Summary
- keep reviewed silent bootstrapper installs observable with bounded PSADT progress heartbeats
- add the Logitech G HUB process-close and exact full-uninstall adapter
- bind the same adapter into customer and QA package profiles

## Validation
- 1,245 tests passed
- lint passed
- production build passed