### PR TITLE
Emit reviewed asynchronous install arguments

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2428,7 +2428,7 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                     $lines += @(
                         "    `$installerPath = Join-Path `$adtSession.DirFiles '$installerFileNameSingleQuoteEscaped'"
                         "    `$installDeadline = [DateTime]::UtcNow.AddMinutes($reviewedInstallCompletionTimeoutMinutes)"
-                        '    $installHandle = Start-ADTProcess -FilePath $installerPath -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
+                        "    `$installHandle = Start-ADTProcess -FilePath `$installerPath -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru"
                         '    $nextInstallProgressLog = [DateTime]::UtcNow'
                         '    while (-not $installHandle.Task.IsCompleted) {'
                         '        if ([DateTime]::UtcNow -ge $installDeadline) {'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1873,8 +1873,9 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       );
 
       expect(generated).toContain(
-        'Start-ADTProcess -FilePath $installerPath -ArgumentList $installerArgumentList -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
+        "Start-ADTProcess -FilePath $installerPath -ArgumentList '--silent' -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru"
       );
+      expect(generated).not.toContain('-ArgumentList $installerArgumentList');
       expect(generated).toContain(
         'Write-ADTLogEntry -Message "The reviewed vendor installer is still working."'
       );


### PR DESCRIPTION
## Summary
- expand the generator-owned installer argument expression before writing the PSADT script
- prevent the generated package from referencing an undefined generator-only variable
- strengthen the G HUB contract test against this regression

## Validation
- 1,246 tests passed
- lint passed