### PR TITLE
Pin RobotStudio exact package identity

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2829,10 +2829,16 @@ if ($reviewedAppxInstallEvidenceConfigured) {
             '            })'
             '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
             '        }'
-            '        if ($selectedApplications.Count -eq 0) {'
-            '            $bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
-            '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
-            '        }'
+        '        if ($selectedApplications.Count -eq 0 -and -not $configuredUninstallProductCode -and $configuredUninstallPublisherName) {'
+        '            # A wrapper fallback must remain vendor-bound. Background updaters can be the only'
+        '            # non-MSI ARP delta while the real installer is still working; accepting one by count'
+        '            # alone can capture and later remove an unrelated shared application.'
+        '            $bundleCandidates = @($changedApplications | Where-Object {'
+        '                -not $_.WindowsInstaller -and'
+        '                    [string]$_.Publisher -eq $configuredUninstallPublisherName'
+        '            })'
+        '            if ($bundleCandidates.Count -eq 1) { $selectedApplications = $bundleCandidates }'
+        '        }'
         )
     }
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -811,6 +811,26 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('pins RobotStudio to its complete silent install and exact 2025.2 MSI identity', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'abb.robotstudio',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe(
+      '/s /v"/qn ADDLOCAL=ALL /norestart"'
+    );
+    expect(adapted.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(
+      resolveApplicationUninstallCommand(
+        'ABB.RobotStudio',
+        'REGISTRY_UNINSTALL:RobotStudio'
+      )
+    ).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{F8E387C8-8D36-4513-A1AB-9C438461D926}:ABB RobotStudio 2025.2'
+    );
+  });
+
   it('uses Mozilla NSIS silent mode with the exact Zen Browser ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'zen-team.zen-browser',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -118,6 +118,15 @@ const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
   {
+    // ABB documents ADDLOCAL=ALL for a complete unattended RobotStudio
+    // installation. The 2025.2 InstallShield wrapper also services Edge while
+    // it runs, so keep the long-running nested process observable and bind the
+    // resulting package to RobotStudio's exact MSI identity below.
+    wingetId: 'ABB.RobotStudio',
+    reviewedInstallArgumentsOverride: '/s /v"/qn ADDLOCAL=ALL /norestart"',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // Ava Desktop's NSIS bootstrapper installs below the invoking account's
     // LocalAppData even though its WinGet manifest omits Scope. Running it as
     // LocalSystem records a systemprofile uninstaller that is absent by the
@@ -1097,6 +1106,14 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   registeredDisplayName: string;
   registeredRegistryKey?: string;
 }>>> = {
+  // RobotStudio's InstallShield wrapper updates Edge during installation. The
+  // exact 2025.2 MSI identity prevents that unrelated servicing delta from
+  // being captured as RobotStudio's uninstall command.
+  'abb.robotstudio': {
+    generatedDisplayName: 'RobotStudio',
+    registeredDisplayName: 'ABB RobotStudio 2025.2',
+    registeredRegistryKey: '{F8E387C8-8D36-4513-A1AB-9C438461D926}',
+  },
   // The EXE package's catalog name distinguishes it from Google.Chrome, but
   // Google's machine installer registers the ordinary `Google Chrome` ARP
   // identity. Keep that exact vendor identity for capture, verification, and

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1985,6 +1985,12 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(packager).not.toContain(
       '$selectedApplications = @($changedApplications[0])'
     );
+    expect(packager).toContain(
+      'if ($selectedApplications.Count -eq 0 -and -not $configuredUninstallProductCode -and $configuredUninstallPublisherName)'
+    );
+    expect(packager).toContain(
+      '[string]$_.Publisher -eq $configuredUninstallPublisherName'
+    );
   });
 
   it('prefers a registered Burn helper and keeps the packaged fallback for disposable caches', () => {
@@ -2032,7 +2038,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     );
     expect(packager).toContain('-WindowStyle Hidden -WaitForMsiExec -NoWait -PassThru');
     expect(packager).toContain(
-      '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+      '$bundleCandidates = @($changedApplications | Where-Object {'
     );
     expect(packager).toContain(
       '$bundleCandidates = @($selectedApplications | Where-Object {'
@@ -2108,7 +2114,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       expect(innoGenerated).not.toContain('$originalInstallerType');
       expect(burnGenerated).not.toContain('$originalInstallerType');
       expect(burnGenerated).toContain(
-        '$bundleCandidates = @($changedApplications | Where-Object { -not $_.WindowsInstaller })'
+        '[string]$_.Publisher -eq $configuredUninstallPublisherName'
       );
       expect(burnGenerated).toContain('$isVisibleApplication -and -not $_.WindowsInstaller');
       expect(burnGenerated).toContain(


### PR DESCRIPTION
## Summary
- use ABB's complete unattended RobotStudio install contract
- bind RobotStudio 2025.2 to its exact MSI product identity
- prevent executable-wrapper fallback from capturing unrelated background ARP updates

## QA evidence
- failed run 32545671719 captured Microsoft Edge after RobotStudio setup serviced it
- install/removal guard now remains vendor-bound and fails closed

## Validation
- 163 focused tests passed
- targeted ESLint passed
- git diff --check passed