### PR TITLE
Activate Build Tools install path packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '20fbdeff5e6a4dc9d911019a244f7e46ab19b708',
+  packagerCommit: '228cd9def01122182631c91910554c05e9181edb',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -317,6 +317,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Tools profiles that previously produced no manageable product instance.
   // Preserve Chrome Beta and every unrelated compatible passing result.
   'c1c9410f58318d055c09a60bc067996a4b9b4597',
+  // Build Tools' explicit instance path changes only profiles using the
+  // reviewed Build Tools lifecycle. Preserve every unrelated compatible pass.
+  '20fbdeff5e6a4dc9d911019a244f7e46ab19b708',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -218,7 +218,7 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries every Build Tools generation after activating its workload', () => {
+  it('retries every Build Tools generation after activating its deterministic install path', () => {
     for (const wingetId of [
       'Microsoft.VisualStudio.BuildTools',
       'Microsoft.VisualStudio.2017.BuildTools',
@@ -231,9 +231,9 @@ describe('QA toolchain targeted retries', () => {
       )).toBe(true);
     }
     expect(shouldRetryTerminalToolchainCandidate(
-      'c1c9410f58318d055c09a60bc067996a4b9b4597',
+      '20fbdeff5e6a4dc9d911019a244f7e46ab19b708',
       { wingetId: 'Microsoft.VisualStudio.2017.BuildTools', status: 'failed' }
-    )).toBe(false);
+    )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       'c1c9410f58318d055c09a60bc067996a4b9b4597',
       { wingetId: 'Microsoft.VisualStudio.2019.BuildTools', status: 'failed' }

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -124,7 +124,23 @@ const VISUAL_STUDIO_BUILD_TOOLS_RELEASE_RETRY_TARGETS = [
   ),
 ] as const;
 
+const VISUAL_STUDIO_BUILD_TOOLS_INSTALL_PATH_RELEASE_RETRY_TARGETS = [
+  // Retry every supported Build Tools generation with an explicit instance
+  // path so install, evidence, and vendor uninstall address the same product.
+  'Microsoft.VisualStudio.BuildTools',
+  'Microsoft.VisualStudio.2017.BuildTools',
+  'Microsoft.VisualStudio.2019.BuildTools',
+  'Microsoft.VisualStudio.2022.BuildTools',
+  // Carry every still-unconsumed bounded target across the atomic pin while
+  // excluding Build Tools entries already declared above.
+  ...VISUAL_STUDIO_BUILD_TOOLS_RELEASE_RETRY_TARGETS.filter(
+    (wingetId) => !wingetId.toLowerCase().endsWith('.buildtools')
+  ),
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '228cd9def01122182631c91910554c05e9181edb':
+    VISUAL_STUDIO_BUILD_TOOLS_INSTALL_PATH_RELEASE_RETRY_TARGETS,
   '20fbdeff5e6a4dc9d911019a244f7e46ab19b708':
     VISUAL_STUDIO_BUILD_TOOLS_RELEASE_RETRY_TARGETS,
   'c1c9410f58318d055c09a60bc067996a4b9b4597':


### PR DESCRIPTION
## Summary
- pin production QA and customer packaging to shared packager commit 228cd9def01122182631c91910554c05e9181edb
- retain the prior packager in release compatibility history
- retry all four supported Build Tools generations with the deterministic instance-path lifecycle

## Verification
- 3 focused test files, 210 tests passed
- full suite: 83 files, 1422 tests passed
- npm run lint
- npm run build:ci