### PR TITLE
fix(packaging): preflight Blender via official mirror

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -428,6 +428,54 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
+  it('preflights Blender through its official mirror while preserving manifest identity', async () => {
+    const manifestUrl =
+      'https://download.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi';
+    const mirrorUrl =
+      'https://mirror.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi';
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: manifestUrl,
+      sha256: 'A'.repeat(64),
+      type: 'wix',
+      scope: 'machine',
+      silentArgs: '',
+      productCode: '{3CA82049-A4E1-4EFC-B529-4ED32AEF3F4F}',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'BlenderFoundation.Blender.LTS.4.2',
+          displayName: 'Blender 4.2 LTS',
+          version: '4.2.16',
+          installerType: 'wix',
+          installerUrl: manifestUrl,
+          installerSha256: 'A'.repeat(64),
+          installCommand: '',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'BlenderFoundation.Blender.LTS.4.2',
+        installerUrl: mirrorUrl,
+        manifestInstallerUrl: manifestUrl,
+        installerSha256: 'A'.repeat(64),
+      }),
+      expect.any(Array),
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledOnce();
+  });
+
   it('does not apply catalog retirement policy to a custom package', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -37,6 +37,7 @@ import {
   enforceInstallerPreflight,
   InstallerPreflightError,
 } from '@/lib/installer-preflight';
+import { applyInstallerUrlOverride } from '@/lib/installer-url-overrides';
 import { ensureQaDemand } from '@/lib/qa/demand';
 import {
   applyApplicationPackagingAdapter,
@@ -337,19 +338,27 @@ export async function POST(request: NextRequest) {
     // batches responsive.
     for (let i = 0; i < win32Items.length; i += 2) {
       const preflightResults = await Promise.allSettled(
-        win32Items.slice(i, i + 2).map((item) => enforceInstallerPreflight(
-          {
+        win32Items.slice(i, i + 2).map((item) => {
+          const executionInstallerUrl = applyInstallerUrlOverride(
+            item.wingetId,
+            item.version,
+            item.architecture || '',
+            item.installerUrl,
+          );
+          return enforceInstallerPreflight({
             wingetId: item.wingetId,
             version: item.version,
             architecture: item.architecture,
-            installerUrl: item.installerUrl,
+            installerUrl: executionInstallerUrl,
+            manifestInstallerUrl: item.installerUrl,
             installerSha256: item.installerSha256,
             installerType: item.installerType,
             installScope: item.installScope,
             sourceType: item.sourceType,
           },
           trustedInstallersByItem.get(item),
-        )),
+          );
+        }),
       );
 
       const failedIndex = preflightResults.findIndex((result) => result.status === 'rejected');

--- a/lib/__tests__/installer-url-overrides.test.ts
+++ b/lib/__tests__/installer-url-overrides.test.ts
@@ -29,6 +29,29 @@ describe('applyInstallerUrlOverride', () => {
     );
   });
 
+  it('routes Blender 4.2 LTS x64 to Blender official mirror service', () => {
+    const url = applyInstallerUrlOverride(
+      'BlenderFoundation.Blender.LTS.4.2',
+      '4.2.16',
+      'x64',
+      'https://download.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi',
+    );
+
+    expect(url).toBe(
+      'https://mirror.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi',
+    );
+  });
+
+  it('does not guess a Blender mirror payload for another architecture', () => {
+    const original = 'https://download.blender.org/release/Blender4.2/setup-arm64.msi';
+    expect(applyInstallerUrlOverride(
+      'BlenderFoundation.Blender.LTS.4.2',
+      '4.2.16',
+      'arm64',
+      original,
+    )).toBe(original);
+  });
+
   it('interpolates the version into the Freeplane GitHub Releases URL', () => {
     const url = applyInstallerUrlOverride(
       'Freeplane.Freeplane',
@@ -63,5 +86,9 @@ describe('applyInstallerUrlOverride', () => {
 describe('INSTALLER_URL_OVERRIDES', () => {
   it('contains the Freeplane entry', () => {
     expect(INSTALLER_URL_OVERRIDES['Freeplane.Freeplane']).toBeDefined();
+  });
+
+  it('contains the Blender 4.2 LTS entry', () => {
+    expect(INSTALLER_URL_OVERRIDES['BlenderFoundation.Blender.LTS.4.2']).toBeDefined();
   });
 });

--- a/lib/installer-url-overrides.ts
+++ b/lib/installer-url-overrides.ts
@@ -16,6 +16,13 @@
 type OverrideFn = (version: string, architecture: string) => string | null;
 
 export const INSTALLER_URL_OVERRIDES: Record<string, OverrideFn> = {
+  // download.blender.org returns HTTP 403 to hosted preflight egress for this
+  // release family. Blender's official mirror service selects a healthy
+  // geographic mirror while the WinGet manifest hash remains authoritative.
+  'BlenderFoundation.Blender.LTS.4.2': (version, architecture) =>
+    architecture.toLowerCase() === 'x64'
+      ? `https://mirror.blender.org/release/Blender4.2/blender-${version}-windows-x64.msi`
+      : null,
   'Freeplane.Freeplane': (version) =>
     `https://github.com/freeplane/freeplane/releases/download/release-${version}/Freeplane-Setup-${version}.exe`,
 };

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -73,11 +73,49 @@ describe('dispatchQaCandidate', () => {
       version: '2.0.0',
       architecture: 'x64',
       installerUrl: 'https://example.test/setup.exe',
+      manifestInstallerUrl: 'https://example.test/setup.exe',
       installerSha256: 'A'.repeat(64),
       installerType: 'wix',
       installScope: 'user',
       sourceType: 'winget',
     });
+  });
+
+  it('uses a reviewed mirror for both QA preflight and the runner payload', async () => {
+    enforceInstallerPreflightMock.mockResolvedValue({
+      cacheKey: 'healthy',
+      status: 'healthy',
+      source: 'live',
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const manifestUrl =
+      'https://download.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi';
+    const mirrorUrl =
+      'https://mirror.blender.org/release/Blender4.2/blender-4.2.16-windows-x64.msi';
+
+    await dispatchQaCandidate({
+      id: '22222222-2222-4222-8222-222222222222',
+      winget_id: 'BlenderFoundation.Blender.LTS.4.2',
+      definition_path: null,
+      version: '4.2.16',
+      architecture: 'x64',
+      installer_url: manifestUrl,
+      installer_sha256: 'B'.repeat(64),
+      installer_file_name: 'blender-4.2.16-windows-x64.msi',
+      installer_type: 'msi',
+      test_level: 'psadt-package',
+      package_profile_sha256: 'C'.repeat(64),
+      test_config: { mode: 'psadt-package', sourceInstallerType: 'wix' },
+    });
+
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(expect.objectContaining({
+      installerUrl: mirrorUrl,
+      manifestInstallerUrl: manifestUrl,
+      installerSha256: 'B'.repeat(64),
+    }));
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(JSON.parse(body.inputs.candidate_payload).installerUrl).toBe(mirrorUrl);
   });
 
   it('surfaces a rejected GitHub dispatch', async () => {

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -1,5 +1,6 @@
 import { getGitHubActionsConfig } from '@/lib/github-actions';
 import { enforceInstallerPreflight } from '@/lib/installer-preflight';
+import { applyInstallerUrlOverride } from '@/lib/installer-url-overrides';
 import type { Json } from '@/types/database';
 
 export interface QaDispatchCandidate {
@@ -25,6 +26,12 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
   const sourceInstallerType = typeof testConfig.sourceInstallerType === 'string' && testConfig.sourceInstallerType.trim()
     ? testConfig.sourceInstallerType.trim()
     : candidate.installer_type;
+  const executionInstallerUrl = applyInstallerUrlOverride(
+    candidate.winget_id,
+    candidate.version,
+    candidate.architecture,
+    candidate.installer_url,
+  );
 
   // Keep the QA dispatch boundary aligned with customer packaging. A vendor
   // can replace the bytes behind a mutable URL after WinGet publishes its
@@ -34,7 +41,8 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
     wingetId: candidate.winget_id,
     version: candidate.version,
     architecture: candidate.architecture,
-    installerUrl: candidate.installer_url,
+    installerUrl: executionInstallerUrl,
+    manifestInstallerUrl: candidate.installer_url,
     installerSha256: candidate.installer_sha256,
     // The candidate column is the normalized execution type (for example,
     // WinGet Wix becomes MSI). Preflight must compare the original WinGet
@@ -65,7 +73,7 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
           wingetId: candidate.winget_id,
           version: candidate.version,
           architecture: candidate.architecture,
-          installerUrl: candidate.installer_url,
+          installerUrl: executionInstallerUrl,
           installerSha256: candidate.installer_sha256,
           installerFileName: candidate.installer_file_name,
           installerType: candidate.installer_type,


### PR DESCRIPTION
Routes Blender 4.2 LTS x64 through Blender's official geographic mirror service while retaining the original WinGet URL for manifest identity and the pinned SHA256 for byte verification. Applies the same reviewed override to the customer portal preflight, QA preflight, runner payload, and existing final packaging dispatch. Full suite: 83 files / 1,386 tests passed.