### PR TITLE
fix(qa): block Gather SYSTEM-profile lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1050,6 +1050,28 @@ describe('ReSharper stable host-dependent install block migration contract', () 
   });
 });
 
+describe('Gather SYSTEM-profile install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822093000_block_gather_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the per-user lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Gather.Gather'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32558961384'
+    );
+    expect(sql).toContain('systemprofile');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('AMD Cloud Edition hardware-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822093000_block_gather_unsupported_managed_install.sql
+++ b/supabase/migrations/20260822093000_block_gather_unsupported_managed_install.sql
@@ -1,0 +1,39 @@
+-- Gather 1.39.2 publishes a scope-less NSIS package. Under Intune LocalSystem,
+-- isolated QA installed it beneath the executing SYSTEM profile and captured
+-- its exact ARP command at:
+-- C:\Windows\system32\config\systemprofile\AppData\Local\Programs\Gather.
+-- Before managed removal began, the registered Uninstall Gather.exe had
+-- disappeared. The package therefore cannot provide a stable machine-wide
+-- install and uninstall lifecycle for employee devices. Block it instead of
+-- shipping a package tied to LocalSystem's private profile or guessing at
+-- vendor switches not declared by the official WinGet manifest.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Gather.Gather',
+  'unsupported_managed_install',
+  'Gather uses a per-user NSIS lifecycle. Under Intune LocalSystem it installs beneath the SYSTEM profile, and isolated QA confirmed that its exact registered uninstaller disappeared before managed removal could begin.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32558961384'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Gather.Gather';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Gather.Gather'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
Blocks Gather.Gather from automated managed packaging. QA run 32558961384 installed it beneath LocalSystem's private systemprofile and captured the exact ARP entry, but the registered uninstaller disappeared before managed removal began. This cannot provide a stable machine-wide Intune lifecycle.\n\nThe migration supersedes queued/failed/error candidates and marks the catalog entry unverified.\n\nValidation: 71 migration contract tests passed.