### PR TITLE
fix: run Elegant Clipboard in user scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -149,6 +149,12 @@ describe('application packaging adapters', () => {
   });
 
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
+    expect(
+      resolveApplicationInstallScope('Y-ASLant.ElegantClipboard', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' y-aslant.elegantclipboard ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -149,6 +149,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // ElegantClipboard's tagged Tauri v2 configuration explicitly builds its
+    // NSIS installer with installMode=currentUser, while the WinGet manifest
+    // omits Scope. The generic machine default installs below LocalSystem's
+    // systemprofile and registers an uninstall.exe path that is already absent
+    // by the managed removal cycle. Keep the package in the intended signed-in
+    // user context so customer deployment and QA share the vendor's lifecycle.
+    wingetId: 'Y-ASLant.ElegantClipboard',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -367,6 +367,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps ElegantClipboard out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Y-ASLant.ElegantClipboard',
+      displayName: 'ElegantClipboard',
+      publisher: 'Y-ASLant',
+      version: '1.2.7',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:ElegantClipboard',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Y_ASLant_ElegantClipboard',
+      }),
+    ]);
+  });
+
   it('binds Logitech Presentation remote deployment to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Logitech.Presentation',


### PR DESCRIPTION
## Summary
- normalize Elegant Clipboard to its publisher-declared current-user Tauri/NSIS scope
- keep customer packaging and QA out of LocalSystem's disposable systemprofile
- generate the Intune detection marker in HKCU for the corrected execution context

## Evidence
- failed QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32573619182
- exact registered uninstaller pointed to systemprofile and was absent by managed removal
- publisher configuration: https://github.com/Y-ASLant/ElegantClipboard/blob/v1.2.7/src-tauri/tauri.conf.json#L58-L63

## Verification
- 241 focused packaging/profile contracts passed
- eslint passed for touched TypeScript files