### PR TITLE
chore(qa): activate Webroot MSI retry

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '49775d3657a1b11b4ec1603e80ba8f78882b174f',
+  packagerCommit: 'b67135eb2f947485e54c2583cfb6083b1e2f24ba',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -281,6 +281,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Removing the ineffective QQ NT /S adapter affects only an app now blocked
   // at the shared eligibility gate. Preserve every unrelated valid pass.
   '765d02a3041cc304d2df403aafc18b6f14258f59',
+  // Webroot's reviewed MSI selection changes only its previously failing EXE
+  // lifecycle. Preserve every unrelated valid pass from the prior release.
+  '49775d3657a1b11b4ec1603e80ba8f78882b174f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Webroot.SecureAnywhere',
       'MiKTeX.MiKTeX',
       'Y-ASLant.ElegantClipboard',
       'Amazon.Music',
@@ -110,6 +111,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Webroot.SecureAnywhere',
         'MiKTeX.MiKTeX',
         'Y-ASLant.ElegantClipboard',
         'Amazon.Music',
@@ -176,6 +178,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'a2fa7cc7aec6faf0b22c0dcb7146ea8301ee9918',
       { wingetId: 'MiKTeX.MiKTeX', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Webroot only after activating its reviewed MSI lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' webroot.secureanywhere ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '49775d3657a1b11b4ec1603e80ba8f78882b174f',
+      { wingetId: 'Webroot.SecureAnywhere', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -89,6 +89,12 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b67135eb2f947485e54c2583cfb6083b1e2f24ba': [
+    // Retry Webroot with its published unattended MSI lifecycle.
+    'Webroot.SecureAnywhere',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
+  ],
   '49775d3657a1b11b4ec1603e80ba8f78882b174f': MIKTEX_RELEASE_RETRY_TARGETS,
   '765d02a3041cc304d2df403aafc18b6f14258f59': [
     // Retry QQ NT with its reviewed non-interactive registered uninstaller.


### PR DESCRIPTION
## Summary
- activate exact packager commit b67135eb2f947485e54c2583cfb6083b1e2f24ba
- schedule Webroot SecureAnywhere for its MSI lifecycle retry
- retain the pending bounded retry targets and compatible prior pass history

## Verification
- 258 focused tests passed
- targeted ESLint passed
- git diff --check passed