### PR TITLE
Activate machine-scope MSI fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4537454fe9f0f942d59a7b748505b2318cf13a6c',
+  packagerCommit: '7c74dc4412c3e6834da9935cc74ab8371a7ed71f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -154,6 +154,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // package's previously failing UAC path. Preserve every compatible pass
   // from the Appx provisioning heartbeat release.
   '7a8401469e353172b652259e731aa505cf8067bd',
+  // Machine-scope normalization changes only MSI/WiX profiles that did not
+  // already declare an ALLUSERS contract. The canonical silent arguments
+  // invalidate those affected profiles while preserving unrelated passes.
+  '4537454fe9f0f942d59a7b748505b2318cf13a6c',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -647,6 +647,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Arduino IDE only after activating machine-scope MSI normalization', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'arduinosa.ide.stable', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '4537454fe9f0f942d59a7b748505b2318cf13a6c',
+      { wingetId: 'ArduinoSA.IDE.stable', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5569c16d136f464cbc014f40c70645414c601751',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1287,7 +1287,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
-  '4537454fe9f0f942d59a7b748505b2318cf13a6c': [
+  '7c74dc4412c3e6834da9935cc74ab8371a7ed71f': [
+    // Arduino IDE's dual-purpose MSI defaults to per-user installation even
+    // though WinGet declares this installer machine-scope. Retry it now that
+    // the shared normalizer explicitly carries that scope into MSI arguments.
+    'ArduinoSA.IDE.stable',
     // G HUB's evergreen bootstrapper can remain active without console output,
     // and its registered bare software-manager command does not remove the
     // product under LocalSystem. Retry the exact failed customer-requested


### PR DESCRIPTION
Activates protected packager commit 7c74dc4412c3e6834da9935cc74ab8371a7ed71f, preserves compatible passes whose canonical profiles are unchanged, and targets the failed Arduino IDE lifecycle for a corrected retry. Verification: 157 focused QA tests, focused ESLint, and git diff --check passed.