### PR TITLE
Activate RMS and Movavi packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -13,7 +13,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4918638adf111a664f2589ce79d8aefe79c33936',
+  packagerCommit: 'b42fb5d02883b199e057c466a2cd9a7b86d994d9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -188,6 +188,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Podman Desktop's all-users NSIS selection affects only that package's
   // failed LocalSystem lifecycle. Preserve every unrelated compatible pass.
   'ab045cb1da3611f91329943fade2263491bb211d',
+  // RMS Client's bounded uninstall wait and Movavi's evidence-guarded vendor
+  // exit code affect only their previously failing lifecycle paths. Preserve
+  // every unrelated compatible pass from the Podman release.
+  '4918638adf111a664f2589ce79d8aefe79c33936',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,8 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Microsoft.RMSClient',
+      'Movavi.MovaviPhotoFocus',
       'RedHat.Podman-Desktop',
       'PDFsam.PDFsam',
       'Mega.MEGASync',
@@ -89,6 +91,8 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Microsoft.RMSClient',
+        'Movavi.MovaviPhotoFocus',
         'RedHat.Podman-Desktop',
         'PDFsam.PDFsam',
         'Mega.MEGASync',
@@ -112,6 +116,20 @@ describe('QA toolchain targeted retries', () => {
     expect(
       terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
     ).not.toContain('Acronis.CyberProtectHomeOffice');
+  });
+
+  it.each([
+    'Microsoft.RMSClient',
+    'Movavi.MovaviPhotoFocus',
+  ])('retries %s only on the combined lifecycle release', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '4918638adf111a664f2589ce79d8aefe79c33936',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
   });
 
   it('does not repeat the consumed .NET Framework retry in the Sonos releases', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -1730,6 +1730,58 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
   ],
+  'b42fb5d02883b199e057c466a2cd9a7b86d994d9': [
+    // RMS Client's Burn child can remove its exact registration shortly after
+    // the parent exits. Retry with the reviewed bounded completion window.
+    'Microsoft.RMSClient',
+    // Movavi installs and registers successfully before its signed NSIS
+    // launcher returns 1223. Retry with the evidence-guarded success code.
+    'Movavi.MovaviPhotoFocus',
+    // Carry still-unconsumed bounded targets across the atomic pin rollout.
+    // Compatible passes and ineligible apps are filtered before enqueue.
+    'RedHat.Podman-Desktop',
+    'Docker.DockerDesktopEdge',
+    'Thinkscape.ZeeDrive',
+    'Microsoft.VisualStudio.2017.Enterprise',
+    'FinancialID.BankID',
+    'Apache.OpenOffice',
+    'ArduinoSA.IDE.stable',
+    'Logitech.GHUB',
+    'Autodesk.AutodeskAccess',
+    'CoreyButler.NVMforWindows',
+    'Logitech.Presentation',
+    'Canonical.Ubuntu.2404',
+    'Daum.PotPlayer',
+    'Autodesk.LicensingService',
+    'AcroSoftware.CutePDFWriter',
+    'PDFsam.PDFsam',
+    'Mega.MEGASync',
+    'Insta360.Link.Controller',
+    'Logitech.SetPoint',
+    'Timely.Memory',
+    'Google.GoogleDrive',
+    'Dropbox.Dropbox',
+    'AOMEI.PartitionAssistant',
+    'Ringler.SnapformViewer',
+    'Cisco.Jabber',
+    'IPEVO.Visualizer',
+    'IPEVO.VisualizerLTSE',
+    'Sonos.Controller',
+    'Microsoft.VisualStudio.BuildTools',
+    'Microsoft.VisualStudio.Community',
+    'Microsoft.VisualStudio.Enterprise',
+    'Microsoft.VisualStudio.Professional',
+    'Microsoft.VisualStudio.2022.BuildTools',
+    'Microsoft.VisualStudio.2022.Community',
+    'Microsoft.VisualStudio.2022.Enterprise',
+    'Microsoft.VisualStudio.2022.Professional',
+    'karakun.OpenWebStart',
+    'MSYS2.MSYS2',
+    'TorProject.TorBrowser',
+    'PTC.CreoView.Express',
+    'Blizzard.BattleNet',
+    'DATEV.SicherheitspaketCompact',
+  ],
 };
 
 export function terminalToolchainRetryTargets(packagerCommit: string): string[] {


### PR DESCRIPTION
## Summary
- activate immutable packager commit b42fb5d02883b199e057c466a2cd9a7b86d994d9
- preserve compatible passing profiles from the preceding release
- carry bounded RMSClient, Movavi, and unconsumed retry targets through the atomic rollout

## Verification
- 145 focused tests passed
- focused ESLint passed