### PR TITLE
Fix ImageGlass packaging after upstream asset rename

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -476,6 +476,54 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledOnce();
   });
 
+  it('preflights ImageGlass through its renamed official asset while preserving manifest identity', async () => {
+    const manifestUrl =
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64.msi';
+    const releaseAssetUrl =
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64_pro-business.msi';
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: manifestUrl,
+      sha256: 'D'.repeat(64),
+      type: 'wix',
+      scope: 'machine',
+      silentArgs: 'ALLUSERS=1',
+      productCode: '{6D0C2C70-3535-5F89-AC42-194E255ED60E}',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'DuongDieuPhap.ImageGlass',
+          displayName: 'ImageGlass',
+          version: '10.0.4.819',
+          installerType: 'wix',
+          installerUrl: manifestUrl,
+          installerSha256: 'D'.repeat(64),
+          installCommand: 'ALLUSERS=1',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'DuongDieuPhap.ImageGlass',
+        installerUrl: releaseAssetUrl,
+        manifestInstallerUrl: manifestUrl,
+        installerSha256: 'D'.repeat(64),
+      }),
+      expect.any(Array),
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledOnce();
+  });
+
   it('does not apply catalog retirement policy to a custom package', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/__tests__/installer-url-overrides.test.ts
+++ b/lib/__tests__/installer-url-overrides.test.ts
@@ -52,6 +52,36 @@ describe('applyInstallerUrlOverride', () => {
     )).toBe(original);
   });
 
+  it('routes the affected ImageGlass x64 release to its renamed official asset', () => {
+    const url = applyInstallerUrlOverride(
+      'DuongDieuPhap.ImageGlass',
+      '10.0.4.819',
+      'x64',
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64.msi',
+    );
+
+    expect(url).toBe(
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64_pro-business.msi',
+    );
+  });
+
+  it('does not guess ImageGlass asset names for other versions or architectures', () => {
+    const original = 'https://github.com/d2phap/ImageGlass/releases/download/setup.msi';
+
+    expect(applyInstallerUrlOverride(
+      'DuongDieuPhap.ImageGlass',
+      '10.0.5.900',
+      'x64',
+      original,
+    )).toBe(original);
+    expect(applyInstallerUrlOverride(
+      'DuongDieuPhap.ImageGlass',
+      '10.0.4.819',
+      'arm64',
+      original,
+    )).toBe(original);
+  });
+
   it('interpolates the version into the Freeplane GitHub Releases URL', () => {
     const url = applyInstallerUrlOverride(
       'Freeplane.Freeplane',
@@ -90,5 +120,9 @@ describe('INSTALLER_URL_OVERRIDES', () => {
 
   it('contains the Blender 4.2 LTS entry', () => {
     expect(INSTALLER_URL_OVERRIDES['BlenderFoundation.Blender.LTS.4.2']).toBeDefined();
+  });
+
+  it('contains the ImageGlass entry', () => {
+    expect(INSTALLER_URL_OVERRIDES['DuongDieuPhap.ImageGlass']).toBeDefined();
   });
 });

--- a/lib/installer-url-overrides.ts
+++ b/lib/installer-url-overrides.ts
@@ -23,6 +23,13 @@ export const INSTALLER_URL_OVERRIDES: Record<string, OverrideFn> = {
     architecture.toLowerCase() === 'x64'
       ? `https://mirror.blender.org/release/Blender4.2/blender-${version}-windows-x64.msi`
       : null,
+  // ImageGlass 10.0.4.819 was published to WinGet with the correct trusted
+  // hash, but the release asset was renamed after publication. Keep this
+  // exact tuple on the official GitHub release without guessing future names.
+  'DuongDieuPhap.ImageGlass': (version, architecture) =>
+    version === '10.0.4.819' && architecture.toLowerCase() === 'x64'
+      ? 'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64_pro-business.msi'
+      : null,
   'Freeplane.Freeplane': (version) =>
     `https://github.com/freeplane/freeplane/releases/download/release-${version}/Freeplane-Setup-${version}.exe`,
 };

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -118,6 +118,43 @@ describe('dispatchQaCandidate', () => {
     expect(JSON.parse(body.inputs.candidate_payload).installerUrl).toBe(mirrorUrl);
   });
 
+  it('uses the renamed ImageGlass release asset for QA preflight and runner payload', async () => {
+    enforceInstallerPreflightMock.mockResolvedValue({
+      cacheKey: 'healthy',
+      status: 'healthy',
+      source: 'live',
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const manifestUrl =
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64.msi';
+    const releaseAssetUrl =
+      'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64_pro-business.msi';
+
+    await dispatchQaCandidate({
+      id: '33333333-3333-4333-8333-333333333333',
+      winget_id: 'DuongDieuPhap.ImageGlass',
+      definition_path: null,
+      version: '10.0.4.819',
+      architecture: 'x64',
+      installer_url: manifestUrl,
+      installer_sha256: 'D'.repeat(64),
+      installer_file_name: 'ImageGlass_10.0.4.819_win-x64.msi',
+      installer_type: 'msi',
+      test_level: 'psadt-package',
+      package_profile_sha256: 'E'.repeat(64),
+      test_config: { mode: 'psadt-package', sourceInstallerType: 'wix' },
+    });
+
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(expect.objectContaining({
+      installerUrl: releaseAssetUrl,
+      manifestInstallerUrl: manifestUrl,
+      installerSha256: 'D'.repeat(64),
+    }));
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(JSON.parse(body.inputs.candidate_payload).installerUrl).toBe(releaseAssetUrl);
+  });
+
   it('surfaces a rejected GitHub dispatch', async () => {
     enforceInstallerPreflightMock.mockResolvedValue({
       cacheKey: 'healthy',


### PR DESCRIPTION
Repairs ImageGlass 10.0.4.819 packaging after the official GitHub release asset was renamed while Microsoft WinGet still references the removed filename. Applies a fail-closed override only to the exact x64 release, preserves the WinGet manifest URL as identity, and keeps the manifest SHA-256 authoritative. Covers the customer portal preflight, QA preflight, and runner payload. Full suite: 83 files and 1,391 tests passed.