### PR TITLE
Fix DesktopOK silent uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -207,6 +207,16 @@ describe('application packaging adapters', () => {
       },
     });
     expect(
+      applyApplicationPackagingAdapter(
+        'SoftwareOK.DesktopOK',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedExactUninstall
+    ).toEqual({
+      executablePath: '%ProgramFiles%\\DesktopOK\\DesktopOK_x64.exe',
+      arguments: ['/silent', '-?uninstall'],
+      completionTimeoutMinutes: 5,
+    });
+    expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/silent', 'forall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -458,6 +458,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // DesktopOK registers its own executable with the interactive
+    // -?uninstall argument. Reuse the vendor's documented /silent mode ahead
+    // of that exact removal verb so SYSTEM deployments do not exit without
+    // deleting the captured DesktopOK registration.
+    wingetId: 'SoftwareOK.DesktopOK',
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles%\\DesktopOK\\DesktopOK_x64.exe',
+      arguments: ['/silent', '-?uninstall'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
   },


### PR DESCRIPTION
## Summary
- bind DesktopOK removal to its exact installed executable
- add the vendor silent mode before DesktopOK's registered `-?uninstall` verb
- preserve exact captured-registration verification for QA and customer Intune packages

## Verification
- 204 focused packager, adapter, and profile tests passed
- full ESLint passed
- `git diff --check` passed

## Evidence
The QA log showed `DesktopOK_x64.exe -?uninstall` exiting with code 1 and leaving the exact `DesktopOK` registration. SoftwareOK documents `/silent` for unattended DesktopOK operation.