### PR TITLE
Use Webroot reviewed quiet MSI mode

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -221,6 +221,7 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     const payload = JSON.parse(String(request.body));
     expect(payload.client_payload.installer.type).toBe('msi');
     expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
+      reviewedInstallArguments: ['CMDLINE=SME,quiet'],
       reviewedInstallCompletionTimeoutMinutes: 30,
     });
   });

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -228,6 +228,7 @@ describe('application packaging adapters', () => {
     expect(
       applyApplicationPackagingAdapter('Webroot.SecureAnywhere', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
+      reviewedInstallArguments: ['CMDLINE=SME,quiet'],
       reviewedInstallCompletionTimeoutMinutes: 30,
     });
     expect(resolveApplicationInstallerSelectionType('Example.App')).toBeUndefined();

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1107,13 +1107,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // standard unattended Windows Installer lifecycle required by Intune.
     // Never fall back to the EXE if the reviewed MSI entry disappears. The
     // MSI's MainWSAInstall custom action can remain quiet beyond the generic
-    // QA inactivity window. Production QA run 32613430533 showed the exact
-    // signed MSI still holding the global MSI mutex after the 15-minute
-    // wrapper ceiling and releasing it at roughly minute 24, so keep that
-    // exact PSADT install observable with a Webroot-only 30-minute bound for
-    // customer Intune execution and QA alike.
+    // QA inactivity window. The exact 9.0.45.63 MSI exposes Webroot's documented
+    // CMDLINE property but defaults it to -null. Production QA run 32617479599
+    // showed that default still owning the global MSI mutex at the reviewed
+    // 30-minute ceiling. Select Webroot's documented SME quiet mode while
+    // retaining the observable, fail-closed bound for customer Intune execution
+    // and QA alike.
     wingetId: 'Webroot.SecureAnywhere',
     reviewedInstallerSelectionType: 'msi',
+    reviewedInstallArguments: ['CMDLINE=SME,quiet'],
     reviewedInstallCompletionTimeoutMinutes: 30,
   },
 ];

--- a/lib/qa/dispatch.test.ts
+++ b/lib/qa/dispatch.test.ts
@@ -141,7 +141,10 @@ describe('dispatchQaCandidate', () => {
       package_profile_sha256: 'A'.repeat(64),
       test_config: {
         mode: 'psadt-package',
-        psadtConfig: { reviewedInstallCompletionTimeoutMinutes: 30 },
+        psadtConfig: {
+          reviewedInstallArguments: ['CMDLINE=SME,quiet'],
+          reviewedInstallCompletionTimeoutMinutes: 30,
+        },
       },
     });
 

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -630,11 +630,15 @@ describe('PSADT QA package identity', () => {
     });
     const profile = normalized.identity.profile as {
       installer: { sourceType: string; silentArgs: string };
-      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+      psadtConfig: {
+        reviewedInstallArguments?: string[];
+        reviewedInstallCompletionTimeoutMinutes?: number;
+      };
     };
 
     expect(profile.installer.sourceType).toBe('msi');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
+    expect(profile.psadtConfig.reviewedInstallArguments).toEqual(['CMDLINE=SME,quiet']);
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(30);
   });
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -192,7 +192,7 @@ if ($script:CapturedFilePath -ne "$env:SystemRoot\\System32\\msiexec.exe") {
 if (-not $script:CapturedArgumentList.Contains(('/i "{0}"' -f $expectedInstallerPath))) {
     throw "The reviewed MSI argument list omitted the exact installer path: $script:CapturedArgumentList"
 }
-if ($script:CapturedArgumentList -notlike '*REBOOT=ReallySuppress /QN /norestart ALLUSERS=1 /L*V*') {
+if ($script:CapturedArgumentList -notlike '*REBOOT=ReallySuppress /QN /norestart ALLUSERS=1 CMDLINE=SME,quiet /L*V*') {
     throw "The reviewed MSI argument list did not retain PSADT defaults, vendor properties, and verbose logging: $script:CapturedArgumentList"
 }
 `;
@@ -2522,7 +2522,10 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         'msi',
         'Webroot SecureAnywhere',
         [],
-        { reviewedInstallCompletionTimeoutMinutes: 15 },
+        {
+          reviewedInstallArguments: ['CMDLINE=SME,quiet'],
+          reviewedInstallCompletionTimeoutMinutes: 30,
+        },
         [],
         'Webroot.SecureAnywhere',
         'Webroot SecureAnywhere',
@@ -2532,7 +2535,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       );
 
       expect(generated).toContain(
-        '$installDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+        '$installDeadline = [DateTime]::UtcNow.AddMinutes(30)'
       );
       expect(generated).toContain(
         "$msiInstallerPath = Join-Path $adtSession.DirFiles 'setup.exe'"
@@ -2541,7 +2544,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         '$msiArgumentList = \'/i "{0}" REBOOT=ReallySuppress /QN\' -f $msiInstallerPath'
       );
       expect(generated).toContain(
-        '$msiAdditionalArgumentList = \'/norestart ALLUSERS=1\''
+        "$msiAdditionalArgumentList = '/norestart ALLUSERS=1 CMDLINE=SME,quiet'"
       );
       expect(generated).toContain(
         '$msiArgumentList = "$msiArgumentList /L*V `"$msiLogPath`""'
@@ -2557,7 +2560,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         '$installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
       );
       expect(generated).toContain(
-        "throw 'The reviewed MSI installer did not complete within 15 minutes.'"
+        "throw 'The reviewed MSI installer did not complete within 30 minutes.'"
       );
       executeReviewedMsiInstallBlock(generated);
     }


### PR DESCRIPTION
Production QA run 32617479599 proved that the exact Webroot 9.0.45.63 MSI can retain the global MSI mutex beyond the reviewed 30-minute customer-package deadline when its CMDLINE property remains at the vendor default -null. The exact signed MSI exposes CMDLINE and Webroot documents SME,quiet for unattended background MSI deployment. This change keeps the reviewed MSI selection and fail-closed 30-minute bound, while appending CMDLINE=SME,quiet through the shared production packaging adapter. The same config now flows to portal/catalog packaging and QA package profiles.\n\nVerification:\n- focused: 5 files, 276 tests\n- full: 83 files, 1411 tests\n- npm run lint\n- npm run build\n- generated PowerShell runtime contract verifies exact msiexec path, PSADT defaults, CMDLINE=SME,quiet, verbose logging, process handle, and bounded completion