### PR TITLE
Repair saved custom detection marker profiles

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -687,6 +687,55 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('restores a saved custom marker root for both QA and customer packaging', async () => {
+    const savedRule = {
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\HBX\\InstalledApps\\8x8_Work',
+      valueName: 'Version',
+      check32BitOn64System: false,
+      detectionType: 'version',
+      operator: 'greaterThanOrEqual',
+      detectionValue: '8.36.2',
+    };
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: '8x8.Work',
+          displayName: '8x8 Work',
+          version: '8.36.2',
+          installerType: 'msi',
+          detectionRules: [savedRule],
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG, detectionRules: [savedRule] },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    for (const serializedConfig of [
+      ensureQaDemandMock.mock.calls[0][1].psadtConfig,
+      triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig,
+    ]) {
+      expect(JSON.parse(serializedConfig)).toMatchObject({
+        registryMarkerPath: 'SOFTWARE\\HBX\\InstalledApps',
+        detectionRules: [savedRule],
+      });
+    }
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      detectionRules: [savedRule],
+      psadtConfig: {
+        registryMarkerPath: 'SOFTWARE\\HBX\\InstalledApps',
+        detectionRules: [savedRule],
+      },
+    });
+  });
+
   it('repairs stale generated MSIX detection before both QA and customer MSI packaging', async () => {
     const staleMsixRule = {
       type: 'script',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -43,6 +43,7 @@ import {
   resolveApplicationInstallScope,
 } from '@/lib/packaging-adapters';
 import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
+import { inferSavedCustomMarkerPath } from '@/lib/registry-marker';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { reconcileCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
 import { evaluatePackagingContract } from '@/lib/packaging-contract';
@@ -526,7 +527,7 @@ export async function POST(request: NextRequest) {
           try {
             if (item.sourceType !== 'custom') {
               const requestedPsadtConfig = item.psadtConfig || DEFAULT_PSADT_CONFIG;
-              const detectionRules = normalizeCatalogDetectionRules({
+              let detectionRules = normalizeCatalogDetectionRules({
                 detectionRules: item.detectionRules,
                 fallbackDetectionRules: requestedPsadtConfig.detectionRules,
                 wingetId: item.wingetId,
@@ -535,10 +536,31 @@ export async function POST(request: NextRequest) {
                 markerPath: requestedPsadtConfig.registryMarkerPath,
                 installerType: item.nestedInstallerType || item.installerType,
               });
+              const inferredMarkerPath = requestedPsadtConfig.registryMarkerPath
+                ? null
+                : inferSavedCustomMarkerPath({
+                    detectionRules,
+                    wingetId: item.wingetId,
+                    version: item.version,
+                    installScope: item.installScope,
+                  });
+              const effectivePsadtConfig = inferredMarkerPath
+                ? { ...requestedPsadtConfig, registryMarkerPath: inferredMarkerPath }
+                : requestedPsadtConfig;
+              if (inferredMarkerPath) {
+                detectionRules = normalizeCatalogDetectionRules({
+                  detectionRules,
+                  wingetId: item.wingetId,
+                  version: item.version,
+                  installScope: item.installScope,
+                  markerPath: inferredMarkerPath,
+                  installerType: item.nestedInstallerType || item.installerType,
+                });
+              }
               item.detectionRules = detectionRules;
               item.psadtConfig = applyApplicationPackagingAdapter(
                 item.wingetId,
-                { ...requestedPsadtConfig, detectionRules }
+                { ...effectivePsadtConfig, detectionRules }
               );
             }
             const jobId = crypto.randomUUID();

--- a/lib/__tests__/registry-marker.test.ts
+++ b/lib/__tests__/registry-marker.test.ts
@@ -1,10 +1,58 @@
 import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_REGISTRY_MARKER_PATH,
+  inferSavedCustomMarkerPath,
   normalizeMarkerPath,
   reconcileManagedMarkerDetectionRules,
   rewriteMarkerKeyPath,
 } from '../registry-marker';
+
+describe('inferSavedCustomMarkerPath', () => {
+  const saved8x8Rule = {
+    type: 'registry' as const,
+    keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\HBX\\InstalledApps\\8x8_Work',
+    valueName: 'Version',
+    check32BitOn64System: false,
+    detectionType: 'version' as const,
+    operator: 'greaterThanOrEqual' as const,
+    detectionValue: '8.36.2',
+  };
+
+  it('recovers the exact custom root from a saved managed marker rule', () => {
+    expect(inferSavedCustomMarkerPath({
+      detectionRules: [saved8x8Rule],
+      wingetId: '8x8.Work',
+      version: '8.36.2',
+      installScope: 'machine',
+    })).toBe('SOFTWARE\\HBX\\InstalledApps');
+  });
+
+  it.each([
+    { detectionRules: [saved8x8Rule, saved8x8Rule], version: '8.36.2', scope: 'machine' },
+    { detectionRules: [{ ...saved8x8Rule, detectionValue: '8.35.0' }], version: '8.36.2', scope: 'machine' },
+    { detectionRules: [{ ...saved8x8Rule, keyPath: saved8x8Rule.keyPath.replace('HKEY_LOCAL_MACHINE', 'HKEY_CURRENT_USER') }], version: '8.36.2', scope: 'machine' },
+    { detectionRules: [{ ...saved8x8Rule, keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\8x8_Work' }], version: '8.36.2', scope: 'machine' },
+  ])('refuses ambiguous or non-marker-shaped saved rules', ({ detectionRules, version, scope }) => {
+    expect(inferSavedCustomMarkerPath({
+      detectionRules,
+      wingetId: '8x8.Work',
+      version,
+      installScope: scope,
+    })).toBeNull();
+  });
+
+  it('does not materialize an explicit config value for the default marker root', () => {
+    expect(inferSavedCustomMarkerPath({
+      detectionRules: [{
+        ...saved8x8Rule,
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\8x8_Work',
+      }],
+      wingetId: '8x8.Work',
+      version: '8.36.2',
+      installScope: 'machine',
+    })).toBeNull();
+  });
+});
 
 describe('normalizeMarkerPath', () => {
   it('should return the default for undefined input', () => {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -271,6 +271,39 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('restores a saved custom marker root before hashing the deployment profile', () => {
+    const savedRule = {
+      type: 'registry',
+      keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\HBX\\InstalledApps\\8x8_Work',
+      valueName: 'Version',
+      check32BitOn64System: false,
+      detectionType: 'version',
+      operator: 'greaterThanOrEqual',
+      detectionValue: '8.36.2',
+    };
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: '8x8.Work',
+      displayName: '8x8.Work',
+      publisher: 'IntuneGet QA',
+      version: '8.36.2',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'wix',
+      silentSwitches: '/qn /norestart',
+      uninstallCommand: 'msiexec /x "{A92AC549-F4B9-4875-B02C-F51FA50A0F19}" /qn /norestart',
+      installScope: 'machine',
+      detectionRules: JSON.stringify([savedRule]),
+      psadtConfig: JSON.stringify({ detectionRules: [savedRule] }),
+    });
+    const psadtConfig = JSON.parse(normalized.psadtConfigJson);
+
+    expect(psadtConfig.registryMarkerPath).toBe('SOFTWARE\\HBX\\InstalledApps');
+    expect(psadtConfig.detectionRules).toEqual(normalized.detectionRules);
+    expect(normalized.detectionRules).toEqual([savedRule]);
+    expect((normalized.identity.profile.psadtConfig as { registryMarkerPath?: string })
+      .registryMarkerPath).toBe('SOFTWARE\\HBX\\InstalledApps');
+  });
+
   it('repairs generated detection when a saved catalog profile changed from MSIX to MSI', () => {
     const staleMsixRule = {
       type: 'script',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { normalizeCatalogDetectionRules } from '@/lib/catalog-detection';
 import { assertPackagingContract } from '@/lib/packaging-contract';
+import { inferSavedCustomMarkerPath } from '@/lib/registry-marker';
 import type { DetectionRule } from '@/types/intune';
 import { DEFAULT_PSADT_CONFIG, type PSADTConfig } from '@/types/psadt';
 import {
@@ -878,7 +879,7 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     input.wingetId,
     input.installScope || 'machine'
   );
-  const detectionRules = normalizeCatalogDetectionRules({
+  let detectionRules = normalizeCatalogDetectionRules({
     detectionRules: parsedDetectionRules,
     fallbackDetectionRules: rawConfig.detectionRules,
     wingetId: input.wingetId,
@@ -887,9 +888,30 @@ export function normalizeQaWorkflowPackageInput(input: QaWorkflowPackageInput): 
     markerPath: preliminaryConfig.registryMarkerPath,
     installerType: input.nestedInstallerType || input.installerType,
   });
+  const inferredMarkerPath = preliminaryConfig.registryMarkerPath
+    ? null
+    : inferSavedCustomMarkerPath({
+        detectionRules,
+        wingetId: input.wingetId,
+        version: input.version,
+        installScope,
+      });
+  const effectiveRawConfig = inferredMarkerPath
+    ? { ...rawConfig, registryMarkerPath: inferredMarkerPath }
+    : rawConfig;
+  if (inferredMarkerPath) {
+    detectionRules = normalizeCatalogDetectionRules({
+      detectionRules,
+      wingetId: input.wingetId,
+      version: input.version,
+      installScope,
+      markerPath: inferredMarkerPath,
+      installerType: input.nestedInstallerType || input.installerType,
+    });
+  }
   const psadtConfig = applyApplicationPackagingAdapter(
     input.wingetId,
-    normalizeQaPsadtConfig(rawConfig, detectionRules)
+    normalizeQaPsadtConfig(effectiveRawConfig, detectionRules)
   );
   const uninstallCommand = resolveApplicationUninstallCommand(
     input.wingetId,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1336,6 +1336,32 @@ describe.skipIf(!canRunWindowsPowerShellPackager)(
 );
 
 describe('PSADT registry uninstall identity contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'writes and removes the exact saved custom marker root used by customer detection',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        '8x8 Work',
+        [],
+        { registryMarkerPath: 'SOFTWARE\\HBX\\InstalledApps' },
+        [],
+        '8x8.Work',
+        '8x8 Work',
+        '8.36.2',
+        'REGISTRY_UNINSTALL:8x8 Work',
+        '/S'
+      );
+
+      expect(generated).toContain(
+        "$regPath = 'HKLM\\SOFTWARE\\HBX\\InstalledApps\\8x8_Work'"
+      );
+      expect(generated).toContain(
+        "$regPathHKLM = 'HKLM\\SOFTWARE\\HBX\\InstalledApps\\8x8_Work'"
+      );
+    },
+    30_000
+  );
+
   it('parses and persists a manifest product code for multi-entry installers', () => {
     expect(packager).toContain(
       "^REGISTRY_UNINSTALL_PRODUCT:(\\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\\}):(.+)$"

--- a/lib/registry-marker.ts
+++ b/lib/registry-marker.ts
@@ -23,6 +23,79 @@ export function sanitizeWingetIdForRegistry(wingetId: string): string {
 }
 
 /**
+ * Recover the custom marker root from an older saved catalog profile that
+ * retained its generated detection rule but lost psadtConfig.registryMarkerPath.
+ *
+ * Inference is intentionally narrow: the profile must contain exactly one
+ * registry rule, and every field must match the marker rule IntuneGet would
+ * generate for this app, version, and scope. The root must live below
+ * SOFTWARE and must differ from the default. Customer-authored rules, mixed
+ * rule sets, stale versions, and uninstall-key rules are left untouched.
+ */
+export function inferSavedCustomMarkerPath({
+  detectionRules,
+  wingetId,
+  version,
+  installScope,
+}: {
+  detectionRules: DetectionRule[];
+  wingetId: string;
+  version: string;
+  installScope?: string;
+}): string | null {
+  if (detectionRules.length !== 1) return null;
+
+  const [rule] = detectionRules;
+  if (
+    rule.type !== 'registry' ||
+    typeof rule.keyPath !== 'string' ||
+    rule.valueName?.toUpperCase() !== 'VERSION' ||
+    rule.check32BitOn64System !== false ||
+    rule.detectionValue !== version
+  ) {
+    return null;
+  }
+
+  const versionParts = /^\d+(?:\.\d+){1,3}$/.test(version) ? version.split('.') : [];
+  const useVersionComparison =
+    versionParts.length >= 2 &&
+    versionParts.length <= 4 &&
+    versionParts.every((part) => Number(part) <= 2_147_483_647);
+  if (
+    rule.detectionType !== (useVersionComparison ? 'version' : 'string') ||
+    rule.operator !== (useVersionComparison ? 'greaterThanOrEqual' : 'equal')
+  ) {
+    return null;
+  }
+
+  const match = /^(HKEY_LOCAL_MACHINE|HKEY_CURRENT_USER)\\(.+)$/i.exec(rule.keyPath);
+  const expectedHive = installScope?.toLowerCase() === 'user'
+    ? 'HKEY_CURRENT_USER'
+    : 'HKEY_LOCAL_MACHINE';
+  if (!match || match[1].toUpperCase() !== expectedHive) return null;
+
+  const segments = match[2].split('\\');
+  const sanitizedWingetId = sanitizeWingetIdForRegistry(wingetId);
+  if (segments.length < 3 || segments.at(-1)?.toUpperCase() !== sanitizedWingetId.toUpperCase()) {
+    return null;
+  }
+
+  const markerPath = normalizeMarkerPath(segments.slice(0, -1).join('\\'));
+  const markerPathUpper = markerPath.toUpperCase();
+  if (
+    !markerPathUpper.startsWith('SOFTWARE\\') ||
+    markerPathUpper === DEFAULT_REGISTRY_MARKER_PATH.toUpperCase() ||
+    /^SOFTWARE\\(?:WOW6432NODE\\)?MICROSOFT\\WINDOWS\\CURRENTVERSION\\UNINSTALL(?:\\|$)/.test(
+      markerPathUpper
+    )
+  ) {
+    return null;
+  }
+
+  return markerPath;
+}
+
+/**
  * Normalize a user-supplied registry marker path into a safe subpath under
  * the hive (e.g. 'SOFTWARE\\Contoso\\Apps').
  *


### PR DESCRIPTION
Restores a missing custom registryMarkerPath only when a saved deployment profile contains one exact IntuneGet-shaped Version marker rule. This keeps QA and customer package generation aligned and fixes the 8x8.Work detection failure without changing arbitrary customer-authored rules. Verification: 226 focused tests passed, generated PowerShell parsed, focused ESLint passed, and the production Next.js build completed.