### PR TITLE
Use explicit per-user MSI context for BlueJ

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -675,7 +675,7 @@ describe('application packaging adapters', () => {
     );
 
     expect(adapted.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
+      '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=1 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
     );
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -222,16 +222,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
-    // BlueJ documents ALLUSERS=0 and an explicit INSTALLDIR for unattended
-    // installs. Its 6.0.0 MSI Directory table still roots INSTALLDIR below
-    // ProgramFiles64Folder when the WiX UI sequence is suppressed, so changing
-    // ALLUSERS alone leaves a limited-rights user writing to Program Files and
-    // rolling back with 1603. Pin the per-user directory to LocalAppData for
-    // both QA and customer packages.
+    // BlueJ 6.0.0 is a dual-purpose WiX MSI. Windows Installer 5 requires
+    // ALLUSERS=2 with MSIINSTALLPERUSER=1 to select its per-user registration
+    // context; the older ALLUSERS=0 example leaves this package failing under a
+    // limited-rights account. Its silent UI also leaves INSTALLDIR rooted below
+    // Program Files, so pin that directory to LocalAppData for QA and customers.
     wingetId: 'BlueJTeam.BlueJ',
     requiredInstallScope: 'user',
     reviewedInstallArgumentsOverride:
-      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
+      '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=1 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
   },
   {
     // PDFsam documents this exact MSI command for managed Windows deployment.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -562,7 +562,7 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.installScope).toBe('user');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=2');
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
+      '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=1 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"'
     );
   });
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1142,7 +1142,7 @@ describe('PSADT vendor argument contract', () => {
         [],
         {
           reviewedInstallArgumentsOverride:
-            '/qn /norestart ALLUSERS=0 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
+            '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=1 INSTALLDIR="%LOCALAPPDATA%\\Programs\\BlueJ"',
         },
         [],
         'BlueJTeam.BlueJ',
@@ -1154,12 +1154,13 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(generated).toContain(
-        "$effectiveMsiProperties = [Environment]::ExpandEnvironmentVariables('/norestart ALLUSERS=0 INSTALLDIR=\"%LOCALAPPDATA%\\Programs\\BlueJ\"')"
+        "$effectiveMsiProperties = [Environment]::ExpandEnvironmentVariables('/norestart ALLUSERS=2 MSIINSTALLPERUSER=1 INSTALLDIR=\"%LOCALAPPDATA%\\Programs\\BlueJ\"')"
       );
       expect(generated).toContain(
         "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList $effectiveMsiProperties"
       );
       expect(generated).not.toContain("AdditionalArgumentList '/norestart ALLUSERS=2'");
+      expect(generated).not.toContain('ALLUSERS=0');
     }
   );
 


### PR DESCRIPTION
Summary: select the BlueJ dual-purpose MSI per-user context with ALLUSERS=2 MSIINSTALLPERUSER=1; retain its explicit LocalAppData install directory; cover the generated PSADT command and reject ALLUSERS=0. Evidence: QA run 32466462593 expanded LocalAppData correctly but failed with MSI 1603 under ALLUSERS=0; read-only MSI inspection confirmed dual-purpose metadata. Verification: 219 focused tests, lint, build:ci, and diff check passed.