### PR TITLE
Fix FSLogix ARP identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -50,6 +50,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses FSLogix\'s registered bundle display identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Microsoft.FSLogix',
+      'REGISTRY_UNINSTALL:FSLogix'
+    )).toBe('REGISTRY_UNINSTALL:Microsoft FSLogix Apps');
+    expect(resolveApplicationUninstallCommand(
+      'microsoft.fslogix',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses the exact stable Inno registry key for every K-Lite edition', () => {
     for (const edition of ['Basic', 'Standard', 'Full', 'Mega']) {
       expect(resolveApplicationUninstallCommand(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -945,6 +945,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'Docker Desktop Edge',
     registeredDisplayName: 'Docker Desktop',
   },
+  // FSLogix is distributed as a ZIP containing Microsoft's Burn-style EXE.
+  // WinGet publishes `Microsoft FSLogix Apps` in ProductCode, but the bundle
+  // creates a generated GUID ARP key with that value as its DisplayName. Bind
+  // the reviewed display identity so prerequisite ARP changes cannot prevent
+  // install capture and the same exact vendor entry drives customer removal.
+  'microsoft.fslogix': {
+    generatedDisplayName: 'FSLogix',
+    registeredDisplayName: 'Microsoft FSLogix Apps',
+  },
   // K-Lite inserts the version between the family and edition in DisplayName
   // (for example `K-Lite Codec Pack 19.9.0 Standard`). All four mutually
   // exclusive editions use the same stable Inno registry key, so use that

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -65,6 +65,33 @@ describe('buildQaCatalogTestConfig', () => {
     });
   });
 
+  it('reconciles FSLogix WinGet metadata to its registered bundle display name', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Microsoft.FSLogix',
+        name: 'FSLogix',
+        publisher: 'Microsoft',
+        version: '3.26.126.19110',
+      },
+      manifest: {
+        InstallerType: 'zip',
+        NestedInstallerType: 'exe',
+        ProductCode: 'Microsoft FSLogix Apps',
+        InstallerSwitches: { Silent: '/install /quiet /norestart' },
+      },
+      installer: {
+        Architecture: 'neutral',
+        InstallerType: 'zip',
+        NestedInstallerType: 'exe',
+        ProductCode: 'Microsoft FSLogix Apps',
+      },
+    });
+
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:Microsoft FSLogix Apps'
+    );
+  });
+
   it.each([
     ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
     ['nullsoft', '/S'],


### PR DESCRIPTION
## Summary
- map the WinGet catalog name to the exact FSLogix bundle display identity
- keep prerequisite ARP changes from making install capture ambiguous
- cover both the shared adapter and catalog QA configuration

## Verification
- npx vitest run lib/packaging-adapters.test.ts lib/qa/test-config.test.ts lib/qa/package-profile.test.ts --reporter=dot
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/test-config.test.ts
- git diff --check