### PR TITLE
Fix Surfshark primary uninstall registration

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -656,6 +656,9 @@ function Get-StrictPSADTBoolean {
 $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
     -Config $psadtConfig `
     -Name 'preserveVendorInstallationOnUninstall'
+$reviewedPreferVisiblePrimaryUninstallRegistration = Get-StrictPSADTBoolean `
+    -Config $psadtConfig `
+    -Name 'reviewedPreferVisiblePrimaryUninstallRegistration'
 if ($reviewedRegistryInstallEvidenceConfigured -and
     -not $preserveVendorInstallationOnUninstall) {
     throw 'PSADT reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall.'
@@ -2916,6 +2919,21 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         )
     }
 
+    if ($reviewedPreferVisiblePrimaryUninstallRegistration) {
+        $lines += @(
+            '        if ($selectedApplications.Count -gt 1) {'
+            '            # This reviewed package registers one visible primary application plus a hidden system'
+            '            # component under the same exact identity. Narrow only the already identity-matched set'
+            '            # and accept it only when exactly one visible registration remains.'
+            '            $visiblePrimaryMatches = @($selectedApplications | Where-Object {'
+            '                $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+            '                -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+            '            })'
+            '            if ($visiblePrimaryMatches.Count -eq 1) { $selectedApplications = $visiblePrimaryMatches }'
+            '        }'
+        )
+    }
+
     $lines += @(
         '        if ($selectedApplications.Count -eq 0 -and $configuredUninstallProductCode) {'
         '            $configuredMatches = @($postInstallApplications | Where-Object { [string]$_.PSChildName -eq $configuredUninstallProductCode })'
@@ -3312,6 +3330,19 @@ if ($useManagedDirectoryLifecycle) {
             '            $isVisibleApplication -and -not $_.WindowsInstaller'
             '        })'
             '        if ($topLevelWrapperMatches.Count -eq 1) { $installedApps = $topLevelWrapperMatches }'
+            '    }'
+        )
+    }
+    if ($reviewedPreferVisiblePrimaryUninstallRegistration) {
+        $lines += @(
+            '    if ($installedApps.Count -gt 1) {'
+            '        # Apply the reviewed primary-registration rule only to the exact/captured identity set.'
+            '        # Never widen the search, and retain fail-closed behavior unless one visible entry remains.'
+            '        $visiblePrimaryMatches = @($installedApps | Where-Object {'
+            '            $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+            '            -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+            '        })'
+            '        if ($visiblePrimaryMatches.Count -eq 1) { $installedApps = $visiblePrimaryMatches }'
             '    }'
         )
     }

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -42,6 +42,19 @@ describe('application packaging adapters', () => {
     )).toEqual([-1073741819, -1073740791]);
   });
 
+  it('selects Surfshark visible primary ARP registration without trusting customer config', () => {
+    expect(
+      applyApplicationPackagingAdapter('Surfshark.Surfshark', DEFAULT_PSADT_CONFIG)
+        .reviewedPreferVisiblePrimaryUninstallRegistration
+    ).toBe(true);
+    expect(
+      applyApplicationPackagingAdapter('Example.App', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedPreferVisiblePrimaryUninstallRegistration: true,
+      }).reviewedPreferVisiblePrimaryUninstallRegistration
+    ).toBeUndefined();
+  });
+
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
     expect(resolveApplicationUninstallCommand(
       'Google.Chrome.EXE',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -24,6 +24,7 @@ interface ApplicationPackagingAdapter {
   reviewedUninstallServiceNames?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
+  reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
   reviewedManagedInstallDirectory?: string;
   reviewedManagedInstallEvidenceFile?: string;
   reviewedManagedInstallCompletionProcess?: string;
@@ -353,6 +354,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallShieldAdministrativeImage: {
       expectedMsiFileName: 'Sonos.msi',
     },
+  },
+  {
+    // Surfshark 6.16 registers the same exact display identity twice: one
+    // visible primary MSI and one hidden MSI system component. QA run
+    // 32654170672 proved that SystemComponent is the only bounded distinction.
+    // Select the single visible entry only after ordinary identity matching;
+    // zero or multiple visible matches remain an ambiguity failure.
+    wingetId: 'Surfshark.Surfshark',
+    reviewedPreferVisiblePrimaryUninstallRegistration: true,
   },
   {
     // TreeSize's dual-mode Inno installer defaults to the invoking account even
@@ -1423,6 +1433,7 @@ export function applyApplicationPackagingAdapter(
     // These internal lifecycle fields are never accepted from customer config.
     if (
       !config.preserveVendorInstallationOnUninstall &&
+      !config.reviewedPreferVisiblePrimaryUninstallRegistration &&
       !config.reviewedInstallArgumentsOverride &&
       !config.reviewedArgumentlessInstall &&
       !config.reviewedInstallCompletionTimeoutMinutes &&
@@ -1443,6 +1454,7 @@ export function applyApplicationPackagingAdapter(
     return {
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
+      reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
       reviewedInstallArgumentsOverride: undefined,
       reviewedArgumentlessInstall: undefined,
       reviewedInstallCompletionTimeoutMinutes: undefined,
@@ -1548,6 +1560,8 @@ export function applyApplicationPackagingAdapter(
       : {}),
     preserveVendorInstallationOnUninstall:
       adapter.preserveVendorInstallationOnUninstall || undefined,
+    reviewedPreferVisiblePrimaryUninstallRegistration:
+      adapter.reviewedPreferVisiblePrimaryUninstallRegistration || undefined,
     reviewedManagedInstallDirectory:
       adapter.reviewedManagedInstallDirectory || undefined,
     reviewedManagedInstallEvidenceFile:

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1200,6 +1200,35 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.preserveVendorInstallationOnUninstall).toBe(true);
   });
 
+  it('binds Surfshark visible-primary ARP selection to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Surfshark.Surfshark',
+      displayName: 'Surfshark',
+      publisher: 'Surfshark',
+      version: '6.16.0.999',
+      architecture: 'x64',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/quiet',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Surfshark',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
+      };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      reviewedPreferVisiblePrimaryUninstallRegistration: true,
+    });
+    expect(
+      profile.psadtConfig.reviewedPreferVisiblePrimaryUninstallRegistration
+    ).toBe(true);
+  });
+
   it('binds reviewed .NET Framework registry evidence to the QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.DotNet.Framework.Runtime',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2293,6 +2293,54 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     );
   });
 
+  it('keeps visible-primary ARP selection opt-in, identity-bounded, and fail-closed', () => {
+    expect(packager).toContain(
+      "-Name 'reviewedPreferVisiblePrimaryUninstallRegistration'"
+    );
+    expect(packager).toContain(
+      '$visiblePrimaryMatches = @($selectedApplications | Where-Object {'
+    );
+    expect(packager).toContain(
+      'if ($visiblePrimaryMatches.Count -eq 1) { $selectedApplications = $visiblePrimaryMatches }'
+    );
+    expect(packager).toContain(
+      '$visiblePrimaryMatches = @($installedApps | Where-Object {'
+    );
+    expect(packager).toContain(
+      'if ($visiblePrimaryMatches.Count -eq 1) { $installedApps = $visiblePrimaryMatches }'
+    );
+    expect(packager.indexOf('$visiblePrimaryMatches = @($selectedApplications')).toBeLessThan(
+      packager.indexOf("'    if ($selectedApplications.Count -eq 1) {'")
+    );
+    expect(packager.indexOf('$visiblePrimaryMatches = @($installedApps')).toBeLessThan(
+      packager.indexOf('if ($installedApps.Count -ne 1)')
+    );
+  });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits the reviewed visible-primary selector only when enabled',
+    () => {
+      const enabled = generateRegistryUninstallPackage(
+        'exe',
+        'Surfshark',
+        [],
+        { reviewedPreferVisiblePrimaryUninstallRegistration: true },
+        [],
+        'Surfshark.Surfshark'
+      );
+      const disabled = generateRegistryUninstallPackage('exe');
+
+      expect(enabled).toContain(
+        '$visiblePrimaryMatches = @($selectedApplications | Where-Object {'
+      );
+      expect(enabled).toContain(
+        '$visiblePrimaryMatches = @($installedApps | Where-Object {'
+      );
+      expect(disabled).not.toContain('$visiblePrimaryMatches');
+    },
+    30_000
+  );
+
   it('logs bounded ARP identity metadata before rejecting an ambiguous install delta', () => {
     expect(packager).toContain(
       'foreach ($ambiguousApplication in @($selectedApplications))'

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -254,6 +254,13 @@ export interface PSADTConfig {
   // the only trusted source for this value; it is not customer-configurable.
   preserveVendorInstallationOnUninstall?: boolean;
 
+  // Internal ARP identity policy for a reviewed package that registers one
+  // visible primary application and a hidden system component under the same
+  // exact display name. The shared packager narrows only an already-matched
+  // identity set and still requires exactly one visible result. Application
+  // adapters are the only trusted source for this value.
+  reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
+
   // Internal lifecycle contract for reviewed self-extracting packages that do
   // not register an application in Add/Remove Programs. The generated package
   // verifies this exact directory after install and removes it on uninstall.
@@ -392,6 +399,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   reviewedUninstallArguments: [],
   reviewedUninstallProcessGuard: undefined,
   reviewedUninstallServiceNames: undefined,
+  reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
 };
 
 /**


### PR DESCRIPTION
## Summary
- add a reviewed Surfshark adapter that selects the sole visible ARP primary only within an already identity-matched set
- apply the same bounded selector during install capture and uninstall fallback
- keep zero/multiple visible matches fail-closed and strip the internal flag from customer-controlled config

## Verification
- 264 focused tests passed
- 84 test files / 1,447 tests passed
- ESLint passed
- production Next.js build passed