### PR TITLE
chore(qa): activate Visual Studio 2017 lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '63172f3739807b25bbd54b970dc6f56d1cfc2c9d',
+  packagerCommit: '6788c71df2ec0844f829b5abe0f5b154ca3abdb4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -166,6 +166,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // previously fell back to display-name registration matching. Preserve all
   // compatible passes from the exact-version ARP capture release.
   '82de31f37d7977906153135fde2eb12cf30909c7',
+  // The Visual Studio 2017 lifecycle correction affects only that previously
+  // failing generation. Preserve every compatible pass from the nested MSI
+  // ProductCode release.
+  '63172f3739807b25bbd54b970dc6f56d1cfc2c9d',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -680,6 +680,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Visual Studio 2017 only after activating its instance lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'microsoft.visualstudio.2017.enterprise', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '63172f3739807b25bbd54b970dc6f56d1cfc2c9d',
+      { wingetId: 'Microsoft.VisualStudio.2017.Enterprise', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5569c16d136f464cbc014f40c70645414c601751',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1287,7 +1287,11 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
-  '63172f3739807b25bbd54b970dc6f56d1cfc2c9d': [
+  '6788c71df2ec0844f829b5abe0f5b154ca3abdb4': [
+    // Visual Studio 2017 was omitted from the shared instance-aware adapter
+    // and fell back to an ARP command that left the product registered. Retry
+    // Enterprise through Microsoft's exact Visual Studio Installer lifecycle.
+    'Microsoft.VisualStudio.2017.Enterprise',
     // BankID is a ZIP with a nested MSI whose exact ProductCode was present
     // in trusted manifest metadata but previously dropped from the canonical
     // uninstall identity. Retry it through the shared QA/customer generator.


### PR DESCRIPTION
## Summary
- activate packager commit `6788c71df2ec0844f829b5abe0f5b154ca3abdb4`
- retain the prior nested-MSI release as compatible for unaffected successful results
- retry only the failed Visual Studio 2017 Enterprise candidate on the new lifecycle while carrying still-unconsumed bounded targets

## Validation
- focused: 138 tests passed
- full: 83 files and 1,263 tests passed
- touched-file ESLint passed
- `git diff --check` passed