### PR TITLE
Advance deterministic QA demand reconciliation

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -83,12 +83,14 @@ function createSupabaseStub(options: {
   deployedApps?: string[];
   pollState?: Record<string, unknown>;
   packageResults?: Array<Record<string, unknown>>;
+  installerHealth?: Array<Record<string, unknown>>;
 }) {
   const pollRunInserts: Array<Record<string, unknown>> = [];
   const pollRunUpdates: Array<Record<string, unknown>> = [];
   const cursorUpdates: Array<Record<string, unknown>> = [];
   const candidateInserts: Array<Record<string, unknown>> = [];
   const compatibilityBlocks: Array<Record<string, unknown>> = [];
+  const catalogReconciliations: Array<Record<string, unknown>> = [];
   const pipelineControlUpdates: Array<Record<string, unknown>> = [];
   const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
   let candidatePageIndex = 0;
@@ -186,10 +188,21 @@ function createSupabaseStub(options: {
       if (table === 'qa_package_results') {
         return query({ data: options.packageResults || [], error: null });
       }
+      if (table === 'installer_health') {
+        return query({ data: options.installerHealth || [], error: null });
+      }
       if (table === 'qa_package_blocks') {
         return {
           upsert: vi.fn((row: Record<string, unknown>) => {
             compatibilityBlocks.push(row);
+            return query({ data: null, error: null });
+          }),
+        };
+      }
+      if (table === 'qa_catalog_reconciliations') {
+        return {
+          upsert: vi.fn((row: Record<string, unknown>) => {
+            catalogReconciliations.push(row);
             return query({ data: null, error: null });
           }),
         };
@@ -221,6 +234,7 @@ function createSupabaseStub(options: {
     cursorUpdates,
     candidateInserts,
     compatibilityBlocks,
+    catalogReconciliations,
     pipelineControlUpdates,
     rpcCalls,
   };
@@ -599,8 +613,120 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
+  it('records a current-head reconciliation when the live installer manifest is unavailable', async () => {
+    const { client, candidateInserts, catalogReconciliations } = createSupabaseStub({
+      demandBackfillApps: ['Unavailable.App'],
+      supportedApps: [{
+        winget_id: 'Unavailable.App',
+        name: 'Unavailable',
+        publisher: 'Contoso',
+        latest_version: '2.0.0',
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue({
+      status: 'unavailable',
+      reason: 'installer_manifest_missing',
+      version: '2.0.0',
+    });
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, unavailable: 1, errorCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(catalogReconciliations).toEqual([
+      expect.objectContaining({
+        winget_id: 'Unavailable.App',
+        catalog_version: '2.0.0',
+        observed_live_version: '2.0.0',
+        observed_head_sha: 'b'.repeat(40),
+        reason_code: 'installer_manifest_missing',
+      }),
+    ]);
+  });
+
+  it('records a current-head reconciliation when no installer can run on the QA VM', async () => {
+    const { client, candidateInserts, catalogReconciliations } = createSupabaseStub({
+      demandBackfillApps: ['Unsupported.Architecture'],
+      supportedApps: [{
+        winget_id: 'Unsupported.Architecture',
+        name: 'Unsupported',
+        publisher: 'Contoso',
+        latest_version: '3.0.0',
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue({
+      status: 'resolved',
+      version: '3.0.0',
+      manifest: { InstallerType: 'exe', Installers: [] },
+      source: 'live',
+    });
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, unavailable: 1, errorCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(catalogReconciliations).toEqual([
+      expect.objectContaining({
+        winget_id: 'Unsupported.Architecture',
+        catalog_version: '3.0.0',
+        observed_live_version: '3.0.0',
+        observed_head_sha: 'b'.repeat(40),
+        reason_code: 'no_compatible_vm_installer',
+      }),
+    ]);
+  });
+
+  it('skips only an exact quarantined installer tuple for the current WinGet head', async () => {
+    const { client, candidateInserts, catalogReconciliations } = createSupabaseStub({
+      demandBackfillApps: ['Quarantined.App'],
+      supportedApps: [{
+        winget_id: 'Quarantined.App',
+        name: 'Quarantined',
+        publisher: 'Contoso',
+        latest_version: '1.0.0',
+      }],
+      installerHealth: [{
+        winget_id: 'Quarantined.App',
+        version: '1.0.0',
+        architecture: 'x64',
+        installer_url: 'https://example.com/setup.exe',
+        expected_sha256: 'A'.repeat(64),
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, unavailable: 1, errorCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(catalogReconciliations).toEqual([
+      expect.objectContaining({
+        winget_id: 'Quarantined.App',
+        catalog_version: '1.0.0',
+        observed_live_version: '1.0.0',
+        observed_head_sha: 'b'.repeat(40),
+        reason_code: 'installer_hash_quarantined',
+      }),
+    ]);
+  });
+
   it('persists a user-scope dependency compatibility block without degrading polling', async () => {
-    const { client, candidateInserts, compatibilityBlocks, pollRunUpdates } =
+    const {
+      client,
+      candidateInserts,
+      compatibilityBlocks,
+      catalogReconciliations,
+      pollRunUpdates,
+    } =
       createSupabaseStub({
         demandBackfillApps: ['Blocked.App'],
         supportedApps: [
@@ -639,6 +765,15 @@ describe('GET /api/cron/qa-enqueue', () => {
         architecture: 'x64',
         installer_sha256: 'A'.repeat(64),
         block_code: 'user_scope_machine_dependencies',
+      }),
+    ]);
+    expect(catalogReconciliations).toEqual([
+      expect.objectContaining({
+        winget_id: 'Blocked.App',
+        catalog_version: '1.0.0',
+        observed_live_version: '1.0.0',
+        observed_head_sha: 'b'.repeat(40),
+        reason_code: 'package_compatibility_blocked',
       }),
     ]);
     expect(pollRunUpdates[0]).toMatchObject({

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -60,6 +60,30 @@ const DEMAND_BACKFILL_BATCH_SIZE = 20;
 const MAX_TARGETED_PACKAGE_IDS = 20;
 const TARGETED_QA_PRIORITY = 1_000;
 
+type QaCatalogReconciliationReason =
+  | 'package_or_version_missing'
+  | 'installer_manifest_missing'
+  | 'no_compatible_vm_installer'
+  | 'missing_trusted_installer_metadata'
+  | 'installer_hash_quarantined'
+  | 'package_compatibility_blocked';
+
+function installerTupleKey(input: {
+  wingetId: string;
+  version: string;
+  architecture: string;
+  installerUrl: string;
+  installerSha256: string;
+}): string {
+  return [
+    input.wingetId.trim().toLowerCase(),
+    input.version.trim(),
+    input.architecture.trim().toLowerCase(),
+    input.installerUrl.trim(),
+    input.installerSha256.trim().toUpperCase(),
+  ].join('\0');
+}
+
 function targetedPackageIds(request: Request): string[] {
   const url = new URL(request.url);
   const values = [
@@ -350,6 +374,36 @@ async function findDemandBackfillIds(
   );
 }
 
+async function persistQaCatalogReconciliation(
+  supabase: ReturnType<typeof createServerClient>,
+  input: {
+    wingetId: string;
+    catalogVersion: string;
+    observedHeadSha: string | null;
+    reasonCode: QaCatalogReconciliationReason;
+    observedLiveVersion?: string;
+  }
+): Promise<void> {
+  if (!input.observedHeadSha || !/^[a-f0-9]{40}$/.test(input.observedHeadSha)) return;
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from('qa_catalog_reconciliations')
+    .upsert({
+      winget_id: input.wingetId,
+      catalog_version: input.catalogVersion,
+      observed_head_sha: input.observedHeadSha,
+      observed_live_version: input.observedLiveVersion || null,
+      reason_code: input.reasonCode,
+      observed_at: now,
+      updated_at: now,
+    }, {
+      onConflict: 'winget_id,catalog_version',
+    });
+  if (error) {
+    throw new Error(`Could not persist the QA catalog reconciliation: ${error.message}`);
+  }
+}
+
 export async function GET(request: Request) {
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret || request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
@@ -589,8 +643,9 @@ export async function GET(request: Request) {
       tested_at_utc: string;
       package_profile_sha256: string | null;
     }> = [];
+    let quarantinedInstallerTuples = new Set<string>();
     if (supportedIds.length > 0) {
-      const [recipeResult, policyResult, deployedResult, resultResult] = await Promise.all([
+      const [recipeResult, policyResult, deployedResult, resultResult, healthResult] = await Promise.all([
         supabase
           .from('qa_recipes')
           .select('winget_id, definition_path, architecture, installer_type')
@@ -612,6 +667,11 @@ export async function GET(request: Request) {
             'winget_id, tested_version, architecture, installer_sha256, outcome, tested_at_utc, package_profile_sha256'
           )
           .in('winget_id', supportedIds),
+        supabase
+          .from('installer_health')
+          .select('winget_id, version, architecture, installer_url, expected_sha256')
+          .in('winget_id', supportedIds)
+          .eq('status', 'quarantined'),
       ]);
       if (recipeResult.error) {
         throw new Error(`Could not read optional QA recipes: ${recipeResult.error.message}`);
@@ -625,10 +685,22 @@ export async function GET(request: Request) {
       if (resultResult.error) {
         throw new Error(`Could not read existing QA results: ${resultResult.error.message}`);
       }
+      if (healthResult.error) {
+        throw new Error(`Could not read quarantined QA installers: ${healthResult.error.message}`);
+      }
       recipes = recipeResult.data || [];
       policies = policyResult.data || [];
       deployedApps = deployedResult.data || [];
       results = resultResult.data || [];
+      quarantinedInstallerTuples = new Set((healthResult.data || []).map((row) =>
+        installerTupleKey({
+          wingetId: row.winget_id,
+          version: row.version,
+          architecture: row.architecture,
+          installerUrl: row.installer_url,
+          installerSha256: row.expected_sha256,
+        })
+      ));
     }
 
     const priorities = new Map<string, number>();
@@ -686,6 +758,17 @@ export async function GET(request: Request) {
               preferLive: true,
             });
             if (resolution.status !== 'resolved') {
+              await persistQaCatalogReconciliation(supabase!, {
+                wingetId: app.winget_id,
+                catalogVersion: app.latest_version!,
+                observedHeadSha: headSha,
+                reasonCode: resolution.reason === 'installer_manifest_missing'
+                  ? 'installer_manifest_missing'
+                  : 'package_or_version_missing',
+                observedLiveVersion: 'version' in resolution && typeof resolution.version === 'string'
+                  ? resolution.version
+                  : undefined,
+              });
               summary.unavailable++;
               structuredQaPollLog('info', 'qa_manifest_resolution_unavailable', {
                 runId,
@@ -712,6 +795,13 @@ export async function GET(request: Request) {
                 })()
               : selectQaVmInstaller(installers, app.winget_id);
             if (!selectedForVm) {
+              await persistQaCatalogReconciliation(supabase!, {
+                wingetId: app.winget_id,
+                catalogVersion: app.latest_version!,
+                observedHeadSha: headSha,
+                reasonCode: 'no_compatible_vm_installer',
+                observedLiveVersion: resolution.version,
+              });
               summary.unavailable++;
               return;
             }
@@ -728,6 +818,13 @@ export async function GET(request: Request) {
               recipe?.installer_type || 'exe'
             );
             if (!installerUrl.startsWith('https://') || !installerSha256) {
+              await persistQaCatalogReconciliation(supabase!, {
+                wingetId: app.winget_id,
+                catalogVersion: app.latest_version!,
+                observedHeadSha: headSha,
+                reasonCode: 'missing_trusted_installer_metadata',
+                observedLiveVersion: resolution.version,
+              });
               summary.unavailable++;
               structuredQaPollLog('info', 'qa_manifest_installer_unavailable', {
                 runId,
@@ -739,6 +836,29 @@ export async function GET(request: Request) {
             }
 
             const architecture = selectedForVm.architecture;
+            if (quarantinedInstallerTuples.has(installerTupleKey({
+              wingetId: app.winget_id,
+              version: resolution.version,
+              architecture,
+              installerUrl,
+              installerSha256,
+            }))) {
+              await persistQaCatalogReconciliation(supabase!, {
+                wingetId: app.winget_id,
+                catalogVersion: app.latest_version!,
+                observedHeadSha: headSha,
+                reasonCode: 'installer_hash_quarantined',
+                observedLiveVersion: resolution.version,
+              });
+              summary.unavailable++;
+              structuredQaPollLog('info', 'qa_installer_hash_quarantined', {
+                runId,
+                wingetId: app.winget_id,
+                version: resolution.version,
+                architecture,
+              });
+              return;
+            }
             const testConfig = buildQaCatalogTestConfig({
               app: { ...app, wingetId: app.winget_id, version: resolution.version },
               manifest,
@@ -774,6 +894,13 @@ export async function GET(request: Request) {
               if (blockError) {
                 throw new Error(`Could not persist the QA compatibility block: ${blockError.message}`);
               }
+              await persistQaCatalogReconciliation(supabase!, {
+                wingetId: app.winget_id,
+                catalogVersion: app.latest_version!,
+                observedHeadSha: headSha,
+                reasonCode: 'package_compatibility_blocked',
+                observedLiveVersion: resolution.version,
+              });
               summary.unavailable++;
               structuredQaPollLog('info', 'qa_package_compatibility_blocked', {
                 runId,

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1307,3 +1307,41 @@ describe('Webroot tenant-provisioned install block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('QA demand reconciliation migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260823180000_advance_qa_demand_reconciliation.sql'
+    ),
+    'utf8'
+  );
+
+  it('keeps deterministic unavailable observations private and scoped to a WinGet head', () => {
+    expect(sql).toContain('create table public.qa_catalog_reconciliations');
+    expect(sql).toContain('primary key (winget_id, catalog_version)');
+    expect(sql).toContain("observed_head_sha ~ '^[a-f0-9]{40}$'");
+    expect(sql).toContain('enable row level security');
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+    expect(sql).toContain('poll_state.head_sha = reconciliation.observed_head_sha');
+  });
+
+  it('uses captured catalog versions and seeds only exact quarantined tuples', () => {
+    expect(sql).toContain('candidate.catalog_version_at_enqueue = app.latest_version');
+    expect(sql).toContain('join public.installer_health as health');
+    expect(sql).toContain("health.status = 'quarantined'");
+    expect(sql).toContain('health.installer_url = candidate.installer_url');
+    expect(sql).toContain('health.expected_sha256 = candidate.installer_sha256');
+    expect(sql).toContain("'installer_hash_quarantined'");
+    expect(sql).not.toContain('health.version = app.latest_version');
+    expect(sql).toContain('from public.package_eligibility_blocks as eligibility_block');
+    expect(sql).toContain('from public.qa_package_blocks as block');
+  });
+
+  it('preserves bounded deployed-only demand and failed-app priority', () => {
+    expect(sql).toContain('from public.upload_history as history');
+    expect(sql).toContain('failure.last_failed_at desc nulls last');
+    expect(sql).toContain('limit greatest(1, least(coalesce(p_limit, 3), 100))');
+  });
+});

--- a/supabase/migrations/20260823180000_advance_qa_demand_reconciliation.sql
+++ b/supabase/migrations/20260823180000_advance_qa_demand_reconciliation.sql
@@ -1,0 +1,185 @@
+-- Avoid repeatedly selecting the same deployed app when the current WinGet
+-- repository head cannot provide an immutable installer tuple for isolated QA.
+-- A later WinGet head automatically makes the app eligible for reconciliation
+-- again, while catalog-version mappings and quarantined tuples remain durable.
+
+create table public.qa_catalog_reconciliations (
+  winget_id text not null
+    references public.curated_apps(winget_id) on update cascade on delete cascade,
+  catalog_version text not null,
+  observed_head_sha text not null check (observed_head_sha ~ '^[a-f0-9]{40}$'),
+  observed_live_version text,
+  reason_code text not null check (
+    reason_code in (
+      'package_or_version_missing',
+      'installer_manifest_missing',
+      'no_compatible_vm_installer',
+      'missing_trusted_installer_metadata',
+      'installer_hash_quarantined',
+      'package_compatibility_blocked'
+    )
+  ),
+  observed_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (winget_id, catalog_version)
+);
+
+comment on table public.qa_catalog_reconciliations is
+  'Service-only WinGet-head observations that prevent deterministic unavailable QA demand from starving later deployed apps.';
+
+create index qa_catalog_reconciliations_head_idx
+  on public.qa_catalog_reconciliations(observed_head_sha, winget_id, catalog_version);
+
+alter table public.qa_catalog_reconciliations enable row level security;
+revoke all on table public.qa_catalog_reconciliations from public, anon, authenticated;
+grant select, insert, update, delete on table public.qa_catalog_reconciliations to service_role;
+
+-- Seed only exact quarantined tuples observed for the current catalog mapping.
+-- A future WinGet head is not excluded; the enqueue route rechecks the live
+-- tuple and records a new head-scoped observation only if it is still bad.
+insert into public.qa_catalog_reconciliations (
+  winget_id,
+  catalog_version,
+  observed_head_sha,
+  observed_live_version,
+  reason_code
+)
+select distinct on (candidate.winget_id, candidate.catalog_version_at_enqueue)
+  candidate.winget_id,
+  candidate.catalog_version_at_enqueue,
+  poll_state.head_sha,
+  candidate.version,
+  'installer_hash_quarantined'
+from public.qa_candidates as candidate
+join public.installer_health as health
+  on health.winget_id = candidate.winget_id
+ and health.version = candidate.version
+ and health.architecture = candidate.architecture
+ and health.installer_url = candidate.installer_url
+ and health.expected_sha256 = candidate.installer_sha256
+ and health.status = 'quarantined'
+join public.qa_winget_poll_state as poll_state
+  on poll_state.id = 'microsoft/winget-pkgs'
+ and poll_state.head_sha ~ '^[a-f0-9]{40}$'
+where nullif(btrim(candidate.catalog_version_at_enqueue), '') is not null
+  and candidate.test_level = 'psadt-package'
+  and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+order by
+  candidate.winget_id,
+  candidate.catalog_version_at_enqueue,
+  candidate.updated_at desc
+on conflict (winget_id, catalog_version) do update
+set observed_head_sha = excluded.observed_head_sha,
+    observed_live_version = excluded.observed_live_version,
+    reason_code = excluded.reason_code,
+    observed_at = now(),
+    updated_at = now();
+
+create or replace function public.qa_missing_demand_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with deployed as (
+    select
+      history.winget_id,
+      max(history.deployed_at) as last_deployed_at
+    from public.upload_history as history
+    where nullif(btrim(history.winget_id), '') is not null
+    group by history.winget_id
+  ),
+  demand as (
+    select
+      deployed.winget_id,
+      exists (
+        select 1
+        from public.app_update_policies as policy
+        where policy.winget_id = deployed.winget_id
+          and policy.policy_type = 'auto_update'
+          and policy.is_enabled is true
+      ) as has_auto_update,
+      deployed.last_deployed_at as last_demanded_at
+    from deployed
+  ),
+  current_version_failures as (
+    select
+      candidate.winget_id,
+      max(candidate.finished_at) as last_failed_at
+    from public.qa_candidates as candidate
+    join public.curated_apps as current_app
+      on current_app.winget_id = candidate.winget_id
+     and (
+       candidate.catalog_version_at_enqueue = current_app.latest_version
+       or (
+         candidate.catalog_version_at_enqueue is null
+         and candidate.version = current_app.latest_version
+       )
+     )
+    where candidate.test_level = 'psadt-package'
+      and candidate.status in ('failed', 'error')
+    group by candidate.winget_id
+  )
+  select app.winget_id
+  from demand
+  join public.curated_apps as app on app.winget_id = demand.winget_id
+  left join current_version_failures as failure
+    on failure.winget_id = app.winget_id
+  where app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.package_eligibility_blocks as eligibility_block
+      where eligibility_block.winget_id = app.winget_id
+    )
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and (
+          candidate.catalog_version_at_enqueue = app.latest_version
+          or (
+            candidate.catalog_version_at_enqueue is null
+            and candidate.version = app.latest_version
+          )
+        )
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+    and not exists (
+      select 1
+      from public.qa_package_blocks as block
+      where block.winget_id = app.winget_id
+        and block.version = app.latest_version
+    )
+    and not exists (
+      select 1
+      from public.qa_catalog_reconciliations as reconciliation
+      join public.qa_winget_poll_state as poll_state
+        on poll_state.id = 'microsoft/winget-pkgs'
+       and poll_state.head_sha = reconciliation.observed_head_sha
+      where reconciliation.winget_id = app.winget_id
+        and reconciliation.catalog_version = app.latest_version
+    )
+  order by
+    failure.last_failed_at desc nulls last,
+    demand.has_auto_update desc,
+    demand.last_demanded_at desc nulls last,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 100));
+$$;
+
+comment on function public.qa_missing_demand_backfill_ids(integer) is
+  'Returns customer-deployed Win32 apps missing current catalog QA, excluding current-head unavailable observations and quarantined immutable installer tuples.';
+
+revoke all on function public.qa_missing_demand_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_missing_demand_backfill_ids(integer)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -23,6 +23,41 @@ type GenericRelationship = {
 export interface Database {
   public: {
     Tables: {
+      installer_health: {
+        Row: {
+          cache_key: string;
+          winget_id: string;
+          version: string;
+          architecture: string;
+          installer_url: string;
+          expected_sha256: string;
+          actual_sha256: string | null;
+          status: 'checking' | 'healthy' | 'quarantined' | 'error';
+          reason_code: string | null;
+          reason_message: string | null;
+          checked_at: string | null;
+          expires_at: string | null;
+          lease_expires_at: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['installer_health']['Row'],
+          'actual_sha256' | 'reason_code' | 'reason_message' | 'checked_at' |
+          'expires_at' | 'lease_expires_at' | 'created_at' | 'updated_at'
+        > & {
+          actual_sha256?: string | null;
+          reason_code?: string | null;
+          reason_message?: string | null;
+          checked_at?: string | null;
+          expires_at?: string | null;
+          lease_expires_at?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['installer_health']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
       qa_results: {
         Row: {
           winget_id: string;
@@ -307,6 +342,34 @@ export interface Database {
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_package_blocks']['Insert']>;
+        Relationships: GenericRelationship[];
+      };
+      qa_catalog_reconciliations: {
+        Row: {
+          winget_id: string;
+          catalog_version: string;
+          observed_head_sha: string;
+          observed_live_version: string | null;
+          reason_code:
+            | 'package_or_version_missing'
+            | 'installer_manifest_missing'
+            | 'no_compatible_vm_installer'
+            | 'missing_trusted_installer_metadata'
+            | 'installer_hash_quarantined'
+            | 'package_compatibility_blocked';
+          observed_at: string;
+          updated_at: string;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['qa_catalog_reconciliations']['Row'],
+          'observed_at' | 'updated_at'
+        > & {
+          observed_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<
+          Database['public']['Tables']['qa_catalog_reconciliations']['Insert']
+        >;
         Relationships: GenericRelationship[];
       };
       package_eligibility_blocks: {


### PR DESCRIPTION
Fixes the deployed-app QA backfill retry trap by matching catalog_version_at_enqueue, recording deterministic current-head manifest gaps, and reconciling only exact quarantined installer tuples. A corrected tuple or later WinGet head remains eligible. Validation: 83 test files / 1428 tests, lint, and production build passed.