### PR TITLE
Activate Chrome Beta registry-safe packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '00983d36128aef319cc36f901beeff6dd03d847f',
+  packagerCommit: 'c1c9410f58318d055c09a60bc067996a4b9b4597',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -309,6 +309,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // uninstall path. Webroot is blocked at the shared eligibility gate; preserve
   // every unrelated compatible pass from the prior protected release.
   'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec',
+  // Chrome Beta's exact vendor ARP identity and final customer-payload
+  // normalization change only adapter-resolved uninstall paths. Preserve every
+  // unrelated compatible pass from the prior protected release.
+  '00983d36128aef319cc36f901beeff6dd03d847f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -105,6 +105,7 @@ describe('QA toolchain targeted retries', () => {
       'BlueJTeam.BlueJ',
       'Autodesk.DesignReview',
       'AppiumDevelopers.AppiumInspector',
+      'Google.Chrome.Beta.EXE',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -127,6 +128,7 @@ describe('QA toolchain targeted retries', () => {
         'Speek.Speek',
         '8x8.Work',
         'Microsoft.FSLogix',
+        'Google.Chrome.Beta.EXE',
         'Microsoft.RMSClient',
         'SoftwareOK.DesktopOK',
         'Movavi.MovaviPhotoFocus',
@@ -194,6 +196,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '49775d3657a1b11b4ec1603e80ba8f78882b174f',
       { wingetId: 'Webroot.SecureAnywhere', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Chrome Beta EXE only after activating its exact vendor ARP identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' google.chrome.beta.exe ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '00983d36128aef319cc36f901beeff6dd03d847f',
+      { wingetId: 'Google.Chrome.Beta.EXE', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -102,7 +102,17 @@ const FSLOGIX_RELEASE_RETRY_TARGETS = [
   ),
 ] as const;
 
+const CHROME_BETA_REGISTRY_RELEASE_RETRY_TARGETS = [
+  // Retry Chrome Beta EXE with Chromium's exact channel-specific ARP key after
+  // the stale WinGet stable-channel identity made capture ambiguous.
+  'Google.Chrome.Beta.EXE',
+  // Carry every still-unconsumed bounded target across the atomic pin.
+  ...FSLOGIX_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'c1c9410f58318d055c09a60bc067996a4b9b4597':
+    CHROME_BETA_REGISTRY_RELEASE_RETRY_TARGETS,
   '00983d36128aef319cc36f901beeff6dd03d847f':
     FSLOGIX_RELEASE_RETRY_TARGETS,
   'db444b2d99905ecbf17ed20e20bfa0b3abc1aeec': [


### PR DESCRIPTION
## Summary
- activate protected packager commit c1c9410f58318d055c09a60bc067996a4b9b4597
- preserve compatible unrelated QA passes from 00983d36128aef319cc36f901beeff6dd03d847f
- prioritize Google.Chrome.Beta.EXE for production proof while retaining prior retry targets and excluding blocked Webroot

## Verification
- focused activation: 7 files, 440 tests
- full: 83 files, 1421 tests
- npm run lint
- npm run build:ci