### PR TITLE
fix(qa): require Webroot MSI lifecycle

### DIFF
--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -700,12 +700,17 @@ export async function GET(request: Request) {
             const installers = (manifest.Installers || []) as Array<Record<string, unknown>>;
             const selectedForVm = recipe
               ? (() => {
-                  const installer = selectWingetInstaller(installers, recipe.architecture);
+                  const installer = selectWingetInstaller(
+                    installers,
+                    recipe.architecture,
+                    undefined,
+                    app.winget_id,
+                  );
                   return installer
                     ? { installer, architecture: recipe.architecture as 'x64' | 'x86' | 'arm64' }
                     : null;
                 })()
-              : selectQaVmInstaller(installers);
+              : selectQaVmInstaller(installers, app.winget_id);
             if (!selectedForVm) {
               summary.unavailable++;
               return;

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -937,7 +937,8 @@ export async function getLatestInstallerInfo(
     const selectedInstaller = selectWingetInstaller(
       versionInfo.installers,
       architecture,
-      requestedScope
+      requestedScope,
+      wingetId,
     );
     if (!selectedInstaller) {
       return {

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -126,6 +126,96 @@ describe('catalog installer reconciliation', () => {
     expect(selected?.productCode).toBe('{1DE15838-06D0-4C9D-B513-F86B806149D5}');
   });
 
+  it('selects Webroot MSI instead of its machine EXE lifecycle', () => {
+    const webrootInstallers: NormalizedInstaller[] = [
+      {
+        architecture: 'x86',
+        url: 'https://example.test/wsainstall.msi',
+        sha256: 'A'.repeat(64),
+        type: 'msi',
+        silentArgs: '/qn /norestart',
+        productCode: '{11111111-1111-1111-1111-111111111111}',
+      },
+      {
+        architecture: 'x86',
+        url: 'https://example.test/wsainstall.exe',
+        sha256: 'B'.repeat(64),
+        type: 'exe',
+        scope: 'machine',
+        silentArgs: '/silent /exeshowaddremove /lang=en',
+      },
+    ];
+
+    const selected = selectTrustedCatalogInstaller(webrootInstallers, {
+      wingetId: 'Webroot.SecureAnywhere',
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installScope: 'machine',
+      installerUrl: webrootInstallers[1].url,
+      installerSha256: webrootInstallers[1].sha256,
+    });
+
+    expect(selected?.type).toBe('msi');
+    expect(selected?.url).toBe('https://example.test/wsainstall.msi');
+  });
+
+  it('fails closed when Webroot no longer publishes its reviewed MSI lifecycle', () => {
+    const selected = selectTrustedCatalogInstaller([{
+      architecture: 'x86',
+      url: 'https://example.test/wsainstall.exe',
+      sha256,
+      type: 'exe',
+      scope: 'machine',
+      silentArgs: '/silent /exeshowaddremove /lang=en',
+    }], {
+      wingetId: 'Webroot.SecureAnywhere',
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installScope: 'machine',
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it('rebuilds Webroot packaging around the manifest MSI lifecycle', async () => {
+    getLiveInstallersMock.mockResolvedValue([
+      {
+        architecture: 'x86',
+        url: 'https://example.test/wsainstall.msi',
+        sha256: 'B'.repeat(64),
+        type: 'msi',
+      },
+      {
+        architecture: 'x86',
+        url: 'https://example.test/wsainstall.exe',
+        sha256,
+        type: 'exe',
+        scope: 'machine',
+        silentArgs: '/silent /exeshowaddremove /lang=en',
+      },
+    ] satisfies NormalizedInstaller[]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Webroot.SecureAnywhere',
+      displayName: 'Webroot SecureAnywhere',
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installerType: 'exe',
+      installerUrl: 'https://example.test/wsainstall.exe',
+      installCommand: '"wsainstall.exe" /silent /exeshowaddremove /lang=en',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Webroot SecureAnywhere',
+    }));
+
+    expect(reconciled.item.installerType).toBe('msi');
+    expect(reconciled.item.installerUrl).toBe('https://example.test/wsainstall.msi');
+    expect(reconciled.item.installCommand).toBe(
+      'msiexec /i "wsainstall.msi" /qn ALLUSERS=1 /norestart'
+    );
+    expect(reconciled.item.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:Webroot SecureAnywhere'
+    );
+  });
+
   it('rebuilds a stale cart command from the trusted machine manifest entry', async () => {
     const reconciled = await reconcileCatalogInstaller(operaItem());
 

--- a/lib/catalog-installer-reconciliation.ts
+++ b/lib/catalog-installer-reconciliation.ts
@@ -9,6 +9,7 @@ import { getLiveInstallers } from '@/lib/manifest-api';
 import {
   resolveApplicationInstallScope,
   resolveApplicationInstallerSelectionScope,
+  resolveApplicationInstallerSelectionType,
   resolveApplicationUninstallCommand,
 } from '@/lib/packaging-adapters';
 import { evaluatePackagingContract } from '@/lib/packaging-contract';
@@ -98,8 +99,14 @@ export function selectTrustedCatalogInstaller(
   const architectureCandidates = exactArchitecture.length > 0
     ? exactArchitecture
     : installers.filter((installer) => normalized(installer.architecture) === 'neutral');
+  const reviewedInstallerType = resolveApplicationInstallerSelectionType(input.wingetId);
+  const typeCandidates = reviewedInstallerType
+    ? architectureCandidates.filter(
+        (installer) => normalized(installer.type) === reviewedInstallerType
+      )
+    : architectureCandidates;
 
-  const exactScope = architectureCandidates.filter(
+  const exactScope = typeCandidates.filter(
     (installer) => normalized(installer.scope) === input.installScope
   );
   if (exactScope.length > 0) {
@@ -109,7 +116,7 @@ export function selectTrustedCatalogInstaller(
     );
   }
 
-  const unspecifiedScope = architectureCandidates.filter(
+  const unspecifiedScope = typeCandidates.filter(
     (installer) => !installer.scope?.trim()
   );
   return selectPreferredIdentity(
@@ -145,9 +152,12 @@ export async function reconcileCatalogInstaller(
     localeCode: item.localeCode,
   });
   if (!installer) {
+    const reviewedInstallerType = resolveApplicationInstallerSelectionType(item.wingetId);
     throw new InstallerPreflightError(
-      'INSTALL_SCOPE_UNAVAILABLE',
-      `WinGet does not publish a ${item.architecture || 'x64'} ${installerSelectionScope}-scope installer for ${item.wingetId} ${item.version}`,
+      reviewedInstallerType ? 'INSTALLER_TYPE_UNAVAILABLE' : 'INSTALL_SCOPE_UNAVAILABLE',
+      reviewedInstallerType
+        ? `WinGet does not publish the reviewed ${reviewedInstallerType.toUpperCase()} lifecycle for ${item.wingetId} ${item.version} (${item.architecture || 'x64'}, ${installerSelectionScope} scope)`
+        : `WinGet does not publish a ${item.architecture || 'x64'} ${installerSelectionScope}-scope installer for ${item.wingetId} ${item.version}`,
     );
   }
   if (!installer.url?.trim() || !/^[A-Fa-f0-9]{64}$/.test(installer.sha256?.trim() || '')) {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -5,6 +5,7 @@ import {
   resolveApplicationInstallScope,
   resolveApplicationInstallerSuccessCodes,
   resolveApplicationInstallerSelectionScope,
+  resolveApplicationInstallerSelectionType,
   resolveApplicationUninstallCommand,
 } from './packaging-adapters';
 
@@ -198,6 +199,12 @@ describe('application packaging adapters', () => {
       'AppiumDevelopers.AppiumInspector',
       'user'
     )).toBe('machine');
+  });
+
+  it('requires Webroot SecureAnywhere to use its unattended MSI lifecycle', () => {
+    expect(resolveApplicationInstallerSelectionType('Webroot.SecureAnywhere')).toBe('msi');
+    expect(resolveApplicationInstallerSelectionType(' webroot.secureanywhere ')).toBe('msi');
+    expect(resolveApplicationInstallerSelectionType('Example.App')).toBeUndefined();
   });
 
   it('runs Logitech Presentation elevated without weakening catalog scope matching', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1,10 +1,11 @@
 import type { ProcessToClose, PSADTConfig } from '@/types/psadt';
-import type { WingetScope } from '@/types/winget';
+import type { WingetInstallerType, WingetScope } from '@/types/winget';
 
 interface ApplicationPackagingAdapter {
   wingetId: string;
   requiredInstallScope?: WingetScope;
   reviewedInstallerSelectionScope?: WingetScope;
+  reviewedInstallerSelectionType?: WingetInstallerType;
   reviewedInstallerSuccessCodes?: readonly number[];
   requiredProcessesToClose?: readonly ProcessToClose[];
   reviewedInstallArguments?: readonly string[];
@@ -1067,6 +1068,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       { name: 'download', description: 'OCS Inventory download helper' },
     ],
   },
+  {
+    // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
+    // registered WRUNINST removal route is interactive, while the MSI has the
+    // standard unattended Windows Installer lifecycle required by Intune.
+    // Never fall back to the EXE if the reviewed MSI entry disappears.
+    wingetId: 'Webroot.SecureAnywhere',
+    reviewedInstallerSelectionType: 'msi',
+  },
 ];
 
 function applicationPackagingAdapter(
@@ -1146,6 +1155,17 @@ export function resolveApplicationInstallerSelectionScope(
 ): WingetScope {
   return applicationPackagingAdapter(wingetId)?.reviewedInstallerSelectionScope ||
     executionScope;
+}
+
+/**
+ * Return an app-specific trusted manifest installer type. A reviewed type is a
+ * strict lifecycle requirement: callers must fail closed rather than fall back
+ * to a different wrapper when the requested type is absent.
+ */
+export function resolveApplicationInstallerSelectionType(
+  wingetId: string
+): WingetInstallerType | undefined {
+  return applicationPackagingAdapter(wingetId)?.reviewedInstallerSelectionType;
 }
 
 const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{

--- a/lib/qa/candidate.test.ts
+++ b/lib/qa/candidate.test.ts
@@ -78,6 +78,37 @@ describe('QA candidate normalization', () => {
       .toBe('wix');
   });
 
+  it('requires Webroot MSI across QA and deployment selection', () => {
+    const webrootInstallers = [
+      {
+        Architecture: 'x86',
+        InstallerType: 'msi',
+        InstallerUrl: 'https://example.test/wsainstall.msi',
+      },
+      {
+        Architecture: 'x86',
+        InstallerType: 'exe',
+        Scope: 'machine',
+        InstallerUrl: 'https://example.test/wsainstall.exe',
+      },
+    ];
+
+    expect(
+      selectQaVmInstaller(webrootInstallers, 'Webroot.SecureAnywhere')?.installer.InstallerType
+    ).toBe('msi');
+    expect(
+      selectWingetInstaller(
+        webrootInstallers,
+        'x86',
+        'machine',
+        'Webroot.SecureAnywhere',
+      )?.InstallerType
+    ).toBe('msi');
+    expect(
+      selectQaVmInstaller([webrootInstallers[1]], 'Webroot.SecureAnywhere')
+    ).toBeNull();
+  });
+
   it('falls back to user scope when no machine or unspecified-scope installer exists', () => {
     const userInstaller = {
       Architecture: 'x64',

--- a/lib/qa/candidate.ts
+++ b/lib/qa/candidate.ts
@@ -98,17 +98,27 @@ export function normalizeQaArchitecture(value?: string | null): 'x64' | 'x86' | 
 export function selectWingetInstaller(
   installers: WingetInstallerCandidate[] | null | undefined,
   architecture?: string | null,
-  requestedScope?: 'machine' | 'user'
+  requestedScope?: 'machine' | 'user',
+  wingetId?: string,
 ): WingetInstallerCandidate | null {
   if (!installers?.length) return null;
+  const reviewedInstallerType = wingetId
+    ? resolveApplicationInstallerSelectionType(wingetId)
+    : undefined;
+  const typeCandidates = reviewedInstallerType
+    ? installers.filter(
+        (installer) => installer.InstallerType?.trim().toLowerCase() === reviewedInstallerType
+      )
+    : installers;
+  if (!typeCandidates.length) return null;
   const target = normalizeQaArchitecture(architecture);
-  const exactArchitecture = installers.filter(
+  const exactArchitecture = typeCandidates.filter(
     (installer) => installer.Architecture?.toLowerCase() === target
   );
   if (exactArchitecture.length) {
     return preferredScopeInstaller(exactArchitecture, requestedScope);
   }
-  const neutral = installers.filter(
+  const neutral = typeCandidates.filter(
     (installer) => installer.Architecture?.toLowerCase() === 'neutral'
   );
   return preferredScopeInstaller(neutral, requestedScope);
@@ -119,19 +129,29 @@ export function selectWingetInstaller(
  * machine scope so elevated PSADT execution does not launch a per-user setup.
  */
 export function selectQaVmInstaller(
-  installers: WingetInstallerCandidate[] | null | undefined
+  installers: WingetInstallerCandidate[] | null | undefined,
+  wingetId?: string,
 ): QaInstallerSelection | null {
   if (!installers?.length) return null;
+  const reviewedInstallerType = wingetId
+    ? resolveApplicationInstallerSelectionType(wingetId)
+    : undefined;
+  const typeCandidates = reviewedInstallerType
+    ? installers.filter(
+        (installer) => installer.InstallerType?.trim().toLowerCase() === reviewedInstallerType
+      )
+    : installers;
+  if (!typeCandidates.length) return null;
   const x64 = preferredScopeInstaller(
-    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'x64')
+    typeCandidates.filter((installer) => installer.Architecture?.toLowerCase() === 'x64')
   );
   if (x64) return { installer: x64, architecture: 'x64' };
   const neutral = preferredScopeInstaller(
-    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'neutral')
+    typeCandidates.filter((installer) => installer.Architecture?.toLowerCase() === 'neutral')
   );
   if (neutral) return { installer: neutral, architecture: 'x64' };
   const x86 = preferredScopeInstaller(
-    installers.filter((installer) => installer.Architecture?.toLowerCase() === 'x86')
+    typeCandidates.filter((installer) => installer.Architecture?.toLowerCase() === 'x86')
   );
   return x86 ? { installer: x86, architecture: 'x86' } : null;
 }
@@ -162,3 +182,4 @@ export function qaInstallerFileName(installerUrl: string, installerType: string)
   return resolveInstallerFileName(installerUrl, normalizeQaInstallerType(installerType));
 }
 import { resolveInstallerFileName } from '@/lib/installer-filename';
+import { resolveApplicationInstallerSelectionType } from '@/lib/packaging-adapters';

--- a/lib/update-policies/build-deployment-config.ts
+++ b/lib/update-policies/build-deployment-config.ts
@@ -292,7 +292,9 @@ export async function buildDefaultDeploymentConfig(
     : [];
   const selectedManifestInstaller = selectWingetInstaller(
     manifestInstallers,
-    'x64'
+    'x64',
+    undefined,
+    wingetId,
   ) as WingetInstaller | null;
   const normalizedInstaller: NormalizedInstaller = selectedManifestInstaller
     ? normalizeInstaller({


### PR DESCRIPTION
## Summary
- require Webroot SecureAnywhere to use its published MSI lifecycle across QA and customer/update installer selection
- fail closed instead of falling back to the interactive EXE removal route
- rebuild live catalog reconciliation around the MSI tuple

## Verification
- 83 test files passed
- 1,373 tests passed
- targeted ESLint passed
- git diff --check passed