### PR TITLE
fix: block unsafe Wise Disk Cleaner uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1210,3 +1210,27 @@ describe('Teradata TTU Base suite managed uninstall block migration contract', (
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Wise Disk Cleaner managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822133000_block_wise_disk_cleaner_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the incomplete vendor removal lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'WiseCleaner.WiseDiskCleaner'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32569486048'
+    );
+    expect(sql).toContain('Wise Disk Cleaner_is1');
+    expect(sql).toContain('both shortcuts');
+    expect(sql).toContain('2,967');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260822133000_block_wise_disk_cleaner_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260822133000_block_wise_disk_cleaner_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- Wise Disk Cleaner 11.2.7 installs and detects successfully under LocalSystem,
+-- but its exact registered Inno Setup uninstaller does not provide a complete
+-- unattended removal lifecycle. Isolated QA run 32569486048 invoked
+-- unins000.exe with the captured silent arguments and waited five minutes for
+-- the authoritative Wise Disk Cleaner_is1 registration to disappear. The ARP
+-- entry and both shortcuts remained, while the residual snapshot contained
+-- roughly 2,967 added files. Block publication instead of treating the cleared
+-- IntuneGet detection marker as proof that the vendor application was removed.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'WiseCleaner.WiseDiskCleaner',
+  'unsupported_managed_uninstall',
+  'Wise Disk Cleaner installs unattended, but its exact registered silent uninstaller did not remove the application within five minutes. Isolated QA retained the ARP entry, both shortcuts, and roughly 2,967 added files, so automated managed removal cannot be verified.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32569486048'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'WiseCleaner.WiseDiskCleaner';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'WiseCleaner.WiseDiskCleaner'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block WiseCleaner.WiseDiskCleaner after its exact registered silent uninstaller left the application installed
- supersede non-terminal QA candidates
- document the authoritative ARP, shortcut, and file residuals

## Evidence
- protected QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32569486048
- exact registration Wise Disk Cleaner_is1 remained after five minutes
- residual: 1 ARP entry, 2 shortcuts, ~2,967 files

## Verification
- npm test -- lib/qa/migration-contract.test.ts (77/77)