### PR TITLE
Block unsupported SQL Server 2017 Express packaging

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -920,6 +920,29 @@ describe('WPS Office unsupported managed install block migration contract', () =
   });
 });
 
+describe('SQL Server 2017 Express unsupported managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260821233000_block_sql_server_2017_express_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the deployment-specific SQL Server lifecycle from generic packaging', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Microsoft.SQLServer.2017.Express'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32536238628'
+    );
+    expect(sql).toContain('features or role, instance identity, and SQL sysadmin accounts');
+    expect(sql).toContain('exact manifest command exited -1');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260821233000_block_sql_server_2017_express_unsupported_managed_install.sql
+++ b/supabase/migrations/20260821233000_block_sql_server_2017_express_unsupported_managed_install.sql
@@ -1,0 +1,39 @@
+-- SQL Server Express is a configurable server workload rather than a generic
+-- desktop application. Microsoft requires unattended setup to choose the
+-- features or role, instance identity, and SQL sysadmin accounts explicitly:
+-- https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt
+-- The current WinGet bootstrapper omits that deployment-specific contract. In
+-- isolated LocalSystem lifecycle QA its exact manifest command exited -1,
+-- created no SQL Server instance or unambiguous ARP identity, and therefore
+-- exposed no safe generic uninstall target. Do not guess customer SQL security
+-- or instance settings in automated packaging.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Microsoft.SQLServer.2017.Express',
+  'unsupported_managed_install',
+  'SQL Server 2017 Express requires deployment-specific feature, instance, and SQL administrator configuration. Its exact WinGet bootstrapper command exits -1 under LocalSystem, creates no SQL instance or unambiguous uninstall identity, and cannot provide a safe generic managed lifecycle.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32536238628'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.SQLServer.2017.Express';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Microsoft.SQLServer.2017.Express'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block generic managed packaging for Microsoft.SQLServer.2017.Express
- supersede queued and failed lifecycle candidates for the unsupported profile
- add migration contract coverage

## Evidence
- QA run 32536238628 used the exact WinGet installer bytes and switches but exited -1 under LocalSystem, created no SQL Server instance, and exposed no unambiguous uninstall identity
- Microsoft documents unattended SQL setup as requiring deployment-specific feature/role, instance, and SQL sysadmin account choices

## Validation
- npm exec -- vitest run lib/qa/migration-contract.test.ts (66 passed)
- npm exec -- eslint lib/qa/migration-contract.test.ts
- git diff --check