### PR TITLE
Activate QA empty EXE argument fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c2af5b6dfdd0a6bf44d344366abc23878c23d48b',
+  packagerCommit: '3ce4c3b514ade5658515f6ba9d7a790f695e44f3',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -257,6 +257,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Greenshot Preview's exact Inno registry identity affects only its failed
   // preview-channel lifecycle. Preserve every unrelated valid pass.
   '21fbdbc5a29ca42ac0d2dd1c5939b9ad1f94adc2',
+  // Empty EXE argument handling affects only catalog installers that omit
+  // silent arguments. Preserve every unrelated valid pass.
+  'c2af5b6dfdd0a6bf44d344366abc23878c23d48b',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Amazon.Music',
       'Greenshot.Greenshot.Preview',
       'ABB.RobotStudio',
       'Microsoft.msodbcsql.13',
@@ -106,6 +107,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Amazon.Music',
         'Greenshot.Greenshot.Preview',
         'ABB.RobotStudio',
         'Microsoft.msodbcsql.13',
@@ -561,6 +563,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Greenshot.Greenshot', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Amazon Music only through the empty EXE argument release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Amazon.Music', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'c2af5b6dfdd0a6bf44d344366abc23878c23d48b',
+      { wingetId: 'Amazon.Music', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -9,8 +9,7 @@ export interface QaToolchainBackfillCandidate {
 // application failure. Record only the apps whose previously failing path is
 // changed by the current packager release. Successful and never-tested apps
 // continue through the normal compatibility/backfill logic.
-const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
-  'c2af5b6dfdd0a6bf44d344366abc23878c23d48b': [
+const EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS = [
     // Retry Preview with the vendor's exact Greenshot_is1 Inno identity.
     'Greenshot.Greenshot.Preview',
     // Carry every still-unconsumed bounded target across the atomic pin.
@@ -72,7 +71,17 @@ const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[
     'PTC.CreoView.Express',
     'Blizzard.BattleNet',
     'DATEV.SicherheitspaketCompact',
+  ] as const;
+
+const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3ce4c3b514ade5658515f6ba9d7a790f695e44f3': [
+    // Retry Amazon Music now that argument-free EXE launches omit PSADT's
+    // invalid empty ArgumentList parameter.
+    'Amazon.Music',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
   ],
+  'c2af5b6dfdd0a6bf44d344366abc23878c23d48b': EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
   '1490844284f84f807e207fb9970bddc499bbe446': [
     // Evernote's NSIS uninstaller cannot finish while its desktop process is
     // active. This release closes it through the shared PSADT lifecycle.


### PR DESCRIPTION
## Summary
- pin QA packaging to the immutable empty-argument fix `3ce4c3b514ade5658515f6ba9d7a790f695e44f3`
- preserve prior compatible passing coverage
- target the failed Amazon.Music lifecycle for a fresh retry while carrying outstanding bounded targets

## Verification
- `npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts` (167 passed)