### PR TITLE
fix(icons): record extractions that reproduce an already-correct icon

### DIFF
--- a/.github/scripts/mark-changed-results.mjs
+++ b/.github/scripts/mark-changed-results.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Records, per extraction result, whether it actually changed any file.
+ *
+ * An extraction that reproduces the bytes already committed is a success that
+ * leaves no diff. The collector builds its committed-apps list from the
+ * publication PR, so such an app never appears there, the database never
+ * learns it is binary-sourced, and it stays heal-eligible: every future wave
+ * downloads the same installer, extracts the same icon, publishes nothing and
+ * records nothing.
+ *
+ * That is not hypothetical. Wave 32657709971 extracted 373 icons successfully
+ * and recorded 7. The other 366 were already correct on disk and had been
+ * re-extracted on every previous wave for the same reason.
+ *
+ * Distinguishing "already correct" from "not published" needs the shard's own
+ * view, because only the shard knows which paths it changed. The collector
+ * cannot infer it: a missing diff and a lost artifact look identical there.
+ *
+ * Usage: mark-changed-results.mjs <changed-paths-file> <output-results-file>
+ * Reads RESULTS_FILE (default icon-results.json).
+ */
+
+import fs from 'node:fs';
+
+const CHANGED_FILE = process.argv[2];
+const OUTPUT_FILE = process.argv[3];
+const RESULTS_FILE = process.env.RESULTS_FILE || 'icon-results.json';
+
+if (!CHANGED_FILE || !OUTPUT_FILE) {
+  console.error('Usage: mark-changed-results.mjs <changed-paths-file> <output-results-file>');
+  process.exit(1);
+}
+
+const results = fs.existsSync(RESULTS_FILE)
+  ? JSON.parse(fs.readFileSync(RESULTS_FILE, 'utf8'))
+  : [];
+
+// Paths look like public/icons/<winget_id>/icon-64.png, so the id is the third
+// segment. Anything shorter is not a package file and is ignored.
+const changed = new Set(
+  (fs.existsSync(CHANGED_FILE) ? fs.readFileSync(CHANGED_FILE, 'utf8') : '')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(p => p.split('/')[2])
+    .filter(Boolean)
+);
+
+let unchanged = 0;
+for (const result of results) {
+  if (result.status !== 'success') continue;
+  result.files_changed = changed.has(result.winget_id);
+  if (!result.files_changed) unchanged++;
+}
+
+fs.writeFileSync(OUTPUT_FILE, JSON.stringify(results, null, 2));
+
+const successes = results.filter(r => r.status === 'success').length;
+console.log(
+  `Annotated ${successes} successes: ${successes - unchanged} changed files, ` +
+    `${unchanged} already matched what is committed`
+);

--- a/.github/scripts/update-icon-db.mjs
+++ b/.github/scripts/update-icon-db.mjs
@@ -37,8 +37,21 @@ async function main() {
   const results = JSON.parse(fs.readFileSync(RESULTS_FILE, 'utf8'));
   const now = new Date().toISOString();
 
-  const toUpdate = results.filter(r => r.status === 'success' && committedApps.has(r.winget_id));
-  console.log(`Marking ${toUpdate.length} healed icons (of ${results.length} results)`);
+  // An extraction whose bytes matched what is already committed produces no
+  // diff, so it is absent from the publication PR. It is still a correct
+  // result: the desired icon is on main. Recording only the committed ones
+  // left those apps looking unhealed forever, so every wave re-downloaded and
+  // re-extracted them. Wave 32657709971 recorded 7 of 373 successes for this
+  // reason. files_changed comes from the shard, which is the only place that
+  // can tell "already correct" apart from "artifact lost".
+  const toUpdate = results.filter(
+    r => r.status === 'success' && (committedApps.has(r.winget_id) || r.files_changed === false)
+  );
+  const alreadyCorrect = toUpdate.filter(r => !committedApps.has(r.winget_id)).length;
+  console.log(
+    `Marking ${toUpdate.length} healed icons (of ${results.length} results); ` +
+      `${alreadyCorrect} already matched what is committed`
+  );
 
   for (const result of toUpdate) {
     const { error } = await supabase
@@ -110,6 +123,7 @@ async function main() {
         '## Icon Heal Results',
         '',
         `- **Healed:** ${toUpdate.length}`,
+        `  - of which already matched what is committed: ${alreadyCorrect}`,
         `- **Failed:** ${failed.length}`,
         ...Object.entries(failureBreakdown).map(([k, v]) => `  - ${k}: ${v}`),
         ''

--- a/.github/workflows/heal-icons.yml
+++ b/.github/workflows/heal-icons.yml
@@ -162,7 +162,6 @@ jobs:
         shell: bash
         run: |
           mkdir -p out
-          cp icon-results.json "out/results-${{ matrix.shard }}.json" 2>/dev/null || echo '[]' > "out/results-${{ matrix.shard }}.json"
           # core.quotePath makes git wrap any path with a non-ASCII byte in
           # quotes and octal-escape it, which tar -T then cannot stat. Nine
           # catalog ids are non-ASCII (ReceitaFederaldoBrasil.SpedContabil and
@@ -180,6 +179,10 @@ jobs:
           else
             echo "No icon files changed in this shard"
           fi
+          # Tells the collector which successes actually wrote something, so an
+          # app whose icon was already correct is recorded rather than being
+          # re-extracted on every future wave.
+          node .github/scripts/mark-changed-results.mjs changed.txt "out/results-${{ matrix.shard }}.json"
 
       - name: Upload shard output
         if: always()


### PR DESCRIPTION
## The campaign could not converge

The collector marks an app healed only if it appears in the publication PR:

```js
const toUpdate = results.filter(r => r.status === 'success' && committedApps.has(r.winget_id));
```

An extraction whose bytes match what is already committed produces **no diff**, so it never enters that list. The database never learns the app is binary-sourced, the row keeps saying `github_avatar`, and the app stays heal-eligible. Every later wave downloads the same installer, extracts the same icon, publishes nothing, and records nothing.

**Wave `32657709971` extracted 373 icons successfully and recorded 7.**

`Azul.Zulu.10.JDK` is typical:

| | |
| --- | --- |
| This wave's extraction | success, `binary_msi` |
| Files on main | already present, byte-identical |
| Database row | `icon_source = github_avatar`, `attempts = 0` |

It had been re-extracted on every previous wave for the same reason, and would have been forever. That is most of what the last few waves were doing.

## The fix

Only the shard knows which paths it wrote. From the collector, "no diff" and "artifact lost" look identical, so the distinction has to be recorded upstream. The shard now annotates each success with `files_changed`, and the collector treats `files_changed === false` as healed.

Results produced by an older shard carry no such field, and `undefined !== false`, so they keep the previous conservative behaviour rather than being marked on a guess.

## Validation

Direct run of the annotator over a fixture with one changed success, one unchanged success and one failure:

```
Annotated 2 successes: 1 changed files, 1 already matched what is committed
Changed.App      success  files_changed= true
Unchanged.App    success  files_changed= false
Failed.App       failed   files_changed= undefined
collector would heal: Changed.App, Unchanged.App
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)