### PR TITLE
Handle leaf-only registered uninstall commands

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -3509,7 +3509,12 @@ if ($useManagedDirectoryLifecycle) {
             '        # PSADT correctly prefers QuietUninstallString. Some vendors only publish an interactive'
             '        # UninstallString, so add narrowly verified unattended arguments for known signatures.'
             '        $registeredUninstallLeaf = Split-Path -Leaf $registeredUninstallFile'
-            '        $registeredUninstallParentLeaf = Split-Path -Leaf (Split-Path -Parent $registeredUninstallFile)'
+            '        $registeredUninstallParentPath = Split-Path -Parent $registeredUninstallFile'
+            '        $registeredUninstallParentLeaf = if ([string]::IsNullOrWhiteSpace($registeredUninstallParentPath)) {'
+            "            ''"
+            '        } else {'
+            '            Split-Path -Leaf $registeredUninstallParentPath'
+            '        }'
             '        $autodeskOdisInstaller = [Environment]::ExpandEnvironmentVariables(''%ProgramW6432%\Autodesk\AdODIS\V1\Installer.exe'')'
             '        $isAutodeskOdisUninstall = ('
             '            $registeredUninstallFile -ieq $autodeskOdisInstaller -and'

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3057,6 +3057,19 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(actionBoundArgumentCheck).toBeGreaterThan(registryIdentityCheck);
   });
 
+  it('accepts leaf-only registered uninstall executables before exact command parsing', () => {
+    expect(packager).toContain(
+      '$registeredUninstallParentPath = Split-Path -Parent $registeredUninstallFile'
+    );
+    expect(packager).toContain(
+      '$registeredUninstallParentLeaf = if ([string]::IsNullOrWhiteSpace($registeredUninstallParentPath)) {'
+    );
+    expect(packager).toContain("Split-Path -Leaf $registeredUninstallParentPath");
+    expect(packager).not.toContain(
+      'Split-Path -Leaf (Split-Path -Parent $registeredUninstallFile)'
+    );
+  });
+
   it('preserves reboot requests observed from asynchronous uninstallers', () => {
     expect(packager).toContain(
       '$script:UninstallRebootExitCode = 3010'


### PR DESCRIPTION
## Summary
- avoid nested Split-Path failure when ARP registers a leaf-only executable such as msiexec.exe
- retain exact captured identity and the existing product-code-bound quiet MSI removal path
- add a generator contract that forbids the empty-parent failure

## Evidence
Surfshark production QA run 32656355484 proved install and detection pass with the visible-primary adapter, then failed at generated uninstall line 375 with ParameterArgumentValidationErrorEmptyStringNotAllowed before product-code parsing.

## Verification
- PowerShell parser passed
- 120 PSADT generator contracts passed
- 85 test files / 1,449 tests passed
- ESLint passed
- production Next.js build passed