### PR TITLE
Verify Windows App Runtime through exact Appx evidence

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -555,9 +555,58 @@ if ($psadtConfig.Contains('reviewedRegistryInstallEvidence') -and
     $reviewedRegistryInstallEvidenceConfigured = $true
 }
 
+$reviewedAppxInstallEvidenceConfigured = $false
+$reviewedAppxInstallEvidencePackageName = ''
+$reviewedAppxInstallEvidencePublisherId = ''
+$reviewedAppxInstallEvidenceMinimumVersion = [version]'0.0.0.0'
+if ($psadtConfig.Contains('reviewedAppxInstallEvidence') -and
+    $null -ne $psadtConfig['reviewedAppxInstallEvidence']) {
+    $rawAppxEvidence = $psadtConfig['reviewedAppxInstallEvidence']
+    if ($rawAppxEvidence -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedAppxInstallEvidence must be a JSON object.'
+    }
+
+    $allowedAppxEvidenceKeys = @('packageName', 'publisherId', 'minimumVersion')
+    foreach ($appxEvidenceKey in @($rawAppxEvidence.Keys)) {
+        if ([string]$appxEvidenceKey -notin $allowedAppxEvidenceKeys) {
+            throw "PSADT reviewedAppxInstallEvidence contains an unsupported property: $appxEvidenceKey"
+        }
+    }
+    foreach ($requiredAppxEvidenceKey in $allowedAppxEvidenceKeys) {
+        if (-not $rawAppxEvidence.Contains($requiredAppxEvidenceKey) -or
+            $rawAppxEvidence[$requiredAppxEvidenceKey] -isnot [string]) {
+            throw "PSADT reviewedAppxInstallEvidence must include string property $requiredAppxEvidenceKey."
+        }
+    }
+
+    $reviewedAppxInstallEvidencePackageName = ([string]$rawAppxEvidence['packageName']).Trim()
+    $reviewedAppxInstallEvidencePublisherId = ([string]$rawAppxEvidence['publisherId']).Trim()
+    $reviewedAppxInstallEvidenceMinimumVersionText = ([string]$rawAppxEvidence['minimumVersion']).Trim()
+    if ($reviewedAppxInstallEvidencePackageName -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]{0,127}$') {
+        throw 'PSADT reviewedAppxInstallEvidence packageName must be a safe exact Appx package name.'
+    }
+    if ($reviewedAppxInstallEvidencePublisherId -notmatch '^[a-z0-9]{13}$') {
+        throw 'PSADT reviewedAppxInstallEvidence publisherId must be a 13-character package publisher ID.'
+    }
+    if ($reviewedAppxInstallEvidenceMinimumVersionText -notmatch '^\d{1,5}\.\d{1,5}\.\d{1,5}\.\d{1,5}$') {
+        throw 'PSADT reviewedAppxInstallEvidence minimumVersion must contain four numeric components.'
+    }
+    try {
+        $reviewedAppxInstallEvidenceMinimumVersion = [version]$reviewedAppxInstallEvidenceMinimumVersionText
+    } catch {
+        throw 'PSADT reviewedAppxInstallEvidence minimumVersion is invalid.'
+    }
+    $reviewedAppxInstallEvidenceConfigured = $true
+}
+
 if ($reviewedRegistryInstallEvidenceConfigured -and
     $reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0) {
     throw 'PSADT reviewed registry and multi-product install evidence cannot be combined.'
+}
+if ($reviewedAppxInstallEvidenceConfigured -and
+    ($reviewedRegistryInstallEvidenceConfigured -or
+     $reviewedMultiProductInstallDisplayNamePrefixes.Count -gt 0)) {
+    throw 'PSADT reviewed Appx install evidence cannot be combined with registry or multi-product evidence.'
 }
 
 $uninstallCompletionTimeoutMinutes = 5
@@ -601,6 +650,10 @@ $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
 if ($reviewedRegistryInstallEvidenceConfigured -and
     -not $preserveVendorInstallationOnUninstall) {
     throw 'PSADT reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall.'
+}
+if ($reviewedAppxInstallEvidenceConfigured -and
+    -not $preserveVendorInstallationOnUninstall) {
+    throw 'PSADT reviewedAppxInstallEvidence requires preserveVendorInstallationOnUninstall.'
 }
 
 function Expand-ReviewedVersionPlaceholder {
@@ -1069,6 +1122,8 @@ $reviewedExactUninstallArgumentsLiteral = @(
 ) -join ', '
 $reviewedRegistryInstallEvidenceProviderPathEscaped = $reviewedRegistryInstallEvidenceProviderPath -replace "'", "''"
 $reviewedRegistryInstallEvidenceValueNameEscaped = $reviewedRegistryInstallEvidenceValueName -replace "'", "''"
+$reviewedAppxInstallEvidencePackageNameEscaped = $reviewedAppxInstallEvidencePackageName -replace "'", "''"
+$reviewedAppxInstallEvidencePublisherIdEscaped = $reviewedAppxInstallEvidencePublisherId -replace "'", "''"
 $reviewedInstallShieldMsiExpectedFileNameEscaped = $reviewedInstallShieldMsiExpectedFileName -replace "'", "''"
 $displayNameEscaped = $DisplayName -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
 $publisherEscaped = $Publisher -replace "'", "''" -replace '`', '``' -replace '\$', '`$'
@@ -1340,6 +1395,16 @@ if ($useManagedDirectoryLifecycle) {
     # Never let unrelated background servicing become the captured identity.
     $useRegistryUninstall = $false
     Write-Host "Using reviewed managed-directory lifecycle: $reviewedManagedInstallDirectory"
+}
+
+if ($reviewedAppxInstallEvidenceConfigured) {
+    # A reviewed Appx framework lifecycle is deliberately not an ARP lifecycle.
+    # Never capture unrelated background servicing such as WebView2.
+    $useRegistryUninstall = $false
+    if ($IsUserScope) {
+        throw 'PSADT reviewedAppxInstallEvidence requires a machine-scope package.'
+    }
+    Write-Host "Using reviewed Appx framework evidence: $reviewedAppxInstallEvidencePackageName"
 }
 
 if ($reviewedRegistryInstallEvidenceConfigured) {
@@ -2061,7 +2126,22 @@ $lines += @(
 )
 $lines += $dependencyInstallLines
 
-if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
+if ($reviewedAppxInstallEvidenceConfigured) {
+    $lines += @(
+        '    # Verify the exact adapter-reviewed shared Appx framework identity.'
+        '    function Test-IntuneGetReviewedAppxInstallEvidence {'
+        "        `$minimumAppxVersion = [version]'$reviewedAppxInstallEvidenceMinimumVersion'"
+        "        `$matchingPackages = @(Get-AppxPackage -AllUsers -Name '$reviewedAppxInstallEvidencePackageNameEscaped' -ErrorAction SilentlyContinue | Where-Object {"
+        "            [string]`$_.Name -eq '$reviewedAppxInstallEvidencePackageNameEscaped' -and"
+        "            [string]`$_.PublisherId -eq '$reviewedAppxInstallEvidencePublisherIdEscaped' -and"
+        '            [bool]$_.IsFramework -and'
+        '            [version]$_.Version -ge $minimumAppxVersion'
+        '        })'
+        '        return $matchingPackages.Count -gt 0'
+        '    }'
+        ''
+    )
+} elseif ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
     $lines += @(
         '    # Verify the adapter-reviewed Windows runtime signal instead of guessing an ARP identity.'
         '    $capturedUninstallKey = $null'
@@ -2565,7 +2645,24 @@ if ($useManagedDirectoryLifecycle) {
 # Optional post-install verification (opt-in via PSADT config)
 # Throwing here routes through the standard catch -> Close-ADTSession error exit,
 # and the detection marker write below is skipped because it never runs
-if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
+if ($reviewedAppxInstallEvidenceConfigured) {
+    $lines += @(
+        '    # Wait briefly for the exact shared Appx framework to become visible.'
+        '    $reviewedAppxInstallationVerified = $false'
+        '    foreach ($verificationAttempt in 1..30) {'
+        '        if (Test-IntuneGetReviewedAppxInstallEvidence) {'
+        '            $reviewedAppxInstallationVerified = $true'
+        '            break'
+        '        }'
+        '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'
+        '    }'
+        '    if (-not $reviewedAppxInstallationVerified) {'
+        "        throw 'Reviewed Appx install verification failed: expected framework $reviewedAppxInstallEvidencePackageNameEscaped from publisher $reviewedAppxInstallEvidencePublisherIdEscaped at version $reviewedAppxInstallEvidenceMinimumVersion or newer.'"
+        '    }'
+        "    Write-ADTLogEntry -Message 'Verified reviewed shared Appx framework evidence.' -Severity 'Success' -Source 'Install-ADTDeployment'"
+        ''
+    )
+} elseif ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
     $lines += @(
         '    # Wait briefly for the documented Windows runtime registry signal to become visible.'
         '    foreach ($verificationAttempt in 1..30) {'
@@ -2788,7 +2885,16 @@ if ($useRegistryUninstall -and $reviewedRegistryInstallEvidenceConfigured) {
 
 if ($verifyInstall) {
     Write-Host "Post-install verification enabled"
-    if ($useRegistryUninstall) {
+    if ($reviewedAppxInstallEvidenceConfigured) {
+        $lines += @(
+            ''
+            '    ## Recheck the exact adapter-reviewed shared Appx framework evidence.'
+            '    if (-not (Test-IntuneGetReviewedAppxInstallEvidence)) {'
+            '        throw "Post-install verification failed: the reviewed shared Appx framework was not found."'
+            '    }'
+            "    Write-ADTLogEntry -Message 'Post-install verification passed for reviewed shared Appx framework evidence' -Source 'Install-ADTDeployment'"
+        )
+    } elseif ($useRegistryUninstall) {
         if ($reviewedRegistryInstallEvidenceConfigured) {
             $lines += @(
                 ''

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -791,6 +791,22 @@ describe('application packaging adapters', () => {
     ).toBe(true);
   });
 
+  it('uses exact Microsoft Appx evidence for Windows App Runtime 1.8', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'microsoft.windowsappruntime.1.8',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedAppxInstallEvidence: {
+        packageName: 'Microsoft.WindowsAppRuntime.1.8',
+        publisherId: '8wekyb3d8bbwe',
+        minimumVersion: '8000.879.2017.0',
+      },
+    });
+  });
+
   it('uses reviewed multi-product evidence for the shared Visual C++ runtime bundle', () => {
     expect(
       applyApplicationPackagingAdapter('ABBODI1406.VCREDIST', DEFAULT_PSADT_CONFIG)
@@ -831,6 +847,11 @@ describe('application packaging adapters', () => {
         valueName: 'Release',
         minimumDword: 1,
       },
+      reviewedAppxInstallEvidence: {
+        packageName: 'Example.Framework',
+        publisherId: 'example1234567',
+        minimumVersion: '1.0.0.0',
+      },
       reviewedInstallShieldAdministrativeImage: {
         expectedMsiFileName: 'customer-controlled.msi',
       },
@@ -856,6 +877,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedMultiProductInstallDisplayNamePrefixes).toBeUndefined();
     expect(adapted.reviewedMultiProductInstallMinimumCount).toBeUndefined();
     expect(adapted.reviewedRegistryInstallEvidence).toBeUndefined();
+    expect(adapted.reviewedAppxInstallEvidence).toBeUndefined();
     expect(adapted.reviewedInstallShieldAdministrativeImage).toBeUndefined();
     expect(adapted.reviewedInstallCompletionTimeoutMinutes).toBeUndefined();
     expect(adapted.reviewedManagedInstallDirectory).toBeUndefined();

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -43,6 +43,11 @@ interface ApplicationPackagingAdapter {
     valueName: string;
     minimumDword: number;
   }>;
+  reviewedAppxInstallEvidence?: Readonly<{
+    packageName: string;
+    publisherId: string;
+    minimumVersion: string;
+  }>;
 }
 
 const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
@@ -830,6 +835,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSuccessCodes: [1223],
   },
   {
+    // Windows App Runtime is a shared MSIX framework. Microsoft's package
+    // identity is Microsoft.WindowsAppRuntime.1.8, and the 1.8.9 installer
+    // deploys framework version 8000.879.2017.0 under Microsoft's publisher.
+    // Verify that exact Appx identity and retain it when Intune relinquishes
+    // ownership; ARP activity from WebView2 or other servicing is unrelated.
+    wingetId: 'Microsoft.WindowsAppRuntime.1.8',
+    preserveVendorInstallationOnUninstall: true,
+    reviewedAppxInstallEvidence: {
+      packageName: 'Microsoft.WindowsAppRuntime.1.8',
+      publisherId: '8wekyb3d8bbwe',
+      minimumVersion: '8000.879.2017.0',
+    },
+  },
+  {
     // The Evergreen WebView2 Runtime is shared by every WebView2 application,
     // automatically serviced by Microsoft, and preinstalled on Windows 11.
     // Removing the shared runtime can break unrelated applications, while the
@@ -1171,6 +1190,7 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
       !config.reviewedMultiProductInstallMinimumCount &&
       !config.reviewedRegistryInstallEvidence &&
+      !config.reviewedAppxInstallEvidence &&
       !config.reviewedUninstallProcessGuard &&
       !config.reviewedUninstallServiceNames &&
       !config.reviewedManagedInstallDirectory &&
@@ -1189,6 +1209,7 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedRegistryInstallEvidence: undefined,
+      reviewedAppxInstallEvidence: undefined,
       reviewedUninstallProcessGuard: undefined,
       reviewedUninstallServiceNames: undefined,
       reviewedManagedInstallDirectory: undefined,
@@ -1314,6 +1335,9 @@ export function applyApplicationPackagingAdapter(
       adapter.reviewedMultiProductInstallMinimumCount,
     reviewedRegistryInstallEvidence: adapter.reviewedRegistryInstallEvidence
       ? { ...adapter.reviewedRegistryInstallEvidence }
+      : undefined,
+    reviewedAppxInstallEvidence: adapter.reviewedAppxInstallEvidence
+      ? { ...adapter.reviewedAppxInstallEvidence }
       : undefined,
   };
 }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -920,6 +920,42 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds reviewed Windows App Runtime Appx evidence to the QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.WindowsAppRuntime.1.8',
+      displayName: 'Windows App Runtime 1.8',
+      publisher: 'Microsoft',
+      version: '1.8.9',
+      architecture: 'x64',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Windows App Runtime 1.8',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedEvidence = {
+      packageName: 'Microsoft.WindowsAppRuntime.1.8',
+      publisherId: '8wekyb3d8bbwe',
+      minimumVersion: '8000.879.2017.0',
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        preserveVendorInstallationOnUninstall?: boolean;
+        reviewedAppxInstallEvidence?: typeof expectedEvidence;
+      };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedAppxInstallEvidence: expectedEvidence,
+    });
+    expect(profile.psadtConfig.reviewedAppxInstallEvidence).toEqual(
+      expectedEvidence
+    );
+  });
+
   it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -424,6 +424,97 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies Windows App Runtime with exact shared Appx framework evidence',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Windows App Runtime 1.8',
+        [],
+        {
+          verifyInstall: true,
+          preserveVendorInstallationOnUninstall: true,
+          reviewedAppxInstallEvidence: {
+            packageName: 'Microsoft.WindowsAppRuntime.1.8',
+            publisherId: '8wekyb3d8bbwe',
+            minimumVersion: '8000.879.2017.0',
+          },
+        },
+        [],
+        'Microsoft.WindowsAppRuntime.1.8'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "Get-AppxPackage -AllUsers -Name 'Microsoft.WindowsAppRuntime.1.8'"
+      );
+      expect(installFunction).toContain(
+        "[string]$_.PublisherId -eq '8wekyb3d8bbwe'"
+      );
+      expect(installFunction).toContain('[bool]$_.IsFramework');
+      expect(installFunction).toContain(
+        "[version]$_.Version -ge $minimumAppxVersion"
+      );
+      expect(installFunction).toContain(
+        'Post-install verification passed for reviewed shared Appx framework evidence'
+      );
+      expect(installFunction).not.toContain('$preInstallApplications');
+      expect(installFunction).not.toContain(
+        'Could not select one vendor uninstall entry'
+      );
+      expect(uninstallFunction).toContain(
+        'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
+      );
+      expect(uninstallFunction).not.toContain('Microsoft EdgeWebView');
+      expect(uninstallFunction).not.toContain('Start-ADTProcess @uninstallProcessParameters');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects wildcard and unretained reviewed Appx evidence',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe Appx Evidence',
+          [],
+          {
+            preserveVendorInstallationOnUninstall: true,
+            reviewedAppxInstallEvidence: {
+              packageName: 'Microsoft.WindowsAppRuntime.*',
+              publisherId: '8wekyb3d8bbwe',
+              minimumVersion: '8000.879.2017.0',
+            },
+          }
+        )
+      ).toThrow('packageName must be a safe exact Appx package name');
+
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unretained Appx Evidence',
+          [],
+          {
+            reviewedAppxInstallEvidence: {
+              packageName: 'Microsoft.WindowsAppRuntime.1.8',
+              publisherId: '8wekyb3d8bbwe',
+              minimumVersion: '8000.879.2017.0',
+            },
+          }
+        )
+      ).toThrow(
+        'reviewedAppxInstallEvidence requires preserveVendorInstallationOnUninstall'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects unsafe reviewed registry install evidence',
     () => {
       expect(() =>

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -291,6 +291,16 @@ export interface PSADTConfig {
     minimumDword: number;
   };
 
+  // Internal install-evidence contract for reviewed shared Appx/MSIX
+  // frameworks. The generated package requires an exact package identity,
+  // Microsoft-style publisher ID, framework flag, and minimum package
+  // version. Application adapters are the only source.
+  reviewedAppxInstallEvidence?: {
+    packageName: string;
+    publisherId: string;
+    minimumVersion: string;
+  };
+
   // Additional commands run as extra PSADT steps after the main install /
   // uninstall (e.g. delete a desktop shortcut after installing). Each entry is a
   // full command line executed via cmd.exe /c, in order. Empty/absent = none.


### PR DESCRIPTION
## Summary
- add a reviewed Appx/MSIX framework evidence contract with exact name, publisher, framework flag, and minimum version
- use it for Microsoft.WindowsAppRuntime.1.8 and bypass unrelated ARP deltas
- retain the shared runtime on uninstall while removing only the IntuneGet marker

Microsoft documents the shared framework identity and warns that removing Windows App SDK runtime packages can break dependent apps: https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/remove-windows-app-sdk-versions

## Verification
- 224 focused tests passed
- ESLint passed for modified TypeScript files
- git diff --check passed
- repository-wide tsc remains blocked by existing test-global/baseline type errors unrelated to this change