### PR TITLE
Activate Webroot quiet MSI adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ecc0b406cf37259aed2947e4d9b26af5c2abf648',
+  packagerCommit: 'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -302,6 +302,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Webroot's measured 30-minute MSI completion ceiling changes only its
   // previously timed-out custom-action lifecycle. Preserve every unrelated pass.
   '3af4748ef271a2abb26003b2c42182a2769c8b53',
+  // Webroot's reviewed vendor quiet property changes only its previously timed-out
+  // MSI lifecycle. Preserve every unrelated valid pass from the prior release.
+  'ecc0b406cf37259aed2947e4d9b26af5c2abf648',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -187,7 +187,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Webroot only after activating its reviewed MSI lifecycle', () => {
+  it('retries Webroot on the current reviewed quiet MSI release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' webroot.secureanywhere ', status: 'failed' }

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -89,6 +89,16 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec': [
+    // Retry Webroot with the vendor-documented SME quiet MSI property after its
+    // default -null command line retained the global MSI mutex past 30 minutes.
+    'Webroot.SecureAnywhere',
+    // Carry every still-unconsumed bounded target across the atomic pin.
+    'Tricentis.NeoLoad',
+    'Piriform.Recuva',
+    'Trimble.SketchUp.2022',
+    ...MIKTEX_RELEASE_RETRY_TARGETS,
+  ],
   'ecc0b406cf37259aed2947e4d9b26af5c2abf648': [
     // Retry Webroot with the measured 30-minute ceiling after its signed MSI
     // remained active beyond the former 15-minute bound in production QA.


### PR DESCRIPTION
Pins production QA package profiles to the reviewed Webroot quiet-mode packager merged in #803 at db444b2d99905ecbf17ed20e20bfa0b3abc1aeec. The prior ecc0b406 revision remains in compatible release history so unrelated passing apps retain coverage, while Webroot is explicitly retried with the changed package profile and all unconsumed bounded targets carry forward.\n\nVerification:\n- focused activation tests: 179 passed\n- full suite: 83 files, 1411 tests\n- npm run lint\n- npm run build