### PR TITLE
Reconcile reviewed Appium installer scope

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -105,6 +105,28 @@ describe('installer dispatch preflight', () => {
     }));
   });
 
+  it('accepts Appium machine-labelled manifest bytes for reviewed user execution', async () => {
+    const appiumRequest = {
+      ...request,
+      wingetId: 'AppiumDevelopers.AppiumInspector',
+      installerUrl: 'https://example.test/appium-inspector.exe',
+      installScope: 'user' as const,
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: appiumRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'exe',
+      scope: 'machine',
+    }]);
+
+    await expect(enforceInstallerPreflight(appiumRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts Logitech Presentation user manifest bytes for reviewed SYSTEM execution', async () => {
     const logitechRequest = {
       ...request,

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -155,6 +155,17 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
   });
 
+  it('keeps Appium Inspector on its machine-labelled manifest bytes while executing per-user', () => {
+    expect(resolveApplicationInstallScope(
+      'AppiumDevelopers.AppiumInspector',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallerSelectionScope(
+      'AppiumDevelopers.AppiumInspector',
+      'user'
+    )).toBe('machine');
+  });
+
   it('runs Logitech Presentation elevated without weakening catalog scope matching', () => {
     expect(resolveApplicationInstallScope('Logitech.Presentation', 'user')).toBe('machine');
     expect(resolveApplicationInstallerSelectionScope(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -151,6 +151,9 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // removal cycle. Run the package in the intended signed-in user context.
     wingetId: 'AppiumDevelopers.AppiumInspector',
     requiredInstallScope: 'user',
+    // Keep selecting and attesting the exact machine-labelled WinGet bytes;
+    // only their execution context is corrected by the reviewed adapter.
+    reviewedInstallerSelectionScope: 'machine',
   },
   {
     // UHK Agent is built with Electron Builder's assisted NSIS profile


### PR DESCRIPTION
## Summary
- keep Appium Inspector on its exact machine-labelled WinGet installer tuple
- execute it in the adapter-reviewed per-user context
- preserve strict opposite-scope rejection for unreviewed apps

## Verification
- 72 focused tests passed