### PR TITLE
Use silent Zen Browser uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -811,6 +811,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('uses Mozilla NSIS silent mode with the exact Zen Browser ARP command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'zen-team.zen-browser',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/S']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('selects Podman Desktop all-users mode for the full Intune lifecycle', () => {
     const adapted = applyApplicationPackagingAdapter(
       'redhat.podman-desktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -352,6 +352,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/Silent=True'],
   },
   {
+    // Zen Browser uses Mozilla's NSIS helper.exe lifecycle. Its captured ARP
+    // command omits the silent switch and opens the hidden uninstall wizard
+    // under SYSTEM, leaving the exact registration present until timeout.
+    // Mozilla's enterprise removal contract documents helper.exe /S.
+    wingetId: 'Zen-Team.Zen-Browser',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.


### PR DESCRIPTION
## Summary
- append Mozilla NSIS /S to Zen Browser's exact captured helper.exe uninstall command
- keep installation, ARP identity, and bounded completion tracking unchanged
- cover the application adapter contract

## Evidence
- QA run 32533402788 installed and detected Zen Browser, but bare helper.exe left the ARP registration for the full completion window
- Mozilla enterprise documentation specifies helper.exe /S for silent uninstall

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (128 passed)
- npm run lint