### PR TITLE
fix(packaging): support Visual Studio 2017 lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -476,6 +476,27 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
+        'Microsoft.VisualStudio.2017.Enterprise',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2019.BuildTools',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -69,6 +69,16 @@ const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
     '%ProgramFiles%\\Microsoft Visual Studio\\18\\Enterprise',
   'Microsoft.VisualStudio.Professional':
     '%ProgramFiles%\\Microsoft Visual Studio\\18\\Professional',
+  // Visual Studio 2017 and 2019 are 32-bit products and use the versioned
+  // Program Files (x86) instance root on 64-bit Windows.
+  'Microsoft.VisualStudio.2017.BuildTools':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\BuildTools',
+  'Microsoft.VisualStudio.2017.Community':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Community',
+  'Microsoft.VisualStudio.2017.Enterprise':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise',
+  'Microsoft.VisualStudio.2017.Professional':
+    '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Professional',
   'Microsoft.VisualStudio.2019.BuildTools':
     '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools',
   'Microsoft.VisualStudio.2019.Community':

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -494,6 +494,46 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds the Visual Studio 2017 instance lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.VisualStudio.2017.Enterprise',
+      displayName: 'Visual Studio Enterprise 2017',
+      publisher: 'Microsoft',
+      version: '15.9.70',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet --wait',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Visual Studio Enterprise 2017',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedPath =
+      '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise';
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: expectedPath,
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          expectedPath,
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+  });
+
   it('binds the Visual Studio 2019 instance lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2019.BuildTools',


### PR DESCRIPTION
## Summary
- add Visual Studio 2017 Build Tools, Community, Enterprise, and Professional to the shared instance-aware packaging adapter
- use the Visual Studio Installer with the exact 2017 Program Files (x86) install path for unattended removal
- verify that the same adapter is present in both QA package identity and customer package generation

## Evidence
- failing isolated run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32230140260
- install and detection succeeded, while the generic ARP removal left registration `c76fc08c` after 310 seconds
- Microsoft documents the typical Visual Studio 2017 root as `C:\Program Files (x86)\Microsoft Visual Studio\2017\<edition>` and the instance-aware Visual Studio Installer command at `C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe`

## Validation
- focused: 196 tests passed
- full: 83 files and 1,262 tests passed
- touched-file ESLint passed
- `git diff --check` passed
- standalone `tsc --noEmit` reports only the repository's existing test-global baseline errors and no changed-file error