### PR TITLE
fix(qa): allow Amazon Music cleanup to finish

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -15,7 +15,7 @@ describe('application packaging adapters', () => {
       { ...DEFAULT_PSADT_CONFIG }
     );
     expect(adapted.reviewedArgumentlessInstall).toBe(true);
-    expect(adapted.uninstallCompletionTimeoutMinutes).toBe(10);
+    expect(adapted.uninstallCompletionTimeoutMinutes).toBe(15);
     expect(applyApplicationPackagingAdapter(
       'Example.App',
       { ...DEFAULT_PSADT_CONFIG, reviewedArgumentlessInstall: true }

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -125,10 +125,11 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     wingetId: 'Amazon.Music',
     reviewedArgumentlessInstall: true,
     // The signed vendor uninstaller removes the app immediately but its exact
-    // per-user registration can remain for slightly more than five minutes.
+    // per-user registration remained for slightly more than ten minutes in
+    // isolated QA run 32557346184.
     // Keep waiting for that exact identity rather than reporting failure while
     // the verified removal is still completing.
-    uninstallCompletionTimeoutMinutes: 10,
+    uninstallCompletionTimeoutMinutes: 15,
   },
   {
     // ABB documents ADDLOCAL=ALL for a complete unattended RobotStudio


### PR DESCRIPTION
Extends only Amazon Music's exact ARP removal wait from 10 to 15 minutes. QA run 32557346184 crossed the 10-minute deadline by seconds, returned uninstall 60001, and then passed complete removal verification immediately afterward. Exact registration disappearance remains authoritative; no generic timeout or success criteria change.\n\nValidation: 240 focused tests passed; ESLint passed.