### PR TITLE
fix: block unprovisioned Webroot catalog installs

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1282,3 +1282,28 @@ describe('Git for Windows SDK managed uninstall block migration contract', () =>
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Webroot tenant-provisioned install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260823061000_block_webroot_unlicensed_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unprovisioned generic catalog install across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Webroot.SecureAnywhere'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32620368724'
+    );
+    expect(sql).toContain('32617479599');
+    expect(sql).toContain('GUILIC');
+    expect(sql).toContain('CMDLINE=SME,quiet');
+    expect(sql).toContain('30-minute');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260823061000_block_webroot_unlicensed_managed_install.sql
+++ b/supabase/migrations/20260823061000_block_webroot_unlicensed_managed_install.sql
@@ -1,0 +1,41 @@
+-- Webroot SecureAnywhere's WinGet consumer MSI requires customer-specific
+-- provisioning rather than providing a complete generic managed-install
+-- contract. The exact MSI exposes GUILIC and CMDLINE properties, but WinGet
+-- supplies neither a tenant license nor a documented unattended command. In
+-- isolated LocalSystem QA, run 32617479599 reached the 30-minute ceiling with
+-- the manifest defaults. Run 32620368724 reached the same 30-minute ceiling
+-- after the shared production adapter supplied Webroot's documented business
+-- quiet command, CMDLINE=SME,quiet, because GUILIC remained customer-specific.
+-- Block the generic catalog package instead of shipping an installer that can
+-- stall while remaining unprovisioned. Customer-specific sources remain
+-- separate from catalog eligibility and can carry their tenant configuration.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Webroot.SecureAnywhere',
+  'unsupported_managed_install',
+  'Webroot SecureAnywhere requires customer-specific tenant provisioning through GUILIC. The exact generic WinGet MSI reached the 30-minute LocalSystem installation ceiling both with manifest defaults and with CMDLINE=SME,quiet, so it cannot provide a reliable unattended catalog install.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32620368724'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Webroot.SecureAnywhere';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Webroot.SecureAnywhere'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block the generic Webroot SecureAnywhere catalog package because unattended installation requires customer-specific GUILIC provisioning
- mark the curated app unverified and supersede stale QA candidates
- preserve the shared quiet adapter for customer-specific/custom packaging

## Evidence
- manifest-default LocalSystem QA timed out after 30 minutes: run 32617479599
- reviewed CMDLINE=SME,quiet LocalSystem QA also timed out after 30 minutes: run 32620368724

## Verification
- npm test (83 files, 1412 tests)
- npm run lint
- npm run build:ci