### PR TITLE
perf(landing): viewport-deferred mounting for below-fold sections

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -2,14 +2,16 @@ import {
   Header,
   HeroSection,
   TrustSection,
-  CapabilitiesSection,
-  ComparisonSection,
   HowItWorksSection,
-  MSPSection,
   FAQSectionAnimated,
-  CTASection,
   Footer,
 } from "@/components/landing";
+import {
+  DeferredCapabilities,
+  DeferredComparison,
+  DeferredMSP,
+  DeferredCTA,
+} from "@/components/landing/DeferredSections";
 import { faqData } from "@/lib/data/faq-data";
 import {
   getPublicLandingStats,
@@ -160,12 +162,12 @@ export default async function LandingPage() {
           <main id="main-content" className="flex-1">
             <HeroSection initialStats={stats} />
             <HowItWorksSection />
-            <CapabilitiesSection />
-            <ComparisonSection />
-            <MSPSection />
+            <DeferredCapabilities />
+            <DeferredComparison />
+            <DeferredMSP />
             <TrustSection initialStats={stats} />
             <FAQSectionAnimated />
-            <CTASection initialStats={stats} />
+            <DeferredCTA initialStats={stats} />
           </main>
           <Footer />
         </div>

--- a/components/landing/DeferredSections.tsx
+++ b/components/landing/DeferredSections.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import dynamic from "next/dynamic";
+import type { LandingStatValues } from "@/hooks/useLandingStats";
+
+/**
+ * Viewport-deferred below-fold sections. These are animation-heavy marketing
+ * sections with low SEO value; skipping their SSR + initial hydration keeps
+ * the landing page's first load JS and main-thread work down (they were part
+ * of a ~2s hydration burst on throttled mobile). Each mounts when the visitor
+ * scrolls within 600px of it. SEO-relevant sections (How It Works, Trust,
+ * FAQ, Footer) intentionally stay server-rendered and eager.
+ */
+
+const CapabilitiesSection = dynamic(
+  () => import("./sections/FeaturesSection").then((m) => m.CapabilitiesSection),
+  { ssr: false }
+);
+const ComparisonSection = dynamic(
+  () => import("./sections/ComparisonSection").then((m) => m.ComparisonSection),
+  { ssr: false }
+);
+const MSPSection = dynamic(
+  () => import("./sections/MSPSection").then((m) => m.MSPSection),
+  { ssr: false }
+);
+const CTASection = dynamic(
+  () => import("./sections/CTASection").then((m) => m.CTASection),
+  { ssr: false }
+);
+
+interface LazyMountProps {
+  children: ReactNode;
+  /** Approximate section height so the scrollbar doesn't jump on mount. */
+  minHeight: number;
+  /** Anchor id kept on the placeholder so #links scroll here before mount. */
+  anchorId?: string;
+}
+
+function LazyMount({ children, minHeight, anchorId }: LazyMountProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setMounted(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setMounted(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "600px 0px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      // The mounted section renders its own anchor id; drop it here to avoid
+      // duplicate ids in the document.
+      id={mounted ? undefined : anchorId}
+      style={mounted ? undefined : { minHeight }}
+    >
+      {mounted ? children : null}
+    </div>
+  );
+}
+
+export function DeferredCapabilities() {
+  return (
+    <LazyMount minHeight={900}>
+      <CapabilitiesSection />
+    </LazyMount>
+  );
+}
+
+export function DeferredComparison() {
+  return (
+    <LazyMount minHeight={800}>
+      <ComparisonSection />
+    </LazyMount>
+  );
+}
+
+export function DeferredMSP() {
+  return (
+    <LazyMount minHeight={700}>
+      <MSPSection />
+    </LazyMount>
+  );
+}
+
+export function DeferredCTA({ initialStats }: { initialStats?: LandingStatValues }) {
+  return (
+    <LazyMount minHeight={700} anchorId="get-started">
+      <CTASection initialStats={initialStats} />
+    </LazyMount>
+  );
+}


### PR DESCRIPTION
Capabilities, Comparison, MSP, and CTA sections now mount only when the visitor scrolls within 600px (IntersectionObserver gate + `dynamic(..., { ssr: false })`), removing their code and hydration from the initial load — Lighthouse attributed ~2s of throttled-mobile main-thread time to hydrating the full page at once.

Kept server-rendered and eager for SEO: How It Works (#how-it-works), Trust, FAQ (#faq), Footer. Placeholders reserve approximate heights; the #get-started anchor sits on the CTA placeholder until mount, so the footer link still works.

Verified: build + lint pass; SSR HTML contains hero/HowItWorks/FAQ but no deferred content; scripted-scroll test confirms sections mount on approach and the anchor is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)