### PR TITLE
fix: suppress FSLogix uninstall restarts

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -226,6 +226,34 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     });
   });
 
+  it('dispatches FSLogix removal with restart suppression through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Microsoft.FSLogix',
+      displayName: 'FSLogix',
+      publisher: 'Microsoft',
+      version: '3.26.126.19110',
+      architecture: 'x64',
+      installerSha256: 'C'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      silentSwitches: '/install /quiet /norestart',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Microsoft FSLogix Apps',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:Microsoft FSLogix Apps'
+    );
+    expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
+      reviewedUninstallArguments: ['/norestart'],
+    });
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -92,6 +92,12 @@ describe('application packaging adapters', () => {
       'microsoft.fslogix',
       'vendor-uninstall.exe --custom'
     )).toBe('vendor-uninstall.exe --custom');
+    expect(
+      applyApplicationPackagingAdapter(
+        'Microsoft.FSLogix',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['/norestart']);
   });
 
   it('uses the exact stable Inno registry key for every K-Lite edition', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -913,6 +913,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // Microsoft's FSLogix bundle documents /norestart for suppressing every
+    // restart attempt. The registered Burn uninstall command contains only
+    // /uninstall /quiet; production QA run 32622117211 confirmed that exact
+    // command powered off the isolated endpoint before the lifecycle report
+    // could be written. Append the vendor-supported restart suppression to the
+    // exact captured command for both customer Intune removal and QA.
+    wingetId: 'Microsoft.FSLogix',
+    reviewedUninstallArguments: ['/norestart'],
+  },
+  {
     // The VSTO redistributable registers a visible External Installer command
     // with no arguments. Invoking that bare install.exe returns successfully
     // without removing the runtime. Supply the redistributable's unattended
@@ -1255,6 +1265,8 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   // creates a generated GUID ARP key with that value as its DisplayName. Bind
   // the reviewed display identity so prerequisite ARP changes cannot prevent
   // install capture and the same exact vendor entry drives customer removal.
+  // The application adapter also appends Microsoft's documented /norestart so
+  // that removal cannot unexpectedly restart the managed endpoint.
   'microsoft.fslogix': {
     generatedDisplayName: 'FSLogix',
     registeredDisplayName: 'Microsoft FSLogix Apps',

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -210,6 +210,37 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/S']);
   });
 
+  it('binds FSLogix restart suppression to customer and QA package identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.FSLogix',
+      displayName: 'FSLogix',
+      publisher: 'Microsoft',
+      version: '3.26.126.19110',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerPath: 'x64\\Release\\FSLogixAppsSetup.exe',
+      silentSwitches: '/install /quiet /norestart',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Microsoft FSLogix Apps',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(normalized.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:Microsoft FSLogix Apps'
+    );
+    expect(profile.installer.uninstallCommand).toBe(normalized.uninstallCommand);
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual([
+      '/norestart',
+    ]);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/norestart']);
+  });
+
   it('binds offline dependency installers to the execution profile only when present', () => {
     const baseline = buildQaPackageIdentity(input);
     const dependency = {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -276,6 +276,35 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'appends FSLogix restart suppression to the exact captured Burn command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'zip',
+        'FSLogix',
+        [],
+        { reviewedUninstallArguments: ['/norestart'] },
+        [],
+        'Microsoft.FSLogix',
+        'FSLogix',
+        '3.26.126.19110',
+        'REGISTRY_UNINSTALL:Microsoft FSLogix Apps',
+        '/install /quiet /norestart'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "$reviewedUninstallArguments = @('/norestart')"
+      );
+      expect(uninstallFunction).toContain(
+        '$registeredUninstallArguments += $reviewedArgument'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'appends SketchUp silent removal to the exact captured InstallShield command',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -90,6 +90,9 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.uninstallCommand).toBe(
       'REGISTRY_UNINSTALL:Microsoft FSLogix Apps'
     );
+    expect(config.psadtConfig.reviewedUninstallArguments).toEqual([
+      '/norestart',
+    ]);
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- append Microsoft's documented /norestart switch to the exact captured FSLogix bundle uninstall command
- carry the adapter through customer workflow payloads, QA configuration, package identity hashing, and generated PSADT runtime
- preserve the exact Microsoft FSLogix Apps ARP identity

## Evidence
- QA run 32622117211 installed and detected FSLogix successfully, then the registered /uninstall /quiet command powered off the isolated endpoint
- Microsoft documents /norestart as suppressing restart attempts for FSLogixAppsSetup.exe

## Verification
- focused: 5 files, 301 tests
- full: 83 files, 1415 tests
- npm run lint
- npm run build:ci