### PR TITLE
chore(qa): activate darktable extended lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -12,7 +12,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7391c73a8eacb01becfc76682bfbb37b1d60b17f',
+  packagerCommit: '20546b8280874ba955b8d14182ad69bde8eacb58',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -174,6 +174,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // NSIS lifecycle. Preserve every unrelated compatible pass from the Visual
   // Studio 2017 lifecycle release.
   '6788c71df2ec0844f829b5abe0f5b154ca3abdb4',
+  // The extended darktable ceiling changes only that release's still-running
+  // NSIS extraction. Preserve every compatible pass from the first bounded
+  // heartbeat release.
+  '7391c73a8eacb01becfc76682bfbb37b1d60b17f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1546,6 +1546,53 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     // window ended during exact installer preflight.
     'DATEV.SicherheitspaketCompact',
   ],
+  '20546b8280874ba955b8d14182ad69bde8eacb58': [
+    // The protected 8 GB retry extracted 3,071 files but still had no ARP
+    // identity at ten minutes. Give darktable one final run through the
+    // existing reviewed 15-minute ceiling; another timeout is terminal.
+    'darktable.darktable',
+    // Carry still-unconsumed bounded targets across the atomic pin rollout.
+    // Compatible passes and ineligible apps are filtered before enqueue.
+    'Microsoft.VisualStudio.2017.Enterprise',
+    'FinancialID.BankID',
+    'Apache.OpenOffice',
+    'ArduinoSA.IDE.stable',
+    'Logitech.GHUB',
+    'Autodesk.AutodeskAccess',
+    'CoreyButler.NVMforWindows',
+    'Logitech.Presentation',
+    'Canonical.Ubuntu.2404',
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate exact packager commit 20546b8280874ba955b8d14182ad69bde8eacb58
- preserve compatible evidence from the preceding heartbeat release
- carry the bounded darktable retry and still-unconsumed targets through the atomic rollover

## Verification
- focused Vitest: 168 passed
- focused ESLint: passed