### PR TITLE
fix(icons): bound the installer body download, not just its headers

### DIFF
--- a/.github/scripts/save-safe-download.ps1
+++ b/.github/scripts/save-safe-download.ps1
@@ -15,7 +15,21 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 900)]
-    [int]$TimeoutSeconds = 90
+    [int]$TimeoutSeconds = 90,
+
+    # HttpCompletionOption.ResponseHeadersRead means $client.Timeout only
+    # bounds the response headers. The body is then read straight off the
+    # stream, which has no timeout of its own -- a server that accepts the
+    # connection and then stops sending would hang the caller until its own
+    # job timeout. These two bound the body: a stall between chunks, and the
+    # total time spent pulling one installer.
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 900)]
+    [int]$ReadTimeoutSeconds = 60,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 3600)]
+    [int]$BodyTimeoutSeconds = 300
 )
 
 $ErrorActionPreference = 'Stop'
@@ -112,10 +126,25 @@ try {
             try {
                 $buffer = [byte[]]::new(1048576)
                 [long]$total = 0
-                while (($read = $input.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                $bodyDeadline = [DateTime]::UtcNow.AddSeconds($BodyTimeoutSeconds)
+                while ($true) {
+                    $cts = [System.Threading.CancellationTokenSource]::new([TimeSpan]::FromSeconds($ReadTimeoutSeconds))
+                    try {
+                        $read = $input.ReadAsync($buffer, 0, $buffer.Length, $cts.Token).GetAwaiter().GetResult()
+                    } catch [System.OperationCanceledException] {
+                        throw "Installer stalled for more than $ReadTimeoutSeconds seconds"
+                    } finally {
+                        $cts.Dispose()
+                    }
+
+                    if ($read -le 0) { break }
                     $total += $read
                     if ($total -gt $MaxBytes) { throw "Installer exceeds the $MaxBytes byte limit" }
                     $output.Write($buffer, 0, $read)
+
+                    if ([DateTime]::UtcNow -gt $bodyDeadline) {
+                        throw "Installer body exceeded the $BodyTimeoutSeconds second limit"
+                    }
                 }
             } finally {
                 $output.Dispose()


### PR DESCRIPTION
## The problem

`save-safe-download.ps1` requests with `HttpCompletionOption.ResponseHeadersRead`:

```powershell
$client.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
$response = $client.GetAsync($currentUri, [HttpCompletionOption]::ResponseHeadersRead)...
$input = $response.Content.ReadAsStreamAsync()...
while (($read = $input.Read($buffer, 0, $buffer.Length)) -gt 0) { ... }   # unbounded
```

With `ResponseHeadersRead`, `$client.Timeout` stops applying once the headers arrive. The body is then pulled off a raw stream with **no timeout at all**. A server that accepts the connection and then stops sending hangs the caller until the job's own timeout fires.

That is what one shard of heal wave `32631753605` did: it sat on a single app for **over 30 minutes** while its 19 siblings finished, holding up the whole wave's collector job. The `budget_minutes` guard could not help, because it only gets to run between apps.

## The fix

Bound the body two ways:

- **Per-chunk stall timeout** (`ReadTimeoutSeconds`, default 60) via a `CancellationTokenSource` on `ReadAsync`, so a connection that goes quiet fails instead of hanging.
- **Total body deadline** (`BodyTimeoutSeconds`, default 300), checked between chunks, so a very slow but not-quite-stalled transfer cannot run indefinitely either.

Both surface as ordinary download failures, which the extractor already records as `download_timeout` and retries on a later wave.

## Validation

Exercised the patched script directly:

- Normal fetch of a real HTTPS URL succeeds (3,678 bytes written).
- `-MaxBytes 10` against the same URL still rejects with `Installer exceeds the 10 byte limit`, so the existing size guard is intact.
- Parses clean via `[System.Management.Automation.Language.Parser]::ParseFile`.

This script has exactly one consumer, `extract-icons-batch.ps1`, so the new parameters carry defaults and no call site needs to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)