### PR TITLE
fix(qa): block TreeSize unsupported uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -874,6 +874,29 @@ describe('.NET Framework Developer Pack managed uninstall block migration contra
   });
 });
 
+describe('TreeSize managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260821195200_block_treesize_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks TreeSize after both exact Inno install modes fail managed removal', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'JAMSoftware.TreeSize'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32519690272'
+    );
+    expect(sql).toContain('default current-user mode');
+    expect(sql).toContain('reviewed /ALLUSERS administrative mode');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260821195200_block_treesize_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260821195200_block_treesize_unsupported_managed_uninstall.sql
@@ -1,0 +1,34 @@
+-- TreeSize installs and registers under LocalSystem, but its exact Inno
+-- uninstaller does not remove the registered product within the bounded QA
+-- window. This was reproduced in both the default current-user mode and the
+-- reviewed /ALLUSERS administrative mode. Do not claim a managed lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'JAMSoftware.TreeSize',
+  'unsupported_managed_uninstall',
+  'TreeSize installs and detects under LocalSystem, but its exact Inno uninstaller leaves the registered product installed after both the default current-user mode and the reviewed /ALLUSERS administrative mode.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32519690272'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'JAMSoftware.TreeSize';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'JAMSoftware.TreeSize'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block JAMSoftware.TreeSize as unsupported_managed_uninstall
- unverify it in the curated catalog
- supersede queued and failed QA candidates
- cover the migration contract

## Verification
- npm test -- --run lib/qa/migration-contract.test.ts (64 passed)
- npx eslint lib/qa/migration-contract.test.ts
- git diff --check