### PR TITLE
Preserve nested MSI product identity across QA and customer packaging

### DIFF
--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -897,6 +897,24 @@ describe('generateUninstallCommand', () => {
     );
   });
 
+  it('should preserve a nested MSI product code for archive packages', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x86',
+      url: 'https://example.com/bankid.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'msi',
+      nestedInstallerPath: 'BankID.msi',
+      productCode: '{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}',
+    };
+
+    expect(
+      generateUninstallCommand(installer, 'BankID säkerhetsprogram')
+    ).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}:BankID säkerhetsprogram'
+    );
+  });
+
   it('should canonicalize a braceless product code and reject malformed GUID shapes', () => {
     const base: NormalizedInstaller = {
       architecture: 'x64',

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -135,6 +135,36 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.trustedInstallers).toBe(operaInstallers);
   });
 
+  it('rebuilds customer archive packages with the nested MSI product identity', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x86',
+      url: 'https://example.test/bankid.zip',
+      sha256,
+      type: 'zip',
+      nestedInstallerType: 'msi',
+      nestedInstallerPath: 'BankID.msi',
+      scope: 'machine',
+      silentArgs: '/qn /norestart ALLUSERS=1',
+      productCode: '{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'FinancialID.BankID',
+      displayName: 'BankID säkerhetsprogram',
+      version: '7.17.101.2526',
+      architecture: 'x86',
+      installerType: 'zip',
+      installerUrl: 'https://example.test/bankid.zip',
+      installCommand: '',
+      uninstallCommand: 'REGISTRY_UNINSTALL:BankID säkerhetsprogram',
+    }));
+
+    expect(reconciled.item.nestedInstallerType).toBe('msi');
+    expect(reconciled.item.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}:BankID säkerhetsprogram'
+    );
+  });
+
   it('selects Logitech Presentation user bytes for reviewed LocalSystem execution', async () => {
     getLiveInstallersMock.mockResolvedValue([{
       architecture: 'x86',

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -416,6 +416,21 @@ export function generateUninstallCommand(
       // intentionally invalid so both packagers reject it before deployment.
       return 'MSIX_UNINSTALL:{PACKAGE_NAME}';
 
+    case 'zip':
+      // Archive packages execute their nested installer, so a nested MSI/WiX
+      // ProductCode is the authoritative installed-product identity. Preserve
+      // it for post-install capture and removal instead of falling back to a
+      // localized display name that may not match the registered MSI title.
+      if (displayName) {
+        const nestedMsiProductCode = ['msi', 'wix'].includes(
+          installer.nestedInstallerType || ''
+        )
+          ? installer.productCode
+          : undefined;
+        return generateRegistryUninstallCommand(displayName, nestedMsiProductCode);
+      }
+      return '# Manual uninstall required';
+
     case 'exe':
     case 'inno':
     case 'nullsoft':

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -122,6 +122,39 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     }));
   });
 
+  it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'FinancialID.BankID',
+      displayName: 'BankID säkerhetsprogram',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      uninstallCommand: 'REGISTRY_UNINSTALL:BankID säkerhetsprogram',
+    }), config, { skipRunCapture: true });
+
+    const reconciledItem = reconcileCatalogInstallerMock.mock.calls[0][0];
+    expect(reconciledItem.psadtConfig.uninstallCommand).toBeUndefined();
+  });
+
+  it('preserves a customer-provided uninstall override during reconciliation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Example.App',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      uninstallCommand: 'vendor-remover.exe /tenant-approved',
+    }), config, { skipRunCapture: true });
+
+    const reconciledItem = reconcileCatalogInstallerMock.mock.calls[0][0];
+    expect(reconciledItem.psadtConfig.uninstallCommand).toBe(
+      'vendor-remover.exe /tenant-approved'
+    );
+  });
+
   it('dispatches calculate mode for a custom installer without a trusted hash', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -132,6 +132,17 @@ export async function triggerPackagingWorkflow(
       inputs.wingetId,
       inputs.uninstallCommand,
     );
+    const generatedDisplayUninstallCommand = resolveApplicationUninstallCommand(
+      inputs.wingetId,
+      `REGISTRY_UNINSTALL:${inputs.displayName}`,
+    );
+    // A display-name registry marker is the catalog fallback, not a customer
+    // override. Let live manifest reconciliation replace it with a stronger
+    // ProductCode or exact ARP key when the trusted installer now provides one.
+    const customerUninstallOverride = resolvedUninstallCommand.trim() &&
+      resolvedUninstallCommand.trim() !== generatedDisplayUninstallCommand
+      ? resolvedUninstallCommand
+      : undefined;
     try {
       const reconciled = await reconcileCatalogInstaller({
         id: inputs.jobId,
@@ -155,7 +166,7 @@ export async function triggerPackagingWorkflow(
         requirementRules: [],
         psadtConfig: {
           installCommand: inputs.silentSwitches,
-          uninstallCommand: resolvedUninstallCommand,
+          uninstallCommand: customerUninstallOverride,
         } as Win32CartItem['psadtConfig'],
       });
       effectiveInputs = {

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -88,6 +88,38 @@ describe('buildQaCatalogTestConfig', () => {
     });
   });
 
+  it('keeps a nested MSI ProductCode in the canonical QA uninstall identity', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'FinancialID.BankID',
+        name: 'BankID säkerhetsprogram',
+        publisher: 'FinancialID',
+        version: '7.17.101.2526',
+      },
+      manifest: {
+        InstallerType: 'zip',
+        NestedInstallerType: 'msi',
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'zip',
+        NestedInstallerType: 'msi',
+        NestedInstallerFiles: [{ RelativeFilePath: 'BankID.msi' }],
+        ProductCode: '{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}',
+        Scope: 'machine',
+      },
+    });
+
+    expect(config).toMatchObject({
+      sourceInstallerType: 'zip',
+      nestedInstallerType: 'msi',
+      nestedInstallerFiles: ['BankID.msi'],
+      productCode: '{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}:BankID säkerhetsprogram',
+    });
+  });
+
   it('appends inherited custom switches to the derived silent default', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- preserve exact ProductCode uninstall identity for ZIP packages with nested MSI/WiX installers
- allow live customer reconciliation to strengthen generated display-name fallbacks while preserving explicit customer overrides
- add regression coverage for BankID across generator, QA profile, reconciliation, and dispatch boundaries

## Validation
- npm test (83 files, 1,260 tests)
- touched-file ESLint
- git diff --check
- npx tsc --noEmit reports only the existing repository-wide test-global baseline errors