### PR TITLE
Activate nested MSI product identity release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '82de31f37d7977906153135fde2eb12cf30909c7',
+  packagerCommit: '63172f3739807b25bbd54b970dc6f56d1cfc2c9d',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -162,6 +162,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // observed product name did not already match a stronger identity. Preserve
   // every compatible pass from the machine-scope MSI release.
   '7c74dc4412c3e6834da9935cc74ab8371a7ed71f',
+  // Nested MSI ProductCode preservation changes only archive profiles that
+  // previously fell back to display-name registration matching. Preserve all
+  // compatible passes from the exact-version ARP capture release.
+  '82de31f37d7977906153135fde2eb12cf30909c7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -669,6 +669,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries BankID only after preserving the nested MSI product identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'financialid.bankid', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '82de31f37d7977906153135fde2eb12cf30909c7',
+      { wingetId: 'FinancialID.BankID', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5569c16d136f464cbc014f40c70645414c601751',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1287,7 +1287,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
-  '82de31f37d7977906153135fde2eb12cf30909c7': [
+  '63172f3739807b25bbd54b970dc6f56d1cfc2c9d': [
+    // BankID is a ZIP with a nested MSI whose exact ProductCode was present
+    // in trusted manifest metadata but previously dropped from the canonical
+    // uninstall identity. Retry it through the shared QA/customer generator.
+    'FinancialID.BankID',
     // OpenOffice's Nullsoft bootstrapper installs an MSI whose ARP display
     // name appends a marketing version. Retry it with the exact requested
     // DisplayVersion and strict configured-name-prefix identity contract.


### PR DESCRIPTION
## Summary
- activate shared packager commit 63172f3739807b25bbd54b970dc6f56d1cfc2c9d
- preserve compatible passes from the preceding exact-version ARP release
- target FinancialID.BankID for one corrected lifecycle retry

## Validation
- npm test (83 files, 1,261 tests)
- focused QA profile and retry tests
- touched-file ESLint
- git diff --check