### PR TITLE
Honor reviewed installer timeout in QA dispatch

### DIFF
--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -118,6 +118,37 @@ describe('dispatchQaCandidate', () => {
     expect(JSON.parse(body.inputs.candidate_payload).installerUrl).toBe(mirrorUrl);
   });
 
+  it('keeps the outer QA guard beyond a reviewed customer-package installer deadline', async () => {
+    enforceInstallerPreflightMock.mockResolvedValue({
+      cacheKey: 'healthy',
+      status: 'healthy',
+      source: 'live',
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dispatchQaCandidate({
+      id: '44444444-4444-4444-8444-444444444444',
+      winget_id: 'Webroot.SecureAnywhere',
+      definition_path: null,
+      version: '9.0.45.63',
+      architecture: 'x86',
+      installer_url: 'https://example.test/wsainstall.msi',
+      installer_sha256: 'F'.repeat(64),
+      installer_file_name: 'wsainstall.msi',
+      installer_type: 'msi',
+      test_level: 'psadt-package',
+      package_profile_sha256: 'A'.repeat(64),
+      test_config: {
+        mode: 'psadt-package',
+        psadtConfig: { reviewedInstallCompletionTimeoutMinutes: 30 },
+      },
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.inputs.timeout_minutes).toBe('35');
+  });
+
   it('uses the renamed ImageGlass release asset for QA preflight and runner payload', async () => {
     enforceInstallerPreflightMock.mockResolvedValue({
       cacheKey: 'healthy',

--- a/lib/qa/dispatch.ts
+++ b/lib/qa/dispatch.ts
@@ -18,6 +18,36 @@ export interface QaDispatchCandidate {
   test_config: Json;
 }
 
+const DEFAULT_QA_COMMAND_TIMEOUT_MINUTES = 20;
+const REVIEWED_INSTALL_TIMEOUT_HEADROOM_MINUTES = 5;
+
+function qaCommandTimeoutMinutes(
+  testConfig: Record<string, Json | undefined>
+): number {
+  const psadtConfig = testConfig.psadtConfig;
+  if (!psadtConfig || typeof psadtConfig !== 'object' || Array.isArray(psadtConfig)) {
+    return DEFAULT_QA_COMMAND_TIMEOUT_MINUTES;
+  }
+
+  const reviewedTimeout = psadtConfig.reviewedInstallCompletionTimeoutMinutes;
+  if (
+    typeof reviewedTimeout !== 'number' ||
+    !Number.isInteger(reviewedTimeout) ||
+    reviewedTimeout < 1 ||
+    reviewedTimeout > 60
+  ) {
+    return DEFAULT_QA_COMMAND_TIMEOUT_MINUTES;
+  }
+
+  // The generated customer package owns the reviewed installer deadline. Keep
+  // the outer QA command guard beyond it so PSADT can report its bounded result
+  // and perform teardown instead of QA terminating a still-valid installer.
+  return Math.max(
+    DEFAULT_QA_COMMAND_TIMEOUT_MINUTES,
+    reviewedTimeout + REVIEWED_INSTALL_TIMEOUT_HEADROOM_MINUTES
+  );
+}
+
 export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promise<void> {
   const testConfig = candidate.test_config && typeof candidate.test_config === 'object' && !Array.isArray(candidate.test_config)
     ? candidate.test_config as Record<string, Json | undefined>
@@ -81,7 +111,7 @@ export async function dispatchQaCandidate(candidate: QaDispatchCandidate): Promi
           packageProfileSha256: candidate.package_profile_sha256,
           testConfig: candidate.test_config,
         }),
-        timeout_minutes: '20',
+        timeout_minutes: String(qaCommandTimeoutMinutes(testConfig)),
       },
     }),
   });


### PR DESCRIPTION
## Summary
- derive the outer isolated-QA command timeout from the reviewed customer PSADT installer deadline
- retain the normal 20-minute guard for ordinary apps and 15-minute reviewed installers
- add five minutes of reporting/teardown headroom, so Webroot's 30-minute customer package receives a 35-minute QA guard instead of being killed at minute 20

## Production evidence
Run 32615552441 remained healthy beyond the previous 15-minute package ceiling, but the hardcoded 20-minute outer QA guard terminated the still-valid MSI and caused uninstall error 1618.

## Validation
- targeted dispatch/profile tests: 100 passed
- full test suite: 83 files, 1,411 tests passed
- ESLint passed
- production Next.js build passed