### PR TITLE
fix(icons): require pixel confirmation before rejecting an icon

### DIFF
--- a/.github/data/generic-icon-hashes.json
+++ b/.github/data/generic-icon-hashes.json
@@ -1,36 +1,44 @@
 {
-  "_comment": "Average-hash fingerprints of images that are not product icons. Binary extraction pulls the icon out of an installer, and a wrapper installer that carries no app icon yields its toolkit's default artwork instead: the Windows generic-application glyph, the Windows Installer disc, an Inno/NSIS install arrow, the PyInstaller bundler icon. Recording one of those as an app's icon is worse than recording nothing, because hundreds of unrelated apps end up identical. Entries are matched with a Hamming distance of 2, which absorbs resampling variants without colliding with real icons (the closest real-icon cluster sits far outside that radius). Derived from a full scan of public/icons and confirmed by eye; regenerate with audit-duplicate-icons.mjs, which reports each cluster's hash.",
+  "_comment": "Images that are not product icons. Binary extraction pulls the icon out of an installer, and a wrapper installer carrying no app icon yields its toolkit's own artwork instead, which is then recorded as hundreds of unrelated apps' icon. An entry matches only when the 8x8 average hash is within max_hamming_distance AND the 32x32 greyscale pixel digest is one of pixel_keys. The average hash alone is not sufficient evidence: it collapses an icon to 64 bits, so ArtisteerLimited.Nicepage (a real logo) collides with Arihant25.Chargle. Treating that as a match would delete real icons. To add an entry, run inspect-icon-cluster.mjs against a candidate hash: it reports how many distinct pictures share it, and only a cluster that resolves to a handful of confirmed-generic pictures belongs here. An entry with no pixel_keys never matches anything.",
   "max_hamming_distance": 2,
+  "blank_max_std_dev": 4,
+  "_blank_note": "Separate rule, a property rather than a picture: an image whose greyscale standard deviation is at or below this has no detail to show. Measured blanks scored 0.00 and 1.36; the least contrasty real icon in the catalog scored 34.63, so this threshold has roughly an 8x margin.",
   "hashes": [
     {
       "hash": "0000000011111111111001111110001111000011110000111111111100111100",
       "label": "windows_generic_application",
-      "note": "Default Windows application-window glyph. Largest cluster: 769 packages across ~700 publishers."
+      "note": "Default Windows application-window glyph. 894 packages resolved to just 2 pictures.",
+      "pixel_keys": ["5ef659bd25802b77", "88b875c5d8188380"]
     },
     {
       "hash": "1101111001101110100010101000001011001000110101001101010000011100",
       "label": "windows_installer_default",
-      "note": "Classic Windows Installer computer-and-disc icon. 422 packages."
+      "note": "Classic Windows Installer computer-and-disc icon, including its red-X remove variant. 458 packages, 5 pictures.",
+      "pixel_keys": [
+        "0bd43484eea5e863",
+        "7ab3c06ffbb6d02e",
+        "b7f0de0fb51fede6",
+        "32e1d7968c869c0c",
+        "f9bfc169e3228fab"
+      ]
     },
     {
       "hash": "0100100000010000010000100001000011101111111111111111111101111110",
       "label": "generic_install_arrow",
-      "note": "Install/download arrow used as the default by several installer toolkits. 312 packages."
+      "note": "Install/download arrow used as a default by several installer toolkits. 310 packages, 2 pictures.",
+      "pixel_keys": ["80c5b622692b780c", "a809c5e0d1e5485a"]
     },
     {
       "hash": "0011110001111110011111110111110001111110001101100011010000111100",
       "label": "generic_setup_disc",
-      "note": "Setup disc with download arrow. 69 packages."
-    },
-    {
-      "hash": "0000000000000000000000000000000000000000000000000000000000000000",
-      "label": "blank_image",
-      "note": "Uniform image with no detail. An all-equal hash means every pixel sits at the mean, so nothing was extracted. 64 packages."
+      "note": "Setup disc with download arrow. 69 packages, 2 pictures.",
+      "pixel_keys": ["5c1cb4f4e699d41a", "883f20a30af980cd"]
     },
     {
       "hash": "1110000011100000111100001110000001100000001111110011111000111100",
       "label": "pyinstaller_bundler",
-      "note": "PyInstaller/Python bundler icon. Identifies the packaging toolchain, not the application. 57 packages."
+      "note": "PyInstaller bundler icon: identifies the packaging toolchain, not the application. 57 packages, all 1 picture.",
+      "pixel_keys": ["4aff344a8195824c"]
     }
   ]
 }

--- a/.github/scripts/icon-hash.mjs
+++ b/.github/scripts/icon-hash.mjs
@@ -1,21 +1,30 @@
 /**
  * Shared icon fingerprinting.
  *
- * An 8x8 average hash is enough to answer the only question asked of it here:
- * are two icons the same picture? It is cheap, stable across the resamples the
- * pipeline performs, and comparable with a Hamming distance.
+ * Two different questions get asked of an icon here, and they need two
+ * different tools:
  *
- * Used by audit-duplicate-icons.mjs to cluster identical icons, and by
- * reject-generic-icons.mjs to recognise the installer-toolkit defaults listed
- * in .github/data/generic-icon-hashes.json.
+ *   - "which icons look roughly alike?" -- an 8x8 average hash, used by
+ *     audit-duplicate-icons.mjs to cluster the catalog.
+ *   - "is this exactly the picture we decided to reject?" -- a 32x32 greyscale
+ *     raster digest, used to confirm a blocklist hit.
+ *
+ * The average hash alone is not enough to decide the second question. It
+ * collapses an icon to 64 bits, so any two flat logos with a centred glyph
+ * land in the same bucket: ArtisteerLimited.Nicepage (a real product logo)
+ * shares an average hash with Arihant25.Chargle. Deleting on that basis would
+ * destroy real icons. So the average hash is only ever a cheap prefilter, and
+ * a pixel digest has to agree before anything is rejected.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import sharp from 'sharp';
 
 export const HASH_SIZE = 8;
+export const PIXEL_KEY_SIZE = 32;
 export const ICON_SIZE_PREFERENCE = [256, 128, 64];
 
 /** 64-bit average hash of an image, as a string of '0'/'1'. */
@@ -30,6 +39,31 @@ export async function averageHash(filePath) {
   let bits = '';
   for (const byte of data) bits += byte > avg ? '1' : '0';
   return bits;
+}
+
+/**
+ * Digest of the decoded pixels rather than the file. Two PNGs of the same
+ * picture routinely differ byte for byte (different encoder, different resize
+ * path), so hashing the file would report them as unrelated.
+ */
+export async function pixelKey(filePath) {
+  const { data } = await sharp(filePath)
+    .resize(PIXEL_KEY_SIZE, PIXEL_KEY_SIZE, { fit: 'fill' })
+    .greyscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 16);
+}
+
+/** Greyscale standard deviation. Near zero means the image carries no detail. */
+export async function greyscaleStdDev(filePath) {
+  const { data } = await sharp(filePath)
+    .resize(PIXEL_KEY_SIZE, PIXEL_KEY_SIZE, { fit: 'fill' })
+    .greyscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const mean = data.reduce((a, b) => a + b, 0) / data.length;
+  return Math.sqrt(data.reduce((a, b) => a + (b - mean) ** 2, 0) / data.length);
 }
 
 export function hamming(a, b) {
@@ -58,17 +92,39 @@ export function loadGenericHashes(
   const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
   return {
     maxDistance: parsed.max_hamming_distance ?? 2,
+    blankMaxStdDev: parsed.blank_max_std_dev ?? 0,
     hashes: parsed.hashes ?? []
   };
 }
 
 /**
- * Returns the matching blocklist entry, or null when the icon is not one of
- * the known non-product images.
+ * Decides whether an icon is one of the known non-product images.
+ *
+ * Returns the matching entry, or null. A hit requires the average hash to be
+ * within the configured radius AND the pixel digest to be one this entry was
+ * recorded with, so an average-hash collision with a real logo cannot reject
+ * it. Entries carrying no pixel keys never match, which makes a half-filled
+ * blocklist entry inert rather than dangerous.
+ *
+ * The separate blank rule is a property, not a picture: any image whose
+ * greyscale standard deviation is near zero has no detail to show, whatever
+ * its colour.
  */
-export function matchGeneric(hash, { maxDistance, hashes }) {
-  for (const entry of hashes) {
-    if (hamming(hash, entry.hash) <= maxDistance) return entry;
+export async function classifyIcon(filePath, blocklist) {
+  if (blocklist.blankMaxStdDev > 0) {
+    const sd = await greyscaleStdDev(filePath);
+    if (sd <= blocklist.blankMaxStdDev) {
+      return { label: 'blank_image', note: `no detail (greyscale sd ${sd.toFixed(2)})` };
+    }
+  }
+
+  const hash = await averageHash(filePath);
+  const near = blocklist.hashes.filter(e => hamming(hash, e.hash) <= blocklist.maxDistance);
+  if (near.length === 0) return null;
+
+  const key = await pixelKey(filePath);
+  for (const entry of near) {
+    if ((entry.pixel_keys ?? []).includes(key)) return entry;
   }
   return null;
 }

--- a/.github/scripts/inspect-icon-cluster.mjs
+++ b/.github/scripts/inspect-icon-cluster.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Inspects an average-hash cluster before it is trusted as a blocklist entry.
+ *
+ * audit-duplicate-icons.mjs reports clusters of icons that share an 8x8
+ * average hash. That is enough to say "these look alike at 64 bits", which is
+ * not enough to say "these are the same picture". ArtisteerLimited.Nicepage
+ * and Arihant25.Chargle share a hash and are entirely different logos.
+ *
+ * This resolves a cluster into distinct pictures by pixel digest, so you can
+ * see whether it is one generic image repeated (safe to blocklist) or a pile
+ * of unrelated real icons that merely collide (never blocklist). It prints the
+ * pixel_keys array ready to paste, and a sample package per picture so each
+ * can be eyeballed first.
+ *
+ *   node .github/scripts/inspect-icon-cluster.mjs <64-bit-average-hash> [radius]
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { averageHash, pixelKey, hamming, bestIconPath, greyscaleStdDev } from './icon-hash.mjs';
+
+const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
+const target = process.argv[2];
+const radius = parseInt(process.argv[3] || '2', 10);
+
+if (!target || !/^[01]{64}$/.test(target)) {
+  console.error('Usage: inspect-icon-cluster.mjs <64-bit average hash> [radius]');
+  process.exit(1);
+}
+
+const dirs = fs
+  .readdirSync(ICONS_DIR, { withFileTypes: true })
+  .filter(d => d.isDirectory())
+  .map(d => d.name);
+
+const pictures = new Map();
+let members = 0;
+
+for (const id of dirs) {
+  const file = bestIconPath(path.join(ICONS_DIR, id));
+  if (!file) continue;
+  let hash;
+  try {
+    hash = await averageHash(file);
+  } catch {
+    continue;
+  }
+  if (hamming(hash, target) > radius) continue;
+  members++;
+
+  let key;
+  try {
+    key = await pixelKey(file);
+  } catch {
+    continue;
+  }
+  if (!pictures.has(key)) pictures.set(key, { count: 0, sample: id, file });
+  pictures.get(key).count++;
+}
+
+const ranked = [...pictures.entries()].sort((a, b) => b[1].count - a[1].count);
+
+console.log(`Average hash ${target} (radius ${radius})`);
+console.log(`Members: ${members}   Distinct pictures: ${ranked.length}\n`);
+
+for (const [key, info] of ranked) {
+  const share = Math.round((100 * info.count) / members);
+  const sd = await greyscaleStdDev(info.file).catch(() => NaN);
+  console.log(
+    `  ${key}  ${String(info.count).padStart(4)} (${String(share).padStart(3)}%)  sd=${sd.toFixed(1).padStart(6)}  e.g. ${info.sample}`
+  );
+}
+
+// A cluster that is one image repeated resolves to very few pictures. One that
+// resolves to dozens is the average hash colliding on unrelated logos, and
+// blocklisting its hash would delete real icons.
+console.log('');
+if (ranked.length > 5) {
+  console.log(
+    `VERDICT: ${ranked.length} distinct pictures share this hash. That is a collision, not a shared placeholder. Do NOT blocklist it.`
+  );
+} else {
+  console.log(
+    `VERDICT: resolves to ${ranked.length} picture(s). Inspect each sample above; if every one is toolkit artwork, these pixel_keys are safe to add:`
+  );
+  console.log(JSON.stringify(ranked.map(([k]) => k), null, 2));
+}

--- a/.github/scripts/purge-generic-icons.mjs
+++ b/.github/scripts/purge-generic-icons.mjs
@@ -20,7 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createClient } from '@supabase/supabase-js';
-import { averageHash, bestIconPath, loadGenericHashes, matchGeneric } from './icon-hash.mjs';
+import { bestIconPath, loadGenericHashes, classifyIcon } from './icon-hash.mjs';
 
 const MODE = process.env.MODE || 'scan';
 const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
@@ -46,15 +46,13 @@ async function scan() {
     if (!iconPath) continue;
     scanned++;
 
-    let hash;
+    let match;
     try {
-      hash = await averageHash(iconPath);
+      match = await classifyIcon(iconPath, blocklist);
     } catch (err) {
-      console.warn(`Could not hash ${id}: ${err.message}`);
+      console.warn(`Could not screen ${id}: ${err.message}`);
       continue;
     }
-
-    const match = matchGeneric(hash, blocklist);
     if (!match) continue;
 
     fs.rmSync(dir, { recursive: true, force: true });

--- a/.github/scripts/reject-generic-icons.mjs
+++ b/.github/scripts/reject-generic-icons.mjs
@@ -25,7 +25,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { averageHash, bestIconPath, loadGenericHashes, matchGeneric } from './icon-hash.mjs';
+import { bestIconPath, loadGenericHashes, classifyIcon } from './icon-hash.mjs';
 
 const RESULTS_FILE = process.env.RESULTS_FILE || 'icon-results.json';
 const ICONS_DIR = process.env.ICONS_DIR || 'public/icons';
@@ -69,15 +69,13 @@ async function main() {
     const iconPath = bestIconPath(dir);
     if (!iconPath) continue;
 
-    let hash;
+    let match;
     try {
-      hash = await averageHash(iconPath);
+      match = await classifyIcon(iconPath, blocklist);
     } catch (err) {
-      console.warn(`Could not hash ${result.winget_id}: ${err.message}`);
+      console.warn(`Could not screen ${result.winget_id}: ${err.message}`);
       continue;
     }
-
-    const match = matchGeneric(hash, blocklist);
     if (!match) continue;
 
     const disposition = restoreIconDir(dir);


### PR DESCRIPTION
## The latent bug

The generic-icon blocklist matched on an 8x8 average hash alone. That hash collapses an icon to 64 bits, so any two flat logos with a centred glyph land in the same bucket.

`ArtisteerLimited.Nicepage`, a real product logo, shares its average hash with `Arihant25.Chargle`. The new inspection tool resolves that cluster:

```
Average hash 0000000000000000001111000011110000111100001111000000000000000000 (radius 2)
Members: 61   Distinct pictures: 56
  be28d4ca3d324f64  3 (5%)  e.g. Exploitox.CheckIP
  de43dfaed12bc89b  1 (2%)  e.g. Acronis.CyberProtectHomeOffice
  cba8180ff878f6d6  1 (2%)  e.g. Adobe.Connect
  e4a6421d66889e3a  1 (2%)  e.g. Anysphere.Cursor
  ...
```

**56 distinct pictures.** The audit reports it as a 61-member `possibly_generic_placeholder` cluster, which is precisely the signal that invited me to blocklist it. Doing so would have deleted Adobe Connect's, Acronis's and Cursor's real icons.

## The fix

The average hash becomes a **prefilter only**. Each entry now carries the pixel digests it was recorded with, and a hit needs both to agree:

- Pixel digest is a 32x32 greyscale raster hash, not a file hash. Two PNGs of the same picture routinely differ byte for byte (different encoder, different resize path); hashing the file reported 894 copies of one image as 893 "distinct".
- An entry with **no** pixel keys never matches, so a half-filled entry is inert rather than destructive.

The `blank_image` entry becomes a property test rather than a fingerprint, since "carries no detail" is not one picture: reject when greyscale standard deviation is at or below **4**. Measured blanks score 0.00 and 1.36; the least contrasty real icon in the catalog scores 34.63, so the threshold has roughly an 8x margin.

New `inspect-icon-cluster.mjs` resolves a candidate cluster into distinct pictures with a sample of each, and refuses to endorse one that turns out to be a collision. Adding a blocklist entry now starts there.

## Was the purge already shipped a mistake?

No, and I checked rather than assumed. Re-running the analysis against the tree as it stood immediately before the purge commit:

| Entry | Files matched | Distinct **pictures** |
| --- | --- | --- |
| `windows_generic_application` | 894 | **2** |
| `windows_installer_default` | 458 | 5 |
| `generic_install_arrow` | 310 | 2 |
| `generic_setup_disc` | 69 | 2 |
| `blank_image` | 63 | 3 |
| `pyinstaller_bundler` | 57 | **1** |

Each resolved to a handful of near-identical generic pictures, not hundreds of real icons. The small outliers were inspected individually: `Apple.AirPort` and `Canon.i-SENSYS.MF4010-MF4018` are the same installer artwork (Canon's is the red-X remove variant) and `mcp-tool-shop.CommandUI` is a solid navy square. All correctly removed.

## Validation

19-case classification test spanning both trees: every generic still rejected, and `Nicepage`, `Chargle`, `AdoptOpenJDK`, `QuickBMS`, `Firefox`, `PowerToys` and the `VovSoft` publisher logo all kept. All scripts pass `node --check`; the blocklist is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)