### PR TITLE
Activate exact-version ARP capture

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7c74dc4412c3e6834da9935cc74ab8371a7ed71f',
+  packagerCommit: '82de31f37d7977906153135fde2eb12cf30909c7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -158,6 +158,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // already declare an ALLUSERS contract. The canonical silent arguments
   // invalidate those affected profiles while preserving unrelated passes.
   '4537454fe9f0f942d59a7b748505b2318cf13a6c',
+  // Exact-version, strict-name-prefix ARP capture changes only packages whose
+  // observed product name did not already match a stronger identity. Preserve
+  // every compatible pass from the machine-scope MSI release.
+  '7c74dc4412c3e6834da9935cc74ab8371a7ed71f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -658,6 +658,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries OpenOffice only after activating exact-version prefix identity capture', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'apache.openoffice', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '7c74dc4412c3e6834da9935cc74ab8371a7ed71f',
+      { wingetId: 'Apache.OpenOffice', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5569c16d136f464cbc014f40c70645414c601751',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1287,7 +1287,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
-  '7c74dc4412c3e6834da9935cc74ab8371a7ed71f': [
+  '82de31f37d7977906153135fde2eb12cf30909c7': [
+    // OpenOffice's Nullsoft bootstrapper installs an MSI whose ARP display
+    // name appends a marketing version. Retry it with the exact requested
+    // DisplayVersion and strict configured-name-prefix identity contract.
+    'Apache.OpenOffice',
     // Arduino IDE's dual-purpose MSI defaults to per-user installation even
     // though WinGet declares this installer machine-scope. Retry it now that
     // the shared normalizer explicitly carries that scope into MSI arguments.


### PR DESCRIPTION
## Summary
- make `82de31f37d7977906153135fde2eb12cf30909c7` the required QA/customer packager release
- preserve compatible passes from the prior machine-scope MSI release
- schedule Apache OpenOffice for one corrected lifecycle retry while carrying remaining bounded targets

## Verification
- `npm test` (83 files, 1,255 tests)
- focused ESLint for the three changed QA files
- `git diff --check`