### PR TITLE
Keep reviewed MSI installs observable

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2301,22 +2301,46 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
             # leave the trailing token "iet", producing a malformed hidden MSI
             # command that could stall indefinitely under LocalSystem.
             $msiProperties = ($silentSwitchesEscaped -replace '(?i)(?<!\S)/(?:quiet|q[nbrfu]?)(?=\s|$)\s*', '').Trim()
+            $msiPreparationLines = @()
             if ($msiProperties) {
                 $msiPropertiesEscaped = $msiProperties -replace "'", "''"
                 if ($msiPropertiesEscaped -match '%[A-Za-z][A-Za-z0-9()_]*%') {
-                    $lines += @(
+                    $msiPreparationLines = @(
                         "    `$effectiveMsiProperties = [Environment]::ExpandEnvironmentVariables('$msiPropertiesEscaped')"
-                        "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList `$effectiveMsiProperties"
                     )
+                    $msiInstallLine = "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList `$effectiveMsiProperties"
                 } else {
-                    $lines += @(
-                        "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList '$msiPropertiesEscaped'"
-                    )
+                    $msiInstallLine = "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped' -AdditionalArgumentList '$msiPropertiesEscaped'"
                 }
             } else {
+                $msiInstallLine = "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped'"
+            }
+            $lines += $msiPreparationLines
+            if ($reviewedInstallCompletionTimeoutMinutes -gt 0) {
                 $lines += @(
-                    "    Start-ADTMsiProcess -Action 'Install' -FilePath '$installerFileNameSingleQuoteEscaped'"
+                    "    `$installDeadline = [DateTime]::UtcNow.AddMinutes($reviewedInstallCompletionTimeoutMinutes)"
+                    "    `$installHandle = $($msiInstallLine.Trim()) -NoWait -PassThru"
+                    '    $nextInstallProgressLog = [DateTime]::UtcNow'
+                    '    while (-not $installHandle.Task.IsCompleted) {'
+                    '        if ([DateTime]::UtcNow -ge $installDeadline) {'
+                    "            throw 'The reviewed MSI installer did not complete within $reviewedInstallCompletionTimeoutMinutes minutes.'"
+                    '        }'
+                    '        if ([DateTime]::UtcNow -ge $nextInstallProgressLog) {'
+                    '            Write-ADTLogEntry -Message "The reviewed MSI installer is still working." -Source ''Install-ADTDeployment'''
+                    '            $nextInstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)'
+                    '        }'
+                    '        Start-Sleep -Seconds 5'
+                    '    }'
+                    '    $installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+                    '    if ($installProcessExitCode -in @(1641, 3010)) {'
+                    '        $script:InstallRebootExitCode = 3010'
+                    '        Write-ADTLogEntry -Message "The reviewed MSI installer requested a reboot with exit code [$installProcessExitCode]." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+                    '    } elseif ($installProcessExitCode -ne 0) {'
+                    '        throw "The reviewed MSI installer exited with code [$installProcessExitCode]."'
+                    '    }'
                 )
+            } else {
+                $lines += $msiInstallLine
             }
         }
         { $_ -in 'msix', 'appx' } {

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -200,6 +200,31 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
       .toMatchObject({ reviewedUninstallArguments: ['/S'] });
   });
 
+  it('dispatches the observable Webroot MSI lifecycle through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Webroot.SecureAnywhere',
+      displayName: 'Webroot SecureAnywhere',
+      publisher: 'Webroot',
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installerSha256: 'B'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Webroot SecureAnywhere',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.type).toBe('msi');
+    expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -225,6 +225,11 @@ describe('application packaging adapters', () => {
   it('requires Webroot SecureAnywhere to use its unattended MSI lifecycle', () => {
     expect(resolveApplicationInstallerSelectionType('Webroot.SecureAnywhere')).toBe('msi');
     expect(resolveApplicationInstallerSelectionType(' webroot.secureanywhere ')).toBe('msi');
+    expect(
+      applyApplicationPackagingAdapter('Webroot.SecureAnywhere', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
     expect(resolveApplicationInstallerSelectionType('Example.App')).toBeUndefined();
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1105,9 +1105,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
     // registered WRUNINST removal route is interactive, while the MSI has the
     // standard unattended Windows Installer lifecycle required by Intune.
-    // Never fall back to the EXE if the reviewed MSI entry disappears.
+    // Never fall back to the EXE if the reviewed MSI entry disappears. The
+    // MSI's MainWSAInstall custom action can remain quiet beyond the generic
+    // QA inactivity window, so keep that exact PSADT install observable and
+    // bounded for customer Intune execution and QA alike.
     wingetId: 'Webroot.SecureAnywhere',
     reviewedInstallerSelectionType: 'msi',
+    reviewedInstallCompletionTimeoutMinutes: 15,
   },
 ];
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -613,6 +613,31 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
   });
 
+  it('binds the bounded Webroot MSI wait to the QA execution profile', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Webroot.SecureAnywhere',
+      displayName: 'Webroot SecureAnywhere',
+      publisher: 'Webroot',
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Webroot SecureAnywhere',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { sourceType: string; silentArgs: string };
+      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+    };
+
+    expect(profile.installer.sourceType).toBe('msi');
+    expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+  });
+
   it('binds reviewed Wiris and Azure Monitor removal contracts to QA profiles', () => {
     const mathType = normalizeQaWorkflowPackageInput({
       wingetId: 'Wiris.MathType.7',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2451,6 +2451,40 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps a reviewed Webroot MSI custom action observable and bounded',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'Webroot SecureAnywhere',
+        [],
+        { reviewedInstallCompletionTimeoutMinutes: 15 },
+        [],
+        'Webroot.SecureAnywhere',
+        'Webroot SecureAnywhere',
+        '9.0.45.63',
+        'REGISTRY_UNINSTALL:Webroot SecureAnywhere',
+        '/qn /norestart ALLUSERS=1'
+      );
+
+      expect(generated).toContain(
+        '$installDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(generated).toContain(
+        "$installHandle = Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=1' -NoWait -PassThru"
+      );
+      expect(generated).toContain(
+        'Write-ADTLogEntry -Message "The reviewed MSI installer is still working."'
+      );
+      expect(generated).toContain(
+        '$installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+      );
+      expect(generated).toContain(
+        "throw 'The reviewed MSI installer did not complete within 15 minutes.'"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'keeps a reviewed nested FlashPrint bootstrapper observable',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- extend the reviewed install-completion heartbeat to direct MSI/WiX packages
- give Webroot SecureAnywhere's long-running MSI custom action a bounded 15-minute window
- verify the adapter reaches QA profiles and customer workflow payloads

## Verification
- 83 test files / 1,410 tests passed
- npm run lint
- npm run build:ci
- generated Webroot PSADT script parses successfully