### PR TITLE
Fix Atlassian unattended uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -418,6 +418,12 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['-q']);
     expect(
+      applyApplicationPackagingAdapter(
+        'Atlassian.ServiceManagementLTS',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['-q']);
+    expect(
       applyApplicationPackagingAdapter('Ecosia.EcosiaBrowser', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['--force-uninstall']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1127,6 +1127,13 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-q'],
   },
   {
+    // Jira Service Management registers its install4j uninstaller without an
+    // unattended argument. Atlassian documents `uninstall.exe -q` for quiet
+    // Windows removal; append only -q to the exact captured ARP command.
+    wingetId: 'Atlassian.ServiceManagementLTS',
+    reviewedUninstallArguments: ['-q'],
+  },
+  {
     // Postgres Pro's Windows installer is built from the vendor's PostgreSQL
     // NSIS source and registers an ordinary `PostgreSQL <major> (64bit)` ARP
     // entry. Its generated uninstaller accepts NSIS /S; append that reviewed


### PR DESCRIPTION
Adds Atlassian's documented -q switch to the exact registered Jira Service Management LTS uninstaller. Production QA run 32659022475 installed and detected successfully, but the interactive registered uninstaller left exact registration 3069-1244-9928-3021 and returned PSADT 60001 after the bounded completion deadline.\n\nThe adapter changes only Atlassian.ServiceManagementLTS and is shared by portal/catalog PSADT packaging and QA.\n\nVerification:\n- 265 focused adapter/profile/packager tests\n- 1,449 full tests\n- ESLint\n- production Next.js build\n\nVendor documentation: https://confluence.atlassian.com/display/ADMINJIRASERVER0909/Uninstalling+Jira+applications+from+Windows