### PR TITLE
Release leaf-only uninstall parser to QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1',
+  packagerCommit: '326eafef044af8579bc0089c9556a3d59e26cbe0',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -328,6 +328,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // every passing profile while the reviewed Surfshark primary-ARP selector
   // invalidates only Surfshark through its canonical adapter field.
   'bb762159825bb59be2649f4cff4bf25fbbaef8b8',
+  // The leaf-only uninstall-path repair changes only the exact registered
+  // command parser exercised by Surfshark. Preserve every unrelated compatible
+  // pass from the visible-primary release.
+  '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,10 +6,14 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('carries Surfshark from diagnostics into the visible-primary release', () => {
+  it('carries Surfshark through diagnostics, visible-primary, and leaf-only releases', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' surfshark.surfshark ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1',
+      { wingetId: 'Surfshark.Surfshark', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       'bb762159825bb59be2649f4cff4bf25fbbaef8b8',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -153,7 +153,15 @@ const SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS = [
   ...AMBIGUOUS_UNINSTALL_DIAGNOSTICS_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS = [
+  // Re-run Surfshark after allowing its exact leaf-only msiexec.exe command to
+  // reach the existing product-code parser. Carry every bounded target forward.
+  ...SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '326eafef044af8579bc0089c9556a3d59e26cbe0':
+    LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS,
   '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1':
     SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS,
   'bb762159825bb59be2649f4cff4bf25fbbaef8b8':


### PR DESCRIPTION
Activates packager commit 326eafef044af8579bc0089c9556a3d59e26cbe0 in the production QA scheduler after the same exact commit was pinned in IntuneGet-Workflows #2149.\n\nThe retry remains bounded to Surfshark and carried unconsumed targets. Compatible successful profiles remain reusable.\n\nVerification:\n- 232 focused tests\n- 1,449 full tests\n- ESLint\n- production Next.js build