### PR TITLE
chore: activate MiKTeX uninstall repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
+  packagerCommit: '98019d2c6e06ff51a35d178bedc41f9f67a99107',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -272,6 +272,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // ElegantClipboard's publisher-declared current-user scope changes only its
   // failed systemprofile lifecycle. Preserve every unrelated valid pass.
   'ffb7638dd870b188654c84673663b8ff151a7985',
+  // MiKTeX's documented unattended setup command changes only its previously
+  // failed interactive cleanup lifecycle. Preserve every unrelated valid pass.
+  'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'MiKTeX.MiKTeX',
       'Y-ASLant.ElegantClipboard',
       'Amazon.Music',
       'Greenshot.Greenshot.Preview',
@@ -108,6 +109,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'MiKTeX.MiKTeX',
         'Y-ASLant.ElegantClipboard',
         'Amazon.Music',
         'Greenshot.Greenshot.Preview',
@@ -159,6 +161,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'ffb7638dd870b188654c84673663b8ff151a7985',
       { wingetId: 'Y-ASLant.ElegantClipboard', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries MiKTeX only after activating its unattended setup lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' miktex.miktex ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
+      { wingetId: 'MiKTeX.MiKTeX', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -73,14 +73,22 @@ const EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS = [
     'DATEV.SicherheitspaketCompact',
   ] as const;
 
+const ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS = [
+  // Retry ElegantClipboard in the publisher-declared current-user context.
+  'Y-ASLant.ElegantClipboard',
+  // Carry every still-unconsumed bounded target across the atomic pin.
+  'Amazon.Music',
+  ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
-  'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918': [
-    // Retry ElegantClipboard in the publisher-declared current-user context.
-    'Y-ASLant.ElegantClipboard',
+  '98019d2c6e06ff51a35d178bedc41f9f67a99107': [
+    // Retry MiKTeX with its documented integrated unattended setup utility.
+    'MiKTeX.MiKTeX',
     // Carry every still-unconsumed bounded target across the atomic pin.
-    'Amazon.Music',
-    ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
+    ...ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
   ],
+  'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918': ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
   'ffb7638dd870b188654c84673663b8ff151a7985': [
     // Retry Amazon Music with its reviewed fifteen-minute uninstall deadline.
     'Amazon.Music',


### PR DESCRIPTION
## Summary
- activate packager commit 98019d2c6e06ff51a35d178bedc41f9f67a99107`n- preserve compatible passing coverage from 2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918`n- target MiKTeX's failed lifecycle for one corrected retry while carrying unconsumed targets

## Verification
- 171 focused Vitest checks passed
- touched-file ESLint passed
- git diff --check