### PR TITLE
Review Amazon Music argument-free install contract

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -244,6 +244,15 @@ if ($psadtConfig.Contains('reviewedInstallArgumentsOverride') -and
     }
 }
 
+$reviewedArgumentlessInstall = $false
+if ($psadtConfig.Contains('reviewedArgumentlessInstall') -and
+    $null -ne $psadtConfig['reviewedArgumentlessInstall']) {
+    if ($psadtConfig['reviewedArgumentlessInstall'] -isnot [bool]) {
+        throw 'PSADT reviewedArgumentlessInstall must be a boolean.'
+    }
+    $reviewedArgumentlessInstall = $psadtConfig['reviewedArgumentlessInstall']
+}
+
 $reviewedInstallCompletionTimeoutMinutes = 0
 if ($psadtConfig.Contains('reviewedInstallCompletionTimeoutMinutes') -and
     $null -ne $psadtConfig['reviewedInstallCompletionTimeoutMinutes']) {
@@ -1303,6 +1312,14 @@ if ($installerTypeLower -eq 'zip' -and -not [string]::IsNullOrWhiteSpace($Nested
     if ($nestedPathIsUnsafe) {
         throw "Unsafe nested installer path: $NestedInstallerPath"
     }
+}
+
+$executesArgumentlessPlainExe = [string]::IsNullOrWhiteSpace($effectiveSilentSwitches) -and (
+    $installerTypeLower -eq 'exe' -or
+    ($installerTypeLower -eq 'zip' -and $NestedInstallerType.ToLowerInvariant() -eq 'exe')
+)
+if ($executesArgumentlessPlainExe -and -not $reviewedArgumentlessInstall) {
+    throw 'A plain EXE package without installer arguments requires a reviewed argumentless install contract.'
 }
 
 # Registry uninstall behavior belongs to the executable inside an archive, not

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -9,6 +9,17 @@ import {
 } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('attests Amazon Music as an argument-free unattended bootstrapper', () => {
+    expect(applyApplicationPackagingAdapter(
+      'Amazon.Music',
+      { ...DEFAULT_PSADT_CONFIG }
+    ).reviewedArgumentlessInstall).toBe(true);
+    expect(applyApplicationPackagingAdapter(
+      'Example.App',
+      { ...DEFAULT_PSADT_CONFIG, reviewedArgumentlessInstall: true }
+    ).reviewedArgumentlessInstall).toBeUndefined();
+  });
+
   it('adds Movavi Photo Focus vendor success code without weakening other apps', () => {
     expect(resolveApplicationInstallerSuccessCodes(
       'Movavi.MovaviPhotoFocus',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -9,6 +9,7 @@ interface ApplicationPackagingAdapter {
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
   reviewedInstallArgumentsOverride?: string;
+  reviewedArgumentlessInstall?: boolean;
   reviewedInstallCompletionTimeoutMinutes?: number;
   reviewedInstallShieldAdministrativeImage?: Readonly<{
     expectedMsiFileName: string;
@@ -117,6 +118,13 @@ const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
  * in the QA execution-profile hash.
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
+  {
+    // Amazon's official WinGet submission intentionally declares its user-scope
+    // bootstrapper without switches and passed Microsoft's unattended validation
+    // (winget-pkgs#94441). Preserve that exact argument-free vendor contract.
+    wingetId: 'Amazon.Music',
+    reviewedArgumentlessInstall: true,
+  },
   {
     // ABB documents ADDLOCAL=ALL for a complete unattended RobotStudio
     // installation. The 2025.2 InstallShield wrapper also services Edge while
@@ -1081,6 +1089,7 @@ export function hasReviewedApplicationInstallContract(wingetId: string): boolean
     adapter && (
       adapter.reviewedInstallArguments?.some((argument) => argument.trim()) ||
       adapter.reviewedInstallArgumentsOverride?.trim() ||
+      adapter.reviewedArgumentlessInstall ||
       adapter.reviewedInstallCompletionTimeoutMinutes ||
       adapter.reviewedInstallShieldAdministrativeImage
     )
@@ -1268,6 +1277,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedInstallArgumentsOverride &&
+      !config.reviewedArgumentlessInstall &&
       !config.reviewedInstallCompletionTimeoutMinutes &&
       !config.reviewedInstallShieldAdministrativeImage &&
       !config.reviewedMultiProductInstallDisplayNamePrefixes &&
@@ -1287,6 +1297,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedInstallArgumentsOverride: undefined,
+      reviewedArgumentlessInstall: undefined,
       reviewedInstallCompletionTimeoutMinutes: undefined,
       reviewedInstallShieldAdministrativeImage: undefined,
       reviewedMultiProductInstallDisplayNamePrefixes: undefined,
@@ -1368,6 +1379,7 @@ export function applyApplicationPackagingAdapter(
     processesToClose,
     reviewedInstallArguments,
     reviewedInstallArgumentsOverride,
+    reviewedArgumentlessInstall: adapter.reviewedArgumentlessInstall || undefined,
     reviewedInstallCompletionTimeoutMinutes:
       adapter.reviewedInstallCompletionTimeoutMinutes,
     installCommand: adapter.reviewedInstallShieldAdministrativeImage

--- a/lib/packaging-contract.test.ts
+++ b/lib/packaging-contract.test.ts
@@ -21,6 +21,18 @@ describe('evaluatePackagingContract', () => {
     }).valid).toBe(true);
   });
 
+  it('accepts Amazon Music through its reviewed argument-free adapter', () => {
+    expect(evaluatePackagingContract({
+      wingetId: 'Amazon.Music',
+      installerType: 'exe',
+      silentArgs: '',
+    })).toEqual({
+      valid: true,
+      family: 'standard-exe',
+      dependencyMode: 'self-contained',
+    });
+  });
+
   it('accepts an EXE whose reviewed adapter supplies the install contract', () => {
     expect(evaluatePackagingContract({
       wingetId: 'Bitvise.SSH.Client',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -806,6 +806,7 @@ export function normalizeQaPsadtConfig(
     postUninstallCommands: value?.postUninstallCommands || [],
     reviewedInstallArguments: value?.reviewedInstallArguments || [],
     reviewedInstallArgumentsOverride: value?.reviewedInstallArgumentsOverride,
+    reviewedArgumentlessInstall: value?.reviewedArgumentlessInstall,
     reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
     reviewedUninstallServiceNames: value?.reviewedUninstallServiceNames,
   };

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1205,7 +1205,7 @@ describe('PSADT vendor argument contract', () => {
           'exe',
           'No Arguments Contract App',
           [],
-          {},
+          { reviewedArgumentlessInstall: true },
           [],
           'IntuneGet.NoArguments',
           'No Arguments Contract App',
@@ -1222,6 +1222,24 @@ describe('PSADT vendor argument contract', () => {
             : 'Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\setup.exe" -WindowStyle Hidden'
         );
       }
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects an argument-free EXE without the reviewed vendor contract',
+    () => {
+      expect(() => generateRegistryUninstallPackage(
+        'exe',
+        'Unreviewed No Arguments App',
+        [],
+        {},
+        [],
+        'IntuneGet.UnreviewedNoArguments',
+        'Unreviewed No Arguments App',
+        '1.0.0',
+        'REGISTRY_UNINSTALL:Unreviewed No Arguments App',
+        ''
+      )).toThrow('requires a reviewed argumentless install contract');
     }
   );
 

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -204,6 +204,11 @@ export interface PSADTConfig {
   // adapters populate this field; customers cannot supply it directly.
   reviewedInstallArgumentsOverride?: string;
 
+  // Internal attestation for a reviewed vendor bootstrapper whose unattended
+  // contract intentionally uses no command-line arguments. Application
+  // adapters populate this field; customers cannot supply it directly.
+  reviewedArgumentlessInstall?: boolean;
+
   // Internal completion window for a reviewed silent bootstrapper that keeps
   // working without producing console output. The generated PSADT package
   // emits bounded progress heartbeats while it waits, so QA and Intune use the
@@ -381,6 +386,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   uninstallCommand: undefined,
   reviewedInstallArguments: [],
   reviewedInstallArgumentsOverride: undefined,
+  reviewedArgumentlessInstall: undefined,
   reviewedInstallCompletionTimeoutMinutes: undefined,
   reviewedInstallShieldAdministrativeImage: undefined,
   reviewedUninstallArguments: [],


### PR DESCRIPTION
## Summary
- add an exact Amazon.Music adapter for its reviewed argument-free user bootstrapper
- carry the attestation into the execution-profile hash
- enforce the same contract inside the PowerShell packager, so unreviewed argument-free EXEs still fail closed

## Evidence
- official manifest intentionally declares the Amazon user-scope EXE without switches
- microsoft/winget-pkgs#94441 completed unattended validation for these exact installer bytes
- QA run 32553686151 showed PSADT rejected the previously emitted empty ArgumentList before the installer launched

## Verification
- 252 focused tests passed
- ESLint passed