### PR TITLE
Fix Appium Inspector install scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -128,6 +128,12 @@ describe('application packaging adapters', () => {
       'user'
     );
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
+    expect(
+      resolveApplicationInstallScope(
+        'AppiumDevelopers.AppiumInspector',
+        'machine'
+      )
+    ).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -144,6 +144,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Appium Inspector's own Electron Builder configuration uses assisted NSIS
+    // without enabling perMachine. WinGet currently labels the installer as
+    // machine scope, which installs into LocalSystem's disposable systemprofile
+    // and registers an uninstaller that is unavailable for the later Intune
+    // removal cycle. Run the package in the intended signed-in user context.
+    wingetId: 'AppiumDevelopers.AppiumInspector',
+    requiredInstallScope: 'user',
+  },
+  {
     // UHK Agent is built with Electron Builder's assisted NSIS profile
     // (oneClick: false) without perMachine. Electron Builder defaults that
     // profile to per-user installation. WinGet currently omits Scope, so the


### PR DESCRIPTION
## Summary
- override Appium Inspector to its vendor-configured per-user Electron NSIS scope
- avoid LocalSystem systemprofile registrations whose uninstaller is unavailable during Intune removal

## Evidence
QA run 32482228228 installed and detected successfully, but its HKLM entry pointed to a missing systemprofile uninstaller. Appium's v2026.7.1 electron-builder.json uses assisted NSIS without perMachine.

## Tests
- 219 focused Vitest tests passed
- ESLint passed for changed files