### PR TITLE
Block host-dependent ReSharper EAP packaging

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -828,3 +828,25 @@ describe('darktable managed install block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed')");
   });
 });
+
+describe('ReSharper EAP host-dependent install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260821104500_block_resharper_eap_host_dependent_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the Visual Studio-dependent lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'JetBrains.ReSharper.EAP'");
+    expect(sql).toContain(
+      'https://www.jetbrains.com/help/resharper/Installation_Guide.html'
+    );
+    expect(sql).toContain('32472961245');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});

--- a/supabase/migrations/20260821104500_block_resharper_eap_host_dependent_install.sql
+++ b/supabase/migrations/20260821104500_block_resharper_eap_host_dependent_install.sql
@@ -1,0 +1,39 @@
+-- ReSharper EAP 2021.2 EAP 8 is a Visual Studio extension rather than a
+-- standalone application. Its WinGet command explicitly targets Visual Studio
+-- 2019 (/VsVersion=16.0). Isolated LocalSystem QA run 32472961245 invoked the
+-- vendor-documented silent command exactly, but the clean VM has no qualifying
+-- Visual Studio host: the installer returned -1, created no ReSharper product
+-- registration, and left no deterministic uninstall identity. JetBrains also
+-- documents that ReSharper installs into selected Visual Studio versions.
+-- Automated packaging cannot install or attest that external IDE prerequisite,
+-- so block this package instead of publishing a false standalone lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'JetBrains.ReSharper.EAP',
+  'unsupported_managed_install',
+  'ReSharper EAP is a host-dependent Visual Studio extension. Its exact vendor-documented silent command targets Visual Studio 2019, but isolated LocalSystem QA without that external IDE host returned -1 and produced no deterministic managed application identity.',
+  'https://www.jetbrains.com/help/resharper/Installation_Guide.html'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'JetBrains.ReSharper.EAP';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'JetBrains.ReSharper.EAP'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
ReSharper EAP is a Visual Studio extension whose manifest command targets VS 2019. Run 32472961245 used JetBrains' documented silent arguments exactly, but the clean LocalSystem VM has no qualifying IDE host; the installer returned -1 and created no deterministic product identity. This adds a shared eligibility block for customer packaging and QA instead of claiming a standalone lifecycle. Verification: 103 focused tests, lint, build:ci, and diff check passed.