### PR TITLE
fix(qa): block unsupported Git SDK uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1258,3 +1258,27 @@ describe('Tencent QQ NT managed uninstall block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Git for Windows SDK managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260822173000_block_git_sdk_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the extraction-only SDK lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Git.SDK'");
+    expect(sql).toContain(
+      'git-sdk-1.0.8/sdk-installer/release.sh'
+    );
+    expect(sql).toContain('self-extracting .7z archive');
+    expect(sql).toContain('zero matching uninstall entries');
+    expect(sql).toContain('2,944');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260822173000_block_git_sdk_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260822173000_block_git_sdk_unsupported_managed_uninstall.sql
@@ -1,0 +1,41 @@
+-- Git for Windows SDK 1.0.8 is an extraction bootstrapper, not a managed
+-- Windows installer. Its pinned vendor source concatenates a 7-Zip SFX stub,
+-- sets C:\git-sdk-64 as the default extraction path, runs setup-git-sdk.bat,
+-- and explicitly describes the result as a self-extracting .7z archive. It
+-- does not create a product uninstaller or authoritative ARP registration.
+-- Isolated LocalSystem QA run 32584238843 confirmed that installation changed
+-- two pre-existing uninstall entries but produced zero matching uninstall
+-- entries for the SDK. Removal therefore had no vendor command to execute and
+-- the residual snapshot retained roughly 2,944 added files. Do not publish an
+-- Intune lifecycle whose only possible removal would be broad directory
+-- deletion without a vendor-managed uninstall contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Git.SDK',
+  'unsupported_managed_uninstall',
+  'Git for Windows SDK is delivered as a self-extracting .7z archive that creates no product uninstaller or authoritative ARP registration. Isolated QA found zero matching uninstall entries and retained roughly 2,944 added files, so automated managed removal cannot be verified.',
+  'https://github.com/git-for-windows/build-extra/blob/git-sdk-1.0.8/sdk-installer/release.sh'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Git.SDK';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Git.SDK'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Git.SDK at the shared eligibility gate after isolated lifecycle QA found no vendor uninstall registration
- document the vendor's pinned extraction-only .7z SDK design
- supersede terminal and queued Git SDK candidates so serial QA can continue safely

## Verification
- npm test -- lib/qa/migration-contract.test.ts (79 passed)
- npx eslint lib/qa/migration-contract.test.ts