### PR TITLE
feat(icons): reject and purge generic installer icons

### DIFF
--- a/.github/data/generic-icon-hashes.json
+++ b/.github/data/generic-icon-hashes.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Average-hash fingerprints of images that are not product icons. Binary extraction pulls the icon out of an installer, and a wrapper installer that carries no app icon yields its toolkit's default artwork instead: the Windows generic-application glyph, the Windows Installer disc, an Inno/NSIS install arrow, the PyInstaller bundler icon. Recording one of those as an app's icon is worse than recording nothing, because hundreds of unrelated apps end up identical. Entries are matched with a Hamming distance of 2, which absorbs resampling variants without colliding with real icons (the closest real-icon cluster sits far outside that radius). Derived from a full scan of public/icons and confirmed by eye; regenerate with audit-duplicate-icons.mjs, which reports each cluster's hash.",
+  "max_hamming_distance": 2,
+  "hashes": [
+    {
+      "hash": "0000000011111111111001111110001111000011110000111111111100111100",
+      "label": "windows_generic_application",
+      "note": "Default Windows application-window glyph. Largest cluster: 769 packages across ~700 publishers."
+    },
+    {
+      "hash": "1101111001101110100010101000001011001000110101001101010000011100",
+      "label": "windows_installer_default",
+      "note": "Classic Windows Installer computer-and-disc icon. 422 packages."
+    },
+    {
+      "hash": "0100100000010000010000100001000011101111111111111111111101111110",
+      "label": "generic_install_arrow",
+      "note": "Install/download arrow used as the default by several installer toolkits. 312 packages."
+    },
+    {
+      "hash": "0011110001111110011111110111110001111110001101100011010000111100",
+      "label": "generic_setup_disc",
+      "note": "Setup disc with download arrow. 69 packages."
+    },
+    {
+      "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "label": "blank_image",
+      "note": "Uniform image with no detail. An all-equal hash means every pixel sits at the mean, so nothing was extracted. 64 packages."
+    },
+    {
+      "hash": "1110000011100000111100001110000001100000001111110011111000111100",
+      "label": "pyinstaller_bundler",
+      "note": "PyInstaller/Python bundler icon. Identifies the packaging toolchain, not the application. 57 packages."
+    }
+  ]
+}

--- a/.github/scripts/audit-duplicate-icons.mjs
+++ b/.github/scripts/audit-duplicate-icons.mjs
@@ -13,36 +13,9 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import sharp from 'sharp';
+import { averageHash, hamming, bestIconPath } from './icon-hash.mjs';
 
 const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
-const HASH_SIZE = 8;
-
-async function averageHash(filePath) {
-  const { data } = await sharp(filePath)
-    .resize(HASH_SIZE, HASH_SIZE, { fit: 'fill' })
-    .greyscale()
-    .raw()
-    .toBuffer({ resolveWithObject: true });
-  const avg = data.reduce((a, b) => a + b, 0) / data.length;
-  let bits = '';
-  for (const byte of data) bits += byte > avg ? '1' : '0';
-  return bits;
-}
-
-function hamming(a, b) {
-  let d = 0;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) d++;
-  return d;
-}
-
-function bestIconPath(dir) {
-  for (const size of [256, 128, 64]) {
-    const p = path.join(dir, `icon-${size}.png`);
-    if (fs.existsSync(p)) return p;
-  }
-  return null;
-}
 
 async function main() {
   if (!fs.existsSync(ICONS_DIR)) {
@@ -89,6 +62,9 @@ async function main() {
       const topPublisher = Object.entries(publishers).sort((a, b) => b[1] - a[1])[0];
       const dominantShare = topPublisher[1] / c.members.length;
       return {
+        // Reported so a cluster confirmed to be non-product artwork can be
+        // copied straight into .github/data/generic-icon-hashes.json.
+        hash: c.hash,
         cluster_size: c.members.length,
         dominant_publisher: topPublisher[0],
         dominant_publisher_share: Number(dominantShare.toFixed(2)),

--- a/.github/scripts/icon-hash.mjs
+++ b/.github/scripts/icon-hash.mjs
@@ -1,0 +1,74 @@
+/**
+ * Shared icon fingerprinting.
+ *
+ * An 8x8 average hash is enough to answer the only question asked of it here:
+ * are two icons the same picture? It is cheap, stable across the resamples the
+ * pipeline performs, and comparable with a Hamming distance.
+ *
+ * Used by audit-duplicate-icons.mjs to cluster identical icons, and by
+ * reject-generic-icons.mjs to recognise the installer-toolkit defaults listed
+ * in .github/data/generic-icon-hashes.json.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import sharp from 'sharp';
+
+export const HASH_SIZE = 8;
+export const ICON_SIZE_PREFERENCE = [256, 128, 64];
+
+/** 64-bit average hash of an image, as a string of '0'/'1'. */
+export async function averageHash(filePath) {
+  const { data } = await sharp(filePath)
+    .resize(HASH_SIZE, HASH_SIZE, { fit: 'fill' })
+    .greyscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const avg = data.reduce((a, b) => a + b, 0) / data.length;
+  let bits = '';
+  for (const byte of data) bits += byte > avg ? '1' : '0';
+  return bits;
+}
+
+export function hamming(a, b) {
+  let d = 0;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) d++;
+  return d;
+}
+
+/** Largest icon a package directory ships, or null if it has none. */
+export function bestIconPath(dir) {
+  for (const size of ICON_SIZE_PREFERENCE) {
+    const p = path.join(dir, `icon-${size}.png`);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+export function loadGenericHashes(
+  file = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'data',
+    'generic-icon-hashes.json'
+  )
+) {
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return {
+    maxDistance: parsed.max_hamming_distance ?? 2,
+    hashes: parsed.hashes ?? []
+  };
+}
+
+/**
+ * Returns the matching blocklist entry, or null when the icon is not one of
+ * the known non-product images.
+ */
+export function matchGeneric(hash, { maxDistance, hashes }) {
+  for (const entry of hashes) {
+    if (hamming(hash, entry.hash) <= maxDistance) return entry;
+  }
+  return null;
+}

--- a/.github/scripts/purge-generic-icons.mjs
+++ b/.github/scripts/purge-generic-icons.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Removes already-published icons that are installer-toolkit defaults.
+ *
+ * reject-generic-icons.mjs stops new ones being written. This clears the ones
+ * already in the catalog: a scan of public/icons matches ~1,900 packages
+ * spread over ~1,200 publishers against the blocklist, which is what tells us
+ * they are generic artwork rather than any publisher's logo.
+ *
+ * Deleting an icon rather than leaving it looks like a regression, but the
+ * frontend renders a lettered glyph when a package has no icon, and a glyph is
+ * a more honest answer than the same grey installer window shown on nine
+ * hundred unrelated apps. The database reset puts each package back in the
+ * queue so the web tiers can supply something product-specific.
+ *
+ * MODE=scan    delete matching icon directories, write purged-apps.json
+ * MODE=commit  apply the database reset for the packages in that file
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+import { averageHash, bestIconPath, loadGenericHashes, matchGeneric } from './icon-hash.mjs';
+
+const MODE = process.env.MODE || 'scan';
+const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
+const PURGED_FILE = process.env.PURGED_FILE || 'purged-apps.json';
+const MAX_PURGE = parseInt(process.env.MAX_PURGE || '0', 10);
+
+async function scan() {
+  const blocklist = loadGenericHashes();
+  const dirs = fs
+    .readdirSync(ICONS_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .sort();
+
+  const purged = [];
+  const counts = {};
+  let scanned = 0;
+
+  for (const id of dirs) {
+    if (MAX_PURGE > 0 && purged.length >= MAX_PURGE) break;
+    const dir = path.join(ICONS_DIR, id);
+    const iconPath = bestIconPath(dir);
+    if (!iconPath) continue;
+    scanned++;
+
+    let hash;
+    try {
+      hash = await averageHash(iconPath);
+    } catch (err) {
+      console.warn(`Could not hash ${id}: ${err.message}`);
+      continue;
+    }
+
+    const match = matchGeneric(hash, blocklist);
+    if (!match) continue;
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    purged.push({ winget_id: id, label: match.label });
+    counts[match.label] = (counts[match.label] || 0) + 1;
+  }
+
+  fs.writeFileSync(PURGED_FILE, JSON.stringify(purged, null, 2));
+
+  console.log(`Scanned ${scanned} packages, purged ${purged.length}`);
+  for (const [label, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${label}: ${n}`);
+  }
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) fs.appendFileSync(out, `purged=${purged.length}\n`);
+
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary) {
+    fs.appendFileSync(
+      summary,
+      [
+        '## Generic Icon Purge',
+        '',
+        `Removed **${purged.length}** icons that matched a known installer-toolkit default.`,
+        '',
+        ...Object.entries(counts)
+          .sort((a, b) => b[1] - a[1])
+          .map(([label, n]) => `- \`${label}\`: ${n}`),
+        '',
+        'Each package is queued for re-resolution through the web tiers.',
+        ''
+      ].join('\n')
+    );
+  }
+}
+
+async function commit() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) {
+    console.error('SUPABASE_URL and SUPABASE_SERVICE_KEY are required');
+    process.exit(1);
+  }
+  if (!fs.existsSync(PURGED_FILE)) {
+    console.log('No purge list - nothing to update');
+    return;
+  }
+
+  const supabase = createClient(url, key);
+  const purged = JSON.parse(fs.readFileSync(PURGED_FILE, 'utf8'));
+  const now = new Date().toISOString();
+  console.log(`Resetting ${purged.length} packages so the web tiers can refill them`);
+
+  let updated = 0;
+  for (const entry of purged) {
+    // Attempts reset to zero deliberately. Binary extraction will produce the
+    // same generic image and reject-generic-icons.mjs will refuse it again, so
+    // these packages retire on their own after the usual three attempts, while
+    // the web tiers get a clean chance at a product-specific image first.
+    const { error } = await supabase
+      .from('curated_apps')
+      .update({
+        has_icon: false,
+        icon_path: null,
+        icon_source: null,
+        icon_extraction_attempts: 0,
+        icon_failure_reason: 'generic_installer_icon',
+        icon_last_attempted_at: now,
+        updated_at: now
+      })
+      .eq('winget_id', entry.winget_id);
+
+    if (error) console.error(`Failed to reset ${entry.winget_id}: ${error.message}`);
+    else updated++;
+  }
+
+  console.log(`Reset ${updated} of ${purged.length}`);
+}
+
+const run = MODE === 'commit' ? commit : scan;
+run().catch(err => {
+  console.error(`Purge (${MODE}) failed: ${err.message}`);
+  process.exit(1);
+});

--- a/.github/scripts/reject-generic-icons.mjs
+++ b/.github/scripts/reject-generic-icons.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Rejects extracted icons that are installer-toolkit defaults rather than
+ * product icons.
+ *
+ * Binary extraction is authoritative when the installer embeds a real app
+ * icon. When it does not, extraction still succeeds and returns whatever
+ * artwork the wrapper carries: the Windows generic-application glyph, the
+ * Windows Installer disc, an install arrow. Recorded as an app's icon, that is
+ * worse than recording nothing, because every app packaged with the same
+ * toolkit ends up visually identical. A scan of the catalog found 769 packages
+ * sharing one such image and roughly 1,900 in total.
+ *
+ * Runs after extract-icons-batch.ps1 and before the shard is packaged. For
+ * each successful result whose icon matches the blocklist it:
+ *   - restores the icon files to their committed state, so the shard's diff
+ *     carries no generic artwork into the publication PR, and
+ *   - rewrites the result as failed with reason `generic_installer_icon`,
+ *     so the database records an attempt instead of a false success.
+ *
+ * Environment: RESULTS_FILE (default icon-results.json), ICONS_DIR (default
+ * public/icons).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { averageHash, bestIconPath, loadGenericHashes, matchGeneric } from './icon-hash.mjs';
+
+const RESULTS_FILE = process.env.RESULTS_FILE || 'icon-results.json';
+const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
+
+/**
+ * Undo this run's writes for one package. `git checkout` restores a directory
+ * that was already tracked; a directory that is new to this run has nothing to
+ * restore and is removed outright.
+ */
+function restoreIconDir(dir) {
+  try {
+    execFileSync('git', ['checkout', '--', dir], { stdio: 'pipe' });
+    return 'restored';
+  } catch {
+    fs.rmSync(dir, { recursive: true, force: true });
+    return 'removed';
+  }
+}
+
+async function main() {
+  if (!fs.existsSync(RESULTS_FILE)) {
+    console.log(`${RESULTS_FILE} not found - nothing to screen`);
+    return;
+  }
+
+  const blocklist = loadGenericHashes();
+  console.log(`Screening against ${blocklist.hashes.length} known non-product images`);
+
+  const results = JSON.parse(fs.readFileSync(RESULTS_FILE, 'utf8'));
+  const counts = {};
+  let rejected = 0;
+
+  for (const result of results) {
+    if (result.status !== 'success') continue;
+    // Family-inherited icons are a copy of an ancestor that was itself
+    // screened when it was extracted, so re-checking them would only reject
+    // the same image twice and strand the variant.
+    if (result.icon_source === 'family_inherited') continue;
+
+    const dir = path.join(ICONS_DIR, result.winget_id);
+    const iconPath = bestIconPath(dir);
+    if (!iconPath) continue;
+
+    let hash;
+    try {
+      hash = await averageHash(iconPath);
+    } catch (err) {
+      console.warn(`Could not hash ${result.winget_id}: ${err.message}`);
+      continue;
+    }
+
+    const match = matchGeneric(hash, blocklist);
+    if (!match) continue;
+
+    const disposition = restoreIconDir(dir);
+    result.status = 'failed';
+    result.failure_reason = 'generic_installer_icon';
+    result.error = `Extracted image is a known non-product icon (${match.label})`;
+    delete result.icon_path;
+    delete result.icon_source;
+
+    counts[match.label] = (counts[match.label] || 0) + 1;
+    rejected++;
+    console.log(`Rejected ${result.winget_id}: ${match.label} (${disposition})`);
+  }
+
+  fs.writeFileSync(RESULTS_FILE, JSON.stringify(results, null, 2));
+
+  console.log(`\n=== Generic Icon Screen ===`);
+  console.log(`Rejected: ${rejected}`);
+  for (const [label, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${label}: ${n}`);
+  }
+
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary && rejected > 0) {
+    fs.appendFileSync(
+      summary,
+      [
+        '## Generic Icon Screen',
+        '',
+        `Rejected **${rejected}** extracted icons that matched a known installer-toolkit default.`,
+        '',
+        ...Object.entries(counts)
+          .sort((a, b) => b[1] - a[1])
+          .map(([label, n]) => `- \`${label}\`: ${n}`),
+        ''
+      ].join('\n')
+    );
+  }
+}
+
+main().catch(err => {
+  console.error(`Generic icon screen failed: ${err.message}`);
+  process.exit(1);
+});

--- a/.github/workflows/heal-icons.yml
+++ b/.github/workflows/heal-icons.yml
@@ -140,6 +140,14 @@ jobs:
         shell: pwsh
         run: .github/scripts/extract-icons-batch.ps1
 
+      # An installer with no embedded app icon still yields its toolkit's
+      # default artwork, and extraction reports that as a success. Screen it
+      # out here so the shard never carries a generic image into the
+      # publication PR or records one as an app's icon.
+      - name: Screen out generic installer icons
+        shell: bash
+        run: node .github/scripts/reject-generic-icons.mjs
+
       # Only the directories this shard produced are uploaded. Shipping the
       # whole public/icons tree would move tens of thousands of files per shard
       # and make the collector's merge ambiguous about who wrote what.

--- a/.github/workflows/purge-generic-icons.yml
+++ b/.github/workflows/purge-generic-icons.yml
@@ -1,0 +1,84 @@
+name: Purge Generic Installer Icons
+
+# Binary extraction reports success whenever it pulls *an* icon out of an
+# installer. When the installer carries no application icon, what it pulls is
+# the packaging toolkit's own artwork: the Windows generic-application glyph,
+# the Windows Installer disc, an install arrow. Roughly 1,900 catalog packages
+# across ~1,200 publishers currently show one of six such images.
+#
+# reject-generic-icons.mjs stops new ones being written during a heal wave.
+# This workflow clears the ones already published and queues those packages for
+# re-resolution through the web tiers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_purge:
+        description: 'Stop after removing this many icons. 0 removes every match. Use a small number first to inspect the resulting PR.'
+        required: false
+        default: '0'
+
+# Shares the pipeline group: this rewrites the same icon tree the heal waves
+# and the weekly run publish to.
+concurrency:
+  group: curated-apps-pipeline
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  purge:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '26.5.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Purge generic icons
+        id: purge
+        env:
+          ICONS_DIR: public/icons
+          MAX_PURGE: ${{ github.event.inputs.max_purge || '0' }}
+          MODE: scan
+        run: node .github/scripts/purge-generic-icons.mjs
+
+      - name: Upload purge list
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generic-icon-purge
+          path: purged-apps.json
+          if-no-files-found: ignore
+
+      - name: Publish removals
+        id: commit-icons
+        if: steps.purge.outputs.purged != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          .github/scripts/publish-icon-pr.sh generic-purge "chore: remove generic installer icons"
+
+      # Only after the removals are on main. Resetting the database first would
+      # advertise apps as icon-less while their files were still being served.
+      - name: Reset purged apps
+        if: steps.commit-icons.outputs.committed == 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          MODE: commit
+        run: node .github/scripts/purge-generic-icons.mjs


### PR DESCRIPTION
## The problem

Binary extraction reports success whenever it pulls *an* icon out of an installer. When the installer carries no application icon, what it pulls is the packaging toolkit's own artwork. Recorded as an app's icon, that is worse than recording nothing: every app built with the same toolkit ends up visually identical.

A full scan of `public/icons` finds **1,876 packages across 1,234 publishers** showing one of six such images:

| Image | Packages |
| --- | --- |
| Windows generic-application glyph | 909 |
| Windows Installer disc | 465 |
| Install arrow | 312 |
| Setup disc | 69 |
| Blank image | 64 |
| PyInstaller bundler icon | 57 |

The spread across ~1,200 publishers is what distinguishes these from a genuine publisher-level logo. VovSoft's shared icon, for instance, is concentrated in one publisher (share 1.00) and is deliberately left alone.

This was invisible until now because the heal campaign fixed publisher avatars, and binary extraction *replaced some avatars with these*. The largest cluster only fell from 1,161 to 909 across the campaign while two others grew; sampling showed 13 of 18 members were freshly `binary_exe`.

## The change

A blocklist of average-hash fingerprints (`.github/data/generic-icon-hashes.json`), matched with a Hamming radius of 2 so resampling variants are absorbed, plus two consumers:

- **`reject-generic-icons.mjs`** runs in each heal shard after extraction. A match restores the icon files and rewrites the result as `failed` with reason `generic_installer_icon`, so no generic artwork reaches the publication PR and the database records an attempt rather than a false success.
- **`purge-generic-icons.mjs`** and its workflow clear the already-published ones and reset those rows so the web tiers get a chance at a product-specific image.

Deleting an icon looks like a regression, but `AppIcon.tsx` already renders a lettered glyph when a package has no icon, and a glyph is a more honest answer than the same grey installer window on nine hundred unrelated apps.

Hashing helpers move into `icon-hash.mjs`, shared with the audit. The audit now reports each cluster's `hash`, so a future generic image can be promoted into the blocklist straight from its output.

## Validation

Classification checked against ten hand-picked packages, including the ones that must *not* match:

| Package | Result |
| --- | --- |
| `0xJacky.nginx-ui` | reject `windows_generic_application` |
| `AbleWord.AbleWord` | reject `windows_installer_default` |
| `AAAInternetPublishing.WTFast` | reject `generic_install_arrow` |
| `AList.AListDesktop` | reject `generic_setup_disc` |
| `abrignoni.ALEAPP` | reject `pyinstaller_bundler` |
| `Mozilla.Firefox` | **keep** |
| `Microsoft.PowerToys` | **keep** |
| `VovSoft.3DBoxMaker` (real publisher logo) | **keep** |
| `Microsoft.AIShell` (freshly healed) | **keep** |

Full-catalog scan: 14,573 icons screened, 1,876 matched, spread over 1,234 publishers. Random members at indices 300/700/1100/1500/1800 were inspected by eye and all six images confirmed as toolkit artwork. A full dry run of the purge removed exactly 1,876 directories, matching the independent scan.

All three workflows parse as YAML; the blocklist is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)