### PR TITLE
chore: activate FSLogix restart-safe packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec',
+  packagerCommit: '00983d36128aef319cc36f901beeff6dd03d847f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -305,6 +305,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Webroot's reviewed vendor quiet property changes only its previously timed-out
   // MSI lifecycle. Preserve every unrelated valid pass from the prior release.
   'ecc0b406cf37259aed2947e4d9b26af5c2abf648',
+  // FSLogix restart suppression changes only its previously interrupted
+  // uninstall path. Webroot is blocked at the shared eligibility gate; preserve
+  // every unrelated compatible pass from the prior protected release.
+  'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -67,7 +67,6 @@ describe('QA toolchain targeted retries', () => {
       'Tricentis.NeoLoad',
       'Piriform.Recuva',
       'Trimble.SketchUp.2022',
-      'Webroot.SecureAnywhere',
       'MiKTeX.MiKTeX',
       'Y-ASLant.ElegantClipboard',
       'Amazon.Music',
@@ -109,6 +108,7 @@ describe('QA toolchain targeted retries', () => {
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
+    expect(targets).not.toContain('Webroot.SecureAnywhere');
 
     targets.length = 0;
 
@@ -117,7 +117,6 @@ describe('QA toolchain targeted retries', () => {
         'Tricentis.NeoLoad',
         'Piriform.Recuva',
         'Trimble.SketchUp.2022',
-        'Webroot.SecureAnywhere',
         'MiKTeX.MiKTeX',
         'Y-ASLant.ElegantClipboard',
         'Amazon.Music',
@@ -187,11 +186,11 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Webroot on the current reviewed quiet MSI release', () => {
+  it('does not retry blocked Webroot on the current release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' webroot.secureanywhere ', status: 'failed' }
-    )).toBe(true);
+    )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(
       '49775d3657a1b11b4ec1603e80ba8f78882b174f',
       { wingetId: 'Webroot.SecureAnywhere', status: 'failed' }

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -88,7 +88,23 @@ const MIKTEX_RELEASE_RETRY_TARGETS = [
   ...ELEGANT_CLIPBOARD_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const FSLOGIX_RELEASE_RETRY_TARGETS = [
+  // Retry FSLogix with Microsoft's documented restart suppression after its
+  // registered /uninstall /quiet command powered off the isolated endpoint.
+  'Microsoft.FSLogix',
+  // Carry every still-unconsumed bounded target across the atomic pin. Exclude
+  // the existing FSLogix carry-forward entry to keep the dispatch list unique.
+  'Tricentis.NeoLoad',
+  'Piriform.Recuva',
+  'Trimble.SketchUp.2022',
+  ...MIKTEX_RELEASE_RETRY_TARGETS.filter(
+    (wingetId) => wingetId !== 'Microsoft.FSLogix'
+  ),
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '00983d36128aef319cc36f901beeff6dd03d847f':
+    FSLOGIX_RELEASE_RETRY_TARGETS,
   'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec': [
     // Retry Webroot with the vendor-documented SME quiet MSI property after its
     // default -null command line retained the global MSI mutex past 30 minutes.


### PR DESCRIPTION
## Summary
- make packager commit 00983d36128aef319cc36f901beeff6dd03d847f authoritative for customer and QA package profiles
- preserve the prior release as compatible for unaffected passing apps
- retry FSLogix with restart-safe removal and remove production-blocked Webroot from the current retry set

## Verification
- focused: 4 files, 197 tests
- full: 83 files, 1415 tests
- npm run lint
- npm run build:ci