### PR TITLE
fix(packager): honor nested installer completion window

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2457,6 +2457,29 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                         default {
                             if ($IsUserScope) {
                                 $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
+                            } elseif ($reviewedInstallCompletionTimeoutMinutes -gt 0) {
+                                $nestedExecuteLine = @(
+                                    "        `$installDeadline = [DateTime]::UtcNow.AddMinutes($reviewedInstallCompletionTimeoutMinutes)"
+                                    "        `$installHandle = Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru"
+                                    '        $nextInstallProgressLog = [DateTime]::UtcNow'
+                                    '        while (-not $installHandle.Task.IsCompleted) {'
+                                    '            if ([DateTime]::UtcNow -ge $installDeadline) {'
+                                    "                throw 'The reviewed nested vendor installer did not complete within $reviewedInstallCompletionTimeoutMinutes minutes.'"
+                                    '            }'
+                                    '            if ([DateTime]::UtcNow -ge $nextInstallProgressLog) {'
+                                    '                Write-ADTLogEntry -Message "The reviewed nested vendor installer is still working." -Source ''Install-ADTDeployment'''
+                                    '                $nextInstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)'
+                                    '            }'
+                                    '            Start-Sleep -Seconds 5'
+                                    '        }'
+                                    '        $installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+                                    '        if ($installProcessExitCode -in @(1641, 3010)) {'
+                                    '            $script:InstallRebootExitCode = 3010'
+                                    '            Write-ADTLogEntry -Message "The reviewed nested vendor installer requested a reboot with exit code [$installProcessExitCode]." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+                                    '        } elseif ($installProcessExitCode -ne 0) {'
+                                    '            throw "The reviewed nested vendor installer exited with code [$installProcessExitCode]."'
+                                    '        }'
+                                )
                             } else {
                                 $nestedExecuteLine = "        Start-ADTProcess -FilePath `$nestedInstallerPath -ArgumentList '$silentSwitchesEscaped' -WindowStyle Hidden -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
                             }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -35,7 +35,7 @@ const canRunWindowsPowerShellPackager =
   ]).status === 0;
 
 function generateRegistryUninstallPackage(
-  installerType: 'exe' | 'inno' | 'burn' | 'nullsoft' | 'msi',
+  installerType: 'exe' | 'inno' | 'burn' | 'nullsoft' | 'msi' | 'zip',
   displayName = 'Contract Test App',
   installerSuccessCodes: number[] = [],
   psadtConfig: unknown = {},
@@ -45,7 +45,9 @@ function generateRegistryUninstallPackage(
   version = '1.0.0',
   uninstallCommand = `REGISTRY_UNINSTALL:${uninstallDisplayName}`,
   silentSwitches = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
-  installScope: 'machine' | 'user' = 'machine'
+  installScope: 'machine' | 'user' = 'machine',
+  nestedInstallerType = '',
+  nestedInstallerPath = ''
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -59,7 +61,10 @@ function generateRegistryUninstallPackage(
       mkdirSync(join(fixtureRoot, directory), { recursive: true });
     }
 
-    const installerPath = join(fixtureRoot, 'setup.exe');
+    const installerFileName = installerType === 'zip' && nestedInstallerPath
+      ? 'setup.zip'
+      : 'setup.exe';
+    const installerPath = join(fixtureRoot, installerFileName);
     writeFileSync(installerPath, 'fixture');
     writeFileSync(join(fixtureRoot, 'psadt/Invoke-AppDeployToolkit.exe'), 'fixture');
     writeFileSync(
@@ -91,12 +96,14 @@ function generateRegistryUninstallPackage(
         INPUT_WINGET_ID: wingetId,
         INPUT_INSTALLER_TYPE: installerType,
         INPUT_INSTALL_SCOPE: installScope,
+        INPUT_NESTED_INSTALLER_TYPE: nestedInstallerType,
+        INPUT_NESTED_INSTALLER_PATH: nestedInstallerPath,
         INPUT_SILENT_SWITCHES: silentSwitches,
         INPUT_INSTALLER_SUCCESS_CODES: JSON.stringify(installerSuccessCodes),
         INPUT_PACKAGE_DEPENDENCIES: JSON.stringify(packageDependencies),
         INPUT_UNINSTALL_COMMAND: uninstallCommand,
         INSTALLER_PATH: installerPath,
-        INSTALLER_FILENAME: 'setup.exe',
+        INSTALLER_FILENAME: installerFileName,
         ...(packageDependencies.length > 0
           ? { DEPENDENCIES_PATH: dependencyPath }
           : {}),
@@ -2245,6 +2252,43 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       );
       expect(generated).toContain('$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 10 }');
       expect(generated).toContain("@{ Name = 'lghub'; Description = 'Logitech G HUB' }");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps a reviewed nested FlashPrint bootstrapper observable',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'zip',
+        'FlashPrint',
+        [],
+        { reviewedInstallCompletionTimeoutMinutes: 15 },
+        [],
+        'Flashforge.FlashPrint',
+        'FlashPrint',
+        '5.8.3',
+        'REGISTRY_UNINSTALL:FlashPrint',
+        '/exenoui /qb! REBOOT=ReallySuppress',
+        'machine',
+        'exe',
+        'FlashPrint 5_5.8.3_x64.exe'
+      );
+
+      expect(generated).toContain(
+        '$installDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(generated).toContain(
+        "Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '/exenoui /qb! REBOOT=ReallySuppress' -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru"
+      );
+      expect(generated).toContain(
+        'Write-ADTLogEntry -Message "The reviewed nested vendor installer is still working."'
+      );
+      expect(generated).toContain(
+        '$installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+      );
+      expect(generated).not.toContain(
+        "Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '/exenoui /qb! REBOOT=ReallySuppress' -WindowStyle Hidden -WaitForMsiExec -Timeout"
+      );
     }
   );
 

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1020,6 +1020,19 @@ catch
     return raw;
   }
 
+  private getReviewedInstallCompletionTimeoutMinutes(
+    job: PackagingJob
+  ): number | null {
+    const raw = this.getPsadtConfig(job)?.reviewedInstallCompletionTimeoutMinutes;
+    if (raw === undefined || raw === null) return null;
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1 || raw > 60) {
+      throw new Error(
+        'PSADT reviewedInstallCompletionTimeoutMinutes must be an integer from 1 to 60'
+      );
+    }
+    return raw;
+  }
+
   /**
    * Generate PowerShell for additional post-install / post-uninstall commands
    * (issue #118). Each entry runs as its own Start-ADTProcess (cmd.exe /c) step,
@@ -1472,7 +1485,31 @@ ${steps}
         ? `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath -AdditionalArgumentList '${msiProperties}'`
         : `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath`;
     } else {
-      executeLine = `Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec`;
+      const reviewedTimeout = this.getReviewedInstallCompletionTimeoutMinutes(job);
+      if (job.install_scope !== 'user' && reviewedTimeout) {
+        executeLine = `$installDeadline = [DateTime]::UtcNow.AddMinutes(${reviewedTimeout})
+        $installHandle = Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru
+        $nextInstallProgressLog = [DateTime]::UtcNow
+        while (-not $installHandle.Task.IsCompleted) {
+            if ([DateTime]::UtcNow -ge $installDeadline) {
+                throw 'The reviewed nested vendor installer did not complete within ${reviewedTimeout} minutes.'
+            }
+            if ([DateTime]::UtcNow -ge $nextInstallProgressLog) {
+                Write-ADTLogEntry -Message "The reviewed nested vendor installer is still working." -Source 'Install-ADTDeployment'
+                $nextInstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)
+            }
+            Start-Sleep -Seconds 5
+        }
+        $installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode
+        if ($installProcessExitCode -in @(1641, 3010)) {
+            $script:InstallRebootExitCode = 3010
+            Write-ADTLogEntry -Message "The reviewed nested vendor installer requested a reboot with exit code [$installProcessExitCode]." -Severity 'Warning' -Source 'Install-ADTDeployment'
+        } elseif ($installProcessExitCode -ne 0) {
+            throw "The reviewed nested vendor installer exited with code [$installProcessExitCode]."
+        }`;
+      } else {
+        executeLine = `Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '${silentSwitches}' -WindowStyle Hidden -WaitForMsiExec`;
+      }
     }
 
     return `$zipExtractDir = [System.IO.Path]::Combine($env:TEMP, "IntuneGet_Zip_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -481,6 +481,40 @@ describe('Burn bundle PSADT generation', () => {
     );
   });
 
+  it('keeps a reviewed nested EXE installer observable within its bounded wait', () => {
+    const script = generator.getInstallCommand.call(
+      generator,
+      packagingJob({
+        winget_id: 'Flashforge.FlashPrint',
+        installer_type: 'zip',
+        install_command:
+          'FlashPrint.exe /exenoui /qb! REBOOT=ReallySuppress',
+        package_config: {
+          nestedInstallerType: 'exe',
+          nestedInstallerPath: 'FlashPrint 5_5.8.3_x64.exe',
+          psadtConfig: {
+            reviewedInstallCompletionTimeoutMinutes: 15,
+          },
+        },
+      }),
+      'FlashPrint.zip',
+      '/exenoui /qb! REBOOT=ReallySuppress'
+    );
+
+    expect(script).toContain(
+      '$installDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+    );
+    expect(script).toContain(
+      'Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList \'/exenoui /qb! REBOOT=ReallySuppress\' -WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru'
+    );
+    expect(script).toContain(
+      'The reviewed nested vendor installer is still working.'
+    );
+    expect(script).toContain(
+      '$installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+    );
+  });
+
   it('keeps executable-wrapper duplicate-entry narrowing disabled for native framework packages', () => {
     const job = packagingJob({
       installer_type: 'inno',


### PR DESCRIPTION
## Summary
- honor reviewed install completion windows for machine-scope EXEs nested in ZIP packages
- emit bounded 15-second progress logs while awaiting the nested vendor process
- preserve fail-closed timeout, exit-code, reboot, and archive-cleanup handling in both package generators
- add generated-script and hosted-generator regression coverage for FlashPrint

## Verification
- 285 focused Vitest tests
- focused ESLint
- production Next.js build