### PR TITLE
fix(packaging): run NeoLoad uninstall unattended

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -347,6 +347,10 @@ describe('application packaging adapters', () => {
       ).reviewedUninstallArguments
     ).toEqual(['-silent']);
     expect(
+      applyApplicationPackagingAdapter('Tricentis.NeoLoad', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['-q']);
+    expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--force-uninstall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1078,6 +1078,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-silent'],
   },
   {
+    // NeoLoad registers its install4j uninstaller without an unattended
+    // argument. install4j documents -q for both installers and uninstallers;
+    // append it to the exact captured registration instead of guessing a
+    // product path or replacing the vendor command.
+    wingetId: 'Tricentis.NeoLoad',
+    reviewedUninstallArguments: ['-q'],
+  },
+  {
     // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
     // registered WRUNINST removal route is interactive, while the MSI has the
     // standard unattended Windows Installer lifecycle required by Intune.

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -181,6 +181,36 @@ describe('PSADT Inno packaging contract', () => {
 
 describe('PSADT vendor argument contract', () => {
   it.runIf(canRunWindowsPowerShellPackager)(
+    'appends NeoLoad unattended removal to the exact captured install4j command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'NeoLoad',
+        [],
+        { reviewedUninstallArguments: ['-q'] },
+        [],
+        'Tricentis.NeoLoad',
+        'NeoLoad',
+        '8.2.1',
+        'REGISTRY_UNINSTALL_KEY:0878-6793-3006-4848:NeoLoad',
+        '-q'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "$configuredProductCode = '0878-6793-3006-4848'"
+      );
+      expect(uninstallFunction).toContain("$reviewedUninstallArguments = @('-q')");
+      expect(uninstallFunction).toContain(
+        '$registeredUninstallArguments += $reviewedArgument'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'appends SketchUp silent removal to the exact captured InstallShield command',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
Adds an exact Tricentis.NeoLoad catalog adapter that appends install4j's documented -q argument to the captured vendor uninstall command. Includes adapter coverage and a generated PSADT executable contract for the observed NeoLoad 8.2.1 registry identity. Full suite: 83 files / 1,380 tests passed.