### PR TITLE
Fix TreeSize machine-scope lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -773,6 +773,19 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('selects TreeSize administrative Inno mode for LocalSystem deployment', () => {
+    expect(resolveApplicationInstallScope('JAMSoftware.TreeSize', 'user')).toBe('machine');
+    const adapted = applyApplicationPackagingAdapter(
+      'JAMSoftware.TreeSize',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS'
+    );
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('selects Podman Desktop all-users mode for the full Intune lifecycle', () => {
     const adapted = applyApplicationPackagingAdapter(
       'redhat.podman-desktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -321,6 +321,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // TreeSize's dual-mode Inno installer defaults to the invoking account even
+    // when the catalog declares machine scope. Under LocalSystem that places the
+    // app and its uninstaller below the 32-bit system profile, where silent
+    // removal never clears the exact registration. Inno's reviewed /ALLUSERS
+    // contract selects administrative install mode and the machine-wide
+    // Program Files/HKLM lifecycle required by Intune.
+    wingetId: 'JAMSoftware.TreeSize',
+    requiredInstallScope: 'machine',
+    reviewedInstallArgumentsOverride:
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS',
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -600,6 +600,32 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds TreeSize to administrative Inno mode', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'JAMSoftware.TreeSize',
+      displayName: 'TreeSize',
+      publisher: 'JAMSoftware',
+      version: '9.8.2',
+      architecture: 'x64',
+      installerSha256: '3'.repeat(64),
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:TreeSize_is1:TreeSize',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS'
+    );
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',


### PR DESCRIPTION
## Summary
- force TreeSize's Inno installer into documented /ALLUSERS administrative mode
- keep the exact captured product-specific uninstall lifecycle
- cover shared customer packaging and canonical QA profile generation

## Verification
- 123 focused tests passed
- ESLint passed

## QA evidence
Run 32517758984 installed below the 32-bit LocalSystem profile and its silent uninstaller never removed TreeSize_is1.