### PR TITLE
fix(icons): stop git from octal-escaping non-ASCII icon paths

### DIFF
--- a/.github/scripts/publish-icon-pr.sh
+++ b/.github/scripts/publish-icon-pr.sh
@@ -24,7 +24,10 @@ if git diff --staged --quiet; then
   exit 0
 fi
 
-committed_apps=$(git diff --staged --name-only \
+# core.quotePath would octal-escape any path containing a non-ASCII byte, so
+# the app id parsed out of it would not match the winget_id in the database
+# and the app would be committed but never marked as having an icon.
+committed_apps=$(git -c core.quotePath=false diff --staged --name-only \
   | awk -F/ '/^public\/icons\// && NF >= 3 { print $3 }' \
   | sort -u \
   | paste -sd, -)

--- a/.github/workflows/heal-icons.yml
+++ b/.github/workflows/heal-icons.yml
@@ -149,13 +149,17 @@ jobs:
         run: |
           mkdir -p out
           cp icon-results.json "out/results-${{ matrix.shard }}.json" 2>/dev/null || echo '[]' > "out/results-${{ matrix.shard }}.json"
+          # core.quotePath makes git wrap any path with a non-ASCII byte in
+          # quotes and octal-escape it, which tar -T then cannot stat. Nine
+          # catalog ids are non-ASCII (ReceitaFederaldoBrasil.SpedContabil and
+          # friends), and one of them failing takes the whole shard down.
           if [ -d public/icons ] && ! git diff --quiet -- public/icons; then
-            git diff --name-only -- public/icons > changed.txt
+            git -c core.quotePath=false diff --name-only -- public/icons > changed.txt
           else
             : > changed.txt
           fi
           # Untracked directories are new apps that had no icon before.
-          git ls-files --others --exclude-standard -- public/icons >> changed.txt
+          git -c core.quotePath=false ls-files --others --exclude-standard -- public/icons >> changed.txt
           if [ -s changed.txt ]; then
             sort -u changed.txt | tar -cf "out/icons-${{ matrix.shard }}.tar" -T -
             echo "Packaged $(sort -u changed.txt | wc -l) icon files"


### PR DESCRIPTION
## The failure

Shard 13 of heal wave `32638094672` failed:

```
tar: "public/icons/ReceitaFederaldoBrasil.Escritura\303\247\303\243oDigitalECF/icon-32.png": Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```

`git` quotes and octal-escapes any path containing a non-ASCII byte unless `core.quotePath` is off. `tar -T -` then cannot stat the escaped name. Because the packaging step is what uploads the shard's work, **the whole shard was lost, discarding icons already extracted for its other ~107 apps.**

## The quieter half

The same escaping corrupts `publish-icon-pr.sh`:

```bash
committed_apps=$(git diff --staged --name-only | awk -F/ '...{ print $3 }' ...)
```

For a non-ASCII app id, `$3` is the escaped form, which never matches the `winget_id` in `curated_apps`. Those apps get their icons committed to `main` but are **never marked as having one**, so every future wave re-extracts them and they can never converge. This one produces no error at all.

## The fix

Nine catalog ids are non-ASCII (`ReceitaFederaldoBrasil.SpedContábil`, `BRÖTJE.ProfiTool`, `Chappée.PRO`, `JanJoneš.ipaSim`, ...). Set `core.quotePath=false` on all three call sites: the two in the shard packaging step and the one in the publish script.

## Validation

Reproduced in a scratch repo with a real non-ASCII path:

| Command | Result |
| --- | --- |
| `git diff --name-only \| tar -T -` | `Cannot stat`, exit 2 |
| `git -c core.quotePath=false diff --name-only \| tar -T -` | succeeds |
| `git -c core.quotePath=false diff --name-only \| awk ...` | yields exactly `ReceitaFederaldoBrasil.SpedContábil` |

`heal-icons.yml` parses as YAML; `publish-icon-pr.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)