### PR TITLE
Install BlueJ in the user profile

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -675,7 +675,7 @@ describe('application packaging adapters', () => {
     );
 
     expect(adapted.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=0'
+      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
     );
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -222,16 +222,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
-    // BlueJ's WiX source deliberately defaults to WixPerUserFolder so a
-    // limited-rights user can install it. Its official silent-install example
-    // uses ALLUSERS=0, while the WinGet manifest currently supplies
-    // ALLUSERS=2; that automatic-context value makes the 6.0.0 MSI attempt a
-    // Program Files install and roll back with 1603 in the user-scoped Intune
-    // execution. Replace the full command with the vendor's explicit per-user
-    // contract for both QA and customer packages.
+    // BlueJ documents ALLUSERS=0 and an explicit INSTALLDIR for unattended
+    // installs. Its 6.0.0 MSI Directory table still roots INSTALLDIR below
+    // ProgramFiles64Folder when the WiX UI sequence is suppressed, so changing
+    // ALLUSERS alone leaves a limited-rights user writing to Program Files and
+    // rolling back with 1603. Pin the per-user directory to LocalAppData for
+    // both QA and customer packages.
     wingetId: 'BlueJTeam.BlueJ',
     requiredInstallScope: 'user',
-    reviewedInstallArgumentsOverride: '/qn /norestart ALLUSERS=0',
+    reviewedInstallArgumentsOverride:
+      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
   },
   {
     // PDFsam documents this exact MSI command for managed Windows deployment.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -562,7 +562,7 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.installScope).toBe('user');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=2');
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=0'
+      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
     );
   });
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1133,14 +1133,17 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'replaces BlueJ automatic context with its explicit per-user MSI property',
+    'replaces BlueJ automatic context and expands its per-user MSI directory',
     () => {
       const productCode = '{BAF3564F-5DE4-48AC-8CC4-260BFFD56D30}';
       const generated = generateRegistryUninstallPackage(
         'msi',
         'BlueJ',
         [],
-        { reviewedInstallArgumentsOverride: '/qn /norestart ALLUSERS=0' },
+        {
+          reviewedInstallArgumentsOverride:
+            '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
+        },
         [],
         'BlueJTeam.BlueJ',
         'BlueJ',
@@ -1151,7 +1154,10 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(generated).toContain(
-        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=0'"
+        "$effectiveMsiProperties = [Environment]::ExpandEnvironmentVariables('/norestart ALLUSERS=0 INSTALLDIR=\"%LOCALAPPDATA%\\Programs\\BlueJ\"')"
+      );
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList $effectiveMsiProperties"
       );
       expect(generated).not.toContain("AdditionalArgumentList '/norestart ALLUSERS=2'");
     }


### PR DESCRIPTION
## Summary
- set BlueJ's documented per-user MSI install directory to LocalAppData
- avoid the MSI's silent-mode Program Files default that rolls back for a limited-rights user
- verify the generated PSADT package expands the environment path before invoking MSI

## Evidence
- fresh QA run 32463571166 executed ALLUSERS=0 but still returned 1603
- the verified 6.0.0 MSI Directory table roots INSTALLDIR at ProgramFiles64Folder
- BlueJ's official silent-install documentation requires an explicit INSTALLDIR when customizing the MSI

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (219 passed)
- npm run lint
- npm run build:ci
- git diff --check