### PR TITLE
feat(landing): new hero with live QA pipeline panel

### DIFF
--- a/components/landing/sections/HeroSection.tsx
+++ b/components/landing/sections/HeroSection.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useRef } from "react";
-import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
 import { Code2, Container, Package, Scale } from "lucide-react";
-import { T, Var, useGT, useLocale } from "gt-next";
-import { GradientOrb } from "../ui/GradientOrb";
+import { T, Var, useLocale } from "gt-next";
 import { LandingCatalogSearch } from "../ui/LandingCatalogSearch";
+import { LivePipelinePanel } from "../ui/LivePipelinePanel";
 import { FadeIn } from "../animations/FadeIn";
-import { TextReveal } from "../animations/TextReveal";
 import { type LandingStatValues } from "@/hooks/useLandingStats";
 import { useSharedLandingStats } from "@/components/providers/LandingStatsProvider";
 
@@ -16,93 +13,81 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ initialStats }: HeroSectionProps) {
-  const t = useGT();
   // gt-next locale is identical on server and client; the browser's implicit
   // locale is not, and a bare toLocaleString() breaks hydration for non-en users.
   // An empty locale string would make toLocaleString throw a RangeError.
   const localeTag = useLocale() || undefined;
   const { appsSupported } = useSharedLandingStats(initialStats);
-  const shouldReduceMotion = useReducedMotion();
-  const sectionRef = useRef<HTMLElement>(null);
   const supportedAppsDisplay = appsSupported.toLocaleString(localeTag);
 
-  // 3B: Parallax for gradient orbs
-  const { scrollY } = useScroll();
-  const orbY1 = useTransform(scrollY, [0, 500], [0, -30]);
-  const orbY2 = useTransform(scrollY, [0, 500], [0, -20]);
-
   return (
-    <section ref={sectionRef} className="relative isolate min-h-dvh w-full overflow-hidden">
-      {/* Background gradient orbs with parallax */}
-      <motion.div style={{ y: shouldReduceMotion ? 0 : orbY1 }}>
-        <GradientOrb
-          color="cyan"
-          size="xl"
-          intensity="low"
-          className="top-0 right-0 -translate-y-1/4 translate-x-1/4"
-        />
-      </motion.div>
-      <motion.div style={{ y: shouldReduceMotion ? 0 : orbY2 }}>
-        <GradientOrb
-          color="violet"
-          size="xl"
-          intensity="low"
-          className="bottom-0 left-0 translate-y-1/4 -translate-x-1/4"
-        />
-      </motion.div>
+    <section className="relative isolate w-full overflow-hidden">
+      <div className="container relative z-10 mx-auto max-w-6xl px-4 pb-14 pt-28 md:px-6 md:pb-20 md:pt-32">
+        <div className="grid items-center gap-12 lg:grid-cols-[54fr_46fr] lg:gap-16">
+          {/* Left: copy + search */}
+          <div className="flex flex-col items-center text-center lg:items-start lg:text-left">
+            <FadeIn animateOnMount duration={0.4} direction="up">
+              <h1 className="text-balance text-4xl font-extrabold tracking-tight text-text-primary md:text-5xl">
+                <T id="hero.headline">Deploy any Windows app to Intune.</T>{" "}
+                <span className="text-accent-cyan">
+                  <T id="hero.headline.accent">Search it, ship it.</T>
+                </span>
+              </h1>
+            </FadeIn>
 
-      <div className="container relative z-10 mx-auto flex min-h-dvh max-w-6xl items-center px-4 pb-12 pt-24 md:px-6 md:pb-16 md:pt-24">
-        <div className="flex w-full flex-col items-center text-center">
-          <div className="flex max-w-4xl flex-col items-center space-y-5">
-            <TextReveal
-              as="h1"
-              text={t("From Winget to Intune in Minutes")}
-              className="text-balance text-4xl font-extrabold tracking-tight text-text-primary md:text-5xl lg:text-6xl"
-              animateOnMount
-              delay={0.05}
-              staggerDelay={0.04}
-            />
-
-            <FadeIn delay={0.1} animateOnMount duration={0.4} direction="up">
-              <p className="mx-auto max-w-3xl text-base leading-relaxed text-text-secondary sm:text-lg md:text-xl">
+            <FadeIn delay={0.08} animateOnMount duration={0.4} direction="up">
+              <p className="mt-5 max-w-xl text-base leading-relaxed text-text-secondary md:text-lg">
                 {appsSupported > 0 ? (
                   <T id="hero.subheadline">
-                    Search <Var>{supportedAppsDisplay}</Var>+ Winget packages for free. When you find your app,
-                    sign in and upload it to Microsoft Intune - no scripting required.
+                    IntuneGet turns the Winget catalog — <Var>{supportedAppsDisplay}</Var>+ apps —
+                    into ready-to-deploy Intune packages: detection rules, silent switches, and
+                    updates handled for you. No scripting required.
                   </T>
                 ) : (
                   <T id="hero.subheadline.nocount">
-                    Search the Winget catalog for free. When you find your app,
-                    sign in and upload it to Microsoft Intune - no scripting required.
+                    IntuneGet turns the Winget catalog into ready-to-deploy Intune packages:
+                    detection rules, silent switches, and updates handled for you. No scripting
+                    required.
                   </T>
                 )}
               </p>
             </FadeIn>
+
+            <FadeIn delay={0.16} animateOnMount duration={0.45} direction="up" className="mt-7 w-full">
+              <LandingCatalogSearch />
+            </FadeIn>
+
+            <FadeIn delay={0.24} animateOnMount duration={0.4} direction="up" className="mt-5 w-full md:mt-6">
+              <div className="grid grid-cols-2 gap-x-3 rounded-2xl border border-overlay/[0.07] bg-bg-elevated/60 px-3 py-2 text-xs text-text-secondary shadow-soft sm:text-sm lg:px-5">
+                <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start">
+                  <Code2 aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
+                  <T>No scripting</T>
+                </span>
+                <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start">
+                  <Package aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
+                  <T>No per-device fees</T>
+                </span>
+                <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start">
+                  <Container aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
+                  <T>Self-hostable</T>
+                </span>
+                <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start">
+                  <Scale aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
+                  <T>Open source, AGPL-3.0</T>
+                </span>
+              </div>
+            </FadeIn>
           </div>
 
-          <FadeIn delay={0.16} animateOnMount duration={0.45} direction="up" className="mt-7 w-full md:mt-8">
-            <LandingCatalogSearch />
-          </FadeIn>
-
-          <FadeIn delay={0.24} animateOnMount duration={0.4} direction="up" className="mt-5 w-full md:mt-6">
-            <div className="grid grid-cols-2 gap-x-3 rounded-2xl border border-overlay/[0.07] bg-bg-elevated/60 px-3 py-2 text-xs text-text-secondary shadow-soft sm:text-sm lg:grid-cols-4 lg:px-6 lg:py-3">
-              <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start lg:justify-center">
-                <Code2 aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
-                <T>No scripting</T>
-              </span>
-              <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start lg:justify-center">
-                <Package aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
-                <T>No per-device fees</T>
-              </span>
-              <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start lg:justify-center">
-                <Container aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
-                <T>Self-hostable</T>
-              </span>
-              <span className="flex min-h-10 items-center justify-center gap-2 sm:justify-start lg:justify-center">
-                <Scale aria-hidden="true" className="h-4 w-4 text-accent-cyan" />
-                <T>Open source, AGPL-3.0</T>
-              </span>
-            </div>
+          {/* Right: real-time QA pipeline */}
+          <FadeIn delay={0.2} animateOnMount duration={0.45} direction="up">
+            <LivePipelinePanel />
+            <p className="mt-3 px-1 text-xs text-text-muted">
+              <T id="hero.pipeline.caption">
+                Live from the public QA pipeline — every result above is a real run on a real
+                machine.
+              </T>
+            </p>
           </FadeIn>
         </div>
       </div>

--- a/components/landing/ui/LivePipelinePanel.tsx
+++ b/components/landing/ui/LivePipelinePanel.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Check } from "lucide-react";
+import { T, Var, useGT, useLocale } from "gt-next";
+import { useReducedMotion } from "framer-motion";
+import { AppIcon } from "@/components/AppIcon";
+import { cn } from "@/lib/utils";
+import type { QaLivePhase, QaLiveResponse } from "@/types/qa";
+
+/**
+ * Live hero panel showing the real public QA pipeline: the current run as a
+ * CI-style stepper plus the most recent results, polled from /api/qa/live.
+ * Renders a calm placeholder until the first poll resolves, re-renders only
+ * when the payload meaningfully changes, pauses while the tab is hidden, and
+ * keeps the last good snapshot when a poll fails.
+ */
+
+const POLL_INTERVAL_MS = 8000;
+
+// The runner's nine phases grouped into five display steps.
+const STEP_INDEX: Record<QaLivePhase, number> = {
+  queued: 0,
+  scanning_installer: 0,
+  preparing_package: 0,
+  restoring_vm: 0,
+  installing: 1,
+  detecting_install: 2,
+  uninstalling: 3,
+  verifying_removal: 4,
+  publishing: 4,
+};
+
+function formatDuration(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.round(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${String(rest).padStart(2, "0")}s` : `${rest}s`;
+}
+
+function formatAgo(iso: string, nowMs: number, locale: string | undefined): string {
+  const elapsedSec = Math.max(0, (nowMs - Date.parse(iso)) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto", style: "narrow" });
+  if (elapsedSec < 60) return rtf.format(0, "minute");
+  if (elapsedSec < 3600) return rtf.format(-Math.round(elapsedSec / 60), "minute");
+  if (elapsedSec < 86400) return rtf.format(-Math.round(elapsedSec / 3600), "hour");
+  return rtf.format(-Math.round(elapsedSec / 86400), "day");
+}
+
+interface StepRowProps {
+  label: React.ReactNode;
+  state: "done" | "active" | "pending";
+  detail: React.ReactNode;
+  isLast: boolean;
+  reduceMotion: boolean;
+}
+
+function StepRow({ label, state, detail, isLast, reduceMotion }: StepRowProps) {
+  return (
+    <div className="relative flex min-h-9 items-center gap-3">
+      {!isLast && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute bottom-[-8px] left-[10px] top-[26px] w-0.5",
+            state === "done" ? "bg-status-success/30" : "bg-overlay/[0.08]"
+          )}
+        />
+      )}
+      <span
+        className={cn(
+          "z-10 grid h-[22px] w-[22px] flex-shrink-0 place-items-center rounded-full",
+          state === "done" && "bg-status-success/15 text-status-success",
+          state === "active" &&
+            cn(
+              "border-2 border-accent-cyan/30 border-t-accent-cyan bg-bg-elevated",
+              !reduceMotion && "animate-spin [animation-duration:0.9s]"
+            ),
+          state === "pending" && "border-2 border-overlay/[0.12] bg-bg-elevated"
+        )}
+      >
+        {state === "done" && <Check aria-hidden="true" className="h-3 w-3" />}
+      </span>
+      <span
+        className={cn(
+          "text-[13px] font-medium",
+          state === "pending" ? "text-text-muted" : "text-text-primary"
+        )}
+      >
+        {label}
+      </span>
+      <span
+        className={cn(
+          "ml-auto max-w-[55%] truncate font-mono text-[11.5px] tabular-nums",
+          state === "pending" ? "text-text-muted" : "text-text-secondary"
+        )}
+      >
+        {detail}
+      </span>
+    </div>
+  );
+}
+
+function OutcomePill({ outcome }: { outcome: "running" | "passed" | "failed" }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center whitespace-nowrap rounded-full px-2.5 py-0.5 text-[11.5px] font-semibold",
+        outcome === "running" && "bg-accent-cyan/10 text-accent-cyan",
+        outcome === "passed" && "bg-status-success/10 text-status-success",
+        outcome === "failed" && "bg-status-error/10 text-status-error"
+      )}
+    >
+      {outcome === "running" && <T>Running</T>}
+      {outcome === "passed" && <T>Passed</T>}
+      {outcome === "failed" && <T>Failed</T>}
+    </span>
+  );
+}
+
+export function LivePipelinePanel() {
+  const t = useGT();
+  const localeTag = useLocale() || undefined;
+  const reduceMotion = useReducedMotion() ?? false;
+  const [snapshot, setSnapshot] = useState<QaLiveResponse | null>(null);
+  // Self-hosted installs keep the live feed disabled (404 from the host
+  // gate) and outages return errors; in both cases fall back to a static
+  // explainer instead of showing a connecting state forever.
+  const [disabled, setDisabled] = useState(false);
+  const gateClosedRef = useRef(false);
+  const failCountRef = useRef(0);
+  const hasDataRef = useRef(false);
+  const renderKeyRef = useRef("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // A cold failure (never any data) falls back to the explainer after a few
+    // attempts; once a snapshot arrived, transient failures keep showing it.
+    const recordFailure = () => {
+      failCountRef.current += 1;
+      if (!hasDataRef.current && failCountRef.current >= 3) setDisabled(true);
+    };
+
+    const poll = async () => {
+      if (document.hidden || gateClosedRef.current) return;
+      try {
+        const response = await fetch("/api/qa/live", { cache: "no-store" });
+        if (cancelled) return;
+        if (response.status === 404 || response.status === 403) {
+          gateClosedRef.current = true;
+          setDisabled(true);
+          return;
+        }
+        if (!response.ok) {
+          recordFailure();
+          return;
+        }
+        failCountRef.current = 0;
+        hasDataRef.current = true;
+        setDisabled(false);
+        const data = (await response.json()) as QaLiveResponse;
+        // Only re-render when something meaningful changed, so the panel
+        // stays calm between polls.
+        const key = JSON.stringify([
+          data.current?.wingetId,
+          data.current?.phase,
+          data.current ? Math.floor((data.current.elapsedSeconds ?? 0) / 30) : null,
+          data.recent[0]?.testedAtUtc,
+          data.queue.count,
+        ]);
+        if (key !== renderKeyRef.current && !cancelled) {
+          renderKeyRef.current = key;
+          setSnapshot(data);
+        }
+      } catch {
+        if (!cancelled) recordFailure();
+      }
+    };
+
+    void poll();
+    const interval = setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const stepLabels = [
+    <T key="prepare">Prepare</T>,
+    <T key="install">Install</T>,
+    <T key="detect">Detect</T>,
+    <T key="uninstall">Uninstall</T>,
+    <T key="verify">Verify</T>,
+  ];
+
+  const phaseDetail: Record<QaLivePhase, string> = {
+    queued: t("queued"),
+    scanning_installer: t("VirusTotal scan"),
+    preparing_package: t("building package"),
+    restoring_vm: t("restoring VM"),
+    installing: t("installing"),
+    detecting_install: t("checking detection"),
+    uninstalling: t("uninstalling"),
+    verifying_removal: t("residual scan"),
+    publishing: t("publishing results"),
+  };
+
+  const nowMs = snapshot ? Date.parse(snapshot.serverTime) : 0;
+  const current = snapshot?.current ?? null;
+  const recent = snapshot?.recent ?? [];
+  const lastRun = recent[0] ?? null;
+
+  if (disabled) {
+    // Static explainer for installs without the public live feed.
+    return (
+      <div className="overflow-hidden rounded-2xl border border-overlay/[0.08] bg-bg-elevated shadow-soft-lg">
+        <div className="flex items-center justify-between gap-3 border-b border-overlay/[0.06] px-4 py-3 md:px-5">
+          <span className="text-[13.5px] font-semibold text-text-primary">
+            <T>QA pipeline</T>
+          </span>
+          <span className="inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-overlay/[0.08] bg-overlay/[0.03] px-2.5 py-1 text-[11.5px] font-semibold text-text-secondary">
+            <T>Public QA</T>
+          </span>
+        </div>
+        <div className="px-4 pb-3 pt-3.5 md:px-5">
+          <p className="mb-2.5 text-sm text-text-secondary">
+            <T id="hero.pipeline.explainer">
+              Every package goes through the same automated run on a real machine:
+            </T>
+          </p>
+          {stepLabels.map((label, index) => (
+            <StepRow
+              key={index}
+              label={label}
+              state="done"
+              detail=""
+              isLast={index === stepLabels.length - 1}
+              reduceMotion={reduceMotion}
+            />
+          ))}
+        </div>
+        <div className="flex items-center justify-end gap-3 border-t border-overlay/[0.06] bg-overlay/[0.02] px-4 py-2.5 text-xs md:px-5">
+          <Link
+            href="/qa"
+            className="font-semibold text-accent-cyan transition-colors hover:text-accent-cyan-dim"
+          >
+            <T>QA dashboard</T> →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Featured run: the live one, or the most recent completed run when idle.
+  const featured = current
+    ? {
+        wingetId: current.wingetId,
+        displayName: current.displayName,
+        kindLine: `${current.wingetId} @ ${current.version} · ${formatDuration(current.elapsedSeconds ?? 0)}`,
+        activeStep: STEP_INDEX[current.phase] ?? 0,
+        activeDetail: phaseDetail[current.phase] ?? current.phase,
+        outcome: "running" as const,
+      }
+    : lastRun
+      ? {
+          wingetId: lastRun.wingetId,
+          displayName: lastRun.displayName,
+          kindLine: `${lastRun.wingetId} @ ${lastRun.testedVersion}${
+            lastRun.durationSeconds != null ? ` · ${formatDuration(lastRun.durationSeconds)}` : ""
+          }`,
+          activeStep: stepLabels.length,
+          activeDetail: "",
+          outcome: lastRun.outcome === "Passed" ? ("passed" as const) : ("failed" as const),
+        }
+      : null;
+
+  // Recent rows, excluding the run currently featured while idle.
+  const recentRows = (current ? recent : recent.slice(1)).slice(0, 3);
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-overlay/[0.08] bg-bg-elevated shadow-soft-lg">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 border-b border-overlay/[0.06] px-4 py-3 md:px-5">
+        <span className="text-[13.5px] font-semibold text-text-primary">
+          <T>Live pipeline</T>
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center gap-2 whitespace-nowrap rounded-full border px-2.5 py-1 text-[11.5px] font-semibold tabular-nums",
+            current
+              ? "border-accent-cyan/25 bg-accent-cyan/10 text-accent-cyan"
+              : "border-overlay/[0.08] bg-overlay/[0.03] text-text-secondary"
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              "h-[7px] w-[7px] rounded-full",
+              current ? "bg-accent-cyan" : "bg-text-muted",
+              current && !reduceMotion && "animate-pulse"
+            )}
+          />
+          {snapshot === null ? (
+            <T>Connecting…</T>
+          ) : current ? (
+            <T>Running</T>
+          ) : lastRun ? (
+            <>
+              <T>Live</T>
+              <span aria-hidden="true">·</span>
+              {formatAgo(lastRun.testedAtUtc, nowMs, localeTag)}
+            </>
+          ) : (
+            <T>Live</T>
+          )}
+        </span>
+      </div>
+
+      {/* Featured run */}
+      <div className="px-4 pb-1 pt-3.5 md:px-5">
+        <div className="mb-2.5 flex items-center gap-3">
+          {featured ? (
+            <AppIcon packageId={featured.wingetId} packageName={featured.displayName} size="sm" />
+          ) : (
+            <div className="h-8 w-8 flex-shrink-0 rounded-lg bg-overlay/[0.06]" />
+          )}
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-text-primary">
+              {featured ? featured.displayName : t("Connecting to pipeline…")}
+            </p>
+            <p className="truncate font-mono text-[11px] tabular-nums text-text-muted">
+              {featured ? featured.kindLine : <T>Public QA · live</T>}
+            </p>
+          </div>
+          {featured && (
+            <span className="ml-auto flex-shrink-0">
+              <OutcomePill outcome={featured.outcome} />
+            </span>
+          )}
+        </div>
+        <div>
+          {stepLabels.map((label, index) => {
+            const activeStep = featured?.activeStep ?? -1;
+            const state =
+              index < activeStep ? "done" : index === activeStep ? "active" : "pending";
+            return (
+              <StepRow
+                key={index}
+                label={label}
+                state={state}
+                detail={
+                  state === "done" ? (
+                    <T>done</T>
+                  ) : state === "active" ? (
+                    featured?.activeDetail
+                  ) : (
+                    <T>queued</T>
+                  )
+                }
+                isLast={index === stepLabels.length - 1}
+                reduceMotion={reduceMotion}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Recent results */}
+      <div className="mt-2 border-t border-overlay/[0.06] px-4 pb-1 pt-2.5 md:px-5">
+        <p className="pb-1 text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+          <T>Recent</T>
+        </p>
+        {recentRows.length > 0 ? (
+          recentRows.map((run) => (
+            <div
+              key={`${run.wingetId}-${run.testedAtUtc}`}
+              className="flex items-center gap-3 border-t border-overlay/[0.04] py-2 first:border-t-0"
+            >
+              <AppIcon packageId={run.wingetId} packageName={run.displayName} size="sm" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[13px] font-semibold text-text-primary">
+                  {run.displayName} {run.testedVersion}
+                </p>
+                <p className="truncate font-mono text-[11px] text-text-muted">
+                  {run.durationSeconds != null ? `QA · ${formatDuration(run.durationSeconds)}` : "QA"}
+                  {run.virusTotalStatus === "clean" ? ` · ${t("VT clean")}` : ""}
+                </p>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-2.5">
+                <OutcomePill outcome={run.outcome === "Passed" ? "passed" : "failed"} />
+                <span className="min-w-[9ch] text-right font-mono text-[11px] tabular-nums text-text-muted">
+                  {formatAgo(run.testedAtUtc, nowMs, localeTag)}
+                </span>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="space-y-2 py-2" aria-hidden="true">
+            {[0, 1, 2].map((row) => (
+              <div key={row} className="flex items-center gap-3">
+                <div className="h-8 w-8 rounded-lg bg-overlay/[0.05]" />
+                <div className="h-3 flex-1 rounded bg-overlay/[0.05]" />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-3 border-t border-overlay/[0.06] bg-overlay/[0.02] px-4 py-2.5 text-xs text-text-muted md:px-5">
+        <span className="tabular-nums">
+          {snapshot ? (
+            <T id="hero.pipeline.queue">
+              Public QA · <Var>{snapshot.queue.count.toLocaleString(localeTag)}</Var> in queue
+            </T>
+          ) : (
+            <T>Public QA</T>
+          )}
+        </span>
+        <Link
+          href="/qa"
+          className="font-semibold text-accent-cyan transition-colors hover:text-accent-cyan-dim"
+        >
+          <T>QA dashboard</T> →
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Ports the approved hero redesign into the app: two-column layout with the new headline ("Deploy any Windows app to Intune. Search it, ship it.") and a **live QA pipeline panel** on the right, fed by the real `/api/qa/live` endpoint.

**Left column**: new headline/subheadline (live `appsSupported` counter kept), existing `LandingCatalogSearch` unchanged, existing trust chips unchanged.

**Right column**: new `LivePipelinePanel` — current QA run as a CI-style stepper (9 runner phases grouped into 5 steps), recent results with Passed/Failed pills + VirusTotal status + relative times (`Intl.RelativeTimeFormat`), queue depth, link to /qa. Uses `AppIcon` for real app icons.

**Behavior**: polls every 8s, re-renders only on meaningful change, pauses when the tab is hidden, keeps the last good snapshot on transient failures, and falls back to a static pipeline explainer when the feed is host-gated off (self-hosted installs, and Vercel previews — so this PR's preview shows the explainer state; production shows the live feed).

Verified: production build passes, 1330/1330 tests pass, eslint clean, dev-server render checked at 1440px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)