### PR TITLE
Correct DesktopOK and Ava Desktop package scopes

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -110,6 +110,12 @@ describe('application packaging adapters', () => {
   });
 
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
+    expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
+      'user'
+    );
+    expect(resolveApplicationInstallScope(' avacc.avadesktop ', undefined)).toBe(
+      'user'
+    );
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -216,6 +216,9 @@ describe('application packaging adapters', () => {
       arguments: ['/silent', '-?uninstall'],
       completionTimeoutMinutes: 5,
     });
+    expect(resolveApplicationInstallScope('SoftwareOK.DesktopOK', 'user')).toBe(
+      'machine'
+    );
     expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -458,11 +458,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
-    // DesktopOK registers its own executable with the interactive
-    // -?uninstall argument. Reuse the vendor's documented /silent mode ahead
-    // of that exact removal verb so SYSTEM deployments do not exit without
-    // deleting the captured DesktopOK registration.
+    // DesktopOK publishes both user- and machine-scope installers. Intune runs
+    // Win32 packages as SYSTEM, and the reviewed exact uninstaller lives below
+    // Program Files, so keep package creation on the machine-scope variant.
+    // Reuse the vendor's documented /silent mode ahead of the registered
+    // -?uninstall verb so removal never waits for interactive UI.
     wingetId: 'SoftwareOK.DesktopOK',
+    requiredInstallScope: 'machine',
     reviewedExactUninstall: {
       executablePath: '%ProgramFiles%\\DesktopOK\\DesktopOK_x64.exe',
       arguments: ['/silent', '-?uninstall'],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -112,6 +112,14 @@ const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
   {
+    // Ava Desktop's NSIS bootstrapper installs below the invoking account's
+    // LocalAppData even though its WinGet manifest omits Scope. Running it as
+    // LocalSystem records a systemprofile uninstaller that is absent by the
+    // removal cycle. Keep the package in the intended signed-in user context.
+    wingetId: 'AvaCC.AvaDesktop',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.


### PR DESCRIPTION
## Summary
- require the machine-scope DesktopOK installer so its reviewed Program Files uninstaller exists
- run Ava Desktop in its actual per-user context so LocalAppData install and removal paths remain valid
- apply both corrections to the shared QA and customer Intune packager

## Verification
- 45 packaging adapter tests passed
- focused ESLint passed
- git diff --check passed

## Evidence
DesktopOK selected a per-user manifest variant while its reviewed removal contract was machine-wide. Ava Desktop's NSIS bootstrapper installs below the invoking account's LocalAppData even though WinGet omits Scope; under LocalSystem it registered an unusable systemprofile uninstaller.