### PR TITLE
fix(qa): run WPS Office in managed scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -786,6 +786,17 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('runs the elevation-requiring WPS Office installer as LocalSystem', () => {
+    expect(resolveApplicationInstallScope('Kingsoft.WPSOffice', 'user')).toBe('machine');
+    const adapted = applyApplicationPackagingAdapter(
+      'kingsoft.wpsoffice',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('selects Podman Desktop all-users mode for the full Intune lifecycle', () => {
     const adapted = applyApplicationPackagingAdapter(
       'redhat.podman-desktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -333,6 +333,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS',
   },
   {
+    // WPS Office is cataloged as a per-user EXE, but the signed installer
+    // elevates even with its exact -S switch. A standard-user launch therefore
+    // ends at the unattended UAC boundary without creating the registered
+    // product. Run that same vendor command in the already-elevated
+    // LocalSystem context used by managed Intune deployment.
+    wingetId: 'Kingsoft.WPSOffice',
+    requiredInstallScope: 'machine',
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -626,6 +626,31 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds WPS Office to the elevated managed deployment context', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Kingsoft.WPSOffice',
+      displayName: 'WPS Office',
+      publisher: 'Kingsoft',
+      version: '12.2.0.23196',
+      architecture: 'x86',
+      installerSha256: '1'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '-S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:Kingsoft Office:WPS Office',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe('-S');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',


### PR DESCRIPTION
## Summary
- bind Kingsoft.WPSOffice to machine/LocalSystem scope because its exact silent user launch forces elevation
- preserve the catalog-owned -S argument and exact registry identity
- bind the scope correction into the immutable QA profile

## Evidence
- workflow 32521384854: user-context ShellExecute failed with Win32 1223 before any ARP identity was created

## Verification
- 125 focused tests passed
- focused ESLint passed
- git diff --check