### PR TITLE
Activate Visual Studio Build Tools packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c1c9410f58318d055c09a60bc067996a4b9b4597',
+  packagerCommit: '20fbdeff5e6a4dc9d911019a244f7e46ab19b708',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -313,6 +313,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // normalization change only adapter-resolved uninstall paths. Preserve every
   // unrelated compatible pass from the prior protected release.
   '00983d36128aef319cc36f901beeff6dd03d847f',
+  // Build Tools' explicit MSBuild workload changes only Visual Studio Build
+  // Tools profiles that previously produced no manageable product instance.
+  // Preserve Chrome Beta and every unrelated compatible passing result.
+  'c1c9410f58318d055c09a60bc067996a4b9b4597',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -106,6 +106,10 @@ describe('QA toolchain targeted retries', () => {
       'Autodesk.DesignReview',
       'AppiumDevelopers.AppiumInspector',
       'Google.Chrome.Beta.EXE',
+      'Microsoft.VisualStudio.BuildTools',
+      'Microsoft.VisualStudio.2017.BuildTools',
+      'Microsoft.VisualStudio.2019.BuildTools',
+      'Microsoft.VisualStudio.2022.BuildTools',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -156,6 +160,10 @@ describe('QA toolchain targeted retries', () => {
         'BlueJTeam.BlueJ',
         'Autodesk.DesignReview',
         'AppiumDevelopers.AppiumInspector',
+        'Microsoft.VisualStudio.BuildTools',
+        'Microsoft.VisualStudio.2017.BuildTools',
+        'Microsoft.VisualStudio.2019.BuildTools',
+        'Microsoft.VisualStudio.2022.BuildTools',
       ])
     );
     expect(
@@ -207,6 +215,28 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '00983d36128aef319cc36f901beeff6dd03d847f',
       { wingetId: 'Google.Chrome.Beta.EXE', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries every Build Tools generation after activating its workload', () => {
+    for (const wingetId of [
+      'Microsoft.VisualStudio.BuildTools',
+      'Microsoft.VisualStudio.2017.BuildTools',
+      'Microsoft.VisualStudio.2019.BuildTools',
+      'Microsoft.VisualStudio.2022.BuildTools',
+    ]) {
+      expect(shouldRetryTerminalToolchainCandidate(
+        QA_PSADT_TOOLCHAIN.packagerCommit,
+        { wingetId, status: 'failed' }
+      )).toBe(true);
+    }
+    expect(shouldRetryTerminalToolchainCandidate(
+      'c1c9410f58318d055c09a60bc067996a4b9b4597',
+      { wingetId: 'Microsoft.VisualStudio.2017.BuildTools', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'c1c9410f58318d055c09a60bc067996a4b9b4597',
+      { wingetId: 'Microsoft.VisualStudio.2019.BuildTools', status: 'failed' }
     )).toBe(false);
   });
 
@@ -597,7 +627,6 @@ describe('QA toolchain targeted retries', () => {
   });
 
   it.each([
-    'Microsoft.VisualStudio.2019.BuildTools',
     'Microsoft.VisualStudio.2019.Community',
     'Microsoft.VisualStudio.2019.Enterprise',
     'Microsoft.VisualStudio.2019.Professional',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -110,7 +110,23 @@ const CHROME_BETA_REGISTRY_RELEASE_RETRY_TARGETS = [
   ...FSLOGIX_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const VISUAL_STUDIO_BUILD_TOOLS_RELEASE_RETRY_TARGETS = [
+  // Retry every supported Build Tools generation with a minimal explicit
+  // workload so the bootstrapper creates a detectable product instance.
+  'Microsoft.VisualStudio.BuildTools',
+  'Microsoft.VisualStudio.2017.BuildTools',
+  'Microsoft.VisualStudio.2019.BuildTools',
+  'Microsoft.VisualStudio.2022.BuildTools',
+  // Carry every still-unconsumed bounded target across the atomic pin while
+  // excluding Build Tools entries already declared above.
+  ...CHROME_BETA_REGISTRY_RELEASE_RETRY_TARGETS.filter(
+    (wingetId) => !wingetId.toLowerCase().endsWith('.buildtools')
+  ),
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '20fbdeff5e6a4dc9d911019a244f7e46ab19b708':
+    VISUAL_STUDIO_BUILD_TOOLS_RELEASE_RETRY_TARGETS,
   'c1c9410f58318d055c09a60bc067996a4b9b4597':
     CHROME_BETA_REGISTRY_RELEASE_RETRY_TARGETS,
   '00983d36128aef319cc36f901beeff6dd03d847f':


### PR DESCRIPTION
## Summary
- pin production QA/customer packaging to shared packager commit 20fbdeff5e6a4dc9d911019a244f7e46ab19b708
- preserve compatible prior passing profiles
- retry every supported Visual Studio Build Tools generation with the new workload contract

## Verification
- 83 test files / 1,422 tests passed
- lint passed
- production build passed