### PR TITLE
fix(qa): preserve WPS installer manifest scope

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -173,6 +173,29 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts WPS Office user manifest bytes for reviewed SYSTEM execution', async () => {
+    const wpsRequest = {
+      ...request,
+      wingetId: 'Kingsoft.WPSOffice',
+      architecture: 'x86',
+      installerUrl: 'https://example.test/wps-office.exe',
+      installerType: 'exe',
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x86',
+      url: wpsRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'exe',
+      scope: 'user',
+    }]);
+
+    await expect(enforceInstallerPreflight(wpsRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
   it('still rejects an opposite manifest scope without a reviewed adapter', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -788,6 +788,10 @@ describe('application packaging adapters', () => {
 
   it('runs the elevation-requiring WPS Office installer as LocalSystem', () => {
     expect(resolveApplicationInstallScope('Kingsoft.WPSOffice', 'user')).toBe('machine');
+    expect(resolveApplicationInstallerSelectionScope(
+      'Kingsoft.WPSOffice',
+      'machine'
+    )).toBe('user');
     const adapted = applyApplicationPackagingAdapter(
       'kingsoft.wpsoffice',
       DEFAULT_PSADT_CONFIG

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -340,6 +340,7 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // LocalSystem context used by managed Intune deployment.
     wingetId: 'Kingsoft.WPSOffice',
     requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
   },
   {
     // MEGA's installer source makes silent installs current-user by default.


### PR DESCRIPTION
## Summary
- preserve Kingsoft.WPSOffice's user-scoped manifest bytes while executing them in managed LocalSystem scope
- add a direct live-preflight regression contract

## Evidence
- machine-scoped retry candidate 2eb150a2 was quarantined as MANIFEST_CHANGED before execution because manifest matching inherited execution scope

## Verification
- 138 focused tests passed
- focused ESLint passed
- git diff --check