### PR TITLE
fix(packaging): honor uint32 installer success codes

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -34,7 +34,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:INPUT_INSTALLER_SUCCESS_CODES)) {
 }
 $InstallerSuccessCodes = @($InstallerSuccessCodes | ForEach-Object {
     $parsedCode = 0
-    if (-not [int]::TryParse([string]$_, [ref]$parsedCode) -or $parsedCode -lt 0 -or $parsedCode -gt 65535) {
+    if (-not [int]::TryParse([string]$_, [ref]$parsedCode)) {
         throw "Invalid installer success exit code: $_"
     }
     $parsedCode

--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -678,15 +678,25 @@ describe('normalizeManifestInstallers', () => {
   it('preserves manifest-declared installer success codes', () => {
     const [installer] = normalizeManifestInstallers({
       InstallerType: 'exe',
-      InstallerSuccessCodes: [1168, 1168, '3010'],
+      InstallerSuccessCodes: [1168, 1168, '3010', 3221225477, 3221226505],
       Installers: [{
         Architecture: 'x64',
         InstallerUrl: 'https://example.com/installer.exe',
         InstallerSha256: 'abc123',
       }],
     });
-    expect(installer.InstallerSuccessCodes).toEqual([1168, 3010]);
-    expect(normalizeInstaller(installer).installerSuccessCodes).toEqual([1168, 3010]);
+    expect(installer.InstallerSuccessCodes).toEqual([
+      1168,
+      3010,
+      -1073741819,
+      -1073740791,
+    ]);
+    expect(normalizeInstaller(installer).installerSuccessCodes).toEqual([
+      1168,
+      3010,
+      -1073741819,
+      -1073740791,
+    ]);
   });
 
   it('normalizes installer and root AppsAndFeatures product identities', () => {

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -707,7 +707,8 @@ function normalizeInstallerSuccessCodes(value: unknown): number[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const codes = Array.from(new Set(value
     .map((code) => typeof code === 'number' ? code : Number(code))
-    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)));
+    .filter((code) => Number.isInteger(code) && code >= -2147483648 && code <= 4294967295)
+    .map((code) => code > 2147483647 ? code - 4294967296 : code)));
   return codes.length > 0 ? codes : undefined;
 }
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -36,6 +36,10 @@ describe('application packaging adapters', () => {
       'Example.App',
       [3010]
     )).toEqual([3010]);
+    expect(resolveApplicationInstallerSuccessCodes(
+      'Piriform.Recuva',
+      [3221225477, 3221226505]
+    )).toEqual([-1073741819, -1073740791]);
   });
 
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1106,7 +1106,8 @@ function normalizeInstallerSuccessCodes(
 ): number[] {
   return Array.from(new Set((successCodes || [])
     .map(Number)
-    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)))
+    .filter((code) => Number.isInteger(code) && code >= -2147483648 && code <= 4294967295)
+    .map((code) => code > 2147483647 ? code - 4294967296 : code)))
     .sort((left, right) => left - right);
 }
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -130,9 +130,14 @@ describe('PSADT QA package identity', () => {
 
   it('hashes manifest-declared success exit codes without changing empty profiles', () => {
     const baseline = buildQaPackageIdentity(input);
-    const withSuccessCode = buildQaPackageIdentity({ ...input, successCodes: [1168] });
+    const withSuccessCode = buildQaPackageIdentity({
+      ...input,
+      successCodes: [1168, 3221225477, 3221226505],
+    });
     expect(withSuccessCode.packageProfileSha256).not.toBe(baseline.packageProfileSha256);
-    expect(withSuccessCode.profile.installer).toMatchObject({ successCodes: [1168] });
+    expect(withSuccessCode.profile.installer).toMatchObject({
+      successCodes: [-1073741819, -1073740791, 1168],
+    });
     expect(buildQaPackageIdentity({ ...input, successCodes: [] })).toEqual(baseline);
   });
 

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -930,7 +930,8 @@ function parseJsonObject<T>(value: string | undefined, fallback: T): T {
 function normalizeSuccessCodes(value: readonly number[] | undefined): number[] {
   return Array.from(new Set((value || [])
     .map((code) => Number(code))
-    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)))
+    .filter((code) => Number.isInteger(code) && code >= -2147483648 && code <= 4294967295)
+    .map((code) => code > 2147483647 ? code - 4294967296 : code)))
     .sort((left, right) => left - right);
 }
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1259,6 +1259,21 @@ describe('PSADT vendor argument contract', () => {
     expect(generated).toContain('AppSuccessExitCodes = @(0, 1168)');
   });
 
+  it('honors signed process equivalents of unsigned WinGet success codes', () => {
+    if (!canRunWindowsPowerShellPackager) return;
+    const generated = generateRegistryUninstallPackage(
+      'nullsoft',
+      'Recuva',
+      [-1073741819, -1073740791],
+      {},
+      [],
+      'Piriform.Recuva'
+    );
+    expect(generated).toContain(
+      'AppSuccessExitCodes = @(-1073741819, -1073740791, 0)'
+    );
+  });
+
   it('does not rewrite dollar signs or backticks in generic silent switches', () => {
     expect(packager).toContain('$silentSwitchesEscaped = $effectiveSilentSwitches -replace "\'", "\'\'"');
     const assignment = packager.match(/^\$silentSwitchesEscaped\s*=.*$/m)?.[0] ?? '';

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -337,6 +337,23 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.successCodes).toEqual([1168]);
   });
 
+  it('converts Recuva unsigned WinGet success codes to signed process exit codes', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Piriform.Recuva',
+        name: 'Recuva',
+        publisher: 'Piriform',
+        version: '1.54.120',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        InstallerSuccessCodes: [3221225477, 3221226505],
+      },
+      installer: { Architecture: 'x64', InstallerType: 'nullsoft' },
+    });
+    expect(config.successCodes).toEqual([-1073741819, -1073740791]);
+  });
+
   it('uses an EXE AppsAndFeatures product code as the exact uninstall identity', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/lib/qa/test-config.ts
+++ b/lib/qa/test-config.ts
@@ -234,7 +234,8 @@ function normalizeSuccessCodes(value: unknown): number[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const codes = Array.from(new Set(value
     .map((code) => typeof code === 'number' ? code : Number(code))
-    .filter((code) => Number.isInteger(code) && code >= 0 && code <= 65535)));
+    .filter((code) => Number.isInteger(code) && code >= -2147483648 && code <= 4294967295)
+    .map((code) => code > 2147483647 ? code - 4294967296 : code)));
   return codes.length > 0 ? codes : undefined;
 }
 


### PR DESCRIPTION
Recuva 1.54.120 installs successfully but returns 0xC0000005. Its authoritative WinGet manifest declares unsigned success codes 3221225477 and 3221226505; our 16-bit normalization dropped both.\n\nThis converts WinGet uint32 exit codes to their signed Windows process equivalents across manifest ingestion, QA identity, dispatch, and the generated PSADT package. Invalid values outside signed-int32/uint32 bounds remain rejected.\n\nSource: https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests/p/Piriform/Recuva/1.54.120/Piriform.Recuva.installer.yaml\n\nValidation:\n- 83 test files / 1,378 tests passed\n- executable PSADT package contract for Recuva signed exit codes\n- targeted ESLint\n- git diff --check