### PR TITLE
Recover official MariaDB and PostgresPro installer sources

### DIFF
--- a/lib/__tests__/installer-url-overrides.test.ts
+++ b/lib/__tests__/installer-url-overrides.test.ts
@@ -82,6 +82,44 @@ describe('applyInstallerUrlOverride', () => {
     )).toBe(original);
   });
 
+  it('routes the affected MariaDB release to its official archive', () => {
+    const original =
+      'https://downloads.mariadb.org/rest-api/mariadb/12.3.3/mariadb-12.3.3-winx64.msi';
+    expect(applyInstallerUrlOverride(
+      'MariaDB.Server',
+      '12.3.3.0',
+      'x64',
+      original,
+    )).toBe(
+      'https://archive.mariadb.org/mariadb-12.3.3/winx64-packages/mariadb-12.3.3-winx64.msi',
+    );
+    expect(applyInstallerUrlOverride(
+      'MariaDB.Server',
+      '12.3.4.0',
+      'x64',
+      original,
+    )).toBe(original);
+  });
+
+  it('routes the affected PostgresPro release to its official international repository', () => {
+    const original =
+      'https://repo.postgrespro.ru/win/64/PostgreSQL_17.7_64bit_Setup.exe';
+    expect(applyInstallerUrlOverride(
+      'PostgresPro.Standard.17',
+      '17.7',
+      'x64',
+      original,
+    )).toBe(
+      'https://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    );
+    expect(applyInstallerUrlOverride(
+      'PostgresPro.Standard.17',
+      '17.7',
+      'arm64',
+      original,
+    )).toBe(original);
+  });
+
   it('interpolates the version into the Freeplane GitHub Releases URL', () => {
     const url = applyInstallerUrlOverride(
       'Freeplane.Freeplane',
@@ -124,5 +162,10 @@ describe('INSTALLER_URL_OVERRIDES', () => {
 
   it('contains the ImageGlass entry', () => {
     expect(INSTALLER_URL_OVERRIDES['DuongDieuPhap.ImageGlass']).toBeDefined();
+  });
+
+  it('contains the MariaDB and PostgresPro entries', () => {
+    expect(INSTALLER_URL_OVERRIDES['MariaDB.Server']).toBeDefined();
+    expect(INSTALLER_URL_OVERRIDES['PostgresPro.Standard.17']).toBeDefined();
   });
 });

--- a/lib/installer-url-overrides.ts
+++ b/lib/installer-url-overrides.ts
@@ -30,6 +30,19 @@ export const INSTALLER_URL_OVERRIDES: Record<string, OverrideFn> = {
     version === '10.0.4.819' && architecture.toLowerCase() === 'x64'
       ? 'https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64_pro-business.msi'
       : null,
+  // MariaDB removed the REST download endpoint after publishing this WinGet
+  // tuple. Its official archive retains the exact MSI and published hash.
+  'MariaDB.Server': (version, architecture) =>
+    version === '12.3.3.0' && architecture.toLowerCase() === 'x64'
+      ? 'https://archive.mariadb.org/mariadb-12.3.3/winx64-packages/mariadb-12.3.3-winx64.msi'
+      : null,
+  // The Russian PostgresPro repository repeatedly times out from hosted
+  // egress. The official international repository serves the same release
+  // from a separate network while the WinGet SHA256 remains authoritative.
+  'PostgresPro.Standard.17': (version, architecture) =>
+    version === '17.7' && architecture.toLowerCase() === 'x64'
+      ? 'https://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe'
+      : null,
   'Freeplane.Freeplane': (version) =>
     `https://github.com/freeplane/freeplane/releases/download/release-${version}/Freeplane-Setup-${version}.exe`,
 };


### PR DESCRIPTION
Repairs two production preflight failures without weakening WinGet identity or SHA-256 checks. MariaDB Server 12.3.3.0 x64 uses the official MariaDB archive after its REST endpoint returned 404; the archive's published SHA-256 exactly matches WinGet. PostgresPro Standard 17.7 x64 uses the official international repo.postgrespro.com endpoint on a separate network after repeated hosted timeouts from repo.postgrespro.ru. Both overrides are fail-closed to exact versions and architectures and feed customer portal preflight, QA dispatch, and runner payloads. Validation: 83 test files and 1,397 tests passed, lint passed, and the production build including TypeScript passed.