### PR TITLE
Use headless JetBrains Toolbox uninstall

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -144,6 +144,29 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(JSON.parse(payload.client_payload.installer.successCodes)).toEqual([1223]);
   });
 
+  it('dispatches JetBrains Toolbox headless removal through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'JetBrains.Toolbox',
+      displayName: 'JetBrains Toolbox',
+      publisher: 'JetBrains',
+      version: '3.7.2.0',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'exe',
+      silentSwitches: '/headless',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:Toolbox:JetBrains Toolbox',
+      installScope: 'user',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(JSON.parse(payload.client_payload.config.psadtConfig))
+      .toMatchObject({ reviewedUninstallArguments: ['/headless'] });
+  });
+
   it('dispatches the reviewed Postgres Pro lifecycle through the customer packager', async () => {
     reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
       item: {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -922,6 +922,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('uses JetBrains Toolbox\'s documented headless uninstall mode', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'jetbrains.toolbox',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/headless']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('uses Postgres Pro 17\'s reviewed NSIS silent uninstall mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'postgrespro.standard.17',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -386,6 +386,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/Silent=True'],
   },
   {
+    // JetBrains Toolbox registers its per-user Uninstall.exe without a quiet
+    // argument. JetBrains documents /headless as the completely background
+    // Windows uninstall mode; append it to the exact captured Toolbox ARP
+    // command so Intune removal cannot wait behind an invisible UI.
+    wingetId: 'JetBrains.Toolbox',
+    reviewedUninstallArguments: ['/headless'],
+  },
+  {
     // Zen Browser uses Mozilla's NSIS helper.exe lifecycle. Its captured ARP
     // command omits the silent switch and opens the hidden uninstall wizard
     // under SYSTEM, leaving the exact registration present until timeout.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -161,6 +161,28 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.successCodes).toEqual([1223]);
   });
 
+  it('binds JetBrains Toolbox customer packages to headless removal', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'JetBrains.Toolbox',
+      displayName: 'JetBrains Toolbox',
+      publisher: 'JetBrains',
+      version: '3.7.2.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/headless',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:Toolbox:JetBrains Toolbox',
+      installScope: 'user',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/headless']);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/headless']);
+  });
+
   it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'PostgresPro.Standard.17',


### PR DESCRIPTION
## Summary
- append JetBrains' documented /headless mode to the exact captured Toolbox uninstaller
- carry the reviewed argument through deployment identity and customer workflow dispatch
- keep exact ARP removal verification authoritative

Official contract: https://www.jetbrains.com/help/toolbox-app/installation.html#uninstalling-silently-on-windows

## Validation
- npm test (83 files, 1,407 tests)
- npm run lint
- npm run build:ci