### PR TITLE
Extend reviewed Webroot MSI completion ceiling

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -221,7 +221,7 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     const payload = JSON.parse(String(request.body));
     expect(payload.client_payload.installer.type).toBe('msi');
     expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 15,
+      reviewedInstallCompletionTimeoutMinutes: 30,
     });
   });
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -228,7 +228,7 @@ describe('application packaging adapters', () => {
     expect(
       applyApplicationPackagingAdapter('Webroot.SecureAnywhere', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 15,
+      reviewedInstallCompletionTimeoutMinutes: 30,
     });
     expect(resolveApplicationInstallerSelectionType('Example.App')).toBeUndefined();
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1107,11 +1107,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // standard unattended Windows Installer lifecycle required by Intune.
     // Never fall back to the EXE if the reviewed MSI entry disappears. The
     // MSI's MainWSAInstall custom action can remain quiet beyond the generic
-    // QA inactivity window, so keep that exact PSADT install observable and
-    // bounded for customer Intune execution and QA alike.
+    // QA inactivity window. Production QA run 32613430533 showed the exact
+    // signed MSI still holding the global MSI mutex after the 15-minute
+    // wrapper ceiling and releasing it at roughly minute 24, so keep that
+    // exact PSADT install observable with a Webroot-only 30-minute bound for
+    // customer Intune execution and QA alike.
     wingetId: 'Webroot.SecureAnywhere',
     reviewedInstallerSelectionType: 'msi',
-    reviewedInstallCompletionTimeoutMinutes: 15,
+    reviewedInstallCompletionTimeoutMinutes: 30,
   },
 ];
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -635,7 +635,7 @@ describe('PSADT QA package identity', () => {
 
     expect(profile.installer.sourceType).toBe('msi');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
-    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(30);
   });
 
   it('binds reviewed Wiris and Azure Monitor removal contracts to QA profiles', () => {


### PR DESCRIPTION
## Summary
- raise only Webroot SecureAnywhere's reviewed MSI completion ceiling from 15 to 30 minutes
- preserve the shared bounded/observable PSADT execution path used by customer portal, catalog, and QA packages
- document production QA run 32613430533, where the signed MSI remained active past 15 minutes and released the MSI mutex at roughly minute 24

## Validation
- targeted adapter/profile/customer dispatch tests: 157 passed
- full test suite: 83 files, 1,410 tests passed
- ESLint passed
- production Next.js build passed