### PR TITLE
fix(qa): use silent dotPeek removal

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -801,6 +801,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses JetBrains silent mode with the exact dotPeek ARP command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'jetbrains.dotpeek',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/Silent=True']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('selects Podman Desktop all-users mode for the full Intune lifecycle', () => {
     const adapted = applyApplicationPackagingAdapter(
       'redhat.podman-desktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -343,6 +343,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'user',
   },
   {
+    // dotPeek registers a versioned JetBrains.Platform.Installer command with
+    // /HostsToRemove and /PerMachine, but that command opens the interactive
+    // removal path unless JetBrains' documented /Silent=True switch is also
+    // present. Append only that vendor-owned mode to the exact captured ARP
+    // command and keep the versioned host identity unchanged.
+    wingetId: 'JetBrains.dotPeek',
+    reviewedUninstallArguments: ['/Silent=True'],
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -651,6 +651,29 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('binds dotPeek to JetBrains documented silent removal mode', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'JetBrains.dotPeek',
+      displayName: 'JetBrains dotPeek',
+      publisher: 'JetBrains',
+      version: '2026.2.1',
+      architecture: 'x86',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/Silent=True /PerMachine=True',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:{90d6dc38-94fa-5eca-b0fc-228f2e524373}:JetBrains dotPeek 2026.2.1',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/Silent=True']);
+  });
+
   it('binds the elevated NVM lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'CoreyButler.NVMforWindows',


### PR DESCRIPTION
## Summary
- append JetBrains' documented /Silent=True switch to dotPeek's exact captured ARP uninstall command
- preserve the registered versioned /HostsToRemove and /PerMachine arguments
- bind the correction into the immutable QA profile

## Evidence
- workflow 32524060669 waited five minutes on the exact JetBrains registration because its ARP command lacked silent mode
- JetBrains documents /Silent=True for command-line .NET product removal

## Verification
- 127 focused tests passed
- focused ESLint passed
- git diff --check