### PR TITLE
chore(qa): activate Amazon fifteen-minute timeout

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'cf5933d805df9dae22d6ff4d1ace03f5dd4c1655',
+  packagerCommit: 'ffb7638dd870b188654c84673663b8ff151a7985',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -266,6 +266,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Amazon Music's extended uninstall completion deadline affects only its
   // reviewed adapter. Preserve every unrelated valid pass.
   '3add630cf3483c2e9ecff61647ca23b727295b9a',
+  // Amazon Music's longer exact-registration deadline affects only its
+  // reviewed adapter. Preserve every unrelated valid pass.
+  'cf5933d805df9dae22d6ff4d1ace03f5dd4c1655',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -74,6 +74,12 @@ const EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS = [
   ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ffb7638dd870b188654c84673663b8ff151a7985': [
+    // Retry Amazon Music with its reviewed fifteen-minute uninstall deadline.
+    'Amazon.Music',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
+  ],
   'cf5933d805df9dae22d6ff4d1ace03f5dd4c1655': [
     // Retry Amazon Music with its reviewed extended uninstall deadline.
     'Amazon.Music',


### PR DESCRIPTION
Activates packager ffb7638dd870b188654c84673663b8ff151a7985 and preserves unrelated passing coverage. Carries bounded retries forward so Amazon Music is revalidated with the exact fifteen-minute removal deadline.\n\nValidation: 167 focused tests passed.