### PR TITLE
feat(catalog): public per-app deployment pages, category hubs, and segmented sitemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ packager/work/
 packager/tools/
 packager/.env
 packager/.env.*
+
+# Catalog snapshot runtime artifacts
+/data/

--- a/app/(marketing)/apps/CatalogSearch.tsx
+++ b/app/(marketing)/apps/CatalogSearch.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { Loader2, Search } from "lucide-react";
 import { T, Var, useGT } from "gt-next";
 import { AppIcon } from "@/components/AppIcon";
+import { appCatalogHref } from "@/lib/catalog/seo";
 
 interface SearchResult {
   id: string;
@@ -108,9 +110,10 @@ export function CatalogSearch() {
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {results.map((app) => (
-                <div
+                <Link
                   key={app.id}
-                  className="flex items-center gap-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-4"
+                  href={appCatalogHref(app.id)}
+                  className="group flex items-center gap-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-4 transition-colors hover:border-accent-cyan/40 hover:bg-bg-surface"
                 >
                   <AppIcon
                     packageId={app.id}
@@ -119,14 +122,15 @@ export function CatalogSearch() {
                     size="lg"
                   />
                   <div className="min-w-0">
-                    <p className="truncate font-medium text-text-primary">
+                    <p className="truncate font-medium text-text-primary group-hover:text-accent-cyan">
                       {app.name}
                     </p>
                     <p className="truncate text-sm text-text-muted">
                       {app.publisher}
                     </p>
                   </div>
-                </div>
+                  <span className="sr-only"><T>View deployment details</T></span>
+                </Link>
               ))}
             </div>
           )}

--- a/app/(marketing)/apps/[wingetId]/page.tsx
+++ b/app/(marketing)/apps/[wingetId]/page.tsx
@@ -14,6 +14,7 @@ import { getCatalogSource } from '@/lib/catalog';
 import {
   absoluteAppCatalogUrl,
   appCatalogHref,
+  categoryDisplayName,
   categorySlug,
   resolveCatalogIconUrl,
 } from '@/lib/catalog/seo';
@@ -65,16 +66,38 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
+// Maps the catalog's category slugs to schema.org ApplicationCategory values.
 const schemaCategory: Record<string, string> = {
-  browsers: 'BrowserApplication',
+  audio: 'MultimediaApplication',
+  automation: 'DeveloperApplication',
+  backup: 'UtilitiesApplication',
+  browser: 'BrowserApplication',
+  business: 'BusinessApplication',
+  'cloud-storage': 'UtilitiesApplication',
+  collaboration: 'CommunicationApplication',
   communication: 'CommunicationApplication',
-  development: 'DeveloperApplication',
+  database: 'DeveloperApplication',
+  design: 'DesignApplication',
+  'developer-tools': 'DeveloperApplication',
+  devops: 'DeveloperApplication',
   education: 'EducationalApplication',
-  games: 'GameApplication',
-  multimedia: 'MultimediaApplication',
+  finance: 'FinanceApplication',
+  gaming: 'GameApplication',
+  graphics: 'MultimediaApplication',
+  ide: 'DeveloperApplication',
+  media: 'MultimediaApplication',
+  monitoring: 'UtilitiesApplication',
+  networking: 'UtilitiesApplication',
+  office: 'BusinessApplication',
+  'package-management': 'DeveloperApplication',
+  photo: 'MultimediaApplication',
   productivity: 'BusinessApplication',
+  runtime: 'UtilitiesApplication',
   security: 'SecurityApplication',
+  system: 'UtilitiesApplication',
   utilities: 'UtilitiesApplication',
+  video: 'MultimediaApplication',
+  virtualization: 'UtilitiesApplication',
 };
 
 export default async function AppDetailPage({ params }: PageProps) {
@@ -94,6 +117,7 @@ export default async function AppDetailPage({ params }: PageProps) {
   ]);
   const related = (relatedResult?.data ?? []).filter((item) => item.winget_id !== app.winget_id).slice(0, 6);
   const category = app.category || null;
+  const categoryName = category ? categoryDisplayName(category) : null;
   const categoryHref = category ? `/apps/category/${categorySlug(category)}` : null;
   const recentVersions = versions.slice(0, 10);
   const appSource = app.app_source === 'store' ? 'Microsoft Store' : app.app_source === 'winget' ? 'WinGet' : app.app_source;
@@ -141,7 +165,7 @@ export default async function AppDetailPage({ params }: PageProps) {
 
         <header className="space-y-3">
           <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{app.name}</Var> to Microsoft Intune</T></h1>
-          <p className="text-lg text-text-secondary"><T>Published by <Var>{app.publisher}</Var>{category ? <> in <Var>{category}</Var></> : null}</T></p>
+          <p className="text-lg text-text-secondary"><T>Published by <Var>{app.publisher}</Var>{categoryName ? <> in <Var>{categoryName}</Var></> : null}</T></p>
         </header>
 
         <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6">
@@ -153,9 +177,8 @@ export default async function AppDetailPage({ params }: PageProps) {
                 <div><dt className="text-text-muted"><T>Publisher</T></dt><dd className="text-text-primary"><Var>{app.publisher}</Var></dd></div>
                 {app.homepage && <div><dt className="text-text-muted"><T>Homepage</T></dt><dd><a href={app.homepage} target="_blank" rel="noopener nofollow" className="inline-flex items-center gap-1 text-accent-cyan hover:underline"><T>Visit publisher website</T><ExternalLink className="h-3.5 w-3.5" /></a></dd></div>}
                 {app.license && <div><dt className="text-text-muted"><T>License</T></dt><dd className="text-text-primary"><Var>{app.license}</Var></dd></div>}
-                {category && <div><dt className="text-text-muted"><T>Category</T></dt><dd className="text-text-primary"><Var>{category}</Var></dd></div>}
+                {categoryName && <div><dt className="text-text-muted"><T>Category</T></dt><dd className="text-text-primary">{categoryHref ? <Link href={categoryHref} className="text-accent-cyan hover:underline"><Var>{categoryName}</Var></Link> : <Var>{categoryName}</Var>}</dd></div>}
               </dl>
-              {app.tags && app.tags.length > 0 && <div className="flex flex-wrap gap-2">{app.tags.map((tag) => <span key={tag} className="rounded-full bg-bg-surface px-3 py-1 text-xs text-text-secondary"><Var>{tag}</Var></span>)}</div>}
             </div>
           </div>
         </section>
@@ -164,12 +187,12 @@ export default async function AppDetailPage({ params }: PageProps) {
 
         {qa && <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-6"><h2 className="text-2xl font-semibold text-text-primary"><T>Tested by IntuneGet QA</T></h2><div className="flex items-center gap-2">{qa.outcome === 'Passed' ? <CheckCircle2 className="h-5 w-5 text-green-400" /> : <XCircle className="h-5 w-5 text-red-400" />}<span className="font-medium text-text-primary"><Var>{qa.outcome}</Var></span></div><p className="text-sm text-text-secondary"><T>Version <Var>{qa.tested_version}</Var> tested on <Var>{new Date(qa.tested_at_utc).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</Var>.</T></p></section>}
 
-        {recentVersions.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Version history</T></h2><ol className="grid gap-3 sm:grid-cols-2">{recentVersions.map((version) => <li key={version} className="rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 font-mono text-sm text-text-secondary"><Var>{version}</Var></li>)}</ol></section>}
+        {recentVersions.length > 0 && <section className="space-y-4"><h2 className="text-2xl font-semibold text-text-primary"><T>Recent versions</T></h2><ol className="flex flex-wrap gap-2">{recentVersions.map((version) => <li key={version} className="rounded-lg border border-overlay/10 bg-bg-elevated px-3 py-1.5 font-mono text-sm text-text-secondary"><Var>{version}</Var></li>)}</ol></section>}
 
         <section className="space-y-3"><h2 className="text-2xl font-semibold text-text-primary"><T>How deployment works</T></h2><p className="max-w-3xl text-text-secondary"><T>IntuneGet packages <Var>{app.name}</Var> as a Win32 app and uploads it directly to your Microsoft Intune tenant. You review the package settings, configure assignments, and start the deployment from one guided workflow.</T></p></section>
         <CatalogCta appName={app.name} />
 
-        <section className="space-y-5"><div className="flex flex-wrap items-end justify-between gap-3"><h2 className="text-2xl font-semibold text-text-primary"><T>Related apps</T></h2><div className="flex gap-4 text-sm">{categoryHref && <Link href={categoryHref} className="text-accent-cyan hover:underline"><T>Browse <Var>{category}</Var></T></Link>}<Link href="/apps" className="text-accent-cyan hover:underline"><T>View app catalog</T></Link></div></div>{related.length > 0 && <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{related.map((item) => <CatalogAppCard key={item.winget_id} app={item} />)}</div>}</section>
+        <section className="space-y-5"><div className="flex flex-wrap items-end justify-between gap-3"><h2 className="text-2xl font-semibold text-text-primary"><T>Related apps</T></h2><div className="flex gap-4 text-sm">{categoryHref && <Link href={categoryHref} className="text-accent-cyan hover:underline"><T>Browse <Var>{categoryName}</Var></T></Link>}<Link href="/apps" className="text-accent-cyan hover:underline"><T>View app catalog</T></Link></div></div>{related.length > 0 && <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{related.map((item) => <CatalogAppCard key={item.winget_id} app={item} />)}</div>}</section>
       </main>
       <Footer />
     </div>

--- a/app/(marketing)/apps/[wingetId]/page.tsx
+++ b/app/(marketing)/apps/[wingetId]/page.tsx
@@ -144,11 +144,28 @@ export default async function AppDetailPage({ params }: PageProps) {
     image: resolveCatalogIconUrl(app),
   };
 
-  const deploymentRows: { label: ReactNode; value: string; code?: boolean }[] = [];
+  // Prefer values captured during a passed QA run: those commands were actually
+  // executed in an isolated VM with the reviewed packaging adapters applied,
+  // while version_history values come from the WinGet manifest.
+  const qaVerified = qa?.outcome === 'Passed';
+  const installerType = (qaVerified ? qa.installer_type : null) ?? installer?.installer_type;
+  const silentArgs =
+    (qaVerified ? qa.effective_configuration?.vendorSilentArguments : null) ?? installer?.silent_args;
+  const installCommand = qaVerified ? qa.install_command : null;
+  // uninstall_command can hold the internal REGISTRY_UNINSTALL sentinel, which
+  // means the package replays the app's own registered uninstaller.
+  const rawUninstall = qaVerified ? qa.uninstall_command : null;
+  const uninstallCommand = rawUninstall && !rawUninstall.startsWith('REGISTRY_UNINSTALL') ? rawUninstall : null;
+  const usesRegisteredUninstaller = !!rawUninstall && rawUninstall.startsWith('REGISTRY_UNINSTALL');
+
+  const deploymentRows: { label: ReactNode; value: ReactNode; code?: boolean }[] = [];
   if (app.latest_version) deploymentRows.push({ label: <T>Latest version</T>, value: app.latest_version });
-  if (installer?.installer_type) deploymentRows.push({ label: <T>Installer type</T>, value: installer.installer_type });
+  if (installerType) deploymentRows.push({ label: <T>Installer type</T>, value: installerType });
   if (installer?.installer_scope) deploymentRows.push({ label: <T>Install scope</T>, value: installer.installer_scope });
-  if (installer?.silent_args) deploymentRows.push({ label: <T>Silent install arguments</T>, value: installer.silent_args, code: true });
+  if (silentArgs) deploymentRows.push({ label: <T>Silent install arguments</T>, value: silentArgs, code: true });
+  if (installCommand) deploymentRows.push({ label: <T>Install command</T>, value: installCommand, code: true });
+  if (uninstallCommand) deploymentRows.push({ label: <T>Uninstall command</T>, value: uninstallCommand, code: true });
+  if (usesRegisteredUninstaller) deploymentRows.push({ label: <T>Uninstall</T>, value: <T>Uses the app&apos;s own registered uninstaller</T> });
   if (appSource) deploymentRows.push({ label: <T>App source</T>, value: appSource });
 
   return (
@@ -183,7 +200,7 @@ export default async function AppDetailPage({ params }: PageProps) {
           </div>
         </section>
 
-        {deploymentRows.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Deployment details</T></h2><dl className="divide-y divide-overlay/10 rounded-2xl border border-overlay/10 bg-bg-elevated px-6">{deploymentRows.map((row, index) => <div key={index} className="grid gap-1 py-4 sm:grid-cols-3"><dt className="text-text-muted">{row.label}</dt><dd className="sm:col-span-2 text-text-primary">{row.code ? <code className="rounded bg-bg-deepest px-2 py-1 text-sm"><Var>{row.value}</Var></code> : <Var>{row.value}</Var>}</dd></div>)}</dl>{changelog?.install_path && <p className="text-sm text-text-muted"><T>Observed install path: <Var>{changelog.install_path}</Var></T></p>}</section>}
+        {deploymentRows.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Deployment details</T></h2><dl className="divide-y divide-overlay/10 rounded-2xl border border-overlay/10 bg-bg-elevated px-6">{deploymentRows.map((row, index) => <div key={index} className="grid gap-1 py-4 sm:grid-cols-3"><dt className="text-text-muted">{row.label}</dt><dd className="sm:col-span-2 text-text-primary">{row.code ? <code className="rounded bg-bg-deepest px-2 py-1 text-sm"><Var>{row.value}</Var></code> : <Var>{row.value}</Var>}</dd></div>)}</dl>{qaVerified ? <p className="flex items-center gap-2 text-sm text-text-muted"><CheckCircle2 className="h-4 w-4 shrink-0 text-green-400" aria-hidden="true" /><T>Commands and arguments were captured during an automated QA install of version <Var>{qa.tested_version}</Var> in an isolated Windows VM.</T></p> : <p className="text-sm text-text-muted">{qa ? <T>Values come from the WinGet community manifest.</T> : <T>Values come from the WinGet community manifest. This app has not completed an IntuneGet QA run yet.</T>}</p>}{changelog?.install_path && <p className="text-sm text-text-muted"><T>Observed install path: <Var>{changelog.install_path}</Var></T></p>}</section>}
 
         {qa && <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-6"><h2 className="text-2xl font-semibold text-text-primary"><T>Tested by IntuneGet QA</T></h2><div className="flex items-center gap-2">{qa.outcome === 'Passed' ? <CheckCircle2 className="h-5 w-5 text-green-400" /> : <XCircle className="h-5 w-5 text-red-400" />}<span className="font-medium text-text-primary"><Var>{qa.outcome}</Var></span></div><p className="text-sm text-text-secondary"><T>Version <Var>{qa.tested_version}</Var> tested on <Var>{new Date(qa.tested_at_utc).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</Var>.</T></p></section>}
 

--- a/app/(marketing)/apps/[wingetId]/page.tsx
+++ b/app/(marketing)/apps/[wingetId]/page.tsx
@@ -1,0 +1,177 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound, permanentRedirect } from 'next/navigation';
+import { CheckCircle2, ExternalLink, XCircle } from 'lucide-react';
+import { T, Var } from 'gt-next';
+import type { ReactNode } from 'react';
+import { Header } from '@/components/landing/Header';
+import { Footer } from '@/components/landing/sections/Footer';
+import { AppIcon } from '@/components/AppIcon';
+import { CatalogAppCard } from '@/components/catalog/CatalogAppCard';
+import { CatalogCta } from '@/components/catalog/CatalogCta';
+import { getCatalogSource } from '@/lib/catalog';
+import {
+  absoluteAppCatalogUrl,
+  appCatalogHref,
+  categorySlug,
+  resolveCatalogIconUrl,
+} from '@/lib/catalog/seo';
+
+export const dynamicParams = true;
+export const revalidate = 86400;
+
+type PageProps = { params: Promise<{ wingetId: string }> };
+
+function decodeWingetId(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    notFound();
+  }
+}
+
+const resolveApp = cache(async (encodedId: string) => {
+  const id = decodeWingetId(encodedId);
+  const source = getCatalogSource();
+  const details = await source.getAppByWingetId(id).catch(() => null);
+  if (!details) {
+    const canonical = await source.appExistsCaseInsensitive(id).catch(() => null);
+    if (canonical) permanentRedirect(appCatalogHref(canonical.winget_id));
+    notFound();
+  }
+  if (details.app.is_locale_variant && details.app.parent_winget_id) {
+    permanentRedirect(appCatalogHref(details.app.parent_winget_id));
+  }
+  return details;
+});
+
+export async function generateStaticParams() {
+  return getCatalogSource()
+    .getVerifiedAppIds(100)
+    .then((apps) => apps.map((app) => ({ wingetId: app.winget_id })))
+    .catch(() => []);
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { wingetId } = await params;
+  const { app } = await resolveApp(wingetId);
+  const publisher = app.publisher || 'its publisher';
+  return {
+    title: `Deploy ${app.name} to Microsoft Intune - IntuneGet`,
+    description: `Deploy ${app.name} from ${publisher} with IntuneGet, which packages and uploads it to Microsoft Intune automatically.`,
+    alternates: { canonical: absoluteAppCatalogUrl(app.winget_id) },
+    robots: app.is_verified === true ? undefined : { index: false, follow: true },
+  };
+}
+
+const schemaCategory: Record<string, string> = {
+  browsers: 'BrowserApplication',
+  communication: 'CommunicationApplication',
+  development: 'DeveloperApplication',
+  education: 'EducationalApplication',
+  games: 'GameApplication',
+  multimedia: 'MultimediaApplication',
+  productivity: 'BusinessApplication',
+  security: 'SecurityApplication',
+  utilities: 'UtilitiesApplication',
+};
+
+export default async function AppDetailPage({ params }: PageProps) {
+  const { wingetId } = await params;
+  const details = await resolveApp(wingetId);
+  const { app, versions } = details;
+  const source = getCatalogSource();
+  const [qa, changelog, installer, relatedResult] = await Promise.all([
+    source.getQaResult(app.winget_id).catch(() => null),
+    source.getInstallationChangelog(app.winget_id).catch(() => null),
+    app.latest_version
+      ? source.getVersionInstallerInfo(app.winget_id, app.latest_version).catch(() => null)
+      : Promise.resolve(null),
+    app.category
+      ? source.getPopularApps({ limit: 7, offset: 0, category: app.category, sort: 'popular' }).catch(() => null)
+      : Promise.resolve(null),
+  ]);
+  const related = (relatedResult?.data ?? []).filter((item) => item.winget_id !== app.winget_id).slice(0, 6);
+  const category = app.category || null;
+  const categoryHref = category ? `/apps/category/${categorySlug(category)}` : null;
+  const recentVersions = versions.slice(0, 10);
+  const appSource = app.app_source === 'store' ? 'Microsoft Store' : app.app_source === 'winget' ? 'WinGet' : app.app_source;
+  const applicationCategory = category ? schemaCategory[categorySlug(category)] : undefined;
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://intuneget.com' },
+      { '@type': 'ListItem', position: 2, name: 'App Catalog', item: 'https://intuneget.com/apps' },
+      { '@type': 'ListItem', position: 3, name: app.name, item: absoluteAppCatalogUrl(app.winget_id) },
+    ],
+  };
+  const softwareJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: app.name,
+    publisher: { '@type': 'Organization', name: app.publisher },
+    ...(app.latest_version ? { softwareVersion: app.latest_version } : {}),
+    operatingSystem: 'Windows',
+    ...(applicationCategory ? { applicationCategory } : {}),
+    ...(app.license ? { license: app.license } : {}),
+    image: resolveCatalogIconUrl(app),
+  };
+
+  const deploymentRows: { label: ReactNode; value: string; code?: boolean }[] = [];
+  if (app.latest_version) deploymentRows.push({ label: <T>Latest version</T>, value: app.latest_version });
+  if (installer?.installer_type) deploymentRows.push({ label: <T>Installer type</T>, value: installer.installer_type });
+  if (installer?.installer_scope) deploymentRows.push({ label: <T>Install scope</T>, value: installer.installer_scope });
+  if (installer?.silent_args) deploymentRows.push({ label: <T>Silent install arguments</T>, value: installer.silent_args, code: true });
+  if (appSource) deploymentRows.push({ label: <T>App source</T>, value: appSource });
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareJsonLd) }} />
+      <main id="main-content" className="mx-auto w-full max-w-6xl flex-1 space-y-10 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
+        <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+          <Link href="/" className="hover:text-accent-cyan"><T>Home</T></Link><span>/</span>
+          <Link href="/apps" className="hover:text-accent-cyan"><T>App Catalog</T></Link><span>/</span>
+          <span className="text-text-secondary"><Var>{app.name}</Var></span>
+        </nav>
+
+        <header className="space-y-3">
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{app.name}</Var> to Microsoft Intune</T></h1>
+          <p className="text-lg text-text-secondary"><T>Published by <Var>{app.publisher}</Var>{category ? <> in <Var>{category}</Var></> : null}</T></p>
+        </header>
+
+        <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6">
+          <div className="flex flex-col gap-5 sm:flex-row">
+            <AppIcon packageId={app.winget_id} packageName={app.name} iconPath={app.icon_path} size="2xl" />
+            <div className="min-w-0 space-y-4">
+              {app.description && <p className="text-text-secondary"><Var>{app.description}</Var></p>}
+              <dl className="grid gap-3 text-sm sm:grid-cols-2">
+                <div><dt className="text-text-muted"><T>Publisher</T></dt><dd className="text-text-primary"><Var>{app.publisher}</Var></dd></div>
+                {app.homepage && <div><dt className="text-text-muted"><T>Homepage</T></dt><dd><a href={app.homepage} target="_blank" rel="noopener nofollow" className="inline-flex items-center gap-1 text-accent-cyan hover:underline"><T>Visit publisher website</T><ExternalLink className="h-3.5 w-3.5" /></a></dd></div>}
+                {app.license && <div><dt className="text-text-muted"><T>License</T></dt><dd className="text-text-primary"><Var>{app.license}</Var></dd></div>}
+                {category && <div><dt className="text-text-muted"><T>Category</T></dt><dd className="text-text-primary"><Var>{category}</Var></dd></div>}
+              </dl>
+              {app.tags && app.tags.length > 0 && <div className="flex flex-wrap gap-2">{app.tags.map((tag) => <span key={tag} className="rounded-full bg-bg-surface px-3 py-1 text-xs text-text-secondary"><Var>{tag}</Var></span>)}</div>}
+            </div>
+          </div>
+        </section>
+
+        {deploymentRows.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Deployment details</T></h2><dl className="divide-y divide-overlay/10 rounded-2xl border border-overlay/10 bg-bg-elevated px-6">{deploymentRows.map((row, index) => <div key={index} className="grid gap-1 py-4 sm:grid-cols-3"><dt className="text-text-muted">{row.label}</dt><dd className="sm:col-span-2 text-text-primary">{row.code ? <code className="rounded bg-bg-deepest px-2 py-1 text-sm"><Var>{row.value}</Var></code> : <Var>{row.value}</Var>}</dd></div>)}</dl>{changelog?.install_path && <p className="text-sm text-text-muted"><T>Observed install path: <Var>{changelog.install_path}</Var></T></p>}</section>}
+
+        {qa && <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-6"><h2 className="text-2xl font-semibold text-text-primary"><T>Tested by IntuneGet QA</T></h2><div className="flex items-center gap-2">{qa.outcome === 'Passed' ? <CheckCircle2 className="h-5 w-5 text-green-400" /> : <XCircle className="h-5 w-5 text-red-400" />}<span className="font-medium text-text-primary"><Var>{qa.outcome}</Var></span></div><p className="text-sm text-text-secondary"><T>Version <Var>{qa.tested_version}</Var> tested on <Var>{new Date(qa.tested_at_utc).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</Var>.</T></p></section>}
+
+        {recentVersions.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Version history</T></h2><ol className="grid gap-3 sm:grid-cols-2">{recentVersions.map((version) => <li key={version} className="rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 font-mono text-sm text-text-secondary"><Var>{version}</Var></li>)}</ol></section>}
+
+        <section className="space-y-3"><h2 className="text-2xl font-semibold text-text-primary"><T>How deployment works</T></h2><p className="max-w-3xl text-text-secondary"><T>IntuneGet packages <Var>{app.name}</Var> as a Win32 app and uploads it directly to your Microsoft Intune tenant. You review the package settings, configure assignments, and start the deployment from one guided workflow.</T></p></section>
+        <CatalogCta appName={app.name} />
+
+        <section className="space-y-5"><div className="flex flex-wrap items-end justify-between gap-3"><h2 className="text-2xl font-semibold text-text-primary"><T>Related apps</T></h2><div className="flex gap-4 text-sm">{categoryHref && <Link href={categoryHref} className="text-accent-cyan hover:underline"><T>Browse <Var>{category}</Var></T></Link>}<Link href="/apps" className="text-accent-cyan hover:underline"><T>View app catalog</T></Link></div></div>{related.length > 0 && <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{related.map((item) => <CatalogAppCard key={item.winget_id} app={item} />)}</div>}</section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/(marketing)/apps/browse/page.tsx
+++ b/app/(marketing)/apps/browse/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { T, Var } from 'gt-next';
+import { Header } from '@/components/landing/Header';
+import { Footer } from '@/components/landing/sections/Footer';
+import { CatalogAppCard } from '@/components/catalog/CatalogAppCard';
+import { getCatalogSource } from '@/lib/catalog';
+
+const PAGE_SIZE = 60;
+
+type PageProps = { searchParams: Promise<{ page?: string | string[] }> };
+
+function parsePage(value: string | string[] | undefined): number {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = Number.parseInt(raw || '1', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const page = parsePage((await searchParams).page);
+  const canonical = page === 1 ? 'https://intuneget.com/apps/browse' : `https://intuneget.com/apps/browse?page=${page}`;
+  return {
+    title: `Browse all apps, page ${page} - IntuneGet`,
+    description: 'Browse the complete IntuneGet app catalog for Microsoft Intune deployment.',
+    robots: { index: false, follow: true },
+    alternates: { canonical },
+  };
+}
+
+export default async function BrowseAppsPage({ searchParams }: PageProps) {
+  const page = parsePage((await searchParams).page);
+  const result = await getCatalogSource().getPopularApps({
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+    sort: 'name',
+    verifiedOnly: false,
+  }).catch(() => null);
+  const apps = result?.data ?? [];
+  const totalPages = Math.max(1, Math.ceil((result?.total ?? 0) / PAGE_SIZE));
+  const hasPrevious = page > 1;
+  const hasNext = result !== null && page < totalPages;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <main id="main-content" className="mx-auto w-full max-w-6xl flex-1 space-y-10 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
+        <header className="space-y-3">
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Browse all apps</T></h1>
+          <p className="text-lg text-text-secondary"><T>Explore the complete catalog available for Microsoft Intune deployment.</T></p>
+        </header>
+        {apps.length > 0 ? <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{apps.map((app) => <CatalogAppCard key={app.winget_id} app={app} />)}</div> : <p className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6 text-text-secondary"><T>The catalog is temporarily unavailable. Please try again soon.</T></p>}
+        <nav aria-label="Catalog pagination" className="flex items-center justify-center gap-5">
+          {hasPrevious ? <Link href={page === 2 ? '/apps/browse' : `/apps/browse?page=${page - 1}`} className="rounded-lg border border-overlay/10 bg-bg-elevated px-4 py-2 text-text-primary hover:border-accent-cyan/40"><T>Previous</T></Link> : <span className="rounded-lg border border-overlay/5 px-4 py-2 text-text-muted"><T>Previous</T></span>}
+          <span className="text-sm text-text-secondary"><T>Page <Var>{page}</Var> of <Var>{totalPages}</Var></T></span>
+          {hasNext ? <Link href={`/apps/browse?page=${page + 1}`} className="rounded-lg border border-overlay/10 bg-bg-elevated px-4 py-2 text-text-primary hover:border-accent-cyan/40"><T>Next</T></Link> : <span className="rounded-lg border border-overlay/5 px-4 py-2 text-text-muted"><T>Next</T></span>}
+        </nav>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/(marketing)/apps/category/[slug]/page.tsx
+++ b/app/(marketing)/apps/category/[slug]/page.tsx
@@ -1,0 +1,94 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { T, Var } from 'gt-next';
+import { Header } from '@/components/landing/Header';
+import { Footer } from '@/components/landing/sections/Footer';
+import { CatalogAppCard } from '@/components/catalog/CatalogAppCard';
+import { CatalogCta } from '@/components/catalog/CatalogCta';
+import { getCatalogSource } from '@/lib/catalog';
+import { absoluteAppCatalogUrl, categorySlug } from '@/lib/catalog/seo';
+
+export const revalidate = 86400;
+
+type PageProps = { params: Promise<{ slug: string }> };
+
+const resolveCategory = cache(async (slug: string) => {
+  const categories = await getCatalogSource().getCategories().catch(() => []);
+  const match = categories.find((item) => categorySlug(item.category) === slug);
+  if (!match) notFound();
+  return match;
+});
+
+export async function generateStaticParams() {
+  return getCatalogSource().getCategories()
+    .then((categories) => categories.map(({ category }) => ({ slug: categorySlug(category) })))
+    .catch(() => []);
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const { category } = await resolveCategory(slug);
+  return {
+    title: `Deploy ${category} apps to Microsoft Intune - IntuneGet`,
+    description: `Browse ${category} apps that IntuneGet can package and deploy to Microsoft Intune.`,
+    alternates: { canonical: `https://intuneget.com/apps/category/${slug}` },
+  };
+}
+
+export default async function CategoryPage({ params }: PageProps) {
+  const { slug } = await params;
+  const categoryInfo = await resolveCategory(slug);
+  const result = await getCatalogSource()
+    .getPopularApps({ limit: 60, offset: 0, category: categoryInfo.category, sort: 'popular' })
+    .catch(() => null);
+  const apps = result?.data ?? [];
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://intuneget.com' },
+      { '@type': 'ListItem', position: 2, name: 'App Catalog', item: 'https://intuneget.com/apps' },
+      { '@type': 'ListItem', position: 3, name: categoryInfo.category, item: `https://intuneget.com/apps/category/${slug}` },
+    ],
+  };
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    numberOfItems: apps.length,
+    itemListElement: apps.map((app, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: absoluteAppCatalogUrl(app.winget_id),
+      name: app.name,
+    })),
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }} />
+      <main id="main-content" className="mx-auto w-full max-w-6xl flex-1 space-y-10 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
+        <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+          <Link href="/" className="hover:text-accent-cyan"><T>Home</T></Link><span>/</span>
+          <Link href="/apps" className="hover:text-accent-cyan"><T>App Catalog</T></Link><span>/</span>
+          <span className="text-text-secondary"><Var>{categoryInfo.category}</Var></span>
+        </nav>
+        <header className="space-y-4">
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{categoryInfo.category}</Var> apps to Microsoft Intune</T></h1>
+          <p className="max-w-3xl text-lg text-text-secondary"><T>Explore <Var>{categoryInfo.category}</Var> tools that your organization can package as Win32 apps and upload to Microsoft Intune. IntuneGet keeps the deployment workflow consistent while you choose assignments for each app.</T></p>
+          <p className="text-sm text-text-muted"><T><Var>{categoryInfo.count}</Var> apps are available in this category. Showing up to 60 verified apps.</T></p>
+        </header>
+        <section aria-label="Category apps">
+          {apps.length > 0 ? <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{apps.map((app) => <CatalogAppCard key={app.winget_id} app={app} />)}</div> : <p className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6 text-text-secondary"><T>This category is temporarily unavailable. Return to the app catalog to continue browsing.</T></p>}
+        </section>
+        <CatalogCta />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/app/(marketing)/apps/category/[slug]/page.tsx
+++ b/app/(marketing)/apps/category/[slug]/page.tsx
@@ -8,31 +8,33 @@ import { Footer } from '@/components/landing/sections/Footer';
 import { CatalogAppCard } from '@/components/catalog/CatalogAppCard';
 import { CatalogCta } from '@/components/catalog/CatalogCta';
 import { getCatalogSource } from '@/lib/catalog';
-import { absoluteAppCatalogUrl, categorySlug } from '@/lib/catalog/seo';
+import { absoluteAppCatalogUrl, mergeCategoryCounts } from '@/lib/catalog/seo';
 
 export const revalidate = 86400;
 
 type PageProps = { params: Promise<{ slug: string }> };
 
+// The catalog stores category values with inconsistent casing, so resolve
+// against the merged, slug-keyed list rather than raw values.
 const resolveCategory = cache(async (slug: string) => {
   const categories = await getCatalogSource().getCategories().catch(() => []);
-  const match = categories.find((item) => categorySlug(item.category) === slug);
+  const match = mergeCategoryCounts(categories).find((item) => item.slug === slug);
   if (!match) notFound();
   return match;
 });
 
 export async function generateStaticParams() {
   return getCatalogSource().getCategories()
-    .then((categories) => categories.map(({ category }) => ({ slug: categorySlug(category) })))
+    .then((categories) => mergeCategoryCounts(categories).map(({ slug }) => ({ slug })))
     .catch(() => []);
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const { category } = await resolveCategory(slug);
+  const { name } = await resolveCategory(slug);
   return {
-    title: `Deploy ${category} apps to Microsoft Intune - IntuneGet`,
-    description: `Browse ${category} apps that IntuneGet can package and deploy to Microsoft Intune.`,
+    title: `Deploy ${name} apps to Microsoft Intune - IntuneGet`,
+    description: `Browse ${name} apps that IntuneGet can package and deploy to Microsoft Intune.`,
     alternates: { canonical: `https://intuneget.com/apps/category/${slug}` },
   };
 }
@@ -41,7 +43,7 @@ export default async function CategoryPage({ params }: PageProps) {
   const { slug } = await params;
   const categoryInfo = await resolveCategory(slug);
   const result = await getCatalogSource()
-    .getPopularApps({ limit: 60, offset: 0, category: categoryInfo.category, sort: 'popular' })
+    .getPopularApps({ limit: 60, offset: 0, category: categoryInfo.slug, sort: 'popular' })
     .catch(() => null);
   const apps = result?.data ?? [];
 
@@ -51,7 +53,7 @@ export default async function CategoryPage({ params }: PageProps) {
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://intuneget.com' },
       { '@type': 'ListItem', position: 2, name: 'App Catalog', item: 'https://intuneget.com/apps' },
-      { '@type': 'ListItem', position: 3, name: categoryInfo.category, item: `https://intuneget.com/apps/category/${slug}` },
+      { '@type': 'ListItem', position: 3, name: categoryInfo.name, item: `https://intuneget.com/apps/category/${slug}` },
     ],
   };
   const itemListJsonLd = {
@@ -75,12 +77,12 @@ export default async function CategoryPage({ params }: PageProps) {
         <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
           <Link href="/" className="hover:text-accent-cyan"><T>Home</T></Link><span>/</span>
           <Link href="/apps" className="hover:text-accent-cyan"><T>App Catalog</T></Link><span>/</span>
-          <span className="text-text-secondary"><Var>{categoryInfo.category}</Var></span>
+          <span className="text-text-secondary"><Var>{categoryInfo.name}</Var></span>
         </nav>
         <header className="space-y-4">
-          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{categoryInfo.category}</Var> apps to Microsoft Intune</T></h1>
-          <p className="max-w-3xl text-lg text-text-secondary"><T>Explore <Var>{categoryInfo.category}</Var> tools that your organization can package as Win32 apps and upload to Microsoft Intune. IntuneGet keeps the deployment workflow consistent while you choose assignments for each app.</T></p>
-          <p className="text-sm text-text-muted"><T><Var>{categoryInfo.count}</Var> apps are available in this category. Showing up to 60 verified apps.</T></p>
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{categoryInfo.name}</Var> apps to Microsoft Intune</T></h1>
+          <p className="max-w-3xl text-lg text-text-secondary"><T>Explore <Var>{categoryInfo.name}</Var> tools that your organization can package as Win32 apps and upload to Microsoft Intune. IntuneGet keeps the deployment workflow consistent while you choose assignments for each app.</T></p>
+          <p className="text-sm text-text-muted"><T><Var>{categoryInfo.count.toLocaleString('en-US')}</Var> apps are available in this category. Showing up to 60 verified apps.</T></p>
         </header>
         <section aria-label="Category apps">
           {apps.length > 0 ? <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{apps.map((app) => <CatalogAppCard key={app.winget_id} app={app} />)}</div> : <p className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6 text-text-secondary"><T>This category is temporarily unavailable. Return to the app catalog to continue browsing.</T></p>}

--- a/app/(marketing)/apps/page.tsx
+++ b/app/(marketing)/apps/page.tsx
@@ -1,11 +1,12 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
 import { T, Var } from "gt-next";
 import { Header } from "@/components/landing/Header";
 import { Footer } from "@/components/landing/sections/Footer";
-import { AppIcon } from "@/components/AppIcon";
+import { CatalogAppCard } from "@/components/catalog/CatalogAppCard";
+import { CatalogCta } from "@/components/catalog/CatalogCta";
 import { getCatalogSource } from "@/lib/catalog";
+import { categorySlug } from "@/lib/catalog/seo";
 import { formatAppCountLabel } from "@/lib/stats/public-stats";
 import { CatalogSearch } from "./CatalogSearch";
 
@@ -47,11 +48,12 @@ const breadcrumbJsonLd = {
 
 export default async function AppsPage() {
   const source = getCatalogSource();
-  const [popular, stats] = await Promise.all([
+  const [popular, stats, categories] = await Promise.all([
     source
       .getPopularApps({ limit: 24, offset: 0, sort: "popular" })
       .catch(() => null),
     source.getCatalogStats().catch(() => ({ totalApps: 0 })),
+    source.getCategories().catch(() => []),
   ]);
 
   const apps = popular?.data ?? [];
@@ -108,27 +110,7 @@ export default async function AppsPage() {
             </h2>
             {apps.length > 0 ? (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {apps.map((app) => (
-                  <div
-                    key={app.winget_id}
-                    className="flex items-center gap-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-4"
-                  >
-                    <AppIcon
-                      packageId={app.winget_id}
-                      packageName={app.name}
-                      iconPath={app.icon_path ?? undefined}
-                      size="lg"
-                    />
-                    <div className="min-w-0">
-                      <p className="truncate font-medium text-text-primary">
-                        {app.name}
-                      </p>
-                      <p className="truncate text-sm text-text-muted">
-                        {app.publisher}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+                {apps.map((app) => <CatalogAppCard key={app.winget_id} app={app} />)}
               </div>
             ) : (
               <p className="text-text-secondary">
@@ -140,25 +122,23 @@ export default async function AppsPage() {
             )}
           </section>
 
-          {/* Closing CTA band */}
-          <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-8 text-center space-y-4">
-            <h2 className="text-2xl font-bold text-text-primary">
-              <T>Ready to deploy these apps to Intune?</T>
-            </h2>
-            <p className="mx-auto max-w-xl text-text-secondary">
-              <T>
-                Sign in with your Microsoft work account, pick your apps, and
-                deploy your first one in about 5 minutes.
-              </T>
-            </p>
-            <Link
-              href="/auth/signin"
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 text-base font-semibold text-white bg-accent-cyan rounded-xl hover:bg-accent-cyan-dim transition-all duration-300 shadow-glow-cyan hover:shadow-glow-cyan-lg"
-            >
-              <T>Start Deploying Free</T>
-              <ArrowRight className="h-5 w-5" />
-            </Link>
+          <section aria-labelledby="browse-category-heading" className="space-y-6">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <h2 id="browse-category-heading" className="text-xl font-semibold text-text-primary"><T>Browse by category</T></h2>
+              <Link href="/apps/browse" className="text-sm font-medium text-accent-cyan hover:underline"><T>Browse all apps</T></Link>
+            </div>
+            {categories.length > 0 ? (
+              <div className="flex flex-wrap gap-3">
+                {categories.map(({ category, count }) => (
+                  <Link key={category} href={`/apps/category/${categorySlug(category)}`} className="rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 text-sm text-text-secondary transition-colors hover:border-accent-cyan/40 hover:text-accent-cyan">
+                    <T><Var>{category}</Var> <Var>{count}</Var></T>
+                  </Link>
+                ))}
+              </div>
+            ) : <p className="text-text-secondary"><T>Categories are temporarily unavailable. You can still browse the full catalog.</T></p>}
           </section>
+
+          <CatalogCta />
         </div>
       </main>
 

--- a/app/(marketing)/apps/page.tsx
+++ b/app/(marketing)/apps/page.tsx
@@ -1,12 +1,13 @@
 import { Metadata } from "next";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { T, Var } from "gt-next";
 import { Header } from "@/components/landing/Header";
 import { Footer } from "@/components/landing/sections/Footer";
 import { CatalogAppCard } from "@/components/catalog/CatalogAppCard";
 import { CatalogCta } from "@/components/catalog/CatalogCta";
 import { getCatalogSource } from "@/lib/catalog";
-import { categorySlug } from "@/lib/catalog/seo";
+import { mergeCategoryCounts } from "@/lib/catalog/seo";
 import { formatAppCountLabel } from "@/lib/stats/public-stats";
 import { CatalogSearch } from "./CatalogSearch";
 
@@ -58,6 +59,7 @@ export default async function AppsPage() {
 
   const apps = popular?.data ?? [];
   const countLabel = formatAppCountLabel(stats.totalApps);
+  const mergedCategories = mergeCategoryCounts(categories);
 
   return (
     <div className="min-h-screen bg-bg-deepest flex flex-col">
@@ -123,19 +125,36 @@ export default async function AppsPage() {
           </section>
 
           <section aria-labelledby="browse-category-heading" className="space-y-6">
-            <div className="flex flex-wrap items-end justify-between gap-3">
-              <h2 id="browse-category-heading" className="text-xl font-semibold text-text-primary"><T>Browse by category</T></h2>
-              <Link href="/apps/browse" className="text-sm font-medium text-accent-cyan hover:underline"><T>Browse all apps</T></Link>
-            </div>
-            {categories.length > 0 ? (
+            <h2 id="browse-category-heading" className="text-xl font-semibold text-text-primary"><T>Browse by category</T></h2>
+            {mergedCategories.length > 0 ? (
               <div className="flex flex-wrap gap-3">
-                {categories.map(({ category, count }) => (
-                  <Link key={category} href={`/apps/category/${categorySlug(category)}`} className="rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 text-sm text-text-secondary transition-colors hover:border-accent-cyan/40 hover:text-accent-cyan">
-                    <T><Var>{category}</Var> <Var>{count}</Var></T>
+                {mergedCategories.map(({ slug, name, count }) => (
+                  <Link
+                    key={slug}
+                    href={`/apps/category/${slug}`}
+                    className="group inline-flex items-center gap-2.5 rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-2.5 transition-colors hover:border-accent-cyan/40"
+                  >
+                    <span className="text-sm font-medium text-text-primary group-hover:text-accent-cyan">
+                      <Var>{name}</Var>
+                    </span>
+                    <span className="rounded-full bg-bg-surface px-2 py-0.5 text-xs tabular-nums text-text-muted">
+                      <Var>{count.toLocaleString("en-US")}</Var>
+                    </span>
                   </Link>
                 ))}
               </div>
             ) : <p className="text-text-secondary"><T>Categories are temporarily unavailable. You can still browse the full catalog.</T></p>}
+            <Link
+              href="/apps/browse"
+              className="inline-flex items-center gap-2 rounded-xl border border-accent-cyan/40 px-6 py-3 text-base font-semibold text-accent-cyan transition-colors hover:bg-accent-cyan/10"
+            >
+              {countLabel ? (
+                <T>Browse all <Var>{countLabel}</Var> apps</T>
+              ) : (
+                <T>Browse all apps</T>
+              )}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </section>
 
           <CatalogCta />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,5 +1,7 @@
 import { MetadataRoute } from "next";
 
+const CATALOG_DISALLOW = ["/api/winget/search", "/apps/browse"];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
@@ -15,46 +17,65 @@ export default function robots(): MetadataRoute.Robots {
           "/changelog",
           "/about",
         ],
-        disallow: ["/dashboard/", "/auth/", "/api/", "/onboarding/"],
+        disallow: [
+          "/dashboard/",
+          "/auth/",
+          "/api/",
+          ...CATALOG_DISALLOW,
+          "/onboarding/",
+        ],
       },
       // Explicitly allow AI engine crawlers for GEO
       {
         userAgent: "GPTBot",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "ChatGPT-User",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "PerplexityBot",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "Google-Extended",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "ClaudeBot",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "Applebot-Extended",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "Anthropic-ai",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "CCBot",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
       {
         userAgent: "Bytespider",
         allow: ["/"],
+        disallow: CATALOG_DISALLOW,
       },
     ],
-    sitemap: "https://intuneget.com/sitemap.xml",
+    sitemap: [
+      "https://intuneget.com/sitemap/0.xml",
+      "https://intuneget.com/sitemap/1.xml",
+      "https://intuneget.com/sitemap/2.xml",
+    ],
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from "next";
 import { blogPosts } from "@/lib/data/blog-data";
 import { getCatalogSource } from "@/lib/catalog";
-import { absoluteAppCatalogUrl, categorySlug } from "@/lib/catalog/seo";
+import { absoluteAppCatalogUrl, mergeCategoryCounts } from "@/lib/catalog/seo";
 
 const BASE_URL = "https://intuneget.com";
 
@@ -25,8 +25,8 @@ export default async function sitemap({ id }: { id: Promise<number> }): Promise<
 
   if (sitemapId === 2) {
     const categories = await getCatalogSource().getCategories().catch(() => []);
-    return categories.map(({ category }) => ({
-      url: `${BASE_URL}/apps/category/${categorySlug(category)}`,
+    return mergeCategoryCounts(categories).map(({ slug }) => ({
+      url: `${BASE_URL}/apps/category/${slug}`,
       lastModified: now,
       changeFrequency: "weekly" as const,
       priority: 0.7,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,37 @@
 import { MetadataRoute } from "next";
 import { blogPosts } from "@/lib/data/blog-data";
+import { getCatalogSource } from "@/lib/catalog";
+import { absoluteAppCatalogUrl, categorySlug } from "@/lib/catalog/seo";
 
 const BASE_URL = "https://intuneget.com";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export function generateSitemaps() {
+  return [{ id: 0 }, { id: 1 }, { id: 2 }];
+}
+
+export default async function sitemap({ id }: { id: Promise<number> }): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
+  const sitemapId = await id;
+
+  if (sitemapId === 1) {
+    const apps = await getCatalogSource().getVerifiedAppIds().catch(() => []);
+    return apps.map((app) => ({
+      url: absoluteAppCatalogUrl(app.winget_id),
+      lastModified: now,
+      changeFrequency: "daily" as const,
+      priority: 0.8,
+    }));
+  }
+
+  if (sitemapId === 2) {
+    const categories = await getCatalogSource().getCategories().catch(() => []);
+    return categories.map(({ category }) => ({
+      url: `${BASE_URL}/apps/category/${categorySlug(category)}`,
+      lastModified: now,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    }));
+  }
 
   // Static public pages
   const staticPages: MetadataRoute.Sitemap = [
@@ -18,6 +45,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${BASE_URL}/apps`,
       lastModified: now,
       changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/qa`,
+      lastModified: now,
+      changeFrequency: "daily",
       priority: 0.8,
     },
     {

--- a/components/catalog/CatalogAppCard.tsx
+++ b/components/catalog/CatalogAppCard.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { T, Var } from 'gt-next';
+import { AppIcon } from '@/components/AppIcon';
+import { appCatalogHref } from '@/lib/catalog/seo';
+import type { PopularCuratedAppRow } from '@/lib/catalog/types';
+
+export function CatalogAppCard({ app }: { app: PopularCuratedAppRow }) {
+  return (
+    <Link
+      href={appCatalogHref(app.winget_id)}
+      className="group flex items-center gap-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-4 transition-colors hover:border-accent-cyan/40 hover:bg-bg-surface"
+    >
+      <AppIcon
+        packageId={app.winget_id}
+        packageName={app.name}
+        iconPath={app.icon_path ?? undefined}
+        size="lg"
+      />
+      <div className="min-w-0">
+        <p className="truncate font-medium text-text-primary group-hover:text-accent-cyan">
+          <T><Var>{app.name}</Var></T>
+        </p>
+        <p className="truncate text-sm text-text-muted"><T><Var>{app.publisher}</Var></T></p>
+      </div>
+      <span className="sr-only"><T>View deployment details</T></span>
+    </Link>
+  );
+}

--- a/components/catalog/CatalogCta.tsx
+++ b/components/catalog/CatalogCta.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { T, Var } from 'gt-next';
+
+export function CatalogCta({ appName }: { appName?: string }) {
+  return (
+    <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-8 text-center">
+      <h2 className="text-2xl font-bold text-text-primary">
+        {appName ? <T>Deploy <Var>{appName}</Var> to your tenant</T> : <T>Deploy apps to your tenant</T>}
+      </h2>
+      <p className="mx-auto max-w-xl text-text-secondary">
+        <T>Sign in with your Microsoft work account, choose your apps, and let IntuneGet prepare the deployment.</T>
+      </p>
+      <Link
+        href="/auth/signin"
+        className="inline-flex items-center justify-center gap-2 rounded-xl bg-accent-cyan px-8 py-4 text-base font-semibold text-white shadow-glow-cyan transition-all duration-300 hover:bg-accent-cyan-dim hover:shadow-glow-cyan-lg"
+      >
+        <T>Start deploying free</T>
+        <ArrowRight className="h-5 w-5" />
+      </Link>
+    </section>
+  );
+}

--- a/lib/catalog/seo.ts
+++ b/lib/catalog/seo.ts
@@ -4,6 +4,47 @@ export function categorySlug(category: string): string {
   return category.trim().toLowerCase().replace(/\s+/g, '-');
 }
 
+const CATEGORY_DISPLAY_OVERRIDES: Record<string, string> = {
+  devops: 'DevOps',
+  ide: 'IDEs',
+};
+
+/**
+ * Human-readable category name from a stored category value or slug.
+ * Stored values are lowercase slugs ("developer-tools"), so title-case each
+ * word unless a nicer override exists.
+ */
+export function categoryDisplayName(category: string): string {
+  const slug = categorySlug(category);
+  const override = CATEGORY_DISPLAY_OVERRIDES[slug];
+  if (override) return override;
+  return slug
+    .split('-')
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(' ');
+}
+
+/**
+ * The catalog stores category values with inconsistent casing ("Business" and
+ * "business" both exist), so raw category counts contain duplicates. Merge
+ * them by slug, summing counts, sorted by count descending.
+ */
+export function mergeCategoryCounts(
+  categories: { category: string; count: number }[]
+): { slug: string; name: string; count: number }[] {
+  const merged = new Map<string, number>();
+  for (const { category, count } of categories) {
+    const slug = categorySlug(category);
+    if (!slug) continue;
+    merged.set(slug, (merged.get(slug) ?? 0) + count);
+  }
+  return Array.from(merged, ([slug, count]) => ({
+    slug,
+    name: categoryDisplayName(slug),
+    count,
+  })).sort((a, b) => b.count - a.count);
+}
+
 export function appCatalogHref(wingetId: string): string {
   return `/apps/${encodeURIComponent(wingetId)}`;
 }

--- a/lib/catalog/seo.ts
+++ b/lib/catalog/seo.ts
@@ -1,0 +1,19 @@
+export const CATALOG_BASE_URL = 'https://intuneget.com/apps';
+
+export function categorySlug(category: string): string {
+  return category.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+export function appCatalogHref(wingetId: string): string {
+  return `/apps/${encodeURIComponent(wingetId)}`;
+}
+
+export function absoluteAppCatalogUrl(wingetId: string): string {
+  return `${CATALOG_BASE_URL}/${encodeURIComponent(wingetId)}`;
+}
+
+export function resolveCatalogIconUrl(app: { winget_id: string; icon_path?: string | null }): string {
+  if (app.icon_path?.startsWith('http')) return app.icon_path;
+  const base = (app.icon_path || `/icons/${app.winget_id}/`).replace(/\/?$/, '/');
+  return `https://intuneget.com${base}icon-128.png`;
+}

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -62,6 +62,17 @@ const curatedApps = [
     popularity_rank: 5,
   },
   {
+    id: 5,
+    winget_id: 'Example.Unverified',
+    name: 'Unverified Example',
+    publisher: 'Example',
+    latest_version: '1.0',
+    category: 'Utilities',
+    is_verified: false,
+    is_locale_variant: false,
+    popularity_rank: 99,
+  },
+  {
     id: 4,
     winget_id: 'Google.Chrome.de',
     name: 'Google Chrome (German)',
@@ -222,6 +233,25 @@ describe('SnapshotCatalogSource', () => {
     expect((data || [])[0].winget_id).toBe('Google.Chrome');
   });
 
+  it('getPopularApps can include the full non-variant catalog', async () => {
+    const result = await source.getPopularApps({
+      limit: 10,
+      offset: 0,
+      sort: 'name',
+      verifiedOnly: false,
+    });
+    expect(result?.data.map((app) => app.winget_id)).toContain('Example.Unverified');
+    expect(result?.data.map((app) => app.winget_id)).not.toContain('Google.Chrome.de');
+    expect(result?.total).toBe(4);
+  });
+
+  it('getVerifiedAppIds returns canonical apps in popularity order', async () => {
+    await expect(source.getVerifiedAppIds(2)).resolves.toEqual([
+      { winget_id: 'Google.Chrome' },
+      { winget_id: 'Mozilla.Firefox' },
+    ]);
+  });
+
   it('getCategories returns per-category counts', async () => {
     const cats = await source.getCategories();
     const browsers = cats.find((c) => c.category === 'Browsers');
@@ -325,12 +355,12 @@ describe('SnapshotCatalogSource', () => {
 
   it('getCatalogStats counts all curated apps', async () => {
     const stats = await source.getCatalogStats();
-    expect(stats.totalApps).toBe(4);
+    expect(stats.totalApps).toBe(5);
   });
 
   it('getCategoryCount respects verifiedOnly', async () => {
     expect(await source.getCategoryCount({ verifiedOnly: true })).toBe(4);
-    expect(await source.getCategoryCount({ verifiedOnly: false })).toBe(4);
+    expect(await source.getCategoryCount({ verifiedOnly: false })).toBe(5);
   });
 });
 

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -281,7 +281,7 @@ export class SnapshotCatalogSource implements CatalogSource {
     return withDb(
       (db) => {
         const { limit, offset, category, sort, verifiedOnly = true } = opts;
-        const categoryClause = category ? 'AND category = @category' : '';
+        const categoryClause = category ? 'AND category = @category COLLATE NOCASE' : '';
         const verifiedClause = verifiedOnly ? 'AND is_verified = 1' : '';
         const baseParams: Record<string, unknown> = category ? { category } : {};
 

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -276,17 +276,19 @@ export class SnapshotCatalogSource implements CatalogSource {
     offset: number;
     category?: string | null;
     sort: SearchSort;
+    verifiedOnly?: boolean;
   }): Promise<PopularPackagesResult | null> {
     return withDb(
       (db) => {
-        const { limit, offset, category, sort } = opts;
+        const { limit, offset, category, sort, verifiedOnly = true } = opts;
         const categoryClause = category ? 'AND category = @category' : '';
+        const verifiedClause = verifiedOnly ? 'AND is_verified = 1' : '';
         const baseParams: Record<string, unknown> = category ? { category } : {};
 
         const countRow = db
           .prepare(
             `SELECT COUNT(*) AS c FROM curated_apps
-             WHERE is_verified = 1 AND latest_version IS NOT NULL AND is_locale_variant = 0 ${categoryClause}`
+             WHERE latest_version IS NOT NULL AND is_locale_variant = 0 ${verifiedClause} ${categoryClause}`
           )
           .get(baseParams) as { c: number };
 
@@ -308,7 +310,7 @@ export class SnapshotCatalogSource implements CatalogSource {
           .prepare(
             `SELECT ${CURATED_RPC_COLUMNS}
              FROM curated_apps
-             WHERE is_verified = 1 AND latest_version IS NOT NULL AND is_locale_variant = 0 ${categoryClause}
+             WHERE latest_version IS NOT NULL AND is_locale_variant = 0 ${verifiedClause} ${categoryClause}
              ORDER BY ${orderBy}
              LIMIT @limit OFFSET @offset`
           )
@@ -362,6 +364,23 @@ export class SnapshotCatalogSource implements CatalogSource {
           .all() as { category: string; count: number }[];
 
         return rows.map((r) => ({ category: r.category, count: r.count }));
+      },
+      () => []
+    );
+  }
+
+  async getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]> {
+    return withDb(
+      (db) => {
+        const limitClause = limit === undefined ? '' : 'LIMIT @limit';
+        return db
+          .prepare(
+            `SELECT winget_id FROM curated_apps
+             WHERE is_verified = 1 AND is_locale_variant = 0 AND latest_version IS NOT NULL
+             ORDER BY popularity_rank IS NULL, popularity_rank ASC, winget_id ASC
+             ${limitClause}`
+          )
+          .all(limit === undefined ? {} : { limit }) as { winget_id: string }[];
       },
       () => []
     );

--- a/lib/catalog/snapshot-store.ts
+++ b/lib/catalog/snapshot-store.ts
@@ -23,8 +23,10 @@ import { createHash } from 'node:crypto';
 import { createGunzip } from 'node:zlib';
 import { createReadStream, createWriteStream, existsSync } from 'node:fs';
 import { mkdir, rename, readFile, writeFile, rm, stat } from 'node:fs/promises';
+import { get as httpsGet } from 'node:https';
+import type { IncomingMessage } from 'node:http';
 import { pipeline } from 'node:stream/promises';
-import { Readable, Transform } from 'node:stream';
+import { Transform } from 'node:stream';
 import path from 'node:path';
 import type BetterSqlite3 from 'better-sqlite3';
 
@@ -108,16 +110,50 @@ function assertTables(db: DB): void {
   }
 }
 
+/**
+ * Raw https GET (follows redirects). Uses node:https instead of the global
+ * fetch on purpose: Next.js instruments fetch, and a no-store fetch during a
+ * static/ISR page render marks the route as dynamic and fails the render with
+ * DYNAMIC_SERVER_USAGE. These are infrastructure downloads, not page data, so
+ * they must stay invisible to the framework.
+ */
+function httpsGetStream(url: string, redirectsLeft = 5): Promise<IncomingMessage> {
+  if (!url.startsWith('https://')) {
+    return Promise.reject(
+      new SnapshotUnavailableError('CATALOG_SNAPSHOT_BASE_URL must be an https URL')
+    );
+  }
+  return new Promise((resolve, reject) => {
+    const req = httpsGet(url, (res) => {
+      const status = res.statusCode ?? 0;
+      if (status >= 300 && status < 400 && res.headers.location) {
+        res.resume();
+        if (redirectsLeft <= 0) {
+          reject(new SnapshotUnavailableError('Too many redirects downloading catalog snapshot'));
+          return;
+        }
+        resolve(httpsGetStream(new URL(res.headers.location, url).toString(), redirectsLeft - 1));
+        return;
+      }
+      if (status < 200 || status >= 300) {
+        res.resume();
+        reject(new SnapshotUnavailableError(`Failed to download catalog asset (HTTP ${status})`));
+        return;
+      }
+      resolve(res);
+    });
+    req.on('error', reject);
+  });
+}
+
 async function fetchManifest(): Promise<SnapshotManifest | null> {
   const url = `${baseUrl()}/manifest.json`;
-  if (!url.startsWith('https://')) {
-    throw new SnapshotUnavailableError('CATALOG_SNAPSHOT_BASE_URL must be an https URL');
+  const res = await httpsGetStream(url);
+  const chunks: Buffer[] = [];
+  for await (const chunk of res) {
+    chunks.push(chunk as Buffer);
   }
-  const res = await fetch(url, { cache: 'no-store' });
-  if (!res.ok) {
-    throw new SnapshotUnavailableError(`Failed to fetch catalog manifest (HTTP ${res.status})`);
-  }
-  const manifest = (await res.json()) as SnapshotManifest;
+  const manifest = JSON.parse(Buffer.concat(chunks).toString('utf8')) as SnapshotManifest;
   if (manifest.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
     throw new SnapshotUnavailableError(
       `Catalog snapshot schemaVersion ${manifest.schemaVersion} is not supported by this build (expected ${SNAPSHOT_SCHEMA_VERSION}). Update the app.`
@@ -156,14 +192,7 @@ function byteCap(maxBytes: number, message: string): Transform {
 
 async function downloadGz(dest: string): Promise<void> {
   const url = `${baseUrl()}/catalog.sqlite.gz`;
-  if (!url.startsWith('https://')) {
-    throw new SnapshotUnavailableError('CATALOG_SNAPSHOT_BASE_URL must be an https URL');
-  }
-  const res = await fetch(url, { cache: 'no-store' });
-  if (!res.ok || !res.body) {
-    throw new SnapshotUnavailableError(`Failed to download catalog snapshot (HTTP ${res.status})`);
-  }
-  const source = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
+  const source = await httpsGetStream(url);
   // Cap before the WriteStream, so an over-limit asset never fully lands on disk.
   await pipeline(
     source,
@@ -319,6 +348,12 @@ export async function getSnapshotDb(): Promise<DB> {
   const now = Date.now();
   if (_db && now - _lastCheckedAt < REFRESH_INTERVAL_MS) {
     return _db;
+  }
+  if (!_db && !process.env.CATALOG_SNAPSHOT_FILE) {
+    // Cold start: serve a previously downloaded snapshot immediately and check
+    // for a newer one in the background, so page renders never block on (or
+    // fail with) the network.
+    await openExistingIfPresent().catch(() => false);
   }
   if (!_db) {
     await ensureFresh();

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -113,7 +113,7 @@ export class SupabaseCatalogSource implements CatalogSource {
       baseQuery = baseQuery.eq('is_verified', true);
     }
 
-    const countQuery = category ? baseQuery.eq('category', category) : baseQuery;
+    const countQuery = category ? baseQuery.ilike('category', category) : baseQuery;
     const { count: totalCount, error: countError } = await countQuery;
 
     if (countError) {
@@ -134,7 +134,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     }
 
     if (category) {
-      dataQuery = dataQuery.eq('category', category);
+      dataQuery = dataQuery.ilike('category', category);
     }
 
     switch (sort) {

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -89,6 +89,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     offset: number;
     category?: string | null;
     sort: SearchSort;
+    verifiedOnly?: boolean;
   }): Promise<PopularPackagesResult | null> {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseKey =
@@ -100,14 +101,17 @@ export class SupabaseCatalogSource implements CatalogSource {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const { limit, offset, category, sort } = opts;
+    const { limit, offset, category, sort, verifiedOnly = true } = opts;
 
-    const baseQuery = supabase
+    let baseQuery = supabase
       .from('curated_apps')
       .select('*', { count: 'exact', head: true })
-      .eq('is_verified', true)
       .not('latest_version', 'is', null)
       .eq('is_locale_variant', false);
+
+    if (verifiedOnly) {
+      baseQuery = baseQuery.eq('is_verified', true);
+    }
 
     const countQuery = category ? baseQuery.eq('category', category) : baseQuery;
     const { count: totalCount, error: countError } = await countQuery;
@@ -122,9 +126,12 @@ export class SupabaseCatalogSource implements CatalogSource {
       .select(
         'id, winget_id, name, publisher, latest_version, description, homepage, category, tags, icon_path, popularity_rank, app_source, store_package_id'
       )
-      .eq('is_verified', true)
       .not('latest_version', 'is', null)
       .eq('is_locale_variant', false);
+
+    if (verifiedOnly) {
+      dataQuery = dataQuery.eq('is_verified', true);
+    }
 
     if (category) {
       dataQuery = dataQuery.eq('category', category);
@@ -200,6 +207,38 @@ export class SupabaseCatalogSource implements CatalogSource {
       category: c.category,
       count: c.app_count,
     }));
+  }
+
+  async getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]> {
+    const supabase = serviceOrAnonClient();
+    if (!supabase) return [];
+
+    const pageSize = limit === undefined ? 1000 : Math.min(limit, 1000);
+    const rows: { winget_id: string }[] = [];
+    let offset = 0;
+
+    while (limit === undefined || rows.length < limit) {
+      const requested = limit === undefined ? pageSize : Math.min(pageSize, limit - rows.length);
+      const { data, error } = await supabase
+        .from('curated_apps')
+        .select('winget_id')
+        .eq('is_verified', true)
+        .eq('is_locale_variant', false)
+        .not('latest_version', 'is', null)
+        .order('popularity_rank', { ascending: true, nullsFirst: false })
+        .order('winget_id', { ascending: true })
+        .range(offset, offset + requested - 1);
+
+      if (error) {
+        console.error('Failed to list verified catalog apps:', error.message);
+        return rows;
+      }
+      const page = (data || []) as { winget_id: string }[];
+      rows.push(...page);
+      if (page.length < requested) break;
+      offset += page.length;
+    }
+    return rows;
   }
 
   async getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null> {

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -171,6 +171,7 @@ export interface CatalogSource {
     offset: number;
     category?: string | null;
     sort: SearchSort;
+    verifiedOnly?: boolean;
   }): Promise<PopularPackagesResult | null>;
 
   /** RPC get_popular_curated_apps (normalized in winget-api). */
@@ -181,6 +182,9 @@ export interface CatalogSource {
 
   /** RPC get_curated_categories. */
   getCategories(): Promise<CategoryCount[]>;
+
+  /** Verified, canonical app ids for prerendering and segmented sitemaps. */
+  getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]>;
 
   /** curated_apps count(head) with optional is_verified filter. */
   getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null>;

--- a/tasks/app-catalog-seo-result.md
+++ b/tasks/app-catalog-seo-result.md
@@ -1,0 +1,33 @@
+# App catalog SEO result
+
+## Summary
+
+Implemented all six feature sections:
+
+- Added canonical per-app deployment pages with ISR, top-100 static generation, case and locale redirects, verified-only indexing, deployment and QA data, version history, related apps, metadata, and JSON-LD.
+- Added category hubs generated from catalog categories, plus a noindex paginated browse layer for the full non-locale catalog.
+- Updated `/apps` and public search results with detail links, category navigation, full-catalog browsing, and shared catalog cards and calls to action.
+- Added catalog-source support for full-catalog browsing and paginated verified ID listing in both Supabase and snapshot implementations, with snapshot coverage.
+- Split the sitemap into static, verified app, and category segments, added `/qa`, and excluded browse and search surfaces through robots rules.
+
+## Decisions
+
+- Existing `getPopularApps` callers remain verified-only by default. The browse page opts into unverified rows with `verifiedOnly: false`.
+- Verified sitemap IDs are fetched in batches so Supabase's per-request row cap cannot truncate the sitemap.
+- Detail lookup is request-cached so metadata and page rendering reuse the same catalog resolution.
+- Missing catalog data resolves to a real 404 for dynamic detail and category routes, while list surfaces render a friendly unavailable state.
+
+## Verification
+
+- `npm run lint`: passed.
+- Production TypeScript check with repository test files excluded: passed (`npx tsc --noEmit -p tsconfig.feature-check.json`; the temporary config was removed afterward).
+- Full `npx tsc --noEmit`: feature code is clean, but the repository currently fails on pre-existing test-global and unrelated fixture type errors, including missing `vi` and `describe` globals.
+- Catalog Vitest: could not start because the sandbox denied Vite's child-process spawn with `EPERM`.
+- `npm run build:ci`: reached the production compile, then failed because the optional native `better-sqlite3` package could not be installed in this sandbox.
+- `git diff --check`: passed.
+- User-facing app catalog copy contains no em dash or en dash characters.
+
+## Skipped or blocked
+
+- No feature section was skipped.
+- Logical commits could not be created because this linked worktree stores its Git index under the parent repository outside the writable workspace. Git failed to create `index.lock` with `Permission denied`. No push was attempted.

--- a/tasks/app-catalog-seo-spec.md
+++ b/tasks/app-catalog-seo-spec.md
@@ -1,0 +1,93 @@
+# App catalog SEO: per-app pages, category hubs, browse, segmented sitemaps
+
+## Goal
+
+Turn the public /apps marketing page into a real catalog surface with per-app detail pages built for the query space "deploy [app] to Microsoft Intune". Strategy: full catalog browsable for users, curated (verified) subset indexable for Google. Everything below is public and unauthenticated.
+
+All catalog reads MUST go through the existing `CatalogSource` abstraction (`lib/catalog/index.ts`, `getCatalogSource()`, interface in `lib/catalog/types.ts`). Do not query Supabase directly from pages. Follow the existing marketing-page conventions in `app/(marketing)/apps/page.tsx`: `Header`/`Footer` components, gt-next `<T>`/`<Var>` for user-facing copy, Tailwind token classes (bg-bg-deepest, text-text-primary, accent-cyan etc.), `AppIcon` component.
+
+HARD COPY RULE: never use em dashes or en dashes in any user-facing text. Restructure the sentence instead.
+
+## 1. Per-app detail pages: `app/(marketing)/apps/[wingetId]/page.tsx`
+
+Routing and rendering:
+- Dynamic segment is the winget id (e.g. `Google.Chrome`). Winget ids contain dots; they are fine in a path segment. Decode with `decodeURIComponent`.
+- `generateStaticParams`: prerender only the top ~100 apps (verified, ordered by `popularity_rank`) to keep builds fast. Set `export const dynamicParams = true` so every other app renders on demand, and `export const revalidate = 86400` (1 day ISR).
+- Resolution logic:
+  - Load via `source.getAppByWingetId(id)`.
+  - If not found, try `source.appExistsCaseInsensitive(id)`; on a hit, `permanentRedirect` to the canonical-cased URL. Otherwise `notFound()` (real 404, no soft-200 shells).
+  - If `app.is_locale_variant` is true and `parent_winget_id` is set, `permanentRedirect` to the parent's page. We do not want pages for translated/locale variants at all.
+- Indexability gate: if `app.is_verified` is not true, add `robots: { index: false, follow: true }` to the page metadata. Verified apps are indexable; the long tail renders for users but stays out of the index.
+
+Data to fetch (parallel, each with `.catch(() => null)` so one failure does not 500 the page):
+- `getAppByWingetId(id)` for the app row, versions list, locale variants (ignore variants beyond the redirect above).
+- `getQaResult(wingetId)` for the latest QA outcome.
+- `getInstallationChangelog(wingetId)` for install behavior snapshot.
+- `getVersionInstallerInfo(wingetId, latest_version)` for installer type, scope, silent args.
+- Related apps: same `category`, verified, by popularity, excluding self, 6 items. Use `getPopularPackages(limit, category)` and filter, or the closest existing method. Do NOT add new RPCs or migrations; if a needed query does not exist on `CatalogSource`, add a method to the interface and implement it in `supabase-source.ts` AND `snapshot-source.ts` following the existing patterns exactly (both implementations, plus reasonable handling in tests if the existing test files cover the surface).
+
+Page content, in order (all copy Intune-framed, not app-marketing-framed):
+1. Breadcrumb (Home / App Catalog / {name}) + matching BreadcrumbList JSON-LD.
+2. H1: "Deploy {name} to Microsoft Intune". Subline with publisher and category.
+3. App card: AppIcon, description, publisher, homepage link (rel="noopener nofollow"), license, category, tags.
+4. "Deployment details" section: latest version, installer type, install scope (machine/user), silent install arguments (code-styled), app source. Only render rows that have data.
+5. QA section: if a QA result exists, show status (passed/failed), version tested, and when. Frame as "Tested by IntuneGet QA". If none, omit the section entirely (no empty placeholders).
+6. Version history: up to 10 recent versions from the versions list. Omit if empty.
+7. How-it-works blurb: 2-3 sentences on what happens when you deploy this app with IntuneGet (packaged as Win32, uploaded to your tenant, assignments configured). Keep generic but concrete.
+8. CTA band: "Deploy {name} to your tenant" linking to /auth/signin, same styling as the existing CTA band on /apps.
+9. Related apps grid: 6 cards linking to their detail pages, plus a link to the app's category hub and to /apps.
+
+Metadata:
+- Title: "Deploy {name} to Microsoft Intune - IntuneGet". Description: one sentence with app name, publisher, and that IntuneGet packages and uploads it to Intune automatically. Canonical: `https://intuneget.com/apps/{winget_id}` (exact stored casing).
+- JSON-LD `SoftwareApplication`: name, publisher as Organization, softwareVersion (latest), operatingSystem "Windows", applicationCategory (map from category, fallback omit), license URL/text if present, image (icon URL if resolvable). Do NOT emit aggregateRating or offers.
+
+## 2. Category hub pages: `app/(marketing)/apps/category/[slug]/page.tsx`
+
+- Categories come from `source.getCategories()` (name + count). Slugify with a small helper (lowercase, spaces to hyphens); keep a slug-to-category resolver that works by slugifying each known category and matching (no hardcoded list). Unknown slug: `notFound()`.
+- `generateStaticParams` from `getCategories()`, `revalidate = 86400`.
+- Content: H1 "Deploy {Category} apps to Microsoft Intune", one short intro paragraph per category (write a generic but category-aware template sentence set; 2-3 sentences, no filler), grid of apps in the category (verified first, by popularity, server-rendered, cap at 60) with cards linking to detail pages, count line, CTA band.
+- JSON-LD: `ItemList` of the listed app detail URLs + BreadcrumbList.
+- Indexable, canonical `https://intuneget.com/apps/category/{slug}`.
+
+## 3. Browse page (UX layer, not an SEO target): `app/(marketing)/apps/browse/page.tsx`
+
+- Server-rendered paginated list of the whole catalog: 60 per page, `?page=N` searchParams, ordered by name. Use `getPopularApps({ limit, offset, sort: "name" })`.
+- Locale variants must not appear. If the existing method returns them, add a filter (or extend the CatalogSource method with an option) so variants are excluded.
+- Simple prev/next pagination plus a page indicator. Each card links to the detail page.
+- Metadata: `robots: { index: false, follow: true }` on every browse page (deliberate: this layer is for users and crawl paths, not for ranking). Self-canonical.
+
+## 4. Update `/apps` (`app/(marketing)/apps/page.tsx` and `CatalogSearch.tsx`)
+
+- Popular-app cards become `<Link>` to their detail pages (keep exact visual style, add hover state consistent with site).
+- Add a "Browse by category" section: chips/cards for each category (name + count) linking to hubs.
+- Add a "Browse all apps" link to `/apps/browse`.
+- `CatalogSearch` result cards become links to detail pages (client-side `<Link>`).
+
+## 5. Sitemaps
+
+- Convert app sitemap output to segmented sitemaps using Next's `generateSitemaps` in `app/sitemap.ts` (or split files if cleaner with the App Router API in this Next version; check `package.json` for the version and use the supported pattern):
+  - Segment 0: existing static + docs + blog pages, PLUS the missing `/qa` page.
+  - Segment 1 (apps-core): all VERIFIED, non-locale-variant app detail URLs. Add a `CatalogSource` method to list them (winget_id only, verified filter) implemented in both sources.
+  - Segment 2 (apps-categories): category hub URLs.
+- Browse pages stay out of all sitemaps.
+
+## 6. robots.ts
+
+- Add `Disallow: /api/winget/search` and `Disallow: /apps/browse` for all user agents (keep existing rules intact).
+
+## Constraints and quality bar
+
+- TypeScript strict, no `any` unless the surrounding file already does it.
+- No new dependencies. No database migrations. No new RPCs.
+- Both `SupabaseCatalogSource` and `SnapshotCatalogSource` must implement any interface additions; run the existing catalog tests.
+- All user-facing strings wrapped in gt-next `<T>`/`<Var>` following the existing pages, and NO em/en dashes anywhere in copy.
+- Handle the catalog source being unavailable gracefully on every new page (render a friendly fallback or 404, never a crash).
+- Icons in grids: keep using `AppIcon` (it already handles sizing).
+- Verify with: `npm run lint` and `npx tsc --noEmit` (or the repo's typecheck script; check package.json). Run `npm run build` if feasible; if the build needs env vars that are missing, note that instead of faking them.
+- Commit your work in logical commits on the current branch (`feat/app-catalog-seo`). Do not push.
+
+## Definition of done
+
+- All six sections above implemented.
+- Lint and typecheck clean.
+- A short SUMMARY of what was built, decisions taken, and anything skipped, written to `tasks/app-catalog-seo-result.md`.


### PR DESCRIPTION
## Summary

Turns the public /apps page into a real catalog surface built for the query space "deploy [app] to Microsoft Intune". Strategy: the full catalog is browsable for users, while only the verified subset is indexable for search engines.

- **Per-app deployment pages** at `/apps/[wingetId]`: description, publisher, license, deployment details (installer type, scope, silent args), QA results, version history, related apps, and a deploy CTA. Top 100 verified apps prerendered, the rest render on demand with daily ISR. Case-mismatched ids and locale variants permanently redirect to the canonical page; unknown ids 404. Verified apps carry SoftwareApplication + BreadcrumbList JSON-LD; unverified apps are noindexed.
- **Category hubs** at `/apps/category/[slug]` with ItemList JSON-LD, generated from `get_curated_categories`.
- **Full-catalog browse** at `/apps/browse` (paginated, noindexed by design: it is a UX layer and crawl path, not a ranking target).
- **/apps updates**: popular cards and public search results now link to detail pages; new category navigation section.
- **Segmented sitemaps** via `generateSitemaps` (static pages / verified app pages / category hubs), the previously missing `/qa` entry, and robots rules pointing at the new sitemap files while disallowing `/api/winget/search` and `/apps/browse`.
- **Data layer**: `CatalogSource.getVerifiedAppIds` and a `verifiedOnly` opt-out on `getPopularApps`, implemented in both the Supabase and snapshot sources, with snapshot test coverage.

No new dependencies, no migrations, no new RPCs. All catalog reads go through `CatalogSource`.

## Verification

- `npm run lint` passes.
- `npx tsc --noEmit`: no new errors introduced (branch: 548, main baseline: 557, all pre-existing test-global typing issues).
- `npx vitest run lib/catalog`: 53/53 pass.
- `npm run build:ci` succeeds; build output confirms the segmented sitemaps at `/sitemap/{0,1,2}.xml` and the prerendered detail/category routes.

Implemented by Codex (gpt-5.6-sol) from a written spec (`tasks/app-catalog-seo-spec.md`), reviewed and fixed up by Claude: corrected the robots.txt sitemap reference for the segmented sitemap URLs and updated two snapshot fixture assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)