### PR TITLE
feat(icons): binary extraction heals web-sourced icons, family inheritance, duplicate-icon audit

### DIFF
--- a/.github/scripts/audit-duplicate-icons.mjs
+++ b/.github/scripts/audit-duplicate-icons.mjs
@@ -1,0 +1,137 @@
+/**
+ * audit-duplicate-icons.mjs
+ *
+ * Wrong-icon detector: computes an 8x8 average hash for every package's
+ * largest icon and reports clusters of packages that ship pixel-identical
+ * icons. Large clusters are almost always a publisher-level image (an org
+ * avatar or favicon shared by every product of that publisher, e.g. the
+ * Mozilla gift box appearing on all Firefox/Thunderbird variants) or a
+ * generic placeholder -- both mean the real product icon is missing.
+ *
+ * Read-only: writes icon-audit.json and prints a step summary. Never fails.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import sharp from 'sharp';
+
+const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
+const HASH_SIZE = 8;
+
+async function averageHash(filePath) {
+  const { data } = await sharp(filePath)
+    .resize(HASH_SIZE, HASH_SIZE, { fit: 'fill' })
+    .greyscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const avg = data.reduce((a, b) => a + b, 0) / data.length;
+  let bits = '';
+  for (const byte of data) bits += byte > avg ? '1' : '0';
+  return bits;
+}
+
+function hamming(a, b) {
+  let d = 0;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) d++;
+  return d;
+}
+
+function bestIconPath(dir) {
+  for (const size of [256, 128, 64]) {
+    const p = path.join(dir, `icon-${size}.png`);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function main() {
+  if (!fs.existsSync(ICONS_DIR)) {
+    console.log('No icons directory - nothing to audit');
+    return;
+  }
+
+  const packages = fs.readdirSync(ICONS_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name);
+
+  const entries = [];
+  for (const pkg of packages) {
+    const p = bestIconPath(path.join(ICONS_DIR, pkg));
+    if (!p) continue;
+    try {
+      entries.push({ winget_id: pkg, publisher: pkg.split('.')[0], file: p, hash: await averageHash(p) });
+    } catch (err) {
+      console.warn(`Failed to hash ${pkg}: ${err.message}`);
+    }
+  }
+
+  // Exact-match clusters.
+  const byHash = new Map();
+  for (const e of entries) {
+    if (!byHash.has(e.hash)) byHash.set(e.hash, []);
+    byHash.get(e.hash).push(e);
+  }
+
+  // Merge near-duplicates (hamming <= 2) into the same cluster so resampled
+  // variants of the same source image land together.
+  const clusters = [];
+  for (const [hash, members] of [...byHash.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    const existing = clusters.find(c => hamming(c.hash, hash) <= 2);
+    if (existing) existing.members.push(...members);
+    else clusters.push({ hash, members });
+  }
+
+  const suspicious = clusters
+    .filter(c => c.members.length >= 3)
+    .map(c => {
+      const publishers = {};
+      for (const m of c.members) publishers[m.publisher] = (publishers[m.publisher] || 0) + 1;
+      const topPublisher = Object.entries(publishers).sort((a, b) => b[1] - a[1])[0];
+      const dominantShare = topPublisher[1] / c.members.length;
+      return {
+        cluster_size: c.members.length,
+        dominant_publisher: topPublisher[0],
+        dominant_publisher_share: Number(dominantShare.toFixed(2)),
+        classification: topPublisher[1] >= 5 && dominantShare >= 0.5
+          ? 'likely_publisher_level_icon'
+          : 'possibly_generic_placeholder',
+        sample_packages: c.members.slice(0, 25).map(m => m.winget_id),
+      };
+    })
+    .sort((a, b) => b.cluster_size - a.cluster_size);
+
+  const flaggedPackages = new Set();
+  for (const c of suspicious) for (const id of c.sample_packages) flaggedPackages.add(id);
+
+  fs.writeFileSync('icon-audit.json', JSON.stringify({
+    generated_at: new Date().toISOString(),
+    total_icons_audited: entries.length,
+    suspicious_clusters: suspicious.length,
+    flagged_sample_packages: [...flaggedPackages],
+    clusters: suspicious.slice(0, 100),
+  }, null, 2));
+
+  console.log(`\n=== Icon Audit ===`);
+  console.log(`Icons audited: ${entries.length}`);
+  console.log(`Suspicious duplicate clusters (>=3 identical icons): ${suspicious.length}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY && suspicious.length > 0) {
+    const lines = [
+      '## Duplicate Icon Audit',
+      '',
+      `Audited **${entries.length}** icons. Found **${suspicious.length}** clusters where 3+ packages share a near-identical icon.`,
+      '',
+      '| Cluster | Dominant publisher | Share | Classification |',
+      '|---|---|---|---|',
+    ];
+    for (const c of suspicious.slice(0, 20)) {
+      lines.push(`| ${c.cluster_size} | ${c.dominant_publisher} | ${Math.round(c.dominant_publisher_share * 100)}% | \`${c.classification}\` |`);
+    }
+    lines.push('', 'Full report: `icon-audit.json` artifact.');
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
+  }
+}
+
+main().catch(err => {
+  console.error(`Icon audit failed (non-blocking): ${err.message}`);
+});

--- a/.github/scripts/fetch-web-icons.mjs
+++ b/.github/scripts/fetch-web-icons.mjs
@@ -190,6 +190,34 @@ async function resizeAndSave(sourceBuffer, outputDir) {
 }
 
 /**
+ * Family inheritance: locale/variant packages (e.g. Mozilla.Firefox.es-ES)
+ * should reuse the icon already produced for their base package
+ * (e.g. Mozilla.Firefox) instead of hitting the network tiers independently.
+ * Walks proper prefixes of the winget ID from longest to shortest and returns
+ * the best available source buffer (prefers 256 > 128 > 64).
+ * Returns { buffer, ancestorId } on success, null when no ancestor has an icon.
+ */
+function findAncestorIcon(wingetId) {
+  const parts = wingetId.split('.');
+  for (let take = parts.length - 1; take >= 1; take--) {
+    const ancestorId = parts.slice(0, take).join('.');
+    const ancestorDir = path.join(ICONS_DIR, ancestorId);
+    if (!fs.existsSync(ancestorDir)) continue;
+    for (const size of [256, 128, 64]) {
+      const p = path.join(ancestorDir, `icon-${size}.png`);
+      if (fs.existsSync(p)) {
+        try {
+          return { buffer: fs.readFileSync(p), ancestorId };
+        } catch {
+          continue;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Tier 2: Try to fetch the publisher's GitHub avatar.
  * Returns the image buffer on success, null on failure.
  */
@@ -488,6 +516,7 @@ async function main() {
   let faviconHits = 0;
   let storeHits = 0;
   let homepageHits = 0;
+  let inheritedHits = 0;
   let misses = 0;
 
   for (const app of apps) {
@@ -513,6 +542,28 @@ async function main() {
 
     let source = null;
     let buffer = null;
+
+    // Family inheritance first: a locale/variant package whose base package
+    // already has an icon never needs a network fetch. This keeps every
+    // variant visually consistent with its product family and avoids
+    // publisher-level images (org avatars, favicons) leaking onto variants.
+    if (!MISSING_SIZES_ONLY && !BINARY_GAP_FILL) {
+      const ancestor = findAncestorIcon(wingetId);
+      if (ancestor) {
+        const savedInherited = await resizeAndSave(ancestor.buffer, outputDir);
+        if (savedInherited) {
+          console.log(`  [family_inherited] ${wingetId} <- ${ancestor.ancestorId}`);
+          results.push({
+            winget_id: wingetId,
+            status: 'success',
+            icon_source: 'family_inherited',
+            icon_path: `/icons/${wingetId}/`,
+          });
+          inheritedHits++;
+          continue;
+        }
+      }
+    }
 
     if (MISSING_SIZES_ONLY) {
       // Re-use the source that originally produced this app's icon so the
@@ -598,6 +649,7 @@ async function main() {
         if (source === 'github_avatar') githubHits++;
         else if (source === 'microsoft_store') storeHits++;
         else if (source === 'homepage_image') homepageHits++;
+        else if (source === 'family_inherited') inheritedHits++;
         else faviconHits++;
         continue;
       }
@@ -617,6 +669,7 @@ async function main() {
   console.log(`Microsoft Store: ${storeHits}`);
   console.log(`GitHub avatars: ${githubHits}`);
   console.log(`Homepage images: ${homepageHits}`);
+  console.log(`Family inherited: ${inheritedHits}`);
   console.log(`Favicons: ${faviconHits}`);
   console.log(`No icon found: ${misses}`);
   console.log(`Total processed: ${apps.length}`);
@@ -635,11 +688,12 @@ async function main() {
   // Write counts for GitHub Actions output
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {
-    fs.appendFileSync(outputFile, `github_hits=${githubHits}\n`);
-    fs.appendFileSync(outputFile, `favicon_hits=${faviconHits}\n`);
-    fs.appendFileSync(outputFile, `store_hits=${storeHits}\n`);
-    fs.appendFileSync(outputFile, `homepage_hits=${homepageHits}\n`);
-    fs.appendFileSync(outputFile, `total_hits=${githubHits + faviconHits + storeHits + homepageHits}\n`);
+  fs.appendFileSync(outputFile, `github_hits=${githubHits}\n`);
+  fs.appendFileSync(outputFile, `favicon_hits=${faviconHits}\n`);
+  fs.appendFileSync(outputFile, `store_hits=${storeHits}\n`);
+  fs.appendFileSync(outputFile, `homepage_hits=${homepageHits}\n`);
+  fs.appendFileSync(outputFile, `inherited_hits=${inheritedHits}\n`);
+  fs.appendFileSync(outputFile, `total_hits=${githubHits + faviconHits + storeHits + homepageHits + inheritedHits}\n`);
   }
 }
 

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -114,11 +114,27 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          MAX_APPS: ${{ env.MAX_APPS }}
+          # Web fetching is fast (seconds per app); allow a larger batch than
+          # the binary job so the cursor advances meaningfully per run.
+          MAX_APPS: ${{ github.event.inputs.max_apps || '300' }}
           ICONS_DIR: public/icons
           MISSING_SIZES_ONLY: ${{ github.event.inputs.missing_sizes_only || 'false' }}
           BINARY_GAP_FILL: ${{ github.event.inputs.binary_gap_fill || 'false' }}
         run: node .github/scripts/fetch-web-icons.mjs
+
+      - name: Audit duplicate icons
+        if: always()
+        env:
+          ICONS_DIR: public/icons
+        run: node .github/scripts/audit-duplicate-icons.mjs
+
+      - name: Upload icon audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: icon-audit
+          path: icon-audit.json
+          if-no-files-found: ignore
 
       - name: Commit web icons
         id: commit-web-icons
@@ -243,11 +259,13 @@ jobs:
             FAVICON=$(jq '[.[] | select(.icon_source == "favicon")] | length' web-icon-results.json)
             STORE=$(jq '[.[] | select(.icon_source == "microsoft_store")] | length' web-icon-results.json)
             HOMEPAGE=$(jq '[.[] | select(.icon_source == "homepage_image")] | length' web-icon-results.json)
+            INHERITED=$(jq '[.[] | select(.icon_source == "family_inherited")] | length' web-icon-results.json)
             TOTAL=$(jq 'length' web-icon-results.json)
             echo "- **GitHub avatars:** $GITHUB" >> $GITHUB_STEP_SUMMARY
             echo "- **Favicons:** $FAVICON" >> $GITHUB_STEP_SUMMARY
             echo "- **Microsoft Store:** $STORE" >> $GITHUB_STEP_SUMMARY
             echo "- **Homepage images:** $HOMEPAGE" >> $GITHUB_STEP_SUMMARY
+            echo "- **Family inherited:** $INHERITED" >> $GITHUB_STEP_SUMMARY
             echo "- **Total success:** $SUCCESS" >> $GITHUB_STEP_SUMMARY
             echo "- **Total processed:** $TOTAL" >> $GITHUB_STEP_SUMMARY
           fi
@@ -355,7 +373,12 @@ jobs:
           async function getApps() {
             let query = supabase
               .from('curated_apps')
-              .select('winget_id, name, publisher, latest_version, icon_extraction_attempts, icon_source');
+              .select('winget_id, name, publisher, latest_version, has_icon, icon_extraction_attempts, icon_source');
+
+            // Low-fidelity web sources are placeholders: binary extraction
+            // always wins over them, so include them here to heal wrong icons
+            // (e.g. publisher avatars shown for product apps like Firefox).
+            const WEB_SOURCES = ['github_avatar', 'favicon', 'homepage_image'];
 
             if (appIds !== 'all') {
               const targetIds = appIds.split(',').map(id => id.trim());
@@ -377,12 +400,10 @@ jobs:
                 .range(startOffset, startOffset + maxApps - 1);
             } else {
               if (!forceRefresh) {
-                query = query.or('has_icon.is.null,has_icon.eq.false');
-              }
-
-              if (!forceRefresh) {
+                query = query.or('has_icon.is.null,has_icon.eq.false,icon_source.in.(github_avatar,favicon,homepage_image)');
                 query = query.or('icon_extraction_attempts.is.null,icon_extraction_attempts.lt.3');
               }
+              query = query.order('winget_id', { ascending: true });
               query = query.limit(maxApps);
             }
 
@@ -393,7 +414,49 @@ jobs:
               process.exit(1);
             }
 
-            const wingetIds = apps.map(a => a.winget_id);
+            // Resolve an app's package-family ancestors (Mozilla.Firefox.es-ES ->
+            // Mozilla.Firefox). Returns the longest ancestor directory that
+            // already has every target size on disk, so locale/variant packages
+            // reuse their base product's extracted icon instead of each
+            // downloading its own installer.
+            function findFullAncestorDir(wingetId) {
+              const parts = wingetId.split('.');
+              for (let take = parts.length - 1; take >= 2; take--) {
+                const dir = path.join('public/icons', parts.slice(0, take).join('.'));
+                if (!fs.existsSync(dir)) continue;
+                const complete = TARGET_SIZES.every(s => fs.existsSync(path.join(dir, `icon-${s}.png`)));
+                if (complete) return dir;
+              }
+              return null;
+            }
+
+            const wingetIds = [];
+            const inheritedResults = [];
+
+            for (const app of apps) {
+              if (!missingSizesOnly && !forceRefresh) {
+                const ancestorDir = findFullAncestorDir(app.winget_id);
+                if (ancestorDir) {
+                  const iconDir = path.join('public/icons', app.winget_id);
+                  fs.mkdirSync(iconDir, { recursive: true });
+                  for (const file of fs.readdirSync(ancestorDir)) {
+                    if (/^icon-\d+\.png$/.test(file) && !fs.existsSync(path.join(iconDir, file))) {
+                      fs.copyFileSync(path.join(ancestorDir, file), path.join(iconDir, file));
+                    }
+                  }
+                  console.log(`Inherited icon for ${app.winget_id} from ${path.basename(ancestorDir)} (no installer download needed)`);
+                  inheritedResults.push({
+                    winget_id: app.winget_id,
+                    status: 'success',
+                    icon_path: `/icons/${app.winget_id}/`,
+                    icon_source: 'family_inherited'
+                  });
+                  continue;
+                }
+              }
+              wingetIds.push(app.winget_id);
+            }
+
             const installerMap = {};
             if (wingetIds.length > 0) {
               const { data: vhRows } = await supabase
@@ -415,6 +478,7 @@ jobs:
 
             const appsToProcess = [];
             for (const app of apps) {
+              if (inheritedResults.some(r => r.winget_id === app.winget_id)) continue;
               const iconDir = `public/icons/${app.winget_id}`;
               if (missingSizesOnly) {
                 // Process only if at least one target size is missing on disk.
@@ -427,7 +491,8 @@ jobs:
                 appsToProcess.push(app);
               } else {
                 const iconPath = `${iconDir}/icon-64.png`;
-                if (forceRefresh || !fs.existsSync(iconPath)) {
+                const hasWebIcon = WEB_SOURCES.includes(app.icon_source);
+                if (forceRefresh || !fs.existsSync(iconPath) || hasWebIcon) {
                   const attempts = app.icon_extraction_attempts || 0;
                   if (!forceRefresh && attempts >= 3) {
                     console.log(`Skipping ${app.winget_id} (${attempts} failed attempts)`);
@@ -441,13 +506,27 @@ jobs:
               if (appsToProcess.length >= maxApps) break;
             }
 
-            console.log(`Processing ${appsToProcess.length} apps for binary icon extraction`);
+            // Merge inherited successes into the results file so the commit and
+            // database steps publish them even when no installer downloads ran.
+            let existingResults = [];
+            if (inheritedResults.length > 0) {
+              try {
+                existingResults = JSON.parse(fs.readFileSync('icon-results.json', 'utf8'));
+              } catch {}
+              fs.writeFileSync(
+                'icon-results.json',
+                JSON.stringify([...existingResults.filter(r => !inheritedResults.some(i => i.winget_id === r.winget_id)), ...inheritedResults], null, 2)
+              );
+            }
+
+            console.log(`Processing ${appsToProcess.length} apps for binary icon extraction (${inheritedResults.length} resolved via family inheritance)`);
 
             fs.writeFileSync('apps-to-process.json', JSON.stringify(appsToProcess, null, 2));
 
             const outputFile = process.env.GITHUB_OUTPUT;
             if (outputFile) {
-              fs.appendFileSync(outputFile, `app_count=${appsToProcess.length}\n`);
+              fs.appendFileSync(outputFile, `app_count=${appsToProcess.length + inheritedResults.length}\n`);
+              fs.appendFileSync(outputFile, `inherited_count=${inheritedResults.length}\n`);
             }
           }
 
@@ -471,6 +550,13 @@ jobs:
           }
 
           $apps = Get-Content "apps-to-process.json" | ConvertFrom-Json
+
+          # Preserve family-inherited successes written by the get-apps step;
+          # this file is rewritten below so they must be carried through.
+          $priorResults = @()
+          if (Test-Path "icon-results.json") {
+            try { $priorResults = @(Get-Content "icon-results.json" -Raw | ConvertFrom-Json) } catch {}
+          }
 
           $extracted = 0
           $failed = 0
@@ -710,7 +796,7 @@ jobs:
           Write-Host "Extracted: $extracted"
           Write-Host "Failed: $failed"
 
-          ConvertTo-Json -InputObject @($results) -Depth 10 | Out-File "icon-results.json" -Encoding utf8NoBOM
+          ConvertTo-Json -InputObject @($priorResults + $results) -Depth 10 | Out-File "icon-results.json" -Encoding utf8NoBOM
 
           echo "extracted=$extracted" >> $env:GITHUB_OUTPUT
           echo "failed=$failed" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Icon pipeline reliability fixes

- **Precedence inversion fixed:** binary extraction now also targets apps whose icon came from low-fidelity web tiers (\github_avatar\, \avicon\, \homepage_image\) and overwrites them with the real installer-extracted icon (fixes e.g. Mozilla.Firefox showing Mozilla's org avatar).
- **Family inheritance:** locale/variant packages inherit their base package's icon instead of fetching independently (both web job and binary job).
- **Duplicate-icon audit:** new pHash-based audit step flags clusters of 3+ packages sharing near-identical icons (publisher-level image detector), published as step summary + artifact.
- **Throughput:** web job batch raised to 300/run; deterministic ordering in binary job query.