### PR TITLE
Block unsupported OpenSCAD managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -962,6 +962,27 @@ describe('QA canonical sync statement timeout migration contract', () => {
   });
 });
 
+describe('OpenSCAD unsupported managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822005500_block_openscad_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the vendor-confirmed orphaned uninstall registration lifecycle', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'OpenSCAD.OpenSCAD'");
+    expect(sql).toContain('https://github.com/openscad/openscad/issues/5494');
+    expect(sql).toContain('documented /S switch');
+    expect(sql).toContain('full five-minute completion window');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822005500_block_openscad_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260822005500_block_openscad_unsupported_managed_uninstall.sql
@@ -1,0 +1,37 @@
+-- OpenSCAD 2021.01's NSIS uninstaller removes the application files but leaves
+-- its Apps & Features registration behind. The vendor tracks this exact defect:
+-- https://github.com/openscad/openscad/issues/5494
+-- Isolated LocalSystem QA invoked the captured vendor Uninstall.exe with the
+-- documented /S switch and waited the full five-minute completion window; the
+-- OpenSCAD registration remained and removal detection correctly stayed true.
+-- Do not publish a managed package that leaves an orphaned installed-app entry.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'OpenSCAD.OpenSCAD',
+  'unsupported_managed_uninstall',
+  'OpenSCAD 2021.01 removes its application files but leaves the Windows uninstall registration behind. Exact isolated QA invoked the documented NSIS /S uninstaller and confirmed the registration still remained after the full completion window.',
+  'https://github.com/openscad/openscad/issues/5494'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'OpenSCAD.OpenSCAD';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'OpenSCAD.OpenSCAD'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block generic managed uninstall for OpenSCAD.OpenSCAD
- supersede failed/queued lifecycle candidates for the unsupported package
- add migration contract coverage

## Evidence
- QA run 32540838091 installed and detected OpenSCAD successfully
- exact captured Uninstall.exe /S removed files but left the OpenSCAD uninstall registration after the full five-minute wait
- upstream OpenSCAD issue #5494 tracks this exact 2021.01 defect

## Validation
- npm exec -- vitest run lib/qa/migration-contract.test.ts (68 passed)
- npm exec -- eslint lib/qa/migration-contract.test.ts
- git diff --check