### PR TITLE
Bound PostgresPro hosted installer verification

### DIFF
--- a/lib/__tests__/installer-download.test.ts
+++ b/lib/__tests__/installer-download.test.ts
@@ -5,6 +5,8 @@ import {
   isLikelyMutableInstallerUrl,
   isPublicIpAddress,
   parseByteContentRange,
+  parsePublisherChecksum,
+  publisherChecksumUrlForInstaller,
   shouldUseRangedInstallerHash,
 } from '@/lib/installer-download';
 
@@ -51,6 +53,45 @@ describe('installer download safety helpers', () => {
     expect(shouldUseRangedInstallerHash(
       'https://repo.postgrespro.ru.example.test/setup.exe',
     )).toBe(false);
+  });
+
+  it('uses a publisher checksum only for exact official PostgresPro installer URLs', () => {
+    expect(publisherChecksumUrlForInstaller(
+      'https://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBe(
+      'https://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe.sha256sum',
+    );
+    expect(publisherChecksumUrlForInstaller(
+      'http://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
+    expect(publisherChecksumUrlForInstaller(
+      'https://repo.postgrespro.com.example.test/win/64/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
+    expect(publisherChecksumUrlForInstaller(
+      'https://repo.postgrespro.com/win/32/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
+    expect(publisherChecksumUrlForInstaller(
+      'https://repo.postgrespro.com/win/64/archive/PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
+    expect(publisherChecksumUrlForInstaller(
+      'https://repo.postgrespro.com/win/64/PostgreSQL_17.7_64bit_Setup.exe?mirror=1',
+    )).toBeNull();
+  });
+
+  it('strictly parses the publisher checksum for the exact installer filename', () => {
+    const checksum = '58f961e7ee44676c1fecb111e4eb5429701cdbc3ee057df336d378b2094dc94d';
+    expect(parsePublisherChecksum(
+      `${checksum}  PostgreSQL_17.7_64bit_Setup.exe\n`,
+      'PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBe(checksum.toUpperCase());
+    expect(parsePublisherChecksum(
+      `${checksum}  different.exe\n`,
+      'PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
+    expect(parsePublisherChecksum(
+      `${checksum}  PostgreSQL_17.7_64bit_Setup.exe\nextra`,
+      'PostgreSQL_17.7_64bit_Setup.exe',
+    )).toBeNull();
   });
 
   it('builds ordered non-overlapping byte ranges including a short final range', () => {

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -97,7 +97,7 @@ describe('installer dispatch preflight', () => {
 
   it('keeps user and machine health identities separate', () => {
     expect(createInstallerHealthKey(request)).toBe(
-      '3b7e40af357d2af41613cc5526ad84c5fbaa2d2ce127b6c88b66e014fce7f9bd'
+      '4a163d0ab2ee36349a086201a52a30090585393dee25fec8889fee47d254d937'
     );
     expect(createInstallerHealthKey(request)).not.toBe(createInstallerHealthKey({
       ...request,

--- a/lib/installer-download.ts
+++ b/lib/installer-download.ts
@@ -11,11 +11,16 @@ const DEFAULT_RANGE_CHUNK_BYTES = 1024 * 1024;
 const RANGE_DOWNLOAD_CONCURRENCY = 4;
 const RANGE_DOWNLOAD_ATTEMPTS = 3;
 const RANGED_HASH_HOSTS = new Set(['repo.postgrespro.ru']);
+const PUBLISHER_CHECKSUM_HOSTS = new Set(['repo.postgrespro.com']);
+const PUBLISHER_CHECKSUM_MAX_BYTES = 4 * 1024;
+const PUBLISHER_CHECKSUM_TIMEOUT_MS = 15_000;
+const PUBLISHER_CHECKSUM_PROBE_BYTES = 64 * 1024;
 
 export interface InstallerHashResult {
   sha256: string;
   bytes: number;
   finalUrl: string;
+  verificationMethod?: 'content-hash' | 'publisher-checksum';
 }
 
 interface ByteRange {
@@ -114,6 +119,36 @@ export function shouldUseRangedInstallerHash(installerUrl: string): boolean {
   } catch {
     return false;
   }
+}
+
+export function publisherChecksumUrlForInstaller(installerUrl: string): string | null {
+  try {
+    const url = new URL(installerUrl);
+    const filename = url.pathname.split('/').at(-1) || '';
+    if (
+      url.protocol !== 'https:' ||
+      !PUBLISHER_CHECKSUM_HOSTS.has(url.hostname.toLowerCase()) ||
+      (url.port && url.port !== '443') ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      !/^PostgreSQL_[A-Za-z0-9._-]+_64bit_Setup\.exe$/.test(filename) ||
+      url.pathname !== `/win/64/${filename}`
+    ) return null;
+    return `${url.origin}${url.pathname}.sha256sum`;
+  } catch {
+    return null;
+  }
+}
+
+export function parsePublisherChecksum(
+  content: string,
+  expectedFilename: string,
+): string | null {
+  const match = content.match(/^([A-Fa-f0-9]{64})[ \t]+\*?([^\r\n]+)\r?\n?$/);
+  if (!match || match[2] !== expectedFilename) return null;
+  return match[1].toUpperCase();
 }
 
 export function buildByteRanges(
@@ -349,6 +384,166 @@ async function downloadInstallerRangeWithRetry(
   throw lastError instanceof Error ? lastError : new Error('Installer range download failed');
 }
 
+async function readPublisherChecksum(
+  url: URL,
+  redirectsRemaining: number,
+  trustedHostname: string,
+): Promise<string> {
+  const resolved = await resolvePublicAddress(url.hostname);
+  const headers = {
+    Accept: 'text/plain,application/octet-stream',
+    'Accept-Encoding': 'identity',
+    Host: url.host,
+    'User-Agent': 'IntuneGet-Installer-Preflight/1.0',
+  };
+
+  return new Promise<string>((resolve, reject) => {
+    const onResponse = (response: http.IncomingMessage) => {
+      const status = response.statusCode ?? 0;
+      if ([301, 302, 303, 307, 308].includes(status)) {
+        const location = response.headers.location;
+        response.resume();
+        if (!location || redirectsRemaining <= 0) {
+          reject(new Error('Publisher checksum exceeded the redirect limit'));
+          return;
+        }
+
+        let redirectUrl: URL;
+        try {
+          redirectUrl = validateUrl(new URL(location, url).toString());
+          if (
+            redirectUrl.protocol !== 'https:' ||
+            redirectUrl.hostname.toLowerCase() !== trustedHostname ||
+            (redirectUrl.port && redirectUrl.port !== '443')
+          ) {
+            throw new Error('Publisher checksum redirected outside the reviewed origin');
+          }
+        } catch (error) {
+          reject(error);
+          return;
+        }
+
+        readPublisherChecksum(
+          redirectUrl,
+          redirectsRemaining - 1,
+          trustedHostname,
+        ).then(resolve, reject);
+        return;
+      }
+
+      if (status < 200 || status >= 300) {
+        response.resume();
+        reject(new Error(`Publisher checksum returned HTTP ${status}`));
+        return;
+      }
+
+      const contentLength = Number(response.headers['content-length']);
+      if (Number.isFinite(contentLength) && contentLength > PUBLISHER_CHECKSUM_MAX_BYTES) {
+        response.destroy();
+        reject(new Error('Publisher checksum exceeded the size limit'));
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      response.on('data', (chunk: Buffer) => {
+        bytes += chunk.length;
+        if (bytes > PUBLISHER_CHECKSUM_MAX_BYTES) {
+          response.destroy(new Error('Publisher checksum exceeded the size limit'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => resolve(Buffer.concat(chunks, bytes).toString('utf8')));
+      response.on('error', reject);
+    };
+
+    const request = https.request({
+      protocol: 'https:',
+      hostname: resolved.address,
+      family: resolved.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers,
+      servername: url.hostname,
+    }, onResponse);
+    request.setTimeout(PUBLISHER_CHECKSUM_TIMEOUT_MS, () => {
+      request.destroy(new Error(
+        `Publisher checksum timed out after ${PUBLISHER_CHECKSUM_TIMEOUT_MS}ms`,
+      ));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function attestInstallerWithPublisherChecksum(
+  installerUrl: URL,
+  checksumUrl: URL,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<InstallerHashResult> {
+  const trustedHostname = installerUrl.hostname.toLowerCase();
+  const metadata = await readRangeMetadata(
+    installerUrl,
+    MAX_REDIRECTS,
+    maxBytes,
+    timeoutMs,
+  );
+  if (
+    metadata.finalUrl.hostname.toLowerCase() !== trustedHostname ||
+    metadata.finalUrl.protocol !== 'https:' ||
+    (metadata.finalUrl.port && metadata.finalUrl.port !== '443') ||
+    metadata.finalUrl.pathname !== installerUrl.pathname ||
+    !metadata.acceptsRanges ||
+    metadata.totalBytes === null ||
+    metadata.totalBytes < PUBLISHER_CHECKSUM_PROBE_BYTES * 2 ||
+    !metadata.validator
+  ) {
+    throw new Error('Publisher-checksum installer metadata was incomplete or changed origin');
+  }
+
+  const checksumContent = await readPublisherChecksum(
+    checksumUrl,
+    MAX_REDIRECTS,
+    trustedHostname,
+  );
+  const filename = installerUrl.pathname.split('/').at(-1) || '';
+  const sha256 = parsePublisherChecksum(checksumContent, filename);
+  if (!sha256) {
+    throw new Error('Publisher checksum did not contain the exact installer filename and SHA256');
+  }
+
+  const totalBytes = metadata.totalBytes;
+  await Promise.all([
+    downloadInstallerRangeWithRetry(
+      metadata.finalUrl,
+      { start: 0, end: PUBLISHER_CHECKSUM_PROBE_BYTES - 1 },
+      totalBytes,
+      metadata.validator,
+      timeoutMs,
+    ),
+    downloadInstallerRangeWithRetry(
+      metadata.finalUrl,
+      {
+        start: totalBytes - PUBLISHER_CHECKSUM_PROBE_BYTES,
+        end: totalBytes - 1,
+      },
+      totalBytes,
+      metadata.validator,
+      timeoutMs,
+    ),
+  ]);
+
+  return {
+    sha256,
+    bytes: totalBytes,
+    finalUrl: metadata.finalUrl.toString(),
+    verificationMethod: 'publisher-checksum',
+  };
+}
+
 async function hashUrlInRanges(
   url: URL,
   redirectsRemaining: number,
@@ -392,6 +587,7 @@ async function hashUrlInRanges(
     sha256: hash.digest('hex').toUpperCase(),
     bytes,
     finalUrl: metadata.finalUrl.toString(),
+    verificationMethod: 'content-hash',
   };
 }
 
@@ -460,6 +656,7 @@ async function hashUrl(
           sha256: hash.digest('hex').toUpperCase(),
           bytes,
           finalUrl: url.toString(),
+          verificationMethod: 'content-hash',
         });
       });
       response.on('error', reject);
@@ -494,6 +691,15 @@ export async function hashRemoteInstaller(
   const url = validateUrl(installerUrl);
   const maxBytes = options?.maxBytes ?? parseMaximumBytes();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const publisherChecksumUrl = publisherChecksumUrlForInstaller(installerUrl);
+  if (publisherChecksumUrl) {
+    return attestInstallerWithPublisherChecksum(
+      url,
+      validateUrl(publisherChecksumUrl),
+      maxBytes,
+      timeoutMs,
+    );
+  }
   return shouldUseRangedInstallerHash(installerUrl)
     ? hashUrlInRanges(url, MAX_REDIRECTS, maxBytes, timeoutMs)
     : hashUrl(url, MAX_REDIRECTS, maxBytes, timeoutMs);

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -14,7 +14,7 @@ const HEALTHY_MUTABLE_TTL_MS = 5 * 60 * 1000;
 const HEALTHY_VERSIONED_TTL_MS = 6 * 60 * 60 * 1000;
 const ERROR_TTL_MS = 60 * 1000;
 const MANIFEST_CHANGED_TTL_MS = 6 * 60 * 60 * 1000;
-const PREFLIGHT_CACHE_SCHEMA_VERSION = '3';
+const PREFLIGHT_CACHE_SCHEMA_VERSION = '4';
 const LEASE_SECONDS = 240;
 const WAIT_FOR_CLAIM_MS = 240_000;
 const POLL_INTERVAL_MS = 1_500;
@@ -351,6 +351,12 @@ async function performLivePreflight(
       : HEALTHY_VERSIONED_TTL_MS;
     await writeHealth(buildHealthRow(cacheKey, input, 'healthy', {
       actual_sha256: downloaded.sha256,
+      reason_code: downloaded.verificationMethod === 'publisher-checksum'
+        ? 'PUBLISHER_CHECKSUM_ATTESTED'
+        : null,
+      reason_message: downloaded.verificationMethod === 'publisher-checksum'
+        ? 'The trusted WinGet SHA256 matched the publisher checksum and the installer source passed bounded byte-range probes. The packager will still hash the complete downloaded payload.'
+        : null,
       expires_at: new Date(Date.now() + ttl).toISOString(),
     }));
 


### PR DESCRIPTION
Production preflight for PostgresPro 17.7 reached Vercel's five-minute request ceiling while streaming the 157 MB official mirror. This change uses the publisher's adjacent SHA-256 sidecar, requires it to match the trusted WinGet SHA, validates stable HTTPS metadata, and probes strict byte ranges at both ends of the installer. The downstream packager continues to hash the complete downloaded payload before creating the PSADT package. The preflight cache schema is bumped so prior checking/error rows cannot be reused. Validated with 1,399 tests, lint, production build/TypeScript, and a live official-source verification completing in under five seconds.