### PR TITLE
Block unsupported .NET developer pack managed removal

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -851,6 +851,29 @@ describe('FlashPrint managed install block migration contract', () => {
   });
 });
 
+describe('.NET Framework Developer Pack managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260821180000_block_dotnet_developerpack_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the legacy developer pack after both exact vendor removal identities fail', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Microsoft.DotNet.Framework.DeveloperPack.4.6'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32510508197'
+    );
+    expect(sql).toContain('exact Burn removal command');
+    expect(sql).toContain('exact legacy MSI identity');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260821180000_block_dotnet_developerpack_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260821180000_block_dotnet_developerpack_unsupported_managed_uninstall.sql
@@ -1,0 +1,36 @@
+-- The legacy .NET Framework 4.6.2 Developer Pack installs and registers under
+-- LocalSystem, but its managed removal is not reliable on the QA baseline.
+-- The vendor Burn command left the exact product registered. A reviewed retry
+-- then routed the legacy GUID-keyed MsiExec registration through exact MSI
+-- removal, and that also returned without removing the product. Do not claim a
+-- managed lifecycle when neither authoritative vendor identity can remove it.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Microsoft.DotNet.Framework.DeveloperPack.4.6',
+  'unsupported_managed_uninstall',
+  'The .NET Framework 4.6.2 Developer Pack installs and detects under LocalSystem, but both its exact Burn removal command and its exact legacy MSI identity leave the registered product installed.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32510508197'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.DotNet.Framework.DeveloperPack.4.6';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Microsoft.DotNet.Framework.DeveloperPack.4.6'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Microsoft.DotNet.Framework.DeveloperPack.4.6 from automated packaging
- record the final isolated LocalSystem evidence after both exact Burn and MSI removal identities left the product registered
- supersede queued and terminal QA candidates for the unsupported lifecycle

## Verification
- 63 migration contract tests passed
- ESLint passed