### PR TITLE
fix(icons): order version_history by created_at, not a column that does not exist

### DIFF
--- a/.github/scripts/plan-icon-heal.mjs
+++ b/.github/scripts/plan-icon-heal.mjs
@@ -100,7 +100,7 @@ async function fetchInstallerMap(wingetIds) {
       .select('winget_id, installer_url, installer_sha256')
       .in('winget_id', chunk)
       .not('installer_url', 'is', null)
-      .order('detected_at', { ascending: false });
+      .order('created_at', { ascending: false });
 
     if (error) {
       console.error('Failed to fetch version_history:', error.message);

--- a/.github/workflows/extract-icons.yml
+++ b/.github/workflows/extract-icons.yml
@@ -491,12 +491,22 @@ jobs:
 
             const installerMap = {};
             if (wingetIds.length > 0) {
-              const { data: vhRows } = await supabase
+              // version_history has no detected_at column; ordering by it made
+              // PostgREST reject the whole query. The error was discarded, so
+              // installerMap silently stayed empty and every app fell through
+              // to the slower manifest tiers. Surface the error now so a
+              // schema drift like that cannot go unnoticed again.
+              const { data: vhRows, error: vhError } = await supabase
                 .from('version_history')
                 .select('winget_id, installer_url, installer_sha256')
                 .in('winget_id', wingetIds)
                 .not('installer_url', 'is', null)
-                .order('detected_at', { ascending: false });
+                .order('created_at', { ascending: false });
+
+              if (vhError) {
+                console.error('Failed to fetch version_history:', vhError.message);
+                process.exit(1);
+              }
 
               if (vhRows) {
                 for (const row of vhRows) {


### PR DESCRIPTION
## The bug

The installer lookup that feeds Tier 1 of binary icon extraction orders `version_history` by `detected_at`:

```js
const { data: vhRows } = await supabase
  .from('version_history')
  .select('winget_id, installer_url, installer_sha256')
  .in('winget_id', wingetIds)
  .not('installer_url', 'is', null)
  .order('detected_at', { ascending: false });   // <- no such column
```

That column does not exist on `version_history`. PostgREST rejects the whole query with `column version_history.detected_at does not exist`, but the call destructures only `data`, so the error is discarded and `vhRows` is `null`. `installerMap` stays empty on every run.

**Tier 1 has therefore never resolved a single app.** Every extraction falls through to Tier 2/3, which fetch the winget manifest over the GitHub API and raw.githubusercontent, each with a 30 s timeout.

The new heal planner in `plan-icon-heal.mjs` makes the same query but checks `error`, which is how this surfaced: the planner failed loudly where the workflow had been failing silently.

## Impact

**7,573 of the 7,599 heal-eligible apps** have a trusted `installer_url` and `installer_sha256` in `version_history`. Restoring Tier 1 skips two or three HTTPS round trips per app for 99.7% of them.

## The fix

- Order by `created_at` (most recent version first, which is what the loop's first-write-wins assumes).
- Check the query error and exit non-zero instead of discarding it, so schema drift cannot go unnoticed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)