### PR TITLE
Make slow installer preflight resilient with ranged hashing

### DIFF
--- a/lib/__tests__/installer-download.test.ts
+++ b/lib/__tests__/installer-download.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildByteRanges,
   hashesEqual,
   isLikelyMutableInstallerUrl,
   isPublicIpAddress,
+  parseByteContentRange,
+  shouldUseRangedInstallerHash,
 } from '@/lib/installer-download';
 
 describe('installer download safety helpers', () => {
@@ -36,5 +39,37 @@ describe('installer download safety helpers', () => {
       'https://example.test/download/setup.exe?bad=%ZZ',
       '1.2.3',
     )).toBe(true);
+  });
+
+  it('selects ranged hashing only for the reviewed PostgresPro HTTPS origin', () => {
+    expect(shouldUseRangedInstallerHash(
+      'https://repo.postgrespro.ru/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBe(true);
+    expect(shouldUseRangedInstallerHash(
+      'http://repo.postgrespro.ru/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBe(false);
+    expect(shouldUseRangedInstallerHash(
+      'https://repo.postgrespro.ru.example.test/setup.exe',
+    )).toBe(false);
+  });
+
+  it('builds ordered non-overlapping byte ranges including a short final range', () => {
+    expect(buildByteRanges(10, 4)).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 7 },
+      { start: 8, end: 9 },
+    ]);
+    expect(buildByteRanges(0, 4)).toEqual([]);
+  });
+
+  it('strictly parses complete byte content-range headers', () => {
+    expect(parseByteContentRange('bytes 0-1048575/157645328')).toEqual({
+      start: 0,
+      end: 1048575,
+      total: 157645328,
+    });
+    expect(parseByteContentRange('bytes */157645328')).toBeNull();
+    expect(parseByteContentRange('bytes 10-9/100')).toBeNull();
+    expect(parseByteContentRange('bytes 0-100/100')).toBeNull();
   });
 });

--- a/lib/installer-download.ts
+++ b/lib/installer-download.ts
@@ -7,11 +7,26 @@ import * as https from 'node:https';
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_REDIRECTS = 5;
+const DEFAULT_RANGE_CHUNK_BYTES = 16 * 1024 * 1024;
+const RANGE_DOWNLOAD_ATTEMPTS = 3;
+const RANGED_HASH_HOSTS = new Set(['repo.postgrespro.ru']);
 
 export interface InstallerHashResult {
   sha256: string;
   bytes: number;
   finalUrl: string;
+}
+
+interface ByteRange {
+  start: number;
+  end: number;
+}
+
+interface RangeMetadata {
+  finalUrl: URL;
+  totalBytes: number | null;
+  acceptsRanges: boolean;
+  validator: string | null;
 }
 
 function isPrivateIpv4(address: string): boolean {
@@ -89,6 +104,285 @@ function validateUrl(value: string): URL {
     throw new Error('Installer URL uses a disallowed port');
   }
   return url;
+}
+
+export function shouldUseRangedInstallerHash(installerUrl: string): boolean {
+  try {
+    const url = new URL(installerUrl);
+    return url.protocol === 'https:' && RANGED_HASH_HOSTS.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+export function buildByteRanges(
+  totalBytes: number,
+  chunkBytes = DEFAULT_RANGE_CHUNK_BYTES,
+): ByteRange[] {
+  if (!Number.isSafeInteger(totalBytes) || totalBytes < 0) {
+    throw new Error('Installer byte length is invalid');
+  }
+  if (!Number.isSafeInteger(chunkBytes) || chunkBytes < 1) {
+    throw new Error('Installer range chunk size is invalid');
+  }
+
+  const ranges: ByteRange[] = [];
+  for (let start = 0; start < totalBytes; start += chunkBytes) {
+    ranges.push({ start, end: Math.min(start + chunkBytes - 1, totalBytes - 1) });
+  }
+  return ranges;
+}
+
+export function parseByteContentRange(value: string | undefined): {
+  start: number;
+  end: number;
+  total: number;
+} | null {
+  const match = value?.trim().match(/^bytes\s+(\d+)-(\d+)\/(\d+)$/i);
+  if (!match) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const total = Number(match[3]);
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    !Number.isSafeInteger(total) ||
+    start < 0 ||
+    end < start ||
+    total <= end
+  ) return null;
+  return { start, end, total };
+}
+
+async function readRangeMetadata(
+  url: URL,
+  redirectsRemaining: number,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<RangeMetadata> {
+  const resolved = await resolvePublicAddress(url.hostname);
+  const headers = {
+    Accept: 'application/octet-stream,*/*',
+    'Accept-Encoding': 'identity',
+    Host: url.host,
+    'User-Agent': 'IntuneGet-Installer-Preflight/1.0',
+  };
+
+  return new Promise<RangeMetadata>((resolve, reject) => {
+    const onResponse = (response: http.IncomingMessage) => {
+      const status = response.statusCode ?? 0;
+      if ([301, 302, 303, 307, 308].includes(status)) {
+        const location = response.headers.location;
+        response.resume();
+        if (!location || redirectsRemaining <= 0) {
+          reject(new Error('Installer download exceeded the redirect limit'));
+          return;
+        }
+
+        let redirectUrl: URL;
+        try {
+          redirectUrl = validateUrl(new URL(location, url).toString());
+        } catch (error) {
+          reject(error);
+          return;
+        }
+
+        readRangeMetadata(
+          redirectUrl,
+          redirectsRemaining - 1,
+          maxBytes,
+          timeoutMs,
+        ).then(resolve, reject);
+        return;
+      }
+
+      if (status < 200 || status >= 300) {
+        response.resume();
+        reject(new Error(`Installer metadata returned HTTP ${status}`));
+        return;
+      }
+
+      const contentLength = Number(response.headers['content-length']);
+      const totalBytes = Number.isSafeInteger(contentLength) && contentLength >= 0
+        ? contentLength
+        : null;
+      if (totalBytes !== null && totalBytes > maxBytes) {
+        response.resume();
+        reject(new Error(`Installer exceeds the ${maxBytes}-byte preflight limit`));
+        return;
+      }
+
+      const etag = response.headers.etag;
+      const lastModified = response.headers['last-modified'];
+      const validator = etag && !etag.startsWith('W/')
+        ? etag
+        : lastModified || null;
+      response.on('error', reject);
+      response.resume();
+      resolve({
+        finalUrl: url,
+        totalBytes,
+        acceptsRanges: response.headers['accept-ranges']?.toLowerCase() === 'bytes',
+        validator,
+      });
+    };
+
+    const commonOptions = {
+      protocol: url.protocol,
+      hostname: resolved.address,
+      family: resolved.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: 'HEAD',
+      headers,
+    };
+    const request = url.protocol === 'https:'
+      ? https.request({ ...commonOptions, servername: url.hostname }, onResponse)
+      : http.request(commonOptions, onResponse);
+
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`Installer metadata timed out after ${timeoutMs}ms`));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function downloadInstallerRange(
+  url: URL,
+  range: ByteRange,
+  totalBytes: number,
+  validator: string,
+  timeoutMs: number,
+): Promise<Buffer> {
+  const resolved = await resolvePublicAddress(url.hostname);
+  const expectedBytes = range.end - range.start + 1;
+  const headers = {
+    Accept: 'application/octet-stream,*/*',
+    'Accept-Encoding': 'identity',
+    Host: url.host,
+    'If-Range': validator,
+    Range: `bytes=${range.start}-${range.end}`,
+    'User-Agent': 'IntuneGet-Installer-Preflight/1.0',
+  };
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const onResponse = (response: http.IncomingMessage) => {
+      const status = response.statusCode ?? 0;
+      if (status !== 206) {
+        response.resume();
+        reject(new Error(`Installer range download returned HTTP ${status}`));
+        return;
+      }
+
+      const contentRange = parseByteContentRange(response.headers['content-range']);
+      const contentLength = Number(response.headers['content-length']);
+      if (
+        !contentRange ||
+        contentRange.start !== range.start ||
+        contentRange.end !== range.end ||
+        contentRange.total !== totalBytes ||
+        contentLength !== expectedBytes
+      ) {
+        response.resume();
+        reject(new Error('Installer range response did not match the requested bytes'));
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      response.on('data', (chunk: Buffer) => {
+        bytes += chunk.length;
+        if (bytes > expectedBytes) {
+          response.destroy(new Error('Installer range exceeded the requested byte count'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => {
+        if (bytes !== expectedBytes) {
+          reject(new Error('Installer range ended before all requested bytes arrived'));
+          return;
+        }
+        resolve(Buffer.concat(chunks, bytes));
+      });
+      response.on('error', reject);
+    };
+
+    const commonOptions = {
+      protocol: url.protocol,
+      hostname: resolved.address,
+      family: resolved.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers,
+    };
+    const request = url.protocol === 'https:'
+      ? https.request({ ...commonOptions, servername: url.hostname }, onResponse)
+      : http.request(commonOptions, onResponse);
+
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`Installer range timed out after ${timeoutMs}ms`));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function downloadInstallerRangeWithRetry(
+  url: URL,
+  range: ByteRange,
+  totalBytes: number,
+  validator: string,
+  timeoutMs: number,
+): Promise<Buffer> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= RANGE_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    try {
+      return await downloadInstallerRange(url, range, totalBytes, validator, timeoutMs);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Installer range download failed');
+}
+
+async function hashUrlInRanges(
+  url: URL,
+  redirectsRemaining: number,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<InstallerHashResult> {
+  const metadata = await readRangeMetadata(url, redirectsRemaining, maxBytes, timeoutMs);
+  if (
+    !metadata.acceptsRanges ||
+    metadata.totalBytes === null ||
+    !metadata.validator ||
+    metadata.totalBytes <= DEFAULT_RANGE_CHUNK_BYTES
+  ) {
+    return hashUrl(metadata.finalUrl, redirectsRemaining, maxBytes, timeoutMs);
+  }
+
+  const hash = createHash('sha256');
+  let bytes = 0;
+  for (const range of buildByteRanges(metadata.totalBytes)) {
+    const chunk = await downloadInstallerRangeWithRetry(
+      metadata.finalUrl,
+      range,
+      metadata.totalBytes,
+      metadata.validator,
+      timeoutMs,
+    );
+    hash.update(chunk);
+    bytes += chunk.length;
+  }
+
+  return {
+    sha256: hash.digest('hex').toUpperCase(),
+    bytes,
+    finalUrl: metadata.finalUrl.toString(),
+  };
 }
 
 async function hashUrl(
@@ -188,12 +482,11 @@ export async function hashRemoteInstaller(
   options?: { maxBytes?: number; timeoutMs?: number },
 ): Promise<InstallerHashResult> {
   const url = validateUrl(installerUrl);
-  return hashUrl(
-    url,
-    MAX_REDIRECTS,
-    options?.maxBytes ?? parseMaximumBytes(),
-    options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-  );
+  const maxBytes = options?.maxBytes ?? parseMaximumBytes();
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return shouldUseRangedInstallerHash(installerUrl)
+    ? hashUrlInRanges(url, MAX_REDIRECTS, maxBytes, timeoutMs)
+    : hashUrl(url, MAX_REDIRECTS, maxBytes, timeoutMs);
 }
 
 export function hashesEqual(left: string, right: string): boolean {


### PR DESCRIPTION
Repairs repeatable hosted preflight timeouts for the official PostgresPro Windows origin without changing the trusted URL or weakening SHA-256 verification. The reviewed HTTPS host is hashed through ordered 16 MiB ranges with strict Content-Range and validator checks plus bounded per-range retries; other hosts keep the existing single-stream path. This affects both customer portal packaging and QA dispatch. Validation: 83 test files and 1,394 tests passed, lint passed, and the production build including TypeScript passed.