### PR TITLE
fix(qa): block unsupported FlashPrint lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -829,6 +829,28 @@ describe('darktable managed install block migration contract', () => {
   });
 });
 
+describe('FlashPrint managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260821164000_block_flashprint_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the non-terminating nested LocalSystem lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Flashforge.FlashPrint'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32501894421'
+    );
+    expect(sql).toContain('reviewed 15-minute LocalSystem installation ceiling');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260821164000_block_flashprint_unsupported_managed_install.sql
+++ b/supabase/migrations/20260821164000_block_flashprint_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- FlashPrint 5.8.3 uses the WinGet-published Advanced Installer command from
+-- its nested signed EXE, but it never completed or created an authoritative
+-- Apps & Features identity under LocalSystem. The final isolated retry used
+-- the reviewed nested-process contract, emitted continuous PSADT heartbeats,
+-- and remained active for the full 15-minute ceiling. Keep this lifecycle out
+-- of automated customer deployment instead of extending the bounded wait or
+-- claiming detection and managed removal without vendor registration.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Flashforge.FlashPrint',
+  'unsupported_managed_install',
+  'FlashPrint 5.8.3 remains active beyond the reviewed 15-minute LocalSystem installation ceiling without creating an authoritative application registration for detection and managed removal.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32501894421'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Flashforge.FlashPrint';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Flashforge.FlashPrint'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- fail closed Flashforge.FlashPrint after its reviewed nested installer remained active for the full 15-minute LocalSystem ceiling
- disable curated verification and supersede queued/failed QA candidates
- preserve the authoritative run URL and eligibility reason for customer packaging

## Evidence
- run 32501894421 emitted continuous reviewed nested-process heartbeats but never registered an app identity
- install and uninstall exited 60001; both detection checks failed

## Verification
- 62 migration contract tests
- focused ESLint