### PR TITLE
fix(icons): bound each icon run with a wall-clock budget

### DIFF
--- a/.github/scripts/fetch-web-icons.mjs
+++ b/.github/scripts/fetch-web-icons.mjs
@@ -20,6 +20,11 @@ import sharp from 'sharp';
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY;
 const MAX_APPS = parseInt(process.env.MAX_APPS || '500', 10);
+// Wall-clock ceiling for the fetch loop. Apps we never reach keep their current
+// state (no attempt counter is touched), so the next run picks them up again.
+// This lets MAX_APPS be raised for throughput without the job overrunning.
+const BUDGET_MINUTES = parseInt(process.env.BUDGET_MINUTES || '0', 10);
+const BUDGET_MS = BUDGET_MINUTES > 0 ? BUDGET_MINUTES * 60_000 : Infinity;
 const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
 const ICON_SIZES = [32, 64, 128, 256];
 // When true, target apps that already have an icon and only generate sizes
@@ -519,7 +524,21 @@ async function main() {
   let inheritedHits = 0;
   let misses = 0;
 
-  for (const app of apps) {
+  const startedAt = Date.now();
+  let budgetStopped = 0;
+  // Index of the last app the loop actually reached. The cursor below must not
+  // advance past it, or a budget stop would silently skip the untouched tail.
+  let lastReachedIndex = apps.length - 1;
+
+  for (const [index, app] of apps.entries()) {
+    if (Date.now() - startedAt > BUDGET_MS) {
+      budgetStopped = apps.length - index;
+      lastReachedIndex = index - 1;
+      console.log(
+        `Budget of ${BUDGET_MINUTES}m reached - stopping early, ${budgetStopped} apps left for the next run`
+      );
+      break;
+    }
     const wingetId = app.winget_id;
     const publisher = wingetId.split('.')[0];
     const outputDir = path.join(ICONS_DIR, wingetId);
@@ -672,7 +691,10 @@ async function main() {
   console.log(`Family inherited: ${inheritedHits}`);
   console.log(`Favicons: ${faviconHits}`);
   console.log(`No icon found: ${misses}`);
-  console.log(`Total processed: ${apps.length}`);
+  console.log(`Total processed: ${lastReachedIndex + 1}`);
+  if (budgetStopped > 0) {
+    console.log(`Deferred to next run (budget): ${budgetStopped}`);
+  }
 
   fs.writeFileSync('web-icon-results.json', JSON.stringify(results, null, 2));
 
@@ -681,7 +703,7 @@ async function main() {
     // icons have been committed. Upserting it here would advance the cursor
     // even when the commit fails, silently skipping these apps until the
     // cursor wraps around.
-    const nextCursor = apps.length > 0 ? apps[apps.length - 1].winget_id : null;
+    const nextCursor = lastReachedIndex >= 0 ? apps[lastReachedIndex].winget_id : null;
     fs.writeFileSync('web-icon-cursor.json', JSON.stringify({ last_winget_id: nextCursor }));
   }
 

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -43,6 +43,10 @@ on:
         description: 'Pagination offset for missing-sizes-only mode (winget_id-ordered). Use to walk through the binary tier batch by batch.'
         required: false
         default: '0'
+      budget_minutes:
+        description: 'Wall-clock ceiling per job for the per-app loop. Apps not reached stay untouched and are re-selected by the next run, so max_apps can be raised for throughput without long runs. 0 disables the guard.'
+        required: false
+        default: '40'
 
 # Prevent concurrent runs that could cause git conflicts
 # Use same group as build-app-list and sync-manifests to ensure sequential execution
@@ -52,6 +56,7 @@ concurrency:
 
 env:
   MAX_APPS: ${{ github.event.inputs.max_apps || '100' }}
+  BUDGET_MINUTES: ${{ github.event.inputs.budget_minutes || '40' }}
 
 permissions:
   contents: write
@@ -117,6 +122,7 @@ jobs:
           # Web fetching is fast (seconds per app); allow a larger batch than
           # the binary job so the cursor advances meaningfully per run.
           MAX_APPS: ${{ github.event.inputs.max_apps || '300' }}
+          BUDGET_MINUTES: ${{ env.BUDGET_MINUTES }}
           ICONS_DIR: public/icons
           MISSING_SIZES_ONLY: ${{ github.event.inputs.missing_sizes_only || 'false' }}
           BINARY_GAP_FILL: ${{ github.event.inputs.binary_gap_fill || 'false' }}
@@ -566,6 +572,7 @@ jobs:
         if: steps.get-apps.outputs.app_count != '0'
         env:
           MISSING_SIZES_ONLY: ${{ github.event.inputs.missing_sizes_only || 'false' }}
+          BUDGET_MINUTES: ${{ env.BUDGET_MINUTES }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Continue'
@@ -612,9 +619,27 @@ jobs:
 
           $extracted = 0
           $failed = 0
+          $deferred = 0
           $results = @()
 
+          # Wall-clock ceiling. Installer downloads make per-app cost wildly
+          # uneven, so a fixed app count cannot bound the run. Apps we never
+          # reach are left completely untouched -- no attempt counter, no
+          # failure reason -- so the next run re-selects them and resumes
+          # exactly where this one stopped.
+          $budgetMinutes = 0
+          [int]::TryParse($env:BUDGET_MINUTES, [ref]$budgetMinutes) | Out-Null
+          $deadline = if ($budgetMinutes -gt 0) {
+            (Get-Date).AddMinutes($budgetMinutes)
+          } else {
+            [datetime]::MaxValue
+          }
+
           foreach ($app in $apps) {
+            if ((Get-Date) -gt $deadline) {
+              $deferred++
+              continue
+            }
             $wingetId = $app.winget_id
             Write-Host "`n=== Processing $wingetId ===" -ForegroundColor Cyan
 
@@ -854,6 +879,9 @@ jobs:
           Write-Host "`n=== Binary Icon Extraction Summary ===" -ForegroundColor Cyan
           Write-Host "Extracted: $extracted"
           Write-Host "Failed: $failed"
+          if ($deferred -gt 0) {
+            Write-Host "Deferred to next run ($budgetMinutes-minute budget reached): $deferred"
+          }
 
           ConvertTo-Json -InputObject @($priorResults + $results) -Depth 10 | Out-File "icon-results.json" -Encoding utf8NoBOM
 


### PR DESCRIPTION
## Why

Both icon jobs loop over a fixed app count, but per-app cost is wildly uneven:

| Tier | Cost per app |
| --- | --- |
| Web fetch (avatar/favicon/store/homepage) | ~0.4 s |
| Family inheritance | ~0.1 s |
| Binary extraction | ~1.5-2 min (full installer download) |

A run's duration was therefore unpredictable, and raising `max_apps` for throughput risked multi-hour jobs. Run 32606991040 took 22 min for 100 apps; a batch weighted toward binary downloads would have run far longer.

## What

- New `budget_minutes` workflow input (default `40`), honored by both `extract-web-icons` and `extract-binary-icons`.
- Apps the loop never reaches are left **completely untouched** (no attempt counter, no failure reason), so the next run re-selects them and resumes exactly where this one stopped. Successfully processed apps drop out of the selection query as before, so no work is repeated.
- The web job persists a `winget_id` cursor. A budget stop must not advance it past the untouched tail, so the cursor now tracks the last app actually reached rather than the last app fetched.

`max_apps` can now be raised for throughput without unbounded runs. Setting `budget_minutes: 0` disables the guard.

## Validation

- `extract-icons.yml` parses as YAML; `budget_minutes` present in dispatch inputs.
- The `Extract icons` PowerShell body parses clean via `[System.Management.Automation.Language.Parser]::ParseFile`.
- `fetch-web-icons.mjs` loads as an ES module (reaches its runtime credential check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)