### PR TITLE
Fix reviewed MathType and Azure Monitor uninstall lifecycles

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -322,6 +322,38 @@ $reviewedUninstallArgumentsLiteral = @(
     $reviewedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
 
+$reviewedUninstallServiceNames = @()
+if ($psadtConfig.Contains('reviewedUninstallServiceNames') -and
+    $null -ne $psadtConfig['reviewedUninstallServiceNames']) {
+    $rawReviewedServiceNames = $psadtConfig['reviewedUninstallServiceNames']
+    if ($rawReviewedServiceNames -is [string] -or
+        $rawReviewedServiceNames -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedUninstallServiceNames must be an array.'
+    }
+
+    $seenReviewedServiceNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($rawReviewedServiceName in @($rawReviewedServiceNames)) {
+        if ($rawReviewedServiceName -isnot [string]) {
+            throw 'Every PSADT reviewed uninstall service name must be a string.'
+        }
+        $reviewedServiceName = $rawReviewedServiceName.Trim()
+        if ($reviewedServiceName -notmatch '^[A-Za-z0-9_.-]{1,128}$') {
+            throw 'Every PSADT reviewed uninstall service name must be a safe service-name literal.'
+        }
+        if ($seenReviewedServiceNames.Add($reviewedServiceName)) {
+            $reviewedUninstallServiceNames += $reviewedServiceName
+        }
+    }
+    if ($reviewedUninstallServiceNames.Count -gt 10) {
+        throw 'PSADT reviewedUninstallServiceNames must contain at most 10 entries.'
+    }
+}
+$reviewedUninstallServiceNamesLiteral = @(
+    $reviewedUninstallServiceNames | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
+) -join ', '
+
 $reviewedUninstallProcessGuardConfigured = $false
 $reviewedUninstallProcessGuardName = ''
 $reviewedUninstallProcessGuardPattern = ''
@@ -2901,6 +2933,21 @@ if ($uninstallWelcomeCall) {
 # Add pre-uninstall prompts
 if ($preUninstallPromptCalls) {
     $lines += $preUninstallPromptCalls
+}
+
+if ($reviewedUninstallServiceNames.Count -gt 0) {
+    $lines += @(
+        ''
+        '    ## Stop vendor services required by the reviewed uninstall contract'
+        "    foreach (`$reviewedServiceName in @($reviewedUninstallServiceNamesLiteral)) {"
+        '        $reviewedService = Get-Service -Name $reviewedServiceName -ErrorAction SilentlyContinue'
+        '        if ($null -ne $reviewedService -and $reviewedService.Status -ne ''Stopped'') {'
+        '            Write-ADTLogEntry -Message "Stopping reviewed vendor service [$reviewedServiceName] before uninstall." -Source ''Uninstall-ADTDeployment'''
+        '            Stop-Service -Name $reviewedServiceName -Force -ErrorAction Stop'
+        '            $reviewedService.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped, [TimeSpan]::FromSeconds(30))'
+        '        }'
+        '    }'
+    )
 }
 
 # Generate uninstall command. A reviewed shared-runtime adapter takes

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -295,6 +295,20 @@ describe('application packaging adapters', () => {
       ],
     });
     expect(
+      applyApplicationPackagingAdapter('Wiris.MathType.7', DEFAULT_PSADT_CONFIG)
+        .reviewedExactUninstall
+    ).toEqual({
+      executablePath: '%ProgramFiles(x86)%\\MathType\\Setup.exe',
+      arguments: ['-Q', '-R'],
+      completionTimeoutMinutes: 5,
+    });
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.AzureMonitorAgent',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallServiceNames
+    ).toEqual(['AzureMonitorAgent']);
+    expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedExactUninstall: {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -19,6 +19,7 @@ interface ApplicationPackagingAdapter {
     argumentsPattern: string;
     graceSeconds: number;
   }>;
+  reviewedUninstallServiceNames?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedManagedInstallDirectory?: string;
@@ -348,6 +349,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // Wiris documents MathType 7's unattended removal command as Setup.exe
+    // with -Q -R, in that order. The registered command contains only -R, and
+    // the generic Nullsoft /S fallback leaves the exact DSMT7 registration
+    // installed. Bind the official Program Files (x86) command to QA and
+    // customer packages while retaining DSMT7 as authoritative evidence.
+    wingetId: 'Wiris.MathType.7',
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles(x86)%\\MathType\\Setup.exe',
+      arguments: ['-Q', '-R'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.
@@ -376,6 +390,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredProcessesToClose: [
       { name: 'Bria', description: 'Bria' },
     ],
+  },
+  {
+    // Microsoft's Azure Monitor Agent client guidance says to stop the agent
+    // service before retrying an uninstall that cannot stop it. The signed MSI
+    // otherwise returns 1601 and leaves its exact product registration behind.
+    wingetId: 'Microsoft.AzureMonitorAgent',
+    reviewedUninstallServiceNames: ['AzureMonitorAgent'],
   },
   {
     // Link Controller remains active in the notification area after its UI is
@@ -1085,6 +1106,7 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedRegistryInstallEvidence &&
       !config.reviewedUninstallProcessGuard &&
+      !config.reviewedUninstallServiceNames &&
       !config.reviewedManagedInstallDirectory &&
       !config.reviewedManagedInstallEvidenceFile &&
       !config.reviewedManagedInstallCompletionProcess &&
@@ -1102,6 +1124,7 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedRegistryInstallEvidence: undefined,
       reviewedUninstallProcessGuard: undefined,
+      reviewedUninstallServiceNames: undefined,
       reviewedManagedInstallDirectory: undefined,
       reviewedManagedInstallEvidenceFile: undefined,
       reviewedManagedInstallCompletionProcess: undefined,
@@ -1187,6 +1210,9 @@ export function applyApplicationPackagingAdapter(
     reviewedUninstallArguments,
     reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard
       ? { ...adapter.reviewedUninstallProcessGuard }
+      : undefined,
+    reviewedUninstallServiceNames: adapter.reviewedUninstallServiceNames
+      ? [...adapter.reviewedUninstallServiceNames]
       : undefined,
     ...(adapter.uninstallCompletionTimeoutMinutes
       ? { uninstallCompletionTimeoutMinutes: adapter.uninstallCompletionTimeoutMinutes }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -464,6 +464,53 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds reviewed Wiris and Azure Monitor removal contracts to QA profiles', () => {
+    const mathType = normalizeQaWorkflowPackageInput({
+      wingetId: 'Wiris.MathType.7',
+      displayName: 'MathType 7',
+      publisher: 'Wiris',
+      version: '7.12.2',
+      architecture: 'x86',
+      installerSha256: 'f'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '-Q',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:DSMT7:MathType 7',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const azureMonitor = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.AzureMonitorAgent',
+      displayName: 'Azure Monitor Agent',
+      publisher: 'Microsoft',
+      version: '1.44.0.0',
+      architecture: 'x64',
+      installerSha256: 'a'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand:
+        'msiexec /x "{C4F6939C-A3A2-4556-AEB6-889F720A8AB8}" /qn /norestart',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+
+    expect(
+      (mathType.identity.profile as {
+        psadtConfig: { reviewedExactUninstall?: unknown };
+      }).psadtConfig.reviewedExactUninstall
+    ).toEqual({
+      executablePath: '%ProgramFiles(x86)%\\MathType\\Setup.exe',
+      arguments: ['-Q', '-R'],
+      completionTimeoutMinutes: 5,
+    });
+    expect(
+      (azureMonitor.identity.profile as {
+        psadtConfig: { reviewedUninstallServiceNames?: string[] };
+      }).psadtConfig.reviewedUninstallServiceNames
+    ).toEqual(['AzureMonitorAgent']);
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -761,6 +761,7 @@ export function normalizeQaPsadtConfig(
     reviewedInstallArguments: value?.reviewedInstallArguments || [],
     reviewedInstallArgumentsOverride: value?.reviewedInstallArgumentsOverride,
     reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
+    reviewedUninstallServiceNames: value?.reviewedUninstallServiceNames,
   };
 }
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2126,6 +2126,68 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses Wiris MathType official silent removal instead of the generic Nullsoft fallback',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        'MathType 7',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath: '%ProgramFiles(x86)%\\MathType\\Setup.exe',
+            arguments: ['-Q', '-R'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Wiris.MathType.7',
+        'MathType 7',
+        '7.12.2',
+        'REGISTRY_UNINSTALL_KEY:DSMT7:MathType 7',
+        '-Q'
+      );
+
+      expect(generated).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\MathType\\Setup.exe')"
+      );
+      expect(generated).toContain("$registeredUninstallArguments = @('-Q', '-R')");
+      expect(generated).not.toContain("$registeredUninstallArguments = @('-R', '/S')");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'stops the reviewed Azure Monitor Agent service before MSI removal',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Azure Monitor Agent',
+        [],
+        { reviewedUninstallServiceNames: ['AzureMonitorAgent'] },
+        [],
+        'Microsoft.AzureMonitorAgent',
+        'Azure Monitor Agent',
+        '1.44.0.0',
+        'REGISTRY_UNINSTALL:Azure Monitor Agent',
+        '/qn /norestart ALLUSERS=1'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "foreach ($reviewedServiceName in @('AzureMonitorAgent'))"
+      );
+      expect(uninstallFunction).toContain(
+        'Stop-Service -Name $reviewedServiceName -Force -ErrorAction Stop'
+      );
+      expect(uninstallFunction.indexOf('Stop-Service')).toBeLessThan(
+        uninstallFunction.indexOf('Executing MSI uninstall')
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'emits one valid force-countdown parameter set and never combines it with Silent',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -498,6 +498,7 @@ function Uninstall-ADTDeployment
     [CmdletBinding()]
     param ()
 ${processLifecycle.uninstallBlock}
+${this.getReviewedUninstallServiceStopBlock(job)}
 
     ## Uninstall the application
     ${this.getUninstallCommand(job, installerFileName)}
@@ -894,6 +895,49 @@ catch
       }
     }
     return result;
+  }
+
+  /**
+   * Stop only exact, adapter-reviewed Windows services before vendor removal.
+   * This remains declarative and bounded so it cannot become a free-form
+   * customer command surface.
+   */
+  private getReviewedUninstallServiceStopBlock(job: PackagingJob): string {
+    const raw = this.getPsadtConfig(job)?.reviewedUninstallServiceNames;
+    if (raw === undefined || raw === null) return '';
+    if (!Array.isArray(raw) || raw.length > 10) {
+      throw new Error('PSADT reviewedUninstallServiceNames must be an array of at most 10 entries');
+    }
+
+    const serviceNames: string[] = [];
+    const seen = new Set<string>();
+    for (const value of raw) {
+      if (typeof value !== 'string') {
+        throw new Error('Each reviewed uninstall service name must be a string');
+      }
+      const serviceName = value.trim();
+      if (!/^[A-Za-z0-9_.-]{1,128}$/.test(serviceName)) {
+        throw new Error('Each reviewed uninstall service name must be a safe service-name literal');
+      }
+      const key = serviceName.toLowerCase();
+      if (!seen.has(key)) {
+        serviceNames.push(serviceName);
+        seen.add(key);
+      }
+    }
+
+    if (serviceNames.length === 0) return '';
+    const literals = serviceNames.map((name) => `'${name.replace(/'/g, "''")}'`).join(', ');
+    return `
+    ## Stop vendor services required by the reviewed uninstall contract
+    foreach ($reviewedServiceName in @(${literals})) {
+        $reviewedService = Get-Service -Name $reviewedServiceName -ErrorAction SilentlyContinue
+        if ($null -ne $reviewedService -and $reviewedService.Status -ne 'Stopped') {
+            Write-ADTLogEntry -Message "Stopping reviewed vendor service [$reviewedServiceName] before uninstall." -Source 'Uninstall-ADTDeployment'
+            Stop-Service -Name $reviewedServiceName -Force -ErrorAction Stop
+            $reviewedService.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped, [TimeSpan]::FromSeconds(30))
+        }
+    }`;
   }
 
   /**

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -234,6 +234,11 @@ export interface PSADTConfig {
     graceSeconds: number;
   };
 
+  // Internal list of exact Windows service names that a reviewed vendor
+  // requires to be stopped before removal. Application adapters are the only
+  // trusted source; the packager validates every literal before emitting it.
+  reviewedUninstallServiceNames?: string[];
+
   // Internal completion window for vendor uninstallers that hand work to a
   // child process. Application adapters may extend the five-minute default;
   // the exact registry identity remains the authoritative completion signal.
@@ -370,6 +375,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   reviewedInstallShieldAdministrativeImage: undefined,
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,
+  reviewedUninstallServiceNames: undefined,
 };
 
 /**


### PR DESCRIPTION
## Summary
- use Wiris MathType 7's official exact unattended removal command: -Q -R`n- add an adapter-only, validated pre-uninstall Windows service contract
- stop the Azure Monitor Agent service before its MSI removal, per Microsoft guidance
- cover application adapters, QA profile identity, generated customer/QA PowerShell, and parser validation

## Verification
- 271 focused tests passed
- npm run lint
- npm run build:ci