### PR TITLE
Fix Postgres Pro 17 PSADT lifecycle identity

### DIFF
--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -365,4 +365,29 @@ describe('catalog installer reconciliation', () => {
 
     expect(reconciled.item.uninstallCommand).toBe('REGISTRY_UNINSTALL:Google Chrome');
   });
+
+  it('uses Postgres Pro 17\'s exact vendor ARP identity for customer packages', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x64',
+      url: 'https://example.test/postgrespro-17.exe',
+      sha256,
+      type: 'nullsoft',
+      scope: 'machine',
+      silentArgs: '--mode unattended',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'PostgresPro.Standard.17',
+      displayName: 'Postgres Pro Standard 17',
+      version: '17.7',
+      installerType: 'nullsoft',
+      installerUrl: 'https://example.test/postgrespro-17.exe',
+      installCommand: '--mode unattended',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Postgres Pro Standard 17',
+    }));
+
+    expect(reconciled.item.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:PostgreSQL 17 (64bit):PostgreSQL 17 (64bit)'
+    );
+  });
 });

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -144,6 +144,39 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(JSON.parse(payload.client_payload.installer.successCodes)).toEqual([1223]);
   });
 
+  it('dispatches the reviewed Postgres Pro lifecycle through the customer packager', async () => {
+    reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
+      item: {
+        ...item,
+        uninstallCommand:
+          'REGISTRY_UNINSTALL_KEY:PostgreSQL 17 (64bit):PostgreSQL 17 (64bit)',
+      },
+      trustedInstallers: [],
+    }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'PostgresPro.Standard.17',
+      displayName: 'Postgres Pro Standard 17',
+      publisher: 'Postgres Professional',
+      version: '17.7',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'nullsoft',
+      silentSwitches: '--mode unattended',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Postgres Pro Standard 17',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:PostgreSQL 17 (64bit):PostgreSQL 17 (64bit)'
+    );
+    expect(JSON.parse(payload.client_payload.config.psadtConfig))
+      .toMatchObject({ reviewedUninstallArguments: ['/S'] });
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -142,6 +142,23 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Postgres Pro 17\'s exact PostgreSQL NSIS registry identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'PostgresPro.Standard.17',
+      'REGISTRY_UNINSTALL:Postgres Pro Standard 17'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:PostgreSQL 17 (64bit):PostgreSQL 17 (64bit)'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'PostgresPro.Standard.17',
+      'REGISTRY_UNINSTALL:Postgres Pro Standard 16'
+    )).toBe('REGISTRY_UNINSTALL:Postgres Pro Standard 16');
+    expect(resolveApplicationUninstallCommand(
+      'PostgreSQL.PostgreSQL.17',
+      'REGISTRY_UNINSTALL:PostgreSQL 17'
+    )).toBe('REGISTRY_UNINSTALL:PostgreSQL 17');
+  });
+
   it('uses MSYS2\'s registered product family instead of its catalog title', () => {
     expect(resolveApplicationUninstallCommand(
       'MSYS2.MSYS2',
@@ -898,6 +915,16 @@ describe('application packaging adapters', () => {
   it('uses Mozilla NSIS silent mode with the exact Zen Browser ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'zen-team.zen-browser',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/S']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
+  it('uses Postgres Pro 17\'s reviewed NSIS silent uninstall mode', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'postgrespro.standard.17',
       DEFAULT_PSADT_CONFIG
     );
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1086,6 +1086,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-q'],
   },
   {
+    // Postgres Pro's Windows installer is built from the vendor's PostgreSQL
+    // NSIS source and registers an ordinary `PostgreSQL <major> (64bit)` ARP
+    // entry. Its generated uninstaller accepts NSIS /S; append that reviewed
+    // switch to the exact captured command for unattended Intune removal.
+    wingetId: 'PostgresPro.Standard.17',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
     // registered WRUNINST removal route is interactive, while the MSI has the
     // standard unattended Windows Installer lifecycle required by Intune.
@@ -1287,6 +1295,16 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'Memory',
     registeredDisplayName: 'Memory',
     registeredRegistryKey: 'Memory',
+  },
+  // Postgres Pro's official Windows build scripts keep PRODUCT_NAME set to
+  // PostgreSQL and derive the x64 ARP branding as `PostgreSQL <major>
+  // (64bit)`. Bind that exact stable NSIS key so prerequisite registry deltas
+  // cannot win capture and the same identity drives customer detection and
+  // removal.
+  'postgrespro.standard.17': {
+    generatedDisplayName: 'Postgres Pro Standard 17',
+    registeredDisplayName: 'PostgreSQL 17 (64bit)',
+    registeredRegistryKey: 'PostgreSQL 17 (64bit)',
   },
   'msys2.msys2': {
     generatedDisplayName: 'MSYS2 Installer',

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -161,6 +161,33 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.successCodes).toEqual([1223]);
   });
 
+  it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'PostgresPro.Standard.17',
+      displayName: 'Postgres Pro Standard 17',
+      publisher: 'Postgres Professional',
+      version: '17.7',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '--mode unattended',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Postgres Pro Standard 17',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(normalized.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:PostgreSQL 17 (64bit):PostgreSQL 17 (64bit)'
+    );
+    expect(profile.installer.uninstallCommand).toBe(normalized.uninstallCommand);
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/S']);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/S']);
+  });
+
   it('binds offline dependency installers to the execution profile only when present', () => {
     const baseline = buildQaPackageIdentity(input);
     const dependency = {


### PR DESCRIPTION
## Summary
- bind PostgresPro.Standard.17 to the vendor's exact PostgreSQL 17 (64bit) ARP key
- append the reviewed NSIS /S uninstall switch
- prove catalog reconciliation, deployment identity, and customer workflow dispatch all carry the fix

## Validation
- npm test (83 files, 1,404 tests)
- npm run lint
- npm run build:ci