### PR TITLE
Fix Visual Studio Build Tools package lifecycle

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -778,6 +778,57 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('adds a usable Build Tools workload to QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Microsoft.VisualStudio.BuildTools',
+          displayName: 'Visual Studio BuildTools 2026',
+          version: '18.9.1',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedAdapter = {
+      reviewedInstallArguments: [
+        '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+        '--norestart',
+      ],
+      reviewedManagedInstallDirectory:
+        '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
+      reviewedManagedUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe',
+        arguments: [
+          'uninstall',
+          '--installPath',
+          '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
+          '--quiet',
+          '--norestart',
+        ],
+        completionTimeoutMinutes: 15,
+      },
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedAdapter,
+    });
+  });
+
   it('repairs empty catalog detection rules for both QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -662,6 +662,10 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
+      reviewedInstallArguments: [
+        '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+        '--norestart',
+      ],
       reviewedManagedInstallDirectory:
         '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
       reviewedManagedUninstall: {
@@ -717,6 +721,10 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
+      reviewedInstallArguments: [
+        '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+        '--norestart',
+      ],
       reviewedManagedInstallDirectory:
         '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools',
       reviewedManagedUninstall: {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1007,6 +1007,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       // exact edition directory and use Microsoft's setup.exe instance
       // lifecycle for every supported Visual Studio generation and edition.
       wingetId,
+      // A Build Tools bootstrapper without an explicit workload only installs
+      // or updates the shared Visual Studio Installer and leaves no product
+      // instance to detect or manage. Microsoft's unattended examples require
+      // --add; MSBuildTools is the smallest useful, generation-stable workload.
+      reviewedInstallArguments: wingetId.endsWith('.BuildTools')
+        ? ['--add Microsoft.VisualStudio.Workload.MSBuildTools', '--norestart']
+        : undefined,
       reviewedManagedInstallDirectory: installPath,
       reviewedManagedUninstall: {
         executablePath:

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1041,6 +1041,10 @@ describe('PSADT QA package identity', () => {
     const expectedPath =
       '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools';
     const expectedConfig = {
+      reviewedInstallArguments: [
+        '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+        '--norestart',
+      ],
       reviewedManagedInstallDirectory: expectedPath,
       reviewedManagedUninstall: {
         executablePath:
@@ -1143,6 +1147,10 @@ describe('PSADT QA package identity', () => {
     const expectedPath =
       '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools';
     const expectedConfig = {
+      reviewedInstallArguments: [
+        '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+        '--norestart',
+      ],
       reviewedManagedInstallDirectory: expectedPath,
       reviewedManagedUninstall: {
         executablePath:

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1145,10 +1145,14 @@ describe('PSADT vendor argument contract', () => {
     'uses a reviewed vendor command for a managed installation instance',
     () => {
       const generated = generateRegistryUninstallPackage(
-        'inno',
+        'exe',
         'Visual Studio BuildTools 2026',
         [],
         {
+          reviewedInstallArguments: [
+            '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+            '--norestart',
+          ],
           reviewedManagedInstallDirectory:
             '%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools',
           reviewedManagedUninstall: {
@@ -1165,13 +1169,24 @@ describe('PSADT vendor argument contract', () => {
           },
         },
         [],
-        'Microsoft.VisualStudio.BuildTools'
+        'Microsoft.VisualStudio.BuildTools',
+        'Visual Studio BuildTools 2026',
+        '18.9.1',
+        'REGISTRY_UNINSTALL:Visual Studio BuildTools 2026',
+        '--quiet --wait --campaign "winget"'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
       );
       const uninstallFunction = generated.slice(
         generated.indexOf('function Uninstall-ADTDeployment'),
         generated.indexOf('function Repair-ADTDeployment')
       );
 
+      expect(installFunction).toContain(
+        "-ArgumentList '--quiet --wait --campaign \"winget\" --add Microsoft.VisualStudio.Workload.MSBuildTools --norestart'"
+      );
       expect(uninstallFunction).toContain(
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe')"
       );


### PR DESCRIPTION
## Summary
- add Microsoft's minimal MSBuild Tools workload to every supported Visual Studio Build Tools adapter
- suppress vendor-initiated restarts during unattended package installation
- prove the adapter reaches QA profiles, generated PSADT commands, and portal customer workflow payloads

## QA evidence
Production QA run 32629581942 showed the vendor bootstrapper exit 0 after installing only the shared Visual Studio Installer; no Build Tools instance directory was created, so detection and removal verification failed.

## Verification
- 83 test files / 1,422 tests passed
- lint passed
- production build passed