### PR TITLE
Fix Logi Bolt silent uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -309,6 +309,14 @@ describe('application packaging adapters', () => {
       ).reviewedUninstallServiceNames
     ).toEqual(['AzureMonitorAgent']);
     expect(
+      applyApplicationPackagingAdapter('Logitech.LogiBolt', DEFAULT_PSADT_CONFIG)
+        .reviewedExactUninstall
+    ).toEqual({
+      executablePath: '%ProgramFiles%\\Logi\\LogiBolt\\LogiBoltUninstaller.exe',
+      arguments: ['/silent'],
+      completionTimeoutMinutes: 5,
+    });
+    expect(
       applyApplicationPackagingAdapter('Dell.Optimizer', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       reviewedExactUninstall: {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -399,6 +399,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallServiceNames: ['AzureMonitorAgent'],
   },
   {
+    // Logi Bolt's dedicated uninstaller is not a conventional NSIS helper:
+    // the generic /S fallback returns while leaving the exact LogiBolt ARP
+    // registration installed. Its unattended removal verb is /silent. Bind
+    // that switch to the exact machine-wide helper captured by QA so hidden
+    // SYSTEM sessions never wait behind Logitech's confirmation dialog.
+    wingetId: 'Logitech.LogiBolt',
+    reviewedExactUninstall: {
+      executablePath: '%ProgramFiles%\\Logi\\LogiBolt\\LogiBoltUninstaller.exe',
+      arguments: ['/silent'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // Link Controller remains active in the notification area after its UI is
     // closed, and its optional camera helper can hold the Inno installation
     // directory open. The silent uninstaller then exits without removing the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -511,6 +511,33 @@ describe('PSADT QA package identity', () => {
     ).toEqual(['AzureMonitorAgent']);
   });
 
+  it('binds Logi Bolt to its exact /silent uninstaller', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Logitech.LogiBolt',
+      displayName: 'Logi Bolt',
+      publisher: 'Logitech',
+      version: '1.2.6024.0',
+      architecture: 'x64',
+      installerSha256: '6'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:LogiBolt:Logi Bolt',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+
+    expect(
+      (normalized.identity.profile as {
+        psadtConfig: { reviewedExactUninstall?: unknown };
+      }).psadtConfig.reviewedExactUninstall
+    ).toEqual({
+      executablePath: '%ProgramFiles%\\Logi\\LogiBolt\\LogiBoltUninstaller.exe',
+      arguments: ['/silent'],
+      completionTimeoutMinutes: 5,
+    });
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2156,6 +2156,36 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses Logi Bolt /silent instead of the generic Nullsoft /S fallback',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        'Logi Bolt',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath: '%ProgramFiles%\\Logi\\LogiBolt\\LogiBoltUninstaller.exe',
+            arguments: ['/silent'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Logitech.LogiBolt',
+        'Logi Bolt',
+        '1.2.6024.0',
+        'REGISTRY_UNINSTALL_KEY:LogiBolt:Logi Bolt',
+        '/silent'
+      );
+
+      expect(generated).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\Logi\\LogiBolt\\LogiBoltUninstaller.exe')"
+      );
+      expect(generated).toContain("$registeredUninstallArguments = @('/silent')");
+      expect(generated).not.toContain("$registeredUninstallArguments = @('/S')");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'stops the reviewed Azure Monitor Agent service before MSI removal',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- bind Logitech.LogiBolt to its exact machine-wide uninstaller
- use the vendor helper's /silent contract instead of the generic Nullsoft /S fallback
- add adapter, QA profile, and generated PowerShell regression coverage

## Verification
- 216 focused tests passed
- npm run lint -- --quiet
- npm run build:ci