### PR TITLE
Fix Podman Desktop machine-wide lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -618,6 +618,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('selects Podman Desktop all-users mode for the full Intune lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'redhat.podman-desktop',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('/S /allusers');
+    expect(adapted.reviewedUninstallArguments).toEqual(['/allusers', '/S']);
+  });
+
   it('replaces Bitvise generic switches with its documented unattended mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Bitvise.SSH.Client',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -266,6 +266,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/S /MULTIUSER',
   },
   {
+    // Podman Desktop uses Electron Builder's assisted NSIS installer without
+    // a per-machine default. A bare /S therefore selects the invoking account,
+    // which installs below LocalSystem's profile and leaves an unusable vendor
+    // uninstall path. Electron Builder's /allusers contract selects the
+    // machine-wide Program Files/HKLM lifecycle required by Intune. Preserve
+    // that scope on removal as well for both QA and customer packages.
+    wingetId: 'RedHat.Podman-Desktop',
+    reviewedInstallArgumentsOverride: '/S /allusers',
+    reviewedUninstallArguments: ['/allusers', '/S'],
+  },
+  {
     // Google documents that Drive for desktop must be removed through its
     // versioned registered uninstaller with both --silent and --force_stop.
     // The latter is required whenever Drive is running; without it the helper


### PR DESCRIPTION
## Summary
- force Podman Desktop's assisted NSIS installer into its all-users mode under LocalSystem
- preserve the matching all-users silent flags for removal
- add a case-insensitive adapter regression

## Verification
- 241 focused packaging, profile, API, and contract tests pass
- ESLint passes for the changed files

This adapter is shared by QA and customer Intune package generation.