### PR TITLE
fix(qa): block unsafe superProductivity lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1118,6 +1118,29 @@ describe('Standard Notes SYSTEM-profile lifecycle block migration contract', () 
   });
 });
 
+describe('superProductivity SYSTEM-profile lifecycle block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822111500_block_superproductivity_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsafe per-user lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'JohannesMillan.superProductivity'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32564266080'
+    );
+    expect(sql).toContain('LocalSystem profile');
+    expect(sql).toContain('2,914');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('AMD Cloud Edition hardware-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822111500_block_superproductivity_unsupported_managed_install.sql
+++ b/supabase/migrations/20260822111500_block_superproductivity_unsupported_managed_install.sql
@@ -1,0 +1,36 @@
+-- superProductivity is a per-user NSIS application when invoked by LocalSystem.
+-- Isolated QA run 32564266080 installed it beneath the LocalSystem profile and
+-- captured the exact vendor uninstall registration. Before managed removal,
+-- that registration's executable had disappeared while the registration and
+-- 2,914 added files remained. The IntuneGet marker cleared, but the vendor
+-- application did not, so this lifecycle must not be published.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'JohannesMillan.superProductivity',
+  'unsupported_managed_install',
+  'superProductivity installs into the LocalSystem profile during device-context deployment, and its exact registered NSIS uninstaller disappeared before managed removal. Isolated QA retained the application registration and 2,914 installed files, so a safe customer lifecycle cannot be verified.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32564266080'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'JohannesMillan.superProductivity';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'JohannesMillan.superProductivity'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block JohannesMillan.superProductivity from automated customer packaging
- record isolated QA run 32564266080 as authoritative evidence
- supersede queued/failed candidates and clear verified state

## Evidence
The device-context install succeeded under the LocalSystem profile and captured an exact NSIS uninstall registration. Before uninstall, that registered executable was gone. QA retained the app registration and 2,914 added files, so marker removal could not establish a safe managed lifecycle.

## Verification
- npm test -- lib/qa/migration-contract.test.ts (74 passed)