### PR TITLE
fix(packaging): use unattended MiKTeX uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -365,6 +365,15 @@ describe('application packaging adapters', () => {
       completionTimeoutMinutes: 5,
     });
     expect(
+      applyApplicationPackagingAdapter('MiKTeX.MiKTeX', DEFAULT_PSADT_CONFIG)
+        .reviewedExactUninstall
+    ).toEqual({
+      executablePath:
+        '%ProgramFiles%\\MiKTeX\\miktex\\bin\\x64\\miktexsetup.exe',
+      arguments: ['--quiet', '--shared=yes', 'uninstall'],
+      completionTimeoutMinutes: 15,
+    });
+    expect(
       applyApplicationPackagingAdapter(
         'Microsoft.AzureMonitorAgent',
         DEFAULT_PSADT_CONFIG

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -472,6 +472,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // MiKTeX registers its Console cleanup page as the ARP uninstall command.
+    // That command opens an interactive Qt workflow and leaves the exact
+    // registration installed under non-interactive LocalSystem. MiKTeX's
+    // integrated setup utility is the documented unattended removal path;
+    // --shared=yes is required for the all-users installation selected here.
+    wingetId: 'MiKTeX.MiKTeX',
+    reviewedExactUninstall: {
+      executablePath:
+        '%ProgramFiles%\\MiKTeX\\miktex\\bin\\x64\\miktexsetup.exe',
+      arguments: ['--quiet', '--shared=yes', 'uninstall'],
+      completionTimeoutMinutes: 15,
+    },
+  },
+  {
     // Bitvise uses its own unattended switch rather than the generic /S that
     // WinGet currently publishes. The vendor documents -unat together with
     // explicit EULA acceptance for scripted installation.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -395,6 +395,39 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'MiKTeX.MiKTeX',
+      displayName: 'MiKTeX',
+      publisher: 'MiKTeX',
+      version: '25.12',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--unattended --shared',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:MiKTeX:MiKTeX',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        reviewedExactUninstall?: {
+          executablePath: string;
+          arguments: string[];
+          completionTimeoutMinutes: number;
+        };
+      };
+    };
+
+    expect(profile.psadtConfig.reviewedExactUninstall).toEqual({
+      executablePath:
+        '%ProgramFiles%\\MiKTeX\\miktex\\bin\\x64\\miktexsetup.exe',
+      arguments: ['--quiet', '--shared=yes', 'uninstall'],
+      completionTimeoutMinutes: 15,
+    });
+  });
+
   it('binds Logitech Presentation remote deployment to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Logitech.Presentation',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -694,6 +694,45 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses MiKTeX integrated setup instead of its interactive Console cleanup page',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'MiKTeX',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath:
+              '%ProgramFiles%\\MiKTeX\\miktex\\bin\\x64\\miktexsetup.exe',
+            arguments: ['--quiet', '--shared=yes', 'uninstall'],
+            completionTimeoutMinutes: 15,
+          },
+        },
+        [],
+        'MiKTeX.MiKTeX'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\MiKTeX\\miktex\\bin\\x64\\miktexsetup.exe')"
+      );
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallArguments = @('--quiet', '--shared=yes', 'uninstall')"
+      );
+      expect(uninstallFunction).toContain(
+        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 15 }'
+      );
+      expect(uninstallFunction).toContain(
+        'Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed.'
+      );
+      expect(uninstallFunction).not.toContain('--start-page cleanup');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'uses the hash-verified packaged installer for a reviewed vendor removal lifecycle',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- replace MiKTeX's interactive Console cleanup ARP command with its documented integrated setup utility
- run machine-wide removal with --quiet --shared=yes uninstall`n- keep the exact MiKTeX ARP identity as the fail-closed completion signal

## QA evidence
- failing candidate: 357e0165-2dbd-4f0f-85f6-78f17f3ccdfe`n- workflow: 32575545273`n- install/detection succeeded; registered GUI cleanup command left 23,320 files, two shortcuts, and the exact ARP entry

## Verification
- 243 focused Vitest checks passed
- touched-file ESLint passed
- git diff --check