### PR TITLE
fix: constrain responsive grids on mobile across marketing pages

### DIFF
--- a/app/(marketing)/apps/CatalogSearch.tsx
+++ b/app/(marketing)/apps/CatalogSearch.tsx
@@ -106,7 +106,7 @@ export function CatalogSearch() {
               )}
             </p>
           ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {results.map((app) => (
                 <div
                   key={app.id}

--- a/app/(marketing)/apps/page.tsx
+++ b/app/(marketing)/apps/page.tsx
@@ -107,7 +107,7 @@ export default async function AppsPage() {
               <T>Popular apps</T>
             </h2>
             {apps.length > 0 ? (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {apps.map((app) => (
                   <div
                     key={app.winget_id}

--- a/app/(marketing)/docs/database-setup/page.tsx
+++ b/app/(marketing)/docs/database-setup/page.tsx
@@ -47,7 +47,7 @@ export default function DatabaseSetupPage() {
         <p className="text-text-secondary mb-4">
           <T>The self-hosted version of IntuneGet uses SQLite, providing:</T>
         </p>
-        <div className="grid gap-4 sm:grid-cols-3 mb-6">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mb-6">
           <div className="rounded-lg border border-overlay/10 bg-bg-elevated p-4">
             <div className="flex items-center gap-3 mb-3">
               <Database className="h-5 w-5 text-accent-cyan" />

--- a/app/(marketing)/docs/docker/page.tsx
+++ b/app/(marketing)/docs/docker/page.tsx
@@ -324,7 +324,7 @@ services:
           </p>
         </Callout>
 
-        <div className="grid gap-4 sm:grid-cols-3 mt-6">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mt-6">
           <div className="rounded-lg border border-overlay/10 bg-bg-elevated p-4">
             <h3 className="font-semibold text-text-primary mb-2 flex items-center gap-2">
               <Shield className="h-4 w-4 text-accent-cyan" />

--- a/components/landing/sections/Footer.tsx
+++ b/components/landing/sections/Footer.tsx
@@ -220,7 +220,7 @@ export function Footer() {
                   aria-hidden="true"
                 />
               </summary>
-              <ul className="grid gap-3 pb-5 sm:grid-cols-3">
+              <ul className="grid grid-cols-1 gap-3 pb-5 sm:grid-cols-3">
                 {group.links.map((link) => (
                   <li key={link.label}>
                     <FooterNavLink link={link} />


### PR DESCRIPTION
Sweep for the same failure mode as the hero fix (#749): grids declaring column tracks only at `sm:`/`lg:` fall back to an implicit **auto-sized** column on mobile, so nowrap content sets the column width instead of truncating - on /apps the app cards measured 452px wide in a 390px viewport (79px of page overflow, the reported bug).

Adds the `grid-cols-1` base to all five affected grids found in the sweep:
- `/apps` popular-apps grid and `CatalogSearch` results grid (the reported overflow)
- docs/database-setup and docs/docker card grids
- footer link columns

Verified with a scripted 390px browser test on /apps: document overflow 0px, all 27 cards at 358px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)