### PR TITLE
fix(packager): bound FlashPrint installer completion

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -223,6 +223,17 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('keeps the FlashPrint bootstrapper observable within a bounded wait', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Flashforge.FlashPrint',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('does not extend the blocked Acronis managed-uninstall lifecycle', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -218,6 +218,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallCompletionTimeoutMinutes: 15,
   },
   {
+    // FlashPrint 5.8.3 is distributed as a ZIP containing an Advanced
+    // Installer bootstrapper. Its manifest-provided unattended command stays
+    // alive without observable file-system activity for longer than the
+    // generic QA inactivity window before it completes registration. Keep the
+    // vendor command and normal ARP lifecycle, but make the shared packager
+    // wait observable and bounded for both QA and customer Intune packages.
+    wingetId: 'Flashforge.FlashPrint',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // ZeeDrive's official MSI is a command wrapper that deliberately does not
     // register in Add/Remove Programs. Thinkscape documents COMMAND=Install,
     // versioned Program Files detection, and direct directory removal for its

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -464,6 +464,40 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds the bounded FlashPrint nested EXE wait to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Flashforge.FlashPrint',
+      displayName: 'FlashPrint',
+      publisher: 'Flashforge',
+      version: '5.8.3',
+      architecture: 'x64',
+      installerSha256: 'a'.repeat(64),
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerPath: 'FlashPrint 5_5.8.3_x64.exe',
+      silentSwitches: '/exenoui /qb! REBOOT=ReallySuppress',
+      uninstallCommand: 'REGISTRY_UNINSTALL:FlashPrint',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: {
+        sourceType: string;
+        nestedInstallerType: string;
+        nestedInstallerFiles: string[];
+      };
+      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+    };
+
+    expect(profile.installer.sourceType).toBe('zip');
+    expect(profile.installer.nestedInstallerType).toBe('exe');
+    expect(profile.installer.nestedInstallerFiles).toEqual([
+      'FlashPrint 5_5.8.3_x64.exe',
+    ]);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+  });
+
   it('binds reviewed Wiris and Azure Monitor removal contracts to QA profiles', () => {
     const mathType = normalizeQaWorkflowPackageInput({
       wingetId: 'Wiris.MathType.7',


### PR DESCRIPTION
## Summary
- add a reviewed 15-minute install completion window for Flashforge.FlashPrint
- keep the manifest-provided nested EXE command and normal ARP lifecycle
- verify the ZIP-to-EXE profile binds the adapter for QA and customer packaging

## Verification
- 226 focused Vitest tests
- focused ESLint
- production Next.js build