### PR TITLE
Fix Docker Desktop Edge registered identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -23,6 +23,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Docker Desktop Edge\'s actual registered product identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Docker.DockerDesktopEdge',
+      'REGISTRY_UNINSTALL:Docker Desktop Edge'
+    )).toBe('REGISTRY_UNINSTALL:Docker Desktop');
+    expect(resolveApplicationUninstallCommand(
+      'docker.dockerdesktopedge',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses the exact stable Inno registry key for every K-Lite edition', () => {
     for (const edition of ['Basic', 'Standard', 'Full', 'Mega']) {
       expect(resolveApplicationUninstallCommand(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -858,6 +858,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'Google Chrome (EXE)',
     registeredDisplayName: 'Google Chrome',
   },
+  // The legacy Edge-channel package is still named `Docker Desktop Edge` in
+  // the catalog, but Docker registers the installed product as the ordinary
+  // `Docker Desktop` ARP entry. Use that exact vendor identity so install
+  // capture, Intune detection, and unattended removal all address the same
+  // product without broadening the generic registry matcher.
+  'docker.dockerdesktopedge': {
+    generatedDisplayName: 'Docker Desktop Edge',
+    registeredDisplayName: 'Docker Desktop',
+  },
   // K-Lite inserts the version between the family and edition in DisplayName
   // (for example `K-Lite Codec Pack 19.9.0 Standard`). All four mutually
   // exclusive editions use the same stable Inno registry key, so use that


### PR DESCRIPTION
## Summary
- map the legacy Docker Desktop Edge catalog name to the exact Docker Desktop ARP identity
- keep custom uninstall commands untouched
- add regression coverage for QA and customer PSADT packaging

## Verification
- 243 focused packaging tests passed
- ESLint passed for changed files
- git diff --check passed