### PR TITLE
Activate reviewed MSI no-wait packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '59686c39a99aa6202d2d4c8ef947e81a4eb0ef38',
+  packagerCommit: '3af4748ef271a2abb26003b2c42182a2769c8b53',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -296,6 +296,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Webroot's observable MSI completion contract changes only its previously
   // interrupted custom-action lifecycle. Preserve every unrelated valid pass.
   'c163bad8c16908ada436222bc2cdba0bf49f794e',
+  // The PSADT 4.1.8 asynchronous MSI correction changes only reviewed MSI
+  // profiles that failed before launching. Preserve every unrelated valid pass.
+  '59686c39a99aa6202d2d4c8ef947e81a4eb0ef38',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -89,6 +89,16 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3af4748ef271a2abb26003b2c42182a2769c8b53': [
+    // Retry Webroot with the supported PSADT process handle after the pinned
+    // toolkit's MSI no-wait wrapper rejected the exact installer path.
+    'Webroot.SecureAnywhere',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    'Tricentis.NeoLoad',
+    'Piriform.Recuva',
+    'Trimble.SketchUp.2022',
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
+  ],
   '59686c39a99aa6202d2d4c8ef947e81a4eb0ef38': [
     // Retry Webroot with an observable bounded wait around its long-running
     // MSI custom action instead of classifying the quiet work as stalled.


### PR DESCRIPTION
## Summary
- activate shared packager commit 3af4748ef271a2abb26003b2c42182a2769c8b53 for exact QA profiles
- retain unrelated compatible passes from the preceding release
- retry Webroot and the still-unconsumed bounded terminal targets under the atomic pin

## Validation
- 224 targeted tests
- npm run lint
- production packager full gate: 83 files / 1,410 tests and build