### PR TITLE
Fix Movavi Photo Focus verified install result

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -122,6 +122,28 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     }));
   });
 
+  it('dispatches reviewed Movavi success codes through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Movavi.MovaviPhotoFocus',
+      displayName: 'Movavi Photo Focus',
+      publisher: 'Movavi',
+      version: '1.1.0',
+      architecture: 'x86',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Movavi Photo Focus',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(JSON.parse(payload.client_payload.installer.successCodes)).toEqual([1223]);
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -10,7 +10,10 @@ import { applyInstallerUrlOverride } from './installer-url-overrides';
 import { reconcileCatalogInstaller } from './catalog-installer-reconciliation';
 import { enforceInstallerPreflight, InstallerPreflightError } from './installer-preflight';
 import { enforceQaGate } from './qa/gate';
-import { resolveApplicationUninstallCommand } from './packaging-adapters';
+import {
+  resolveApplicationInstallerSuccessCodes,
+  resolveApplicationUninstallCommand,
+} from './packaging-adapters';
 import { assertPackagingContract } from './packaging-contract';
 import {
   normalizeQaWorkflowPackageInput,
@@ -209,7 +212,15 @@ export async function triggerPackagingWorkflow(
     installScope: effectiveInputs.installScope,
     sourceType: effectiveInputs.sourceType,
   }, trustedInstallers);
-  inputs = effectiveInputs;
+  inputs = effectiveInputs.sourceType === 'custom'
+    ? effectiveInputs
+    : {
+        ...effectiveInputs,
+        installerSuccessCodes: resolveApplicationInstallerSuccessCodes(
+          effectiveInputs.wingetId,
+          effectiveInputs.installerSuccessCodes
+        ),
+      };
   // Final dispatch boundary: custom callers bypass catalog reconciliation, so
   // they must still prove an unattended install contract before GitHub sees
   // the installer URL or any tenant-scoped packaging request.

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -3,11 +3,27 @@ import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationInstallerSuccessCodes,
   resolveApplicationInstallerSelectionScope,
   resolveApplicationUninstallCommand,
 } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('adds Movavi Photo Focus vendor success code without weakening other apps', () => {
+    expect(resolveApplicationInstallerSuccessCodes(
+      'Movavi.MovaviPhotoFocus',
+      undefined
+    )).toEqual([1223]);
+    expect(resolveApplicationInstallerSuccessCodes(
+      ' movavi.movaviphotofocus ',
+      [3010, 1223]
+    )).toEqual([1223, 3010]);
+    expect(resolveApplicationInstallerSuccessCodes(
+      'Example.App',
+      [3010]
+    )).toEqual([3010]);
+  });
+
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
     expect(resolveApplicationUninstallCommand(
       'Google.Chrome.EXE',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -5,6 +5,7 @@ interface ApplicationPackagingAdapter {
   wingetId: string;
   requiredInstallScope?: WingetScope;
   reviewedInstallerSelectionScope?: WingetScope;
+  reviewedInstallerSuccessCodes?: readonly number[];
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
@@ -697,6 +698,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     uninstallCompletionTimeoutMinutes: 10,
   },
   {
+    // Movavi Photo Focus 1.1.0's signed NSIS installer returns the Windows
+    // ERROR_CANCELLED code (1223) after it has successfully created the exact
+    // product ARP registration. The shared packager still requires that
+    // post-install registry identity before it writes detection evidence, so
+    // a genuine cancellation without an installed product continues to fail.
+    wingetId: 'Movavi.MovaviPhotoFocus',
+    reviewedInstallerSuccessCodes: [1223],
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the
@@ -825,6 +835,31 @@ function applicationPackagingAdapter(
     return POSTGRESQL_PACKAGING_ADAPTER;
   }
   return undefined;
+}
+
+function normalizeInstallerSuccessCodes(
+  successCodes: readonly number[] | undefined
+): number[] {
+  return Array.from(new Set((successCodes || [])
+    .map(Number)
+    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)))
+    .sort((left, right) => left - right);
+}
+
+/**
+ * Add reviewed vendor exit codes at the final shared packaging boundary.
+ * These codes never replace post-install evidence: the generated PSADT package
+ * must still capture the application's exact installation identity.
+ */
+export function resolveApplicationInstallerSuccessCodes(
+  wingetId: string,
+  successCodes: readonly number[] | undefined
+): number[] {
+  const adapter = applicationPackagingAdapter(wingetId);
+  return normalizeInstallerSuccessCodes([
+    ...(successCodes || []),
+    ...(adapter?.reviewedInstallerSuccessCodes || []),
+  ]);
 }
 
 /**

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -136,6 +136,26 @@ describe('PSADT QA package identity', () => {
     expect(buildQaPackageIdentity({ ...input, successCodes: [] })).toEqual(baseline);
   });
 
+  it('binds the reviewed Movavi success code to deployment QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Movavi.MovaviPhotoFocus',
+      displayName: 'Movavi Photo Focus',
+      publisher: 'Movavi',
+      version: '1.1.0',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Movavi Photo Focus',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { successCodes?: number[] };
+    };
+
+    expect(profile.installer.successCodes).toEqual([1223]);
+  });
+
   it('binds offline dependency installers to the execution profile only when present', () => {
     const baseline = buildQaPackageIdentity(input);
     const dependency = {

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationInstallerSuccessCodes,
   resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
@@ -885,7 +886,10 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     installerSha256: input.installerSha256,
     sourceInstallerType: input.installerType,
     silentArgs: input.silentSwitches,
-    successCodes: input.installerSuccessCodes,
+    successCodes: resolveApplicationInstallerSuccessCodes(
+      input.wingetId,
+      input.installerSuccessCodes
+    ),
     uninstallCommand,
     installScope,
     nestedInstallerType: input.nestedInstallerType || '',

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { buildQaCatalogTestConfig } from './test-config';
 
 describe('buildQaCatalogTestConfig', () => {
+  it('adds the reviewed Movavi success code to catalog QA packaging', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Movavi.MovaviPhotoFocus',
+        name: 'Movavi Photo Focus',
+        publisher: 'Movavi',
+        version: '1.1.0',
+      },
+      manifest: { InstallerType: 'nullsoft' },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'nullsoft',
+        ProductCode: 'Movavi Photo Focus',
+      },
+    });
+
+    expect(config.successCodes).toEqual([1223]);
+  });
+
   it('prefers installer-specific silent switches and product metadata', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
+  resolveApplicationInstallerSuccessCodes,
   resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import { normalizeQaPsadtConfig } from './package-profile';
@@ -210,7 +211,10 @@ export function buildQaCatalogTestConfig({
     publisher: app.publisher,
     sourceInstallerType,
     silentArgs: normalizedInstaller.silentArgs || '',
-    successCodes: normalizedInstaller.installerSuccessCodes || [],
+    successCodes: resolveApplicationInstallerSuccessCodes(
+      app.wingetId,
+      normalizedInstaller.installerSuccessCodes
+    ),
     productCode,
     scope,
     nestedInstallerType: nestedInstallerType || '',


### PR DESCRIPTION
## Summary
- add a reviewed Movavi Photo Focus installer success code adapter for vendor exit 1223
- apply it to catalog QA, deployment QA identity, and the final customer packaging dispatch
- retain exact post-install ARP capture as the authoritative success requirement

## Verification
- 147 focused tests passed
- focused ESLint passed