### PR TITLE
Release Surfshark visible-primary QA toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'bb762159825bb59be2649f4cff4bf25fbbaef8b8',
+  packagerCommit: '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -324,6 +324,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // path. Preserve passing profiles while collecting exact identities for the
   // affected terminal candidate.
   '228cd9def01122182631c91910554c05e9181edb',
+  // Bounded diagnostics did not change successful package behavior. Preserve
+  // every passing profile while the reviewed Surfshark primary-ARP selector
+  // invalidates only Surfshark through its canonical adapter field.
+  'bb762159825bb59be2649f4cff4bf25fbbaef8b8',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,10 +6,14 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Surfshark only on the bounded ambiguity-diagnostics release', () => {
+  it('carries Surfshark from diagnostics into the visible-primary release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' surfshark.surfshark ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'bb762159825bb59be2649f4cff4bf25fbbaef8b8',
+      { wingetId: 'Surfshark.Surfshark', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '228cd9def01122182631c91910554c05e9181edb',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -146,7 +146,16 @@ const AMBIGUOUS_UNINSTALL_DIAGNOSTICS_RELEASE_RETRY_TARGETS = [
   ...VISUAL_STUDIO_BUILD_TOOLS_INSTALL_PATH_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS = [
+  // Re-run the exact failed Surfshark release with the reviewed selector that
+  // distinguishes its visible primary MSI from the hidden system component.
+  // Carry all still-unconsumed bounded targets across the atomic pin.
+  ...AMBIGUOUS_UNINSTALL_DIAGNOSTICS_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1':
+    SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS,
   'bb762159825bb59be2649f4cff4bf25fbbaef8b8':
     AMBIGUOUS_UNINSTALL_DIAGNOSTICS_RELEASE_RETRY_TARGETS,
   '228cd9def01122182631c91910554c05e9181edb':


### PR DESCRIPTION
## Summary
- release packager 2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1 to the production QA scheduler
- preserve prior compatible passes across the diagnostic release
- carry Surfshark and the bounded unconsumed retry set into the new immutable release

## Verification
- 232 focused release/enqueue/dispatch tests passed
- 84 files / 1,447 tests passed
- ESLint passed
- production Next.js build passed
- exact packager deployment is Ready on production aliases
- customer and QA workflows pin the same commit via IntuneGet-Workflows #2147