### PR TITLE
Fix Autodesk Design Review ODIS lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -422,6 +422,35 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
+        'Autodesk.DesignReview',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory:
+        '%ProgramW6432%\\Autodesk\\Autodesk Design Review',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramW6432%\\Autodesk\\Autodesk Design Review\\DesignReview.exe',
+      reviewedManagedInstallCompletionProcess:
+        '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 15,
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+        arguments: [
+          '-i',
+          'uninstall',
+          '--silent',
+          '--trigger_point',
+          'system',
+          '-m',
+          '%ProgramData%\\Autodesk\\ODIS\\metadata\\{C1AF4762-AE0A-3B4E-836B-D4C091BF46F8}\\bundleManifest.xml',
+          '-x',
+          '%ProgramData%\\Autodesk\\ODIS\\metadata\\{C1AF4762-AE0A-3B4E-836B-D4C091BF46F8}\\SetupRes\\manifest.xsd',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Autodesk.NavisworksFreedom.2026',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -656,6 +656,36 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // Design Review is delivered by Autodesk ODIS. Its SFX bootstrapper exits
+    // before ODIS finishes registering the product, so generic ARP capture can
+    // race the background install. Wait for the reviewed product evidence and
+    // ODIS completion, then use the exact manifest lifecycle observed from the
+    // vendor registration and installer URL.
+    wingetId: 'Autodesk.DesignReview',
+    reviewedManagedInstallDirectory:
+      '%ProgramW6432%\\Autodesk\\Autodesk Design Review',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramW6432%\\Autodesk\\Autodesk Design Review\\DesignReview.exe',
+    reviewedManagedInstallCompletionProcess:
+      '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 15,
+    reviewedManagedUninstall: {
+      executablePath: '%ProgramW6432%\\Autodesk\\AdODIS\\V1\\Installer.exe',
+      arguments: [
+        '-i',
+        'uninstall',
+        '--silent',
+        '--trigger_point',
+        'system',
+        '-m',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{C1AF4762-AE0A-3B4E-836B-D4C091BF46F8}\\bundleManifest.xml',
+        '-x',
+        '%ProgramData%\\Autodesk\\ODIS\\metadata\\{C1AF4762-AE0A-3B4E-836B-D4C091BF46F8}\\SetupRes\\manifest.xsd',
+      ],
+      completionTimeoutMinutes: 15,
+    },
+  },
+  {
     // Navisworks Freedom 2026 is installed by Autodesk ODIS. The bootstrapper
     // changes multiple Autodesk registrations, so a generic ARP capture cannot
     // identify the product safely. Autodesk documents the ODIS manifest-based


### PR DESCRIPTION
## Summary
- wait for Autodesk ODIS background installation to finish
- verify the exact Design Review executable
- use the exact manifest-driven ODIS uninstall lifecycle

## Evidence
QA run 32478416170 showed the SFX parent exit 0 before the product registration appeared; install verification raced ODIS and uninstall overlapped the background install.

## Tests
- 151 focused Vitest tests passed
- ESLint passed for the changed files