### PR TITLE
fix(qa): silence SketchUp 2022 removal

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -337,6 +337,12 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['pr', '--confirm-command']);
     expect(
+      applyApplicationPackagingAdapter(
+        'Trimble.SketchUp.2022',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['-silent']);
+    expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--force-uninstall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1069,6 +1069,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // SketchUp Pro 2022 registers its cached InstallShield wrapper with
+    // -remove -runfromtemp, but that command remains interactive and left the
+    // exact {C631706C-...} registration after the bounded QA deadline. The
+    // vendor-family wrapper supports -silent on removal; append only that
+    // missing argument to the exact captured command.
+    wingetId: 'Trimble.SketchUp.2022',
+    reviewedUninstallArguments: ['-silent'],
+  },
+  {
     // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
     // registered WRUNINST removal route is interactive, while the MSI has the
     // standard unattended Windows Installer lifecycle required by Intune.

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -181,6 +181,36 @@ describe('PSADT Inno packaging contract', () => {
 
 describe('PSADT vendor argument contract', () => {
   it.runIf(canRunWindowsPowerShellPackager)(
+    'appends SketchUp silent removal to the exact captured InstallShield command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'SketchUp Pro 2022',
+        [],
+        { reviewedUninstallArguments: ['-silent'] },
+        [],
+        'Trimble.SketchUp.2022',
+        'SketchUp Pro 2022',
+        '22.0.354',
+        'REGISTRY_UNINSTALL_PRODUCT:{C631706C-1735-11EC-9621-0242AC130015}:SketchUp Pro 2022',
+        '/silent'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "$configuredProductCode = '{C631706C-1735-11EC-9621-0242AC130015}'"
+      );
+      expect(uninstallFunction).toContain("$reviewedUninstallArguments = @('-silent')");
+      expect(uninstallFunction).toContain(
+        '$registeredUninstallArguments += $reviewedArgument'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'expands required WinGet install locations on the target machine',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- append the reviewed InstallShield -silent removal flag to SketchUp Pro 2022's exact captured uninstall command
- retain the exact product registration as authoritative lifecycle evidence
- add an executable generated-package regression for product {C631706C-1735-11EC-9621-0242AC130015}`n
## Evidence
- failed run 32590245121 kept the exact product registered through the five-minute deadline
- install and post-install detection passed; vendor removal returned PSADT 60001

## Verification
- generated SketchUp package parses and contains the reviewed argument
- application adapter suite: 59 passed
- full packager contract run: 169 passed, with the corrected assertion re-run green
- targeted ESLint and git diff --check passed