### PR TITLE
fix(qa): block SQL Server 2025 Express

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -943,6 +943,29 @@ describe('SQL Server 2017 Express unsupported managed install block migration co
   });
 });
 
+describe('SQL Server 2025 Express unsupported managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822120000_block_sql_server_2025_express_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the deployment-specific SQL Server lifecycle from generic packaging', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Microsoft.SQLServer.2025.Express'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32566074806'
+    );
+    expect(sql).toContain('features or role, instance identity, and SQL sysadmin accounts');
+    expect(sql).toContain('exact manifest command exited -1');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('QA canonical sync statement timeout migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260822120000_block_sql_server_2025_express_unsupported_managed_install.sql
+++ b/supabase/migrations/20260822120000_block_sql_server_2025_express_unsupported_managed_install.sql
@@ -1,0 +1,39 @@
+-- SQL Server Express is a configurable server workload rather than a generic
+-- desktop application. Microsoft requires unattended setup to choose the
+-- features or role, instance identity, and SQL sysadmin accounts explicitly:
+-- https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt
+-- The current WinGet bootstrapper omits that deployment-specific contract. In
+-- isolated LocalSystem lifecycle QA its exact manifest command exited -1,
+-- created no SQL Server instance or unambiguous ARP identity, and therefore
+-- exposed no safe generic uninstall target. Do not guess customer SQL security
+-- or instance settings in automated packaging.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Microsoft.SQLServer.2025.Express',
+  'unsupported_managed_install',
+  'SQL Server 2025 Express requires deployment-specific feature, instance, and SQL administrator configuration. Its exact WinGet bootstrapper command exits -1 under LocalSystem, creates no SQL instance or unambiguous uninstall identity, and cannot provide a safe generic managed lifecycle.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32566074806'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.SQLServer.2025.Express';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Microsoft.SQLServer.2025.Express'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Microsoft.SQLServer.2025.Express from generic automated packaging
- record isolated QA run 32566074806 as authoritative evidence
- supersede queued/failed candidates and clear verified state

## Evidence
The exact WinGet bootstrapper command exited -1 under LocalSystem, created no SQL instance or unambiguous uninstall identity, and therefore exposed no safe removal target. SQL Server setup requires customer-specific feature, instance, and administrator configuration that the generic catalog profile cannot safely guess.

## Verification
- npm test -- lib/qa/migration-contract.test.ts (75 passed)