### PR TITLE
Fix ZeeDrive no-ARP managed lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -571,13 +571,33 @@ if ($reviewedRegistryInstallEvidenceConfigured -and
     throw 'PSADT reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall.'
 }
 
+function Expand-ReviewedVersionPlaceholder {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Value,
+        [Parameter(Mandatory = $true)]
+        [string]$FieldName
+    )
+
+    if (-not $Value.Contains('<VERSION>')) {
+        return $Value
+    }
+    if ([regex]::Matches($Value, '<VERSION>').Count -ne 1 -or
+        $Version -notmatch '^[0-9A-Za-z][0-9A-Za-z._+-]{0,127}$') {
+        throw "PSADT $FieldName contains an invalid version placeholder or package version."
+    }
+    return $Value.Replace('<VERSION>', $Version)
+}
+
 $reviewedManagedInstallDirectory = ''
 if ($psadtConfig.Contains('reviewedManagedInstallDirectory') -and
     $null -ne $psadtConfig['reviewedManagedInstallDirectory']) {
     if ($psadtConfig['reviewedManagedInstallDirectory'] -isnot [string]) {
         throw 'PSADT reviewedManagedInstallDirectory must be a string.'
     }
-    $reviewedManagedInstallDirectory = ([string]$psadtConfig['reviewedManagedInstallDirectory']).Trim()
+    $reviewedManagedInstallDirectory = Expand-ReviewedVersionPlaceholder `
+        -Value ([string]$psadtConfig['reviewedManagedInstallDirectory']).Trim() `
+        -FieldName 'reviewedManagedInstallDirectory'
     $isReviewedMachineManagedDirectory =
         $reviewedManagedInstallDirectory -match '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$'
     $isReviewedUserDesktopManagedDirectory =
@@ -607,7 +627,9 @@ if ($hasManagedInstallCompletionContract) {
     if ($psadtConfig['reviewedManagedInstallEvidenceFile'] -isnot [string]) {
         throw 'PSADT reviewedManagedInstallEvidenceFile must be a string.'
     }
-    $reviewedManagedInstallEvidenceFile = ([string]$psadtConfig['reviewedManagedInstallEvidenceFile']).Trim()
+    $reviewedManagedInstallEvidenceFile = Expand-ReviewedVersionPlaceholder `
+        -Value ([string]$psadtConfig['reviewedManagedInstallEvidenceFile']).Trim() `
+        -FieldName 'reviewedManagedInstallEvidenceFile'
     if ($reviewedManagedInstallEvidenceFile.Length -gt 260 -or
         $reviewedManagedInstallEvidenceFile -notmatch '^(?:%(?:ProgramW6432|ProgramFiles|ProgramFiles\(x86\))%\\|%SystemDrive%\\SWSetup\\)[^*?"<>|\x00-\x1f]+$' -or
         @($reviewedManagedInstallEvidenceFile -split '\\') -contains '..' -or

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -533,6 +533,22 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('uses ZeeDrive\'s documented no-ARP Intune lifecycle', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Thinkscape.ZeeDrive',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallArguments: ['COMMAND=Install'],
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>\\ZeeDrive.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 5,
+    });
+  });
+
   it('adds the vendor-supported LTspice enterprise install mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'AnalogDevices.LTspice',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -177,6 +177,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallCompletionTimeoutMinutes: 15,
   },
   {
+    // ZeeDrive's official MSI is a command wrapper that deliberately does not
+    // register in Add/Remove Programs. Thinkscape documents COMMAND=Install,
+    // versioned Program Files detection, and direct directory removal for its
+    // Intune lifecycle. Keep that exact no-ARP contract shared by QA and
+    // customer packages instead of attempting to capture dependency ARP noise.
+    wingetId: 'Thinkscape.ZeeDrive',
+    reviewedInstallArguments: ['COMMAND=Install'],
+    reviewedManagedInstallDirectory:
+      '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>\\ZeeDrive.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 5,
+  },
+  {
     // Analog Devices documents this enterprise/server mode for silent SYSTEM
     // deployment. It prevents the MSI from extracting example data into the
     // LocalSystem AppData profile, which otherwise rolls back with exit 1603.

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -690,6 +690,47 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'expands a reviewed versioned managed-directory lifecycle before validation',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Zee Drive',
+        [],
+        {
+          reviewedManagedInstallDirectory:
+            '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>',
+          reviewedManagedInstallEvidenceFile:
+            '%ProgramFiles%\\Thinkscape Zee Drive\\<VERSION>\\ZeeDrive.exe',
+          reviewedManagedInstallCompletionTimeoutMinutes: 5,
+        },
+        [],
+        'Thinkscape.ZeeDrive',
+        'Zee Drive',
+        '68.15.0.0'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\Thinkscape Zee Drive\\68.15.0.0')"
+      );
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\Thinkscape Zee Drive\\68.15.0.0\\ZeeDrive.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        'Remove-Item -LiteralPath $managedInstallDirectory'
+      );
+      expect(generated).not.toContain('<VERSION>');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'verifies and removes the reviewed Tor Browser user Desktop payload',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- use Thinkscape's documented COMMAND=Install MSI contract
- detect ZeeDrive through its versioned Program Files executable
- remove the exact versioned managed directory during uninstall
- add reusable, validated VERSION placeholder expansion and regression coverage

## Verification
- 278 focused tests passed
- ESLint passed for touched TypeScript files
- generated PSADT package contract verifies install evidence and uninstall removal