### PR TITLE
chore(qa): activate QQ NT packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '98019d2c6e06ff51a35d178bedc41f9f67a99107',
+  packagerCommit: '765d02a3041cc304d2df403aafc18b6f14258f59',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -275,6 +275,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // MiKTeX's documented unattended setup command changes only its previously
   // failed interactive cleanup lifecycle. Preserve every unrelated valid pass.
   'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
+  // QQ NT's reviewed /S argument changes only its previously failed hidden
+  // confirmation lifecycle. Preserve every unrelated valid pass.
+  '98019d2c6e06ff51a35d178bedc41f9f67a99107',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Tencent.QQ.NT',
       'MiKTeX.MiKTeX',
       'Y-ASLant.ElegantClipboard',
       'Amazon.Music',
@@ -109,6 +110,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Tencent.QQ.NT',
         'MiKTeX.MiKTeX',
         'Y-ASLant.ElegantClipboard',
         'Amazon.Music',
@@ -172,6 +174,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
       { wingetId: 'MiKTeX.MiKTeX', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries QQ NT only after activating its unattended registered uninstaller', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' tencent.qq.nt ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '98019d2c6e06ff51a35d178bedc41f9f67a99107',
+      { wingetId: 'Tencent.QQ.NT', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -81,13 +81,21 @@ const ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS = [
   ...EMPTY_ARGUMENT_PREDECESSOR_RETRY_TARGETS,
 ] as const;
 
+const MIKTEX_RELEASE_RETRY_TARGETS = [
+  // Retry MiKTeX with its documented integrated unattended setup utility.
+  'MiKTeX.MiKTeX',
+  // Carry every still-unconsumed bounded target across the atomic pin.
+  ...ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
-  '98019d2c6e06ff51a35d178bedc41f9f67a99107': [
-    // Retry MiKTeX with its documented integrated unattended setup utility.
-    'MiKTeX.MiKTeX',
+  '765d02a3041cc304d2df403aafc18b6f14258f59': [
+    // Retry QQ NT with its reviewed non-interactive registered uninstaller.
+    'Tencent.QQ.NT',
     // Carry every still-unconsumed bounded target across the atomic pin.
-    ...ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
   ],
+  '98019d2c6e06ff51a35d178bedc41f9f67a99107': MIKTEX_RELEASE_RETRY_TARGETS,
   'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918': ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
   'ffb7638dd870b188654c84673663b8ff151a7985': [
     // Retry Amazon Music with its reviewed fifteen-minute uninstall deadline.


### PR DESCRIPTION
## Summary
- activate packager commit 765d02a3041cc304d2df403aafc18b6f14258f59
- preserve 98019d2c6e06ff51a35d178bedc41f9f67a99107 as compatible passing history
- retry Tencent.QQ.NT on the reviewed /S uninstall release while carrying unconsumed terminal targets

## Verification
- 173 focused Vitest checks passed
- touched-file ESLint passed