### PR TITLE
chore: activate Elegant Clipboard scope fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ffb7638dd870b188654c84673663b8ff151a7985',
+  packagerCommit: 'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -269,6 +269,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Amazon Music's longer exact-registration deadline affects only its
   // reviewed adapter. Preserve every unrelated valid pass.
   'cf5933d805df9dae22d6ff4d1ace03f5dd4c1655',
+  // ElegantClipboard's publisher-declared current-user scope changes only its
+  // failed systemprofile lifecycle. Preserve every unrelated valid pass.
+  'ffb7638dd870b188654c84673663b8ff151a7985',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Y-ASLant.ElegantClipboard',
       'Amazon.Music',
       'Greenshot.Greenshot.Preview',
       'ABB.RobotStudio',
@@ -107,6 +108,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Y-ASLant.ElegantClipboard',
         'Amazon.Music',
         'Greenshot.Greenshot.Preview',
         'ABB.RobotStudio',
@@ -147,6 +149,17 @@ describe('QA toolchain targeted retries', () => {
     expect(
       terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
     ).not.toContain('Acronis.CyberProtectHomeOffice');
+  });
+
+  it('retries ElegantClipboard only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' y-aslant.elegantclipboard ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'ffb7638dd870b188654c84673663b8ff151a7985',
+      { wingetId: 'Y-ASLant.ElegantClipboard', status: 'failed' }
+    )).toBe(false);
   });
 
   it('carries FSLogix from its reviewed identity release into nested-EXE disambiguation', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -74,6 +74,13 @@ const EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS = [
   ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918': [
+    // Retry ElegantClipboard in the publisher-declared current-user context.
+    'Y-ASLant.ElegantClipboard',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    'Amazon.Music',
+    ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
+  ],
   'ffb7638dd870b188654c84673663b8ff151a7985': [
     // Retry Amazon Music with its reviewed fifteen-minute uninstall deadline.
     'Amazon.Music',


### PR DESCRIPTION
## Summary
- activate protected packager commit a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918
- preserve compatible predecessor passes
- target Elegant Clipboard's failed lifecycle for a corrected user-scope retry

## Verification
- 214 package-profile, backfill, enqueue, and dispatch contracts passed
- eslint passed for touched files