### PR TITLE
Activate G HUB install argument fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7b2938c853d9a799ac76957bd122c5c7eb5406f5',
+  packagerCommit: '4537454fe9f0f942d59a7b748505b2318cf13a6c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -642,7 +642,7 @@ describe('QA toolchain targeted retries', () => {
       { wingetId: 'logitech.ghub', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      '837c54ac684d6a3d36a0ad5f14f258f8add540cf',
+      '7b2938c853d9a799ac76957bd122c5c7eb5406f5',
       { wingetId: 'Logitech.GHUB', status: 'failed' }
     )).toBe(false);
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1287,11 +1287,12 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
-  '7b2938c853d9a799ac76957bd122c5c7eb5406f5': [
+  '4537454fe9f0f942d59a7b748505b2318cf13a6c': [
     // G HUB's evergreen bootstrapper can remain active without console output,
     // and its registered bare software-manager command does not remove the
     // product under LocalSystem. Retry the exact failed customer-requested
-    // package with the observable install and full silent removal adapter.
+    // package with the corrected generated argument expression, observable
+    // install, and full silent removal adapter.
     'Logitech.GHUB',
     // Carry still-unconsumed bounded targets across the atomic pin rollout.
     // Compatible passes and ineligible apps are filtered before enqueue.


### PR DESCRIPTION
Activates packager commit 4537454fe9f0f942d59a7b748505b2318cf13a6c and scopes the bounded G HUB retry to the corrected generated install argument contract.