### PR TITLE
chore(qa): activate SketchUp 2022 lifecycle retry

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b67135eb2f947485e54c2583cfb6083b1e2f24ba',
+  packagerCommit: 'dde6e9ae4e569568b4a15c087ba711d1bb3a8895',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -284,6 +284,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Webroot's reviewed MSI selection changes only its previously failing EXE
   // lifecycle. Preserve every unrelated valid pass from the prior release.
   '49775d3657a1b11b4ec1603e80ba8f78882b174f',
+  // SketchUp 2022's reviewed silent removal argument changes only its failed
+  // lifecycle. Preserve every unrelated valid pass from the prior release.
+  'b67135eb2f947485e54c2583cfb6083b1e2f24ba',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -64,6 +64,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Trimble.SketchUp.2022',
       'Webroot.SecureAnywhere',
       'MiKTeX.MiKTeX',
       'Y-ASLant.ElegantClipboard',
@@ -111,6 +112,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Trimble.SketchUp.2022',
         'Webroot.SecureAnywhere',
         'MiKTeX.MiKTeX',
         'Y-ASLant.ElegantClipboard',
@@ -190,6 +192,20 @@ describe('QA toolchain targeted retries', () => {
       '49775d3657a1b11b4ec1603e80ba8f78882b174f',
       { wingetId: 'Webroot.SecureAnywhere', status: 'failed' }
     )).toBe(false);
+  });
+
+  it('retries SketchUp 2022 only after activating its reviewed silent removal argument', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' trimble.sketchup.2022 ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b67135eb2f947485e54c2583cfb6083b1e2f24ba',
+      { wingetId: 'Trimble.SketchUp.2022', status: 'failed' }
+    )).toBe(false);
+    expect(terminalToolchainRetryTargets(
+      'b67135eb2f947485e54c2583cfb6083b1e2f24ba'
+    )).toContain('Webroot.SecureAnywhere');
   });
 
   it('does not retry blocked QQ NT after removing its ineffective adapter', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -89,6 +89,13 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'dde6e9ae4e569568b4a15c087ba711d1bb3a8895': [
+    // Retry SketchUp 2022 with its reviewed silent removal argument.
+    'Trimble.SketchUp.2022',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    'Webroot.SecureAnywhere',
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
+  ],
   'b67135eb2f947485e54c2583cfb6083b1e2f24ba': [
     // Retry Webroot with its published unattended MSI lifecycle.
     'Webroot.SecureAnywhere',


### PR DESCRIPTION
Activates packager commit dde6e9ae4e569568b4a15c087ba711d1bb3a8895 and scopes the new terminal retry to Trimble.SketchUp.2022 while carrying the still-unconsumed Webroot and existing bounded targets forward.\n\nValidation:\n- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts (174 tests)\n- targeted ESLint\n- git diff --check