### PR TITLE
Fix RMS Client asynchronous uninstall completion

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -453,6 +453,12 @@ describe('application packaging adapters', () => {
     ).toEqual(['/uninstall', '/quiet', '/norestart']);
     expect(
       applyApplicationPackagingAdapter(
+        'Microsoft.RMSClient',
+        DEFAULT_PSADT_CONFIG
+      ).uninstallCompletionTimeoutMinutes
+    ).toBe(10);
+    expect(
+      applyApplicationPackagingAdapter(
         'Microsoft.VisualStudio.2022.BuildTools',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -687,6 +687,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/uninstall', '/quiet', '/norestart'],
   },
   {
+    // The RMS client uses a Burn bootstrapper whose uninstall parent exits
+    // before the bundle registration is removed. The default five-minute
+    // registry-aware completion window can expire even though the vendor child
+    // process finishes successfully shortly afterward. Keep the exact
+    // registration check authoritative, but allow this reviewed lifecycle the
+    // bounded time it needs in both QA and customer deployments.
+    wingetId: 'Microsoft.RMSClient',
+    uninstallCompletionTimeoutMinutes: 10,
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the


### PR DESCRIPTION
## Summary
- give Microsoft RMS Client's reviewed Burn lifecycle a bounded 10-minute uninstall completion window
- retain exact registry removal as the authoritative success condition
- add adapter regression coverage

## Evidence
- QA install and detection passed
- the Burn registration persisted past the default five-minute window, then removal verification passed
- focused adapter tests: 44 passed
- focused ESLint: passed