### PR TITLE
Activate reviewed Amazon Music QA contract

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3ce4c3b514ade5658515f6ba9d7a790f695e44f3',
+  packagerCommit: '3add630cf3483c2e9ecff61647ca23b727295b9a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -260,6 +260,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Empty EXE argument handling affects only catalog installers that omit
   // silent arguments. Preserve every unrelated valid pass.
   'c2af5b6dfdd0a6bf44d344366abc23878c23d48b',
+  // Amazon Music's reviewed argument-free contract affects only its failed
+  // bootstrapper lifecycle. Preserve every unrelated valid pass.
+  '3ce4c3b514ade5658515f6ba9d7a790f695e44f3',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -74,6 +74,12 @@ const EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS = [
   ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3add630cf3483c2e9ecff61647ca23b727295b9a': [
+    // Retry Amazon Music with its exact reviewed argument-free contract.
+    'Amazon.Music',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
+  ],
   '3ce4c3b514ade5658515f6ba9d7a790f695e44f3': [
     // Retry Amazon Music now that argument-free EXE launches omit PSADT's
     // invalid empty ArgumentList parameter.


### PR DESCRIPTION
## Summary
- pin QA to the immutable reviewed Amazon Music contract `3add630cf3483c2e9ecff61647ca23b727295b9a`
- preserve compatible passing coverage
- retain Amazon.Music as the exact targeted terminal retry

## Verification
- 167 focused toolchain/profile tests passed