### PR TITLE
Fix MSI quiet token normalization

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2270,7 +2270,10 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
     }
     switch ($installerTypeLower) {
         { $_ -in 'msi', 'wix' } {
-            $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
+            # Strip only complete MSI UI tokens. Matching /q before /quiet used to
+            # leave the trailing token "iet", producing a malformed hidden MSI
+            # command that could stall indefinitely under LocalSystem.
+            $msiProperties = ($silentSwitchesEscaped -replace '(?i)(?<!\S)/(?:quiet|q[nbrfu]?)(?=\s|$)\s*', '').Trim()
             if ($msiProperties) {
                 $msiPropertiesEscaped = $msiProperties -replace "'", "''"
                 if ($msiPropertiesEscaped -match '%[A-Za-z][A-Za-z0-9()_]*%') {
@@ -2447,7 +2450,7 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                     # Build the execution line for a non-portable nested installer.
                     switch ($nestedInstallerTypeLower) {
                         { $_ -in 'msi', 'wix' } {
-                            $msiProperties = ($silentSwitchesEscaped -replace '/q[nbrfu]?\s*', '' -replace '/quiet\s*', '').Trim()
+                            $msiProperties = ($silentSwitchesEscaped -replace '(?i)(?<!\S)/(?:quiet|q[nbrfu]?)(?=\s|$)\s*', '').Trim()
                             if ($msiProperties) {
                                 $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath -AdditionalArgumentList '$msiProperties'"
                             } else {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1231,6 +1231,29 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'strips the complete MSI quiet token without leaking a trailing fragment',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'Microsoft ODBC Driver 13 for SQL Server',
+        [],
+        {},
+        [],
+        'Microsoft.msodbcsql.13',
+        'Microsoft ODBC Driver 13 for SQL Server',
+        '13.1.4414.46',
+        'msiexec /x "{7E425BFB-1DEB-499F-8F3F-3522A6E98754}" /qn /norestart',
+        '/quiet /norestart IACCEPTMSODBCSQLLICENSETERMS=YES ALLUSERS=1'
+      );
+
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart IACCEPTMSODBCSQLLICENSETERMS=YES ALLUSERS=1'"
+      );
+      expect(generated).not.toMatch(/AdditionalArgumentList '[^']*\biet\b/);
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'replaces BlueJ automatic context and expands its per-user MSI directory',
     () => {
       const productCode = '{BAF3564F-5DE4-48AC-8CC4-260BFFD56D30}';

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -9,6 +9,7 @@ type ScriptGenerator = {
   getInstallCommand(job: PackagingJob, fileName: string, silentSwitches: string): string;
   getUninstallCommand(job: PackagingJob, fileName: string): string;
   getPostInstallVerificationBlock(job: PackagingJob, escapedAppName: string): string;
+  extractMsiProperties(silentSwitches: string): string;
   extractSilentSwitches(
     installCommand: string,
     installerType: string,
@@ -57,6 +58,15 @@ function uninstallScript(job: PackagingJob): string {
 }
 
 describe('nested portable PSADT generation', () => {
+  it('strips complete MSI UI tokens without leaking quiet suffix fragments', () => {
+    expect(
+      generator.extractMsiProperties.call(
+        generator,
+        '/quiet /norestart IACCEPTMSODBCSQLLICENSETERMS=YES ALLUSERS=1'
+      )
+    ).toBe('IACCEPTMSODBCSQLLICENSETERMS=YES ALLUSERS=1');
+  });
+
   it('safely stages a top-level portable zip payload', () => {
     const script = installScript(packagingJob({
       installer_type: 'portable',


### PR DESCRIPTION
## Summary
- strip complete MSI UI tokens in the self-hosted PSADT generator
- prevent /quiet from becoming the malformed trailing token iet`n- cover the exact ODBC 13 arguments and hosted-generator parity

## Verification
- 166 focused Vitest tests passed
- ESLint passed
- packager TypeScript build passed
- PowerShell parse passed

## QA evidence
Run 32512870338 generated /QN iet /norestart ..., stalled under LocalSystem, and failed detection/removal.