### PR TITLE
fix(qa): block host-dependent ReSharper lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1028,6 +1028,28 @@ describe('ReSharper EAP host-dependent install block migration contract', () => 
   });
 });
 
+describe('ReSharper stable host-dependent install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822083000_block_resharper_host_dependent_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the Visual Studio-dependent lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'JetBrains.ReSharper'");
+    expect(sql).toContain(
+      'https://www.jetbrains.com/help/resharper/Installation_Guide.html'
+    );
+    expect(sql).toContain('32556611318');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed')");
+  });
+});
+
 describe('AMD Cloud Edition hardware-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822083000_block_resharper_host_dependent_install.sql
+++ b/supabase/migrations/20260822083000_block_resharper_host_dependent_install.sql
@@ -1,0 +1,38 @@
+-- ReSharper is a Visual Studio extension rather than a standalone application.
+-- JetBrains documents that installation targets selected supported Visual Studio
+-- versions. Isolated LocalSystem QA run 32556611318 invoked the catalog's exact
+-- machine-wide silent command and the vendor bootstrapper returned 0, but the
+-- clean VM had no qualifying IDE host and produced no deterministic ReSharper
+-- application identity. Automated packaging cannot install or attest that
+-- external IDE prerequisite, so block this package instead of publishing a
+-- false standalone lifecycle or guessing at an unrelated uninstall entry.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'JetBrains.ReSharper',
+  'unsupported_managed_install',
+  'ReSharper is a host-dependent Visual Studio extension. Isolated LocalSystem QA used the exact machine-wide silent command, but without a qualifying Visual Studio host it produced no deterministic ReSharper application identity.',
+  'https://www.jetbrains.com/help/resharper/Installation_Guide.html'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'JetBrains.ReSharper';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'JetBrains.ReSharper'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
Extends the existing ReSharper EAP safety policy to the stable JetBrains.ReSharper package. QA run 32556611318 used the catalog's exact machine-wide silent command, but the clean VM had no qualifying Visual Studio host and produced no deterministic ReSharper identity. The migration blocks customer packaging, supersedes queued/failed QA candidates, and avoids unsafe broad uninstall inference.\n\nEvidence: JetBrains documents ReSharper as a Visual Studio extension installed into selected supported Visual Studio versions.\n\nValidation: 70 migration contract tests passed.