### PR TITLE
Fix Greenshot Preview QA registry identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -50,6 +50,21 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Greenshot Preview\'s exact shared Inno registry identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Greenshot.Greenshot.Preview',
+      'REGISTRY_UNINSTALL:Greenshot Preview'
+    )).toBe('REGISTRY_UNINSTALL_KEY:Greenshot_is1:Greenshot');
+    expect(resolveApplicationUninstallCommand(
+      'Greenshot.Greenshot',
+      'REGISTRY_UNINSTALL:Greenshot'
+    )).toBe('REGISTRY_UNINSTALL:Greenshot');
+    expect(resolveApplicationUninstallCommand(
+      'Greenshot.Greenshot.Preview',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses FSLogix\'s registered bundle display identity', () => {
     expect(resolveApplicationUninstallCommand(
       'Microsoft.FSLogix',
@@ -1109,14 +1124,19 @@ describe('application packaging adapters', () => {
   });
 
   it('closes Greenshot before install and removal lifecycle actions', () => {
-    const adapted = applyApplicationPackagingAdapter(
+    for (const wingetId of [
       'Greenshot.Greenshot',
-      DEFAULT_PSADT_CONFIG
-    );
+      'Greenshot.Greenshot.Preview',
+    ]) {
+      const adapted = applyApplicationPackagingAdapter(
+        wingetId,
+        DEFAULT_PSADT_CONFIG
+      );
 
-    expect(adapted.processesToClose).toEqual([
-      { name: 'Greenshot', description: 'Greenshot' },
-    ]);
+      expect(adapted.processesToClose).toEqual([
+        { name: 'Greenshot', description: 'Greenshot' },
+      ]);
+    }
   });
 
   it('closes Qfinder Pro before its NSIS removal lifecycle', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1004,6 +1004,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Preview builds use the same executable and Inno AppId as stable builds.
+    // Close the tray process before the exact vendor uninstaller runs.
+    wingetId: 'Greenshot.Greenshot.Preview',
+    requiredProcessesToClose: [
+      { name: 'Greenshot', description: 'Greenshot' },
+    ],
+  },
+  {
     // Qfinder Pro starts its desktop process after a silent install. Close it
     // before removal so the NSIS uninstaller can delete the product instead
     // of waiting behind the running application or its startup-error dialog.
@@ -1130,6 +1138,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   'docker.dockerdesktopedge': {
     generatedDisplayName: 'Docker Desktop Edge',
     registeredDisplayName: 'Docker Desktop',
+  },
+  // Greenshot's preview catalog title is `Greenshot Preview`, while the
+  // vendor's Inno source keeps AppId and AppName fixed at `Greenshot` for both
+  // channels. Bind the stable `_is1` key so background ARP changes cannot be
+  // selected and stable/preview packages never rely on broad name matching.
+  'greenshot.greenshot.preview': {
+    generatedDisplayName: 'Greenshot Preview',
+    registeredDisplayName: 'Greenshot',
+    registeredRegistryKey: 'Greenshot_is1',
   },
   // FSLogix is distributed as a ZIP containing Microsoft's Burn-style EXE.
   // WinGet publishes `Microsoft FSLogix Apps` in ProductCode, but the bundle


### PR DESCRIPTION
## Summary
- bind Greenshot Preview to the vendor's exact Inno uninstall key Greenshot_is1`n- use the registered Greenshot display identity without widening global matching
- close the Greenshot tray process for Preview lifecycle removal

## Evidence
- failed QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32550548425
- vendor installer source declares AppId=Greenshot and AppName=Greenshot`n
## Verification
- 
pm exec -- vitest run lib/packaging-adapters.test.ts lib/catalog-installer-reconciliation.test.ts (68 passed)