### PR TITLE
fix: mobile overflow audit across all public routes

### DIFF
--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -47,7 +47,7 @@ export default function PrivacyPage() {
       />
 
       {/* Content */}
-      <main className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28">
+      <main className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28 w-full">
         <div className="space-y-8">
           <div>
             <h1 className="text-3xl font-bold text-text-primary sm:text-4xl">

--- a/app/(marketing)/security/page.tsx
+++ b/app/(marketing)/security/page.tsx
@@ -104,7 +104,7 @@ export default function SecurityPage() {
       />
 
       {/* Content */}
-      <main id="main-content" className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28">
+      <main id="main-content" className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28 w-full">
         <div className="space-y-8">
           <div>
             <h1 className="text-3xl font-bold text-text-primary sm:text-4xl">

--- a/app/(marketing)/terms/page.tsx
+++ b/app/(marketing)/terms/page.tsx
@@ -47,7 +47,7 @@ export default function TermsPage() {
       />
 
       {/* Content */}
-      <main className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28">
+      <main className="flex-1 mx-auto max-w-4xl px-4 py-12 lg:px-8 lg:py-16 pt-24 lg:pt-28 w-full">
         <div className="space-y-8">
           <div>
             <h1 className="text-3xl font-bold text-text-primary sm:text-4xl">

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,18 @@
   --font-mono: "JetBrains Mono", "JetBrains Mono Fallback";
 }
 
+/* ===== MOBILE OVERFLOW SAFETY NETS =====
+   Long unbreakable tokens (Winget package IDs, Graph permission scopes,
+   URLs) must wrap instead of stretching the layout on small screens, and
+   code blocks must scroll instead of widening the page. */
+body {
+  overflow-wrap: anywhere;
+}
+pre {
+  overflow-x: auto;
+  max-width: 100%;
+}
+
 /* ===== REDUCED MOTION SUPPORT ===== */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
Scripted audit: loaded **all 29 public routes** at 390px in headless Chrome and measured horizontal overflow. 7 routes failed (/security +28, /changelog +18, /docs/unmanaged-apps +39, /docs/azure-setup +95, /docs/getting-started +51, and two blog posts up to +161).

Three root causes, three fixes:
1. **Shrink-to-fit mains**: `mx-auto` on a flex item disables stretch, so `main` sized itself to the min-content of tables/code inside, defeating their `overflow-x-auto` wrappers. Added `w-full` to the security/privacy/terms mains (about and changelog already had it).
2. **Long unbreakable tokens** (Graph scopes like `DeviceManagementManagedDevices.Read.All`, URLs, package IDs) widening flex text items and cards: global `overflow-wrap: anywhere` on body — unlike `break-word` it also reduces min-content, which is what these intrinsic-sizing overflows needed. Visual spot-checks confirm no aggressive mid-word breaking in normal text.
3. **Code blocks**: global `pre { overflow-x: auto }` safety net for any pre not individually wrapped.

Post-fix scan: **0 of 29 routes overflow**. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)