### PR TITLE
fix(qa): prevent long app names from forcing horizontal overflow on /qa

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -483,8 +483,8 @@ function DashboardContent() {
       <ServiceHealth data={data} />
       <CurrentTest data={data} />
 
-      <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
-        <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-5 sm:p-6" aria-labelledby="queue-heading">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <section className="min-w-0 rounded-2xl border border-overlay/10 bg-bg-elevated p-5 sm:p-6" aria-labelledby="queue-heading">
           <div className="mb-4 flex items-baseline justify-between gap-3">
             <h2 id="queue-heading" className="text-lg font-semibold text-text-primary"><T>Next in queue</T></h2>
             <span className="text-xs text-text-muted"><T>One app tested at a time</T></span>


### PR DESCRIPTION
## Summary
On mobile, a long app name in the "Next in queue" list (e.g. "Microsoft SQL Server Management Studio 22 Preview") pushed the entire /qa page wider than the viewport, clipping the right edge of every card.

Root cause: the queue `<section>` is a grid item with the default `min-width: auto`. Truncated text is `white-space: nowrap`, so the name''s full untruncated width counted as the section''s minimum width and propagated up to the page. The "Recent results" section was unaffected only because it happens to have `overflow-hidden`.

## Changes
- Add `min-w-0` to the "Next in queue" section so it can shrink and the inner `truncate` engages (ellipsis at the card edge).
- Give the `lg:` grid tracks a `minmax(0, ...)` floor so the same overflow cannot occur on the two-column desktop layout (bare `fr` tracks share the `auto`-minimum problem).

Two-line CSS-only change; no markup, data, or behavior changes.

## Test plan
- `tsc --noEmit` clean for the touched file; pre-commit ESLint passed.
- Verified the failure mechanism against the reported mobile screenshot (iPhone-width viewport, long queue entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)