### PR TITLE
feat(icons): let the campaign reach untracked-provenance rows

### DIFF
--- a/.github/scripts/plan-icon-heal.mjs
+++ b/.github/scripts/plan-icon-heal.mjs
@@ -34,6 +34,14 @@ const PLAN_DIR = process.env.PLAN_DIR || 'plan';
 // overwrite. Binary-sourced icons are already authoritative and never queued.
 const WEB_SOURCES = ['github_avatar', 'favicon', 'homepage_image'];
 
+// Rows written before icon_source existed. They claim an icon but nothing
+// records where it came from, and the duplicate audit shows large blocks of
+// them sharing one generic installer image -- the biggest single cluster is
+// 1,161 unrelated packages. Because every heal query filters on icon_source,
+// this population was unreachable. Including it lets binary extraction replace
+// those placeholders with the real product icon.
+const INCLUDE_UNTRACKED = process.env.INCLUDE_UNTRACKED === 'true';
+
 if (!SUPABASE_URL || !SUPABASE_KEY) {
   console.error('SUPABASE_URL and SUPABASE_SERVICE_KEY are required');
   process.exit(1);
@@ -70,7 +78,11 @@ async function fetchAllEligible() {
     const { data, error } = await supabase
       .from('curated_apps')
       .select('winget_id, name, publisher, latest_version, icon_source, icon_extraction_attempts')
-      .in('icon_source', WEB_SOURCES)
+      .or(
+        INCLUDE_UNTRACKED
+          ? `icon_source.in.(${WEB_SOURCES.join(',')}),icon_source.is.null`
+          : `icon_source.in.(${WEB_SOURCES.join(',')})`
+      )
       .or(`icon_extraction_attempts.is.null,icon_extraction_attempts.lt.${MAX_ATTEMPTS}`)
       .order('winget_id', { ascending: true })
       .range(offset, offset + pageSize - 1);
@@ -117,7 +129,8 @@ async function fetchInstallerMap(wingetIds) {
 
 async function main() {
   const [eligible, catalogIds] = await Promise.all([fetchAllEligible(), fetchAllWingetIds()]);
-  console.log(`Heal-eligible apps (web-sourced, under ${MAX_ATTEMPTS} attempts): ${eligible.length}`);
+  const scope = INCLUDE_UNTRACKED ? 'web-sourced or untracked' : 'web-sourced';
+  console.log(`Heal-eligible apps (${scope}, under ${MAX_ATTEMPTS} attempts): ${eligible.length}`);
 
   // Mozilla.Firefox.de is a locale build of Mozilla.Firefox: same product, same
   // icon. Downloading its installer would spend ~2 minutes reproducing a file

--- a/.github/workflows/heal-icons.yml
+++ b/.github/workflows/heal-icons.yml
@@ -30,6 +30,11 @@ on:
         description: 'Wall-clock ceiling for each shard extraction loop. Apps not reached stay untouched and return in the next wave.'
         required: false
         default: '35'
+      include_untracked:
+        description: 'Also heal rows whose icon_source is null. These predate source tracking and include large blocks sharing one generic installer image, but some already carry a good icon, so re-extracting them costs runner time for no gain.'
+        required: false
+        default: 'false'
+        type: boolean
 
 # Shares the pipeline group so a campaign wave and the weekly icon run never
 # race each other into conflicting icon publication PRs.
@@ -73,6 +78,7 @@ jobs:
           MIN_PUBLISHER_APPS: ${{ github.event.inputs.min_publisher_apps || '10' }}
           SHARDS: ${{ github.event.inputs.shards || '20' }}
           MAX_APPS_PER_SHARD: ${{ github.event.inputs.max_apps_per_shard || '40' }}
+          INCLUDE_UNTRACKED: ${{ github.event.inputs.include_untracked || 'false' }}
         run: node .github/scripts/plan-icon-heal.mjs
 
       - name: Upload plan


### PR DESCRIPTION
## What the audit found

`audit-duplicate-icons.mjs` reports **470 suspicious clusters** across 14,562 icons. The largest are not publisher avatars at all:

| Cluster size | Classification | Dominant publisher share |
| --- | --- | --- |
| **1,161** | possibly_generic_placeholder | 0.02 |
| 441 | possibly_generic_placeholder | 0.18 |
| 302 | possibly_generic_placeholder | 0.09 |
| 299 | likely_publisher_level_icon | 1.00 (Mozilla, and correct: these are `family_inherited` Firefox locale builds) |

A dominant-publisher share of 0.02 means those 1,161 packages have almost nothing in common except the image, which is the signature of a generic installer icon rather than a publisher logo.

Sampling 20 members of the top two clusters: **19 of 20 have `icon_source` NULL.**

## Why they were unreachable

Those are rows written before `icon_source` existed. They claim an icon but nothing records where it came from, and every heal query filters on `icon_source`:

```js
.in('icon_source', WEB_SOURCES)   // github_avatar | favicon | homepage_image
```

So all **3,930** untracked rows were invisible to the campaign no matter how far `min_publisher_apps` was lowered. A generic setup icon shared by a thousand unrelated apps is a worse result than the publisher avatars this campaign was built to fix.

## The change

An `include_untracked` input widens the eligible set to `icon_source is null`:

```js
.or(INCLUDE_UNTRACKED
  ? `icon_source.in.(${WEB_SOURCES.join(',')}),icon_source.is.null`
  : `icon_source.in.(${WEB_SOURCES.join(',')})`)
```

**Off by default.** Some untracked rows already carry a perfectly good icon, and re-extracting them costs runner time for no gain, so widening the sweep stays a deliberate operator choice rather than the standing behavior of the weekly pipeline.

## Validation

`heal-icons.yml` parses as YAML and exposes the new input; `plan-icon-heal.mjs` loads as an ES module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)