### PR TITLE
Fix nested EXE uninstall identity selection

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2661,7 +2661,7 @@ if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
     # This is a packager-time decision. Do not emit $originalInstallerType into the
     # generated deployment script: that variable exists only in this generator and
     # StrictMode would turn the fallback check into a post-install 60001 failure.
-    if ($originalInstallerType -in @('burn', 'exe')) {
+    if ($registeredInstallerTypeLower -in @('burn', 'exe')) {
         $lines += @(
             '        if ($selectedApplications.Count -gt 1) {'
             '            # A top-level executable wrapper and its chained MSI can intentionally share the same ARP display name.'
@@ -3035,7 +3035,7 @@ if ($useManagedDirectoryLifecycle) {
         '        }'
         '    }'
     )
-    if ($originalInstallerType -in @('burn', 'exe')) {
+    if ($registeredInstallerTypeLower -in @('burn', 'exe')) {
         $lines += @(
             '    if ($installedApps.Count -gt 1) {'
             '        # Recover a missing marker only when one exact, visible top-level wrapper is distinguishable'
@@ -3055,7 +3055,7 @@ if ($useManagedDirectoryLifecycle) {
         '    }'
         '    Write-ADTLogEntry -Message "Found exact vendor registry entry [$($installedApps[0].DisplayName)], uninstalling..." -Source ''Uninstall-ADTDeployment'''
     )
-    if ($originalInstallerType -eq 'burn') {
+    if ($registeredInstallerTypeLower -eq 'burn') {
         $lines += @(
             '    # Prefer an exact registered vendor removal helper while it exists. Retain the hash-verified'
             '    # packaged bundle as a durable fallback for disposable per-account Package Cache entries.'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1760,7 +1760,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   });
 
   it('prefers a registered Burn helper and keeps the packaged fallback for disposable caches', () => {
-    expect(packager).toContain("if ($originalInstallerType -eq 'burn')");
+    expect(packager).toContain("if ($registeredInstallerTypeLower -eq 'burn')");
     expect(packager).toContain(
       '$capturedMsiProductCode = if ($registeredApplication.WindowsInstaller -and $registeredApplication.ProductCode)'
     );
@@ -1831,6 +1831,27 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       }
     }
   );
+
+  it('uses the effective registered engine for archived executable-wrapper disambiguation', () => {
+    expect(packager).toContain(
+      "if ($registeredInstallerTypeLower -in @('burn', 'exe'))"
+    );
+    expect(packager).toContain(
+      "if ($registeredInstallerTypeLower -eq 'burn')"
+    );
+    expect(packager).not.toContain(
+      "if ($originalInstallerType -in @('burn', 'exe'))"
+    );
+    expect(hostedPackager).toContain(
+      "if ($selectedApplications.Count -gt 1 -and '${registeredInstallerType}' -in @('burn', 'exe'))"
+    );
+    expect(hostedPackager).toContain(
+      "if ($installedApps.Count -gt 1 -and '${registeredInstallerType}' -in @('burn', 'exe'))"
+    );
+    expect(hostedPackager).toContain(
+      "if (registeredInstallerType === 'burn')"
+    );
+  });
 
   it.runIf(canRunWindowsPowerShellPackager)(
     'does not emit executable-wrapper duplicate-entry narrowing for native installer packages',

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1124,6 +1124,11 @@ ${steps}
     const identity = this.getRegistryUninstallIdentity(job);
     if (identity) {
       const escapedPublisher = job.publisher.replace(/'/g, "''");
+      const installerType = job.installer_type.toLowerCase();
+      const nestedInstaller = this.getNestedInstaller(job);
+      const registeredInstallerType = installerType === 'zip' && nestedInstaller.type
+        ? nestedInstaller.type.toLowerCase()
+        : installerType;
       return `
     ## Capture and verify the exact uninstall identity observed for this installation.
     $selectedApplications = @()
@@ -1207,9 +1212,9 @@ ${steps}
             })
             if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
         }
-        if ($selectedApplications.Count -gt 1 -and '${job.installer_type.toLowerCase()}' -eq 'burn') {
-            # A Burn bundle and its chained MSI can intentionally share the same ARP display name.
-            # Narrow only the already identity-matched set to its single non-MSI bundle entry.
+        if ($selectedApplications.Count -gt 1 -and '${registeredInstallerType}' -in @('burn', 'exe')) {
+            # A top-level executable wrapper and its chained MSI can intentionally share the same ARP display name.
+            # Narrow only the already identity-matched set to its single visible non-MSI wrapper entry.
             $bundleCandidates = @($selectedApplications | Where-Object {
                 $systemComponentProperty = $_.PSObject.Properties['SystemComponent']
                 $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value
@@ -1217,7 +1222,7 @@ ${steps}
             })
             if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
         }
-        if ($selectedApplications.Count -eq 0 -and '${job.installer_type.toLowerCase()}' -eq 'burn') {
+        if ($selectedApplications.Count -eq 0 -and '${registeredInstallerType}' -in @('burn', 'exe')) {
             $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })
             if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }
         }
@@ -1644,13 +1649,23 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
         })
         if ($versionedMatches.Count -eq 1) { $installedApps = $versionedMatches }
     }
+    if ($installedApps.Count -gt 1 -and '${registeredInstallerType}' -in @('burn', 'exe')) {
+        # Recover a missing marker only when one exact, visible top-level wrapper is distinguishable
+        # from chained MSI registrations with the same display name. Multiple wrappers remain fail-closed.
+        $topLevelWrapperMatches = @($installedApps | Where-Object {
+            $systemComponentProperty = $_.PSObject.Properties['SystemComponent']
+            $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value
+            $isVisibleApplication -and -not $_.WindowsInstaller
+        })
+        if ($topLevelWrapperMatches.Count -eq 1) { $installedApps = $topLevelWrapperMatches }
+    }
     if ($installedApps.Count -ne 1) {
         throw "Could not find one exact vendor uninstall entry. Found $($installedApps.Count); refusing broad removal."
     }
     $registeredApplication = $installedApps[0]
     $registeredUninstallRegistryKey = [string]$registeredApplication.PSChildName`;
 
-      if (installerType === 'burn') {
+      if (registeredInstallerType === 'burn') {
         return `${selectionBlock}
     $registeredUninstallProperty = if (-not [string]::IsNullOrWhiteSpace($registeredApplication.QuietUninstallStringFilePath)) {
         'QuietUninstallString'

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -440,7 +440,7 @@ describe('Burn bundle PSADT generation', () => {
     );
 
     expect(verification).toContain(
-      "if ($selectedApplications.Count -gt 1 -and 'burn' -eq 'burn')"
+      "if ($selectedApplications.Count -gt 1 -and 'burn' -in @('burn', 'exe'))"
     );
     expect(verification).toContain(
       '$bundleCandidates = @($selectedApplications | Where-Object {'
@@ -451,7 +451,37 @@ describe('Burn bundle PSADT generation', () => {
     );
   });
 
-  it('keeps Burn-only duplicate-entry narrowing disabled for non-Burn packages', () => {
+  it('uses nested EXE behavior for archived wrapper packages', () => {
+    const job = packagingJob({
+      installer_type: 'zip',
+      uninstall_command: 'REGISTRY_UNINSTALL:Microsoft FSLogix Apps',
+      package_config: {
+        nestedInstallerType: 'exe',
+        nestedInstallerPath: 'x64/Release/FSLogixAppsSetup.exe',
+        psadtConfig: {},
+      },
+    });
+
+    const verification = generator.getPostInstallVerificationBlock.call(
+      generator,
+      job,
+      'FSLogix'
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'FSLogix.zip'
+    );
+
+    expect(verification).toContain(
+      "$selectedApplications.Count -gt 1 -and 'exe' -in @('burn', 'exe')"
+    );
+    expect(uninstall).toContain(
+      "$installedApps.Count -gt 1 -and 'exe' -in @('burn', 'exe')"
+    );
+  });
+
+  it('keeps executable-wrapper duplicate-entry narrowing disabled for native framework packages', () => {
     const job = packagingJob({
       installer_type: 'inno',
       uninstall_command: 'REGISTRY_UNINSTALL:Example App',
@@ -463,9 +493,11 @@ describe('Burn bundle PSADT generation', () => {
       'Example App'
     );
 
-    expect(verification).toContain("$selectedApplications.Count -gt 1 -and 'inno' -eq 'burn'");
+    expect(verification).toContain(
+      "$selectedApplications.Count -gt 1 -and 'inno' -in @('burn', 'exe')"
+    );
     expect(verification).not.toContain(
-      "$selectedApplications.Count -gt 1 -and 'inno' -eq 'inno'"
+      "$selectedApplications.Count -gt 1 -and 'inno' -in @('inno')"
     );
   });
 });


### PR DESCRIPTION
## Summary\n- use the effective nested installer engine when resolving executable-wrapper ARP identities\n- apply the same safe single-visible-wrapper rule to the hosted customer packager\n- keep ambiguity fail-closed when more than one wrapper remains\n- add regression coverage for ZIP packages containing an EXE installer\n\n## Validation\n- 
px vitest run lib/qa/psadt-packager-contract.test.ts (97 passed)\n- 
px vitest run packager/tests/psadt-nested-portable.test.ts (57 passed)\n- 
px eslint packager/src/job-processor.ts lib/qa/psadt-packager-contract.test.ts\n- git diff --check\n\nA repository-wide 	sc --noEmit remains red on pre-existing Vitest global/type errors outside this change.