### PR TITLE
Extend Amazon Music uninstall completion window

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -10,10 +10,12 @@ import {
 
 describe('application packaging adapters', () => {
   it('attests Amazon Music as an argument-free unattended bootstrapper', () => {
-    expect(applyApplicationPackagingAdapter(
+    const adapted = applyApplicationPackagingAdapter(
       'Amazon.Music',
       { ...DEFAULT_PSADT_CONFIG }
-    ).reviewedArgumentlessInstall).toBe(true);
+    );
+    expect(adapted.reviewedArgumentlessInstall).toBe(true);
+    expect(adapted.uninstallCompletionTimeoutMinutes).toBe(10);
     expect(applyApplicationPackagingAdapter(
       'Example.App',
       { ...DEFAULT_PSADT_CONFIG, reviewedArgumentlessInstall: true }

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -124,6 +124,11 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // (winget-pkgs#94441). Preserve that exact argument-free vendor contract.
     wingetId: 'Amazon.Music',
     reviewedArgumentlessInstall: true,
+    // The signed vendor uninstaller removes the app immediately but its exact
+    // per-user registration can remain for slightly more than five minutes.
+    // Keep waiting for that exact identity rather than reporting failure while
+    // the verified removal is still completing.
+    uninstallCompletionTimeoutMinutes: 10,
   },
   {
     // ABB documents ADDLOCAL=ALL for a complete unattended RobotStudio


### PR DESCRIPTION
## Summary
- extend only Amazon.Music's exact vendor-registration wait from five to ten minutes
- keep the existing exact captured uninstall identity and removal verification unchanged

## QA evidence
Run 32555474536 installed and detected successfully. Its vendor uninstall parent exited promptly and complete removal verification passed, but the exact ARP registration disappeared just after the generic five-minute deadline, producing exit 60001.

## Verification
- 131 focused tests passed
- ESLint passed