### PR TITLE
Fix Chrome Beta PSADT uninstall identity

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -254,6 +254,31 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     });
   });
 
+  it('dispatches Chrome Beta EXE with the vendor channel uninstall key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Google.Chrome.Beta.EXE',
+      displayName: 'Google Chrome Beta (EXE)',
+      publisher: 'Google',
+      version: '152.0.7977.54',
+      architecture: 'x64',
+      installerSha256: 'D'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'exe',
+      silentSwitches: '--do-not-launch-chrome --system-level --chrome-beta',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:Google Chrome:Google Chrome Beta (EXE)',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta'
+    );
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -243,6 +243,17 @@ export async function triggerPackagingWorkflow(
   const normalizedPackageInput = inputs.sourceType === 'custom'
     ? null
     : normalizeQaWorkflowPackageInput({ ...inputs, packageDependencies });
+  // Keep the workflow payload and its hashed execution profile identical even
+  // when live catalog reconciliation is temporarily unavailable. Reviewed app
+  // identities are resolved again by normalizeQaWorkflowPackageInput; dispatch
+  // that exact command so the customer PSADT package cannot retain stale
+  // manifest metadata while its QA gate evaluates the corrected profile.
+  if (normalizedPackageInput) {
+    inputs = {
+      ...inputs,
+      uninstallCommand: normalizedPackageInput.uninstallCommand,
+    };
+  }
   const packageDependenciesJson = JSON.stringify(packageDependencies);
   const dependencyBundleSignature = packageDependencies.length > 0
     ? (() => {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -148,6 +148,31 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Chrome Beta EXE\'s vendor channel key instead of WinGet\'s stable key', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome.Beta.EXE',
+      'REGISTRY_UNINSTALL_KEY:Google Chrome:Google Chrome Beta (EXE)'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'google.chrome.beta.exe',
+      'REGISTRY_UNINSTALL:Google Chrome Beta (EXE)'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome.Beta.EXE',
+      'REGISTRY_UNINSTALL_KEY:Different Key:Google Chrome Beta (EXE)'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:Different Key:Google Chrome Beta (EXE)'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'Google.Chrome.Beta.EXE',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses Postgres Pro 17\'s exact PostgreSQL NSIS registry identity', () => {
     expect(resolveApplicationUninstallCommand(
       'PostgresPro.Standard.17',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1223,6 +1223,7 @@ export function resolveApplicationInstallerSelectionType(
 
 const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   generatedDisplayName: string;
+  manifestRegistryKey?: string;
   registeredDisplayName: string;
   registeredRegistryKey?: string;
 }>>> = {
@@ -1241,6 +1242,17 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
   'google.chrome.exe': {
     generatedDisplayName: 'Google Chrome (EXE)',
     registeredDisplayName: 'Google Chrome',
+  },
+  // Chromium's own install-mode contract registers the Beta channel below the
+  // `Google Chrome Beta` uninstall key with the same long display name. WinGet's
+  // EXE manifest currently combines the stable-channel `Google Chrome` key with
+  // the catalog-only `Google Chrome Beta (EXE)` label. Bind the vendor's exact
+  // channel identity so Google Updater ARP changes cannot make capture ambiguous.
+  'google.chrome.beta.exe': {
+    generatedDisplayName: 'Google Chrome Beta (EXE)',
+    manifestRegistryKey: 'Google Chrome',
+    registeredDisplayName: 'Google Chrome Beta',
+    registeredRegistryKey: 'Google Chrome Beta',
   },
   // The legacy Edge-channel package is still named `Docker Desktop Edge` in
   // the catalog, but Docker registers the installed product as the ordinary
@@ -1348,7 +1360,14 @@ export function resolveApplicationUninstallCommand(
   const reviewed = REVIEWED_REGISTRY_UNINSTALL_IDENTITIES[wingetId.trim().toLowerCase()];
   if (!reviewed) return uninstallCommand;
   const expected = `REGISTRY_UNINSTALL:${reviewed.generatedDisplayName}`;
-  if (uninstallCommand.trim() !== expected) return uninstallCommand;
+  const expectedManifestKey = reviewed.manifestRegistryKey
+    ? `REGISTRY_UNINSTALL_KEY:${reviewed.manifestRegistryKey}:${reviewed.generatedDisplayName}`
+    : undefined;
+  const normalizedUninstallCommand = uninstallCommand.trim();
+  if (
+    normalizedUninstallCommand !== expected &&
+    normalizedUninstallCommand !== expectedManifestKey
+  ) return uninstallCommand;
   if (!reviewed.registeredRegistryKey) {
     return `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`;
   }

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -241,6 +241,30 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/norestart']);
   });
 
+  it('binds Chrome Beta EXE customer and QA profiles to the vendor channel key', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Google.Chrome.Beta.EXE',
+      displayName: 'Google Chrome Beta (EXE)',
+      publisher: 'Google',
+      version: '152.0.7977.54',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--do-not-launch-chrome --system-level --chrome-beta',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:Google Chrome:Google Chrome Beta (EXE)',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta'
+    );
+    expect(profile.installer.uninstallCommand).toBe(normalized.uninstallCommand);
+  });
+
   it('binds offline dependency installers to the execution profile only when present', () => {
     const baseline = buildQaPackageIdentity(input);
     const dependency = {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1873,6 +1873,35 @@ describe('PSADT registry uninstall identity contract', () => {
     30_000
   );
 
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits Chrome Beta EXE capture and removal against its exact channel key',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Google Chrome Beta (EXE)',
+        [],
+        {},
+        [],
+        'Google.Chrome.Beta.EXE',
+        'Google Chrome Beta (EXE)',
+        '152.0.7977.54',
+        'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta',
+        '--do-not-launch-chrome --system-level --chrome-beta'
+      );
+
+      expect(generated).toContain(
+        "$configuredUninstallProductCode = 'Google Chrome Beta'"
+      );
+      expect(generated).toContain(
+        "$configuredUninstallDisplayName = 'Google Chrome Beta'"
+      );
+      expect(generated).toContain(
+        'No captured entry; searching for manifest registry key: $configuredProductCode'
+      );
+    },
+    30_000
+  );
+
   it('selects one architecture-decorated ARP entry without accepting an ambiguous set', () => {
     expect(packager).toContain('$configuredUninstallComparableName = ((');
     expect(packager).toContain('$architectureAgnosticMatches = @($changedApplications');

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -95,6 +95,37 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
+  it('binds Chrome Beta EXE QA to the vendor channel uninstall key', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Google.Chrome.Beta.EXE',
+        name: 'Google Chrome Beta (EXE)',
+        publisher: 'Google',
+        version: '152.0.7977.54',
+      },
+      manifest: {
+        InstallerType: 'exe',
+        ProductCode: 'Google Chrome',
+        InstallerSwitches: {
+          Silent: '--do-not-launch-chrome --system-level --chrome-beta',
+        },
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'exe',
+        ProductCode: 'Google Chrome',
+        AppsAndFeaturesEntries: [{
+          DisplayName: 'Google Chrome Beta (EXE)',
+          ProductCode: 'Google Chrome',
+        }],
+      },
+    });
+
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:Google Chrome Beta:Google Chrome Beta'
+    );
+  });
+
   it.each([
     ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
     ['nullsoft', '/S'],


### PR DESCRIPTION
## Summary
- bind Google.Chrome.Beta.EXE to Chromium's exact Google Chrome Beta ARP key/display name
- keep the customer workflow payload identical to the adapter-normalized QA execution profile when live catalog reconciliation is unavailable
- cover QA config, package-profile hashing, generated PSADT, and customer workflow dispatch

## Production evidence
- failed QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32626009626
- installer exited 0 but exact identity capture rejected two Google ARP changes, preventing detection and removal
- Chromium source defines the Beta uninstall key as ...\Uninstall\Google Chrome Beta

## Verification
- focused: 6 files, 338 tests
- full: 83 files, 1420 tests
- npm run lint
- npm run build:ci