### PR TITLE
Extend canonical QA sync timeout

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -943,6 +943,25 @@ describe('SQL Server 2017 Express unsupported managed install block migration co
   });
 });
 
+describe('QA canonical sync statement timeout migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822000500_extend_qa_sync_statement_timeout.sql'
+    ),
+    'utf8'
+  );
+
+  it('extends only the secret-gated sync RPC instead of the shared anon role', () => {
+    expect(sql).toContain(
+      'alter function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)'
+    );
+    expect(sql).toContain("set statement_timeout = '30s'");
+    expect(sql).not.toContain('alter role anon');
+    expect(sql).not.toContain('alter role authenticator');
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822000500_extend_qa_sync_statement_timeout.sql
+++ b/supabase/migrations/20260822000500_extend_qa_sync_statement_timeout.sql
@@ -1,0 +1,12 @@
+-- Canonical QA reconciliation rewrites the mirrored catalog metadata and
+-- enriches every exact package result in one atomic RPC. The payload has grown
+-- beyond the anon role's three-second statement timeout (927 catalog rows and
+-- 1,526 exact package rows at diagnosis), causing three consecutive 57014
+-- failures after otherwise successful lifecycle runs.
+--
+-- Keep the broader anon role limit unchanged. This bounded override applies
+-- only while the credential-validated, security-definer sync RPC executes and
+-- automatically restores the caller setting when the function returns.
+
+alter function public.sync_qa_results_v2(text, jsonb, jsonb, boolean)
+  set statement_timeout = '30s';


### PR DESCRIPTION
## Summary
- give only the secret-gated sync_qa_results_v2 RPC a bounded 30-second statement timeout
- preserve the global anon/authenticator role limits
- add migration contract coverage

## Evidence
- canonical payload now covers 927 catalog rows and 1,526 exact package rows
- VC++ 2010 x64 publications and dedicated recovery all failed with PostgreSQL 57014 under the anon role's 3-second setting
- both immutable VM lifecycle attempts passed; only canonical reconciliation timed out

## Validation
- npm exec -- vitest run lib/qa/migration-contract.test.ts (67 passed)
- npm exec -- eslint lib/qa/migration-contract.test.ts
- git diff --check