### PR TITLE
Pin Visual Studio Build Tools install path

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -800,6 +800,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(response.status).toBe(200);
     const expectedAdapter = {
       reviewedInstallArguments: [
+        '--installPath "%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools"',
         '--add Microsoft.VisualStudio.Workload.MSBuildTools',
         '--norestart',
       ],

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -663,6 +663,7 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedInstallArguments: [
+        '--installPath "%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools"',
         '--add Microsoft.VisualStudio.Workload.MSBuildTools',
         '--norestart',
       ],
@@ -722,6 +723,7 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedInstallArguments: [
+        '--installPath "%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools"',
         '--add Microsoft.VisualStudio.Workload.MSBuildTools',
         '--norestart',
       ],

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1010,9 +1010,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       // A Build Tools bootstrapper without an explicit workload only installs
       // or updates the shared Visual Studio Installer and leaves no product
       // instance to detect or manage. Microsoft's unattended examples require
-      // --add; MSBuildTools is the smallest useful, generation-stable workload.
+      // a deterministic --installPath together with --add; MSBuildTools is the
+      // smallest useful, generation-stable workload. Keep install, evidence,
+      // and uninstall pinned to the same reviewed instance path.
       reviewedInstallArguments: wingetId.endsWith('.BuildTools')
-        ? ['--add Microsoft.VisualStudio.Workload.MSBuildTools', '--norestart']
+        ? [
+            `--installPath "${installPath}"`,
+            '--add Microsoft.VisualStudio.Workload.MSBuildTools',
+            '--norestart',
+          ]
         : undefined,
       reviewedManagedInstallDirectory: installPath,
       reviewedManagedUninstall: {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1042,6 +1042,7 @@ describe('PSADT QA package identity', () => {
       '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2019\\BuildTools';
     const expectedConfig = {
       reviewedInstallArguments: [
+        `--installPath "${expectedPath}"`,
         '--add Microsoft.VisualStudio.Workload.MSBuildTools',
         '--norestart',
       ],
@@ -1148,6 +1149,7 @@ describe('PSADT QA package identity', () => {
       '%ProgramFiles(x86)%\\Microsoft Visual Studio\\2022\\BuildTools';
     const expectedConfig = {
       reviewedInstallArguments: [
+        `--installPath "${expectedPath}"`,
         '--add Microsoft.VisualStudio.Workload.MSBuildTools',
         '--norestart',
       ],

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1150,6 +1150,7 @@ describe('PSADT vendor argument contract', () => {
         [],
         {
           reviewedInstallArguments: [
+            '--installPath "%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools"',
             '--add Microsoft.VisualStudio.Workload.MSBuildTools',
             '--norestart',
           ],
@@ -1185,8 +1186,9 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(installFunction).toContain(
-        "-ArgumentList '--quiet --wait --campaign \"winget\" --add Microsoft.VisualStudio.Workload.MSBuildTools --norestart'"
+        "$effectiveInstallerArguments = [Environment]::ExpandEnvironmentVariables('--quiet --wait --campaign \"winget\" --installPath \"%ProgramFiles%\\Microsoft Visual Studio\\18\\BuildTools\" --add Microsoft.VisualStudio.Workload.MSBuildTools --norestart')"
       );
+      expect(installFunction).toContain('-ArgumentList $effectiveInstallerArguments');
       expect(uninstallFunction).toContain(
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\setup.exe')"
       );


### PR DESCRIPTION
## Summary
- pass the reviewed Visual Studio instance path to every Build Tools bootstrapper
- keep install evidence and vendor uninstall pinned to that same path
- verify the adapter through QA profiles, generated PSADT, and customer packaging

## Production diagnosis
QA run 32631346405 proved the workload argument reached the vendor bootstrapper, which returned 0, but only the shared Visual Studio Installer changed and no Build Tools instance was created. Microsoft's unattended examples pair the workload with an explicit install path.

## Verification
- 4 focused test files, 292 tests passed
- full suite: 83 files, 1422 tests passed
- npm run lint
- npm run build:ci