### PR TITLE
Fix BlueJ per-user MSI installation

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -667,6 +667,19 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses BlueJ\'s documented explicit per-user MSI contract', () => {
+    expect(resolveApplicationInstallScope('BlueJTeam.BlueJ', 'machine')).toBe('user');
+    const adapted = applyApplicationPackagingAdapter(
+      'BlueJTeam.BlueJ',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/qn /norestart ALLUSERS=0'
+    );
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('uses PTC Creo View Express documented MSI-forwarding syntax', () => {
     const adapted = applyApplicationPackagingAdapter(
       'PTC.CreoView.Express',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -222,6 +222,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
+    // BlueJ's WiX source deliberately defaults to WixPerUserFolder so a
+    // limited-rights user can install it. Its official silent-install example
+    // uses ALLUSERS=0, while the WinGet manifest currently supplies
+    // ALLUSERS=2; that automatic-context value makes the 6.0.0 MSI attempt a
+    // Program Files install and roll back with 1603 in the user-scoped Intune
+    // execution. Replace the full command with the vendor's explicit per-user
+    // contract for both QA and customer packages.
+    wingetId: 'BlueJTeam.BlueJ',
+    requiredInstallScope: 'user',
+    reviewedInstallArgumentsOverride: '/qn /norestart ALLUSERS=0',
+  },
+  {
     // PDFsam documents this exact MSI command for managed Windows deployment.
     // WinGet currently publishes /quiet with only SKIPTHANKSPAGE, which can
     // leave the WiX install inactive under non-interactive LocalSystem. Keep

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -538,6 +538,34 @@ describe('PSADT QA package identity', () => {
     });
   });
 
+  it('binds BlueJ to the documented explicit per-user MSI contract', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'BlueJTeam.BlueJ',
+      displayName: 'BlueJ',
+      publisher: 'BlueJTeam',
+      version: '6.0.0',
+      architecture: 'x64',
+      installerSha256: '4'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart ALLUSERS=2',
+      uninstallCommand:
+        'msiexec /x "{BAF3564F-5DE4-48AC-8CC4-260BFFD56D30}" /qn /norestart',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=2');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/qn /norestart ALLUSERS=0'
+    );
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -35,7 +35,7 @@ const canRunWindowsPowerShellPackager =
   ]).status === 0;
 
 function generateRegistryUninstallPackage(
-  installerType: 'exe' | 'inno' | 'burn' | 'nullsoft',
+  installerType: 'exe' | 'inno' | 'burn' | 'nullsoft' | 'msi',
   displayName = 'Contract Test App',
   installerSuccessCodes: number[] = [],
   psadtConfig: unknown = {},
@@ -1129,6 +1129,31 @@ describe('PSADT vendor argument contract', () => {
       expect(generated).not.toContain(
         "-ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'"
       );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'replaces BlueJ automatic context with its explicit per-user MSI property',
+    () => {
+      const productCode = '{BAF3564F-5DE4-48AC-8CC4-260BFFD56D30}';
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'BlueJ',
+        [],
+        { reviewedInstallArgumentsOverride: '/qn /norestart ALLUSERS=0' },
+        [],
+        'BlueJTeam.BlueJ',
+        'BlueJ',
+        '6.0.0',
+        `msiexec /x "${productCode}" /qn /norestart`,
+        '/qn /norestart ALLUSERS=2',
+        'user'
+      );
+
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=0'"
+      );
+      expect(generated).not.toContain("AdditionalArgumentList '/norestart ALLUSERS=2'");
     }
   );
 


### PR DESCRIPTION
BlueJ 6.0.0 is authored as a dual-context WiX MSI that defaults to per-user installation. Its current WinGet custom switch ALLUSERS=2 rolls back with exit 1603 in the user-scoped Intune lifecycle. This adds an app-scoped adapter using the vendor-documented explicit ALLUSERS=0 contract while preserving user scope. Validation: 219 focused tests, lint, production build, and generated PowerShell parsing all pass.