### PR TITLE
Fix machine-scope MSI packaging

### DIFF
--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -129,6 +129,49 @@ describe('normalizeInstaller', () => {
     expect(result.scope).toBe('user');
   });
 
+  it('enforces declared machine scope for a dual-purpose MSI package', () => {
+    const installer: WingetInstaller = {
+      Architecture: 'x64',
+      InstallerUrl: 'https://example.com/dual-purpose.msi',
+      InstallerSha256: 'abc123',
+      InstallerType: 'wix',
+      Scope: 'machine',
+    };
+
+    expect(normalizeInstaller(installer).silentArgs).toBe(
+      '/qn /norestart ALLUSERS=1'
+    );
+  });
+
+  it('does not override a manifest-owned MSI ALLUSERS contract', () => {
+    const installer: WingetInstaller = {
+      Architecture: 'x64',
+      InstallerUrl: 'https://example.com/dual-purpose.msi',
+      InstallerSha256: 'abc123',
+      InstallerType: 'msi',
+      Scope: 'machine',
+      InstallerSwitches: {
+        Custom: 'ALLUSERS=2 MSIINSTALLPERUSER=""',
+      },
+    };
+
+    expect(normalizeInstaller(installer).silentArgs).toBe(
+      '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=""'
+    );
+  });
+
+  it('keeps user-scope MSI arguments unchanged', () => {
+    const installer: WingetInstaller = {
+      Architecture: 'x64',
+      InstallerUrl: 'https://example.com/per-user.msi',
+      InstallerSha256: 'abc123',
+      InstallerType: 'msi',
+      Scope: 'user',
+    };
+
+    expect(normalizeInstaller(installer).silentArgs).toBe('/qn /norestart');
+  });
+
   it('should include productCode for MSI installers', () => {
     const installer: WingetInstaller = {
       Architecture: 'x64',

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -797,6 +797,33 @@ function appendRequiredInstallLocation(
 }
 
 /**
+ * Preserve WinGet's declared machine scope when an MSI/WiX package is
+ * authored as a dual-purpose installer. Such packages commonly default to
+ * ALLUSERS=2 plus MSIINSTALLPERUSER=1, which selects a per-user installation
+ * unless the command line explicitly requests the machine context.
+ *
+ * Do not replace a manifest-owned ALLUSERS value. A publisher may use a
+ * reviewed dual-purpose command (for example ALLUSERS=2 together with an
+ * empty MSIINSTALLPERUSER value), and the manifest remains authoritative in
+ * that case.
+ */
+function appendMachineScopeMsiProperty(
+  silentArgs: string,
+  installer: WingetInstaller,
+  effectiveType: WingetInstallerType
+): string {
+  if (
+    installer.Scope !== 'machine' ||
+    !['msi', 'wix'].includes(effectiveType) ||
+    /(?:^|\s)ALLUSERS\s*=/i.test(silentArgs)
+  ) {
+    return silentArgs;
+  }
+
+  return silentArgs ? `${silentArgs} ALLUSERS=1` : 'ALLUSERS=1';
+}
+
+/**
  * Normalize installer to standard format
  */
 export function normalizeInstaller(installer: WingetInstaller): NormalizedInstaller {
@@ -818,6 +845,7 @@ export function normalizeInstaller(installer: WingetInstaller): NormalizedInstal
   }
 
   silentArgs = appendCustomSwitch(silentArgs, installer.InstallerSwitches?.Custom);
+  silentArgs = appendMachineScopeMsiProperty(silentArgs, installer, effectiveType);
   silentArgs = appendRequiredInstallLocation(silentArgs, installer);
 
   // Map manifest package dependencies (PascalCase) to the normalized shape

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -156,6 +156,32 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('preserves the WinGet machine scope for Arduino-style dual-purpose MSI packages', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'ArduinoSA.IDE.stable',
+        name: 'Arduino IDE',
+        publisher: 'ArduinoSA',
+        version: '2.3.10',
+      },
+      manifest: { InstallerType: 'wix' },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'wix',
+        Scope: 'machine',
+        ProductCode: '{2512FA64-8592-4C98-8430-9262623F95F0}',
+      },
+    });
+
+    expect(config).toMatchObject({
+      scope: 'machine',
+      silentArgs: '/qn /norestart ALLUSERS=1',
+      productCode: '{2512FA64-8592-4C98-8430-9262623F95F0}',
+      uninstallCommand:
+        'msiexec /x "{2512FA64-8592-4C98-8430-9262623F95F0}" /qn /norestart',
+    });
+  });
+
   it('preserves Vivaldi-style root silent and installer custom switches', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
Enforces WinGet-declared machine scope for MSI/WiX installers with the standard ALLUSERS=1 property when the manifest does not already own an ALLUSERS contract. Preserves user-scope packages and publisher-defined scope arguments. Adds Arduino IDE 2.3.10 regression coverage for install arguments and exact MSI removal. Verification: 1,250 Vitest tests passed, focused ESLint passed, and git diff --check passed. Repository-wide standalone tsc is still blocked by unrelated existing test-global and baseline type errors.