### PR TITLE
Fix Speek lifecycle without ARP registration

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -646,6 +646,42 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('applies the reviewed Speek non-ARP lifecycle to QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Speek.Speek',
+          displayName: 'Speek',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedAdapter = {
+      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 2,
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedAdapter,
+    });
+  });
+
   it('repairs empty catalog detection rules for both QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -187,6 +187,17 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('models Speek as the reviewed non-ARP Program Files payload', () => {
+    expect(
+      applyApplicationPackagingAdapter('Speek.Speek', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 2,
+    });
+  });
+
   it('keeps the darktable NSIS extraction observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter('darktable.darktable', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -174,6 +174,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
   },
   {
+    // Speek 1.7.0's reviewed NSIS source installs the complete application to
+    // `$PROGRAMFILES\Speek`, writes Speek.exe plus uninstall.exe there, and
+    // never creates an Add/Remove Programs entry. NSIS resolves $PROGRAMFILES
+    // to Program Files (x86) on 64-bit Windows unless the script explicitly
+    // selects the 64-bit view, which Speek does not. Verify and own only that
+    // dedicated vendor directory instead of waiting for an ARP identity that
+    // the package intentionally omits. Direct managed-directory removal also
+    // avoids relying on the vendor uninstaller's incomplete cleanup section.
+    wingetId: 'Speek.Speek',
+    reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+    reviewedManagedInstallEvidenceFile: '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 2,
+  },
+  {
     // darktable's official CPack/NSIS installer writes its ARP registration
     // only after the complete application tree has been extracted. The signed
     // 5.6.0 package can therefore remain quiet longer than the generic QA

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -687,6 +687,35 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds the Speek non-ARP directory lifecycle to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Speek.Speek',
+      displayName: 'Speek',
+      publisher: 'Speek App',
+      version: '1.7.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Speek',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 2,
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+  });
+
   it('binds the Visual Studio 2022 Build Tools x86 instance root to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2022.BuildTools',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -766,6 +766,55 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies and removes Speek from its reviewed non-ARP directory',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        'Speek',
+        [],
+        {
+          reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+          reviewedManagedInstallEvidenceFile:
+            '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+          reviewedManagedInstallCompletionTimeoutMinutes: 2,
+        },
+        [],
+        'Speek.Speek',
+        'Speek',
+        '1.7.0',
+        'REGISTRY_UNINSTALL:Speek',
+        '/S',
+        'machine'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Speek')"
+      );
+      expect(installFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Speek\\Speek.exe')"
+      );
+      expect(installFunction).toContain(
+        'Verified stable managed installation evidence'
+      );
+      expect(installFunction).not.toContain('Captured vendor uninstall entry');
+      expect(uninstallFunction).toContain(
+        'Remove-Item -LiteralPath $managedInstallDirectory'
+      );
+      expect(uninstallFunction).not.toContain(
+        'Waiting for vendor uninstall registration'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects a reviewed user Desktop directory for a machine-scope package',
     () => {
       expect(() =>


### PR DESCRIPTION
Models Speek.Speek as its reviewed non-ARP NSIS payload, verifies the exact Program Files (x86) Speek.exe evidence, and removes only the dedicated Speek directory for both QA and customer packages. Evidence: failed QA run 32414327876 and vendor v1.7.0-release NSIS source. Verification: 241 focused tests passed, focused ESLint passed, and npm run build:ci passed.