### PR TITLE
fix(qa): block incomplete Amazon Music removal

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1072,6 +1072,29 @@ describe('Gather SYSTEM-profile install block migration contract', () => {
   });
 });
 
+describe('Amazon Music managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822100000_block_amazon_music_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the incomplete vendor removal lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Amazon.Music'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32559549247'
+    );
+    expect(sql).toContain('fifteen minutes');
+    expect(sql).toContain('residual snapshot');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('AMD Cloud Edition hardware-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822100000_block_amazon_music_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260822100000_block_amazon_music_unsupported_managed_uninstall.sql
@@ -1,0 +1,39 @@
+-- Amazon Music 9.4.0.2386 installs successfully with the argument-free
+-- bootstrapper validated by Microsoft's WinGet pipeline, but its registered
+-- per-user Uninstall.exe does not provide a complete unattended removal
+-- lifecycle. Exact isolated QA run 32559549247 invoked that captured command
+-- and waited fifteen minutes for the authoritative ARP key to disappear. The
+-- key remained, and the residual snapshot still contained one added uninstall
+-- entry plus roughly 2,500 added files. The IntuneGet detection marker cleared,
+-- but that is not evidence that the vendor application was removed. Block the
+-- app instead of publishing a package that leaves Amazon Music installed.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Amazon.Music',
+  'unsupported_managed_uninstall',
+  'Amazon Music installs unattended, but its exact registered per-user uninstaller did not remove the application after a bounded fifteen-minute wait. Isolated QA retained the ARP entry and installed files, so automated managed removal cannot be verified.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32559549247'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Amazon.Music';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Amazon.Music'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
Blocks Amazon.Music from automated managed packaging. Exact QA run 32559549247 installed and detected successfully, then invoked the captured per-user uninstaller and waited fifteen minutes. The authoritative ARP entry and roughly 2,500 added files remained; only IntuneGet's marker cleared.\n\nThe migration records unsupported_managed_uninstall, marks the catalog app unverified, and supersedes queued/failed/error candidates.\n\nValidation: 72 migration contract tests passed.