### PR TITLE
chore(qa): activate darktable lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '6788c71df2ec0844f829b5abe0f5b154ca3abdb4',
+  packagerCommit: '7391c73a8eacb01becfc76682bfbb37b1d60b17f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -170,6 +170,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // failing generation. Preserve every compatible pass from the nested MSI
   // ProductCode release.
   '63172f3739807b25bbd54b970dc6f56d1cfc2c9d',
+  // darktable's bounded installer wait affects only its previously interrupted
+  // NSIS lifecycle. Preserve every unrelated compatible pass from the Visual
+  // Studio 2017 lifecycle release.
+  '6788c71df2ec0844f829b5abe0f5b154ca3abdb4',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -691,6 +691,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries darktable only after activating its bounded installer wait', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'darktable.darktable', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '6788c71df2ec0844f829b5abe0f5b154ca3abdb4',
+      { wingetId: 'darktable.darktable', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('keeps the consumed .NET Framework retry scoped to its registry-evidence release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5569c16d136f464cbc014f40c70645414c601751',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1347,6 +1347,53 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  '7391c73a8eacb01becfc76682bfbb37b1d60b17f': [
+    // darktable's CPack/NSIS installer extracted its payload but was
+    // interrupted by the generic inactivity guard before final registration.
+    // Retry it through the shared bounded wait with PSADT heartbeats.
+    'darktable.darktable',
+    // Carry still-unconsumed bounded targets across the atomic pin rollout.
+    // Compatible passes and ineligible apps are filtered before enqueue.
+    'Microsoft.VisualStudio.2017.Enterprise',
+    'FinancialID.BankID',
+    'Apache.OpenOffice',
+    'ArduinoSA.IDE.stable',
+    'Logitech.GHUB',
+    'Autodesk.AutodeskAccess',
+    'CoreyButler.NVMforWindows',
+    'Logitech.Presentation',
+    'Canonical.Ubuntu.2404',
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
   '837c54ac684d6a3d36a0ad5f14f258f8add540cf': [
     // Autodesk Access registers the exact ODIS manifest removal command but
     // omits Autodesk's documented -q switch. Retry through the shared PSADT


### PR DESCRIPTION
## Summary
- activate packager commit 7391c73a8eacb01becfc76682bfbb37b1d60b17f
- preserve compatible passing coverage from the previous protected release
- retry darktable plus still-unconsumed bounded targets under the exact new profile

## Verification
- 140 focused Vitest tests passed
- ESLint passed for modified TypeScript files