### PR TITLE
Activate Webroot completion adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3af4748ef271a2abb26003b2c42182a2769c8b53',
+  packagerCommit: 'ecc0b406cf37259aed2947e4d9b26af5c2abf648',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -299,6 +299,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The PSADT 4.1.8 asynchronous MSI correction changes only reviewed MSI
   // profiles that failed before launching. Preserve every unrelated valid pass.
   '59686c39a99aa6202d2d4c8ef947e81a4eb0ef38',
+  // Webroot's measured 30-minute MSI completion ceiling changes only its
+  // previously timed-out custom-action lifecycle. Preserve every unrelated pass.
+  '3af4748ef271a2abb26003b2c42182a2769c8b53',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -89,6 +89,16 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ecc0b406cf37259aed2947e4d9b26af5c2abf648': [
+    // Retry Webroot with the measured 30-minute ceiling after its signed MSI
+    // remained active beyond the former 15-minute bound in production QA.
+    'Webroot.SecureAnywhere',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    'Tricentis.NeoLoad',
+    'Piriform.Recuva',
+    'Trimble.SketchUp.2022',
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
+  ],
   '3af4748ef271a2abb26003b2c42182a2769c8b53': [
     // Retry Webroot with the supported PSADT process handle after the pinned
     // toolkit's MSI no-wait wrapper rejected the exact installer path.


### PR DESCRIPTION
## Summary
- pin production QA/profile generation to adapter commit ecc0b406cf37259aed2947e4d9b26af5c2abf648
- record the prior reviewed-MSI release as compatible for unrelated passing profiles
- carry Webroot and all still-unconsumed bounded retries across the atomic toolchain pin

## Validation
- activation/profile/scheduler tests: 224 passed
- full test suite: 83 files, 1,410 tests passed
- ESLint passed
- production Next.js build passed