### PR TITLE
Release Atlassian quiet uninstall to QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '326eafef044af8579bc0089c9556a3d59e26cbe0',
+  packagerCommit: '2eaa857bc5a1297ec7e7b521307079de4622b0b7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -332,6 +332,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // command parser exercised by Surfshark. Preserve every unrelated compatible
   // pass from the visible-primary release.
   '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1',
+  // The reviewed -q argument changes only Atlassian Service Management LTS.
+  // Preserve every unrelated compatible pass from the parser release.
+  '326eafef044af8579bc0089c9556a3d59e26cbe0',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Atlassian only after activating its documented quiet uninstall', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' atlassian.servicemanagementlts ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '326eafef044af8579bc0089c9556a3d59e26cbe0',
+      { wingetId: 'Atlassian.ServiceManagementLTS', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('carries Surfshark through diagnostics, visible-primary, and leaf-only releases', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -159,7 +159,16 @@ const LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS = [
   ...SURFSHARK_VISIBLE_PRIMARY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Re-run Jira Service Management with Atlassian's documented unattended
+  // uninstaller argument, then carry every still-unconsumed bounded target.
+  'Atlassian.ServiceManagementLTS',
+  ...LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2eaa857bc5a1297ec7e7b521307079de4622b0b7':
+    ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS,
   '326eafef044af8579bc0089c9556a3d59e26cbe0':
     LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS,
   '2d3d1b82c818613b2bd677ddbcf309e1f6dd12b1':


### PR DESCRIPTION
Activates packager merge 2eaa857bc5a1297ec7e7b521307079de4622b0b7 in the production scheduler after IntuneGet-Workflows #2152 pinned the same commit for QA and customer packages.\n\nThe retry is explicit for Atlassian.ServiceManagementLTS and carries existing bounded targets; unrelated passing profiles remain compatible.\n\nVerification:\n- 233 focused tests\n- 1,450 full tests\n- ESLint\n- production Next.js build