### PR TITLE
Use idle QA capacity for catalog backfill

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -80,6 +80,7 @@ function createSupabaseStub(options: {
   candidates?: Array<Record<string, unknown>>;
   candidatePages?: Array<Array<Record<string, unknown>>>;
   demandBackfillApps?: string[];
+  catalogBackfillApps?: string[];
   deployedApps?: string[];
   pollState?: Record<string, unknown>;
   packageResults?: Array<Record<string, unknown>>;
@@ -100,6 +101,12 @@ function createSupabaseStub(options: {
       rpcCalls.push({ name, args });
       if (name === 'record_qa_demand_backfill_selection') {
         return Promise.resolve({ data: null, error: null });
+      }
+      if (name === 'qa_idle_catalog_backfill_ids') {
+        return Promise.resolve({
+          data: (options.catalogBackfillApps || []).map((winget_id) => ({ winget_id })),
+          error: null,
+        });
       }
       if (name !== 'qa_missing_demand_backfill_ids') {
         throw new Error(`Unexpected RPC: ${name}`);
@@ -445,6 +452,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     ]);
     expect(rpcCalls).toEqual([
       { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 20 } },
+      { name: 'qa_idle_catalog_backfill_ids', args: { p_limit: 3 } },
     ]);
     expect(pollRunUpdates).toEqual([
       expect.objectContaining({
@@ -454,6 +462,8 @@ describe('GET /api/cron/qa-enqueue', () => {
         supported_changed_count: 0,
         demand_backfill_requested_count: 0,
         demand_backfill_count: 0,
+        catalog_backfill_requested_count: 0,
+        catalog_backfill_count: 0,
       }),
     ]);
   });
@@ -526,6 +536,10 @@ describe('GET /api/cron/qa-enqueue', () => {
       name: 'record_qa_demand_backfill_selection',
       args: { p_winget_ids: ['Missing.App'] },
     });
+    expect(rpcCalls).toContainEqual({
+      name: 'qa_idle_catalog_backfill_ids',
+      args: { p_limit: 3 },
+    });
     expect(candidateInserts[0]).toMatchObject({
       winget_id: 'Missing.App',
       version: '1.0.0',
@@ -538,6 +552,98 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(pollRunUpdates[0]).toMatchObject({
       demand_backfill_requested_count: 1,
       demand_backfill_count: 1,
+      catalog_backfill_requested_count: 0,
+      catalog_backfill_count: 0,
+    });
+  });
+
+  it('queues popularity-ranked catalog coverage when higher-priority demand is empty', async () => {
+    const { client, candidateInserts, pollRunUpdates, rpcCalls } = createSupabaseStub({
+      catalogBackfillApps: ['Popular.CatalogApp'],
+      supportedApps: [
+        {
+          winget_id: 'Popular.CatalogApp',
+          name: 'Popular Catalog App',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+      deployedApps: [],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      demandBackfillRequestedCount: 0,
+      catalogBackfillRequestedCount: 1,
+      catalogBackfillCount: 1,
+    });
+    expect(rpcCalls).toContainEqual({
+      name: 'qa_idle_catalog_backfill_ids',
+      args: { p_limit: 3 },
+    });
+    expect(candidateInserts).toEqual([
+      expect.objectContaining({
+        winget_id: 'Popular.CatalogApp',
+        status: 'queued',
+        priority: 0,
+        demand_source: 'catalog',
+        catalog_version_at_enqueue: '1.0.0',
+        test_config: expect.objectContaining({ profileKind: 'catalog-default' }),
+      }),
+    ]);
+    expect(pollRunUpdates[0]).toMatchObject({
+      catalog_backfill_requested_count: 1,
+      catalog_backfill_count: 1,
+    });
+  });
+
+  it('keeps customer demand ahead of catalog work selected during the same idle poll', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      demandBackfillApps: ['Customer.App'],
+      catalogBackfillApps: ['Catalog.App'],
+      supportedApps: [
+        {
+          winget_id: 'Customer.App',
+          name: 'Customer App',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+        {
+          winget_id: 'Catalog.App',
+          name: 'Catalog App',
+          publisher: 'Contoso',
+          latest_version: '1.0.0',
+        },
+      ],
+      deployedApps: ['Customer.App'],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 2,
+      queued: 2,
+      demandBackfillCount: 1,
+      catalogBackfillCount: 1,
+    });
+    expect(candidateInserts.find((row) => row.winget_id === 'Customer.App')).toMatchObject({
+      priority: 1,
+      demand_source: 'managed',
+    });
+    expect(candidateInserts.find((row) => row.winget_id === 'Catalog.App')).toMatchObject({
+      priority: 0,
+      demand_source: 'catalog',
     });
   });
 

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -57,6 +57,7 @@ const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
 // deployed-app demand per poll to avoid spending hours reclassifying known
 // payloads three at a time.
 const DEMAND_BACKFILL_BATCH_SIZE = 20;
+const IDLE_CATALOG_BACKFILL_BATCH_SIZE = 3;
 const MAX_TARGETED_PACKAGE_IDS = 20;
 const TARGETED_QA_PRIORITY = 1_000;
 
@@ -374,6 +375,22 @@ async function findDemandBackfillIds(
   );
 }
 
+async function findIdleCatalogBackfillIds(
+  supabase: ReturnType<typeof createServerClient>
+): Promise<string[]> {
+  const { data, error } = await supabase.rpc('qa_idle_catalog_backfill_ids', {
+    p_limit: IDLE_CATALOG_BACKFILL_BATCH_SIZE,
+  });
+  if (error) throw new Error(`Could not select idle catalog QA backfill: ${error.message}`);
+  return Array.from(
+    new Set(
+      ((data || []) as Array<{ winget_id?: unknown }>)
+        .map((row) => (typeof row.winget_id === 'string' ? row.winget_id.trim() : ''))
+        .filter(Boolean)
+    )
+  );
+}
+
 async function persistQaCatalogReconciliation(
   supabase: ReturnType<typeof createServerClient>,
   input: {
@@ -435,6 +452,8 @@ export async function GET(request: Request) {
   let toolchainBackfillPagesScanned = 0;
   let demandBackfillRequestedCount = 0;
   let demandBackfillCount = 0;
+  let catalogBackfillRequestedCount = 0;
+  let catalogBackfillCount = 0;
   let targetedCount = 0;
   let baseSha: string | null = null;
   let headSha: string | null = null;
@@ -468,6 +487,8 @@ export async function GET(request: Request) {
         supported_changed_count: supportedChangedCount,
         demand_backfill_requested_count: demandBackfillRequestedCount,
         demand_backfill_count: demandBackfillCount,
+        catalog_backfill_requested_count: catalogBackfillRequestedCount,
+        catalog_backfill_count: catalogBackfillCount,
       })
       .eq('id', runId);
     if (error) throw new Error(`Could not finalize QA poll run ${runId}: ${error.message}`);
@@ -568,12 +589,14 @@ export async function GET(request: Request) {
         `WinGet GitHub change feed paused until ${changes.rateLimitedUntil}`
       );
     }
-    const [backfill, demandBackfillIds] = await Promise.all([
+    const [backfill, demandBackfillIds, catalogBackfillIds] = await Promise.all([
       findToolchainBackfillIds(supabase),
       findDemandBackfillIds(supabase),
+      findIdleCatalogBackfillIds(supabase),
     ]);
     toolchainBackfillPagesScanned = backfill.pagesScanned;
     demandBackfillRequestedCount = demandBackfillIds.length;
+    catalogBackfillRequestedCount = catalogBackfillIds.length;
     if (demandBackfillIds.length > 0) {
       const { error: demandSelectionError } = await supabase.rpc(
         'record_qa_demand_backfill_selection',
@@ -588,9 +611,16 @@ export async function GET(request: Request) {
     const changedIds = new Set(changes.changedPackageIds);
     const backfillIds = new Set(backfill.ids);
     const demandBackfillIdSet = new Set(demandBackfillIds);
+    const catalogBackfillIdSet = new Set(catalogBackfillIds);
     const targetedIdSet = new Set(requestedPackageIds);
     const targetPackageIds = Array.from(
-      new Set([...changedIds, ...backfillIds, ...demandBackfillIdSet, ...targetedIdSet])
+      new Set([
+        ...changedIds,
+        ...backfillIds,
+        ...demandBackfillIdSet,
+        ...catalogBackfillIdSet,
+        ...targetedIdSet,
+      ])
     );
 
     structuredQaPollLog('info', 'qa_poll_started', {
@@ -604,6 +634,7 @@ export async function GET(request: Request) {
       toolchainBackfillRequestedCount: backfill.ids.length,
       toolchainBackfillPagesScanned,
       demandBackfillRequestedCount,
+      catalogBackfillRequestedCount,
       targetedRequestedCount: requestedPackageIds.length,
     });
 
@@ -712,7 +743,9 @@ export async function GET(request: Request) {
       demandedIds.add(deployed.winget_id);
       if (!priorities.has(deployed.winget_id)) priorities.set(deployed.winget_id, 1);
     }
-    supportedApps = supportedApps.filter((app) => demandedIds.has(app.winget_id));
+    supportedApps = supportedApps.filter((app) =>
+      demandedIds.has(app.winget_id) || catalogBackfillIdSet.has(app.winget_id)
+    );
     targetedCount = supportedApps.filter((app) => targetedIdSet.has(app.winget_id)).length;
     for (const app of supportedApps) {
       if (targetedIdSet.has(app.winget_id)) {
@@ -726,6 +759,9 @@ export async function GET(request: Request) {
     toolchainBackfillCount = supportedApps.filter((app) => backfillIds.has(app.winget_id)).length;
     demandBackfillCount = supportedApps.filter((app) =>
       demandBackfillIdSet.has(app.winget_id)
+    ).length;
+    catalogBackfillCount = supportedApps.filter((app) =>
+      catalogBackfillIdSet.has(app.winget_id)
     ).length;
     const recipeById = new Map(recipes.map((row) => [row.winget_id, row]));
     const passedResultByPayload = new Map<string, (typeof results)[number]>();
@@ -982,7 +1018,9 @@ export async function GET(request: Request) {
                   ? 'auto_update'
                   : targetedIdSet.has(app.winget_id)
                     ? 'operator'
-                  : 'managed',
+                    : catalogBackfillIdSet.has(app.winget_id)
+                      ? 'catalog'
+                      : 'managed',
                 failure_summary: !packagingContract.valid
                   ? `Packaging preflight: ${packagingContract.message}`
                   : null,
@@ -1130,6 +1168,8 @@ export async function GET(request: Request) {
       toolchainBackfillPagesScanned,
       demandBackfillRequestedCount,
       demandBackfillCount,
+      catalogBackfillRequestedCount,
+      catalogBackfillCount,
       targetedRequestedCount: requestedPackageIds.length,
       targetedCount,
       ...summary,
@@ -1150,6 +1190,8 @@ export async function GET(request: Request) {
         toolchainBackfillPagesScanned,
         demandBackfillRequestedCount,
         demandBackfillCount,
+        catalogBackfillRequestedCount,
+        catalogBackfillCount,
         targetedRequestedCount: requestedPackageIds.length,
         targetedCount,
         ...summary,
@@ -1192,6 +1234,8 @@ export async function GET(request: Request) {
         toolchainBackfillPagesScanned,
         demandBackfillRequestedCount,
         demandBackfillCount,
+        catalogBackfillRequestedCount,
+        catalogBackfillCount,
         targetedRequestedCount: requestedPackageIds.length,
         targetedCount,
         ...summary,

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1372,3 +1372,32 @@ describe('QA live-version reconciliation migration contract', () => {
     expect(sql).toContain('limit greatest(1, least(coalesce(p_limit, 3), 100))');
   });
 });
+
+describe('QA idle catalog backfill migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260824101502_add_qa_idle_catalog_backfill.sql'
+    ),
+    'utf8'
+  );
+
+  it('uses idle capacity only and keeps the selector private', () => {
+    expect(sql).toContain("waiting_work.status = 'queued'");
+    expect(sql).toContain("active_work.status in ('dispatched', 'running')");
+    expect(sql).toContain('security invoker');
+    expect(sql).toContain('from public, anon, authenticated');
+    expect(sql).toContain('to service_role');
+    expect(sql).toContain('limit greatest(1, least(coalesce(p_limit, 3), 20))');
+  });
+
+  it('selects popular verified Win32 apps without bypassing QA safety state', () => {
+    expect(sql).toContain("app.app_source = 'win32'");
+    expect(sql).toContain('app.popularity_rank asc nulls last');
+    expect(sql).toContain('app.chocolatey_downloads desc nulls last');
+    expect(sql).toContain('from public.package_eligibility_blocks as eligibility_block');
+    expect(sql).toContain('from public.qa_package_blocks as block');
+    expect(sql).toContain('candidate.version = app.latest_version');
+    expect(sql).toContain('poll_state.head_sha = reconciliation.observed_head_sha');
+  });
+});

--- a/supabase/migrations/20260824101502_add_qa_idle_catalog_backfill.sql
+++ b/supabase/migrations/20260824101502_add_qa_idle_catalog_backfill.sql
@@ -1,0 +1,84 @@
+alter table public.qa_poll_runs
+  add column if not exists catalog_backfill_requested_count integer not null default 0
+    check (catalog_backfill_requested_count >= 0),
+  add column if not exists catalog_backfill_count integer not null default 0
+    check (catalog_backfill_count >= 0);
+
+comment on column public.qa_poll_runs.catalog_backfill_requested_count is
+  'Number of popularity-prioritized catalog app IDs requested while the QA runner and queue were idle.';
+comment on column public.qa_poll_runs.catalog_backfill_count is
+  'Number of requested idle catalog app IDs that remained in the verified Win32 catalog scope.';
+
+create or replace function public.qa_idle_catalog_backfill_ids(
+  p_limit integer default 3
+)
+returns table(winget_id text)
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select app.winget_id
+  from public.curated_apps as app
+  where not exists (
+      select 1
+      from public.qa_candidates as waiting_work
+      where waiting_work.status = 'queued'
+    )
+    and not exists (
+      select 1
+      from public.qa_candidates as active_work
+      where active_work.status in ('dispatched', 'running')
+    )
+    and app.is_verified is true
+    and app.is_winget_verified is true
+    and app.app_source = 'win32'
+    and app.is_locale_variant is false
+    and nullif(btrim(app.latest_version), '') is not null
+    and not exists (
+      select 1
+      from public.package_eligibility_blocks as eligibility_block
+      where eligibility_block.winget_id = app.winget_id
+    )
+    and not exists (
+      select 1
+      from public.qa_candidates as candidate
+      where candidate.winget_id = app.winget_id
+        and (
+          candidate.version = app.latest_version
+          or candidate.catalog_version_at_enqueue = app.latest_version
+        )
+        and candidate.test_level = 'psadt-package'
+        and candidate.status <> 'superseded'
+        and candidate.test_config @> '{"profileKind":"catalog-default"}'::jsonb
+    )
+    and not exists (
+      select 1
+      from public.qa_package_blocks as block
+      where block.winget_id = app.winget_id
+        and block.version = app.latest_version
+    )
+    and not exists (
+      select 1
+      from public.qa_catalog_reconciliations as reconciliation
+      join public.qa_winget_poll_state as poll_state
+        on poll_state.id = 'microsoft/winget-pkgs'
+       and poll_state.head_sha = reconciliation.observed_head_sha
+      where reconciliation.winget_id = app.winget_id
+        and reconciliation.catalog_version = app.latest_version
+    )
+  order by
+    app.popularity_rank asc nulls last,
+    app.chocolatey_downloads desc nulls last,
+    app.updated_at desc,
+    app.winget_id asc
+  limit greatest(1, least(coalesce(p_limit, 3), 20));
+$$;
+
+comment on function public.qa_idle_catalog_backfill_ids(integer) is
+  'Returns popular verified Win32 catalog apps missing current PSADT lifecycle coverage, but only while no QA candidate is queued or active.';
+
+revoke all on function public.qa_idle_catalog_backfill_ids(integer)
+  from public, anon, authenticated;
+grant execute on function public.qa_idle_catalog_backfill_ids(integer)
+  to service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -457,6 +457,8 @@ export interface Database {
           supported_changed_count: number;
           demand_backfill_requested_count: number;
           demand_backfill_count: number;
+          catalog_backfill_requested_count: number;
+          catalog_backfill_count: number;
           created_at: string;
         };
         Insert: {
@@ -481,6 +483,8 @@ export interface Database {
           supported_changed_count?: number;
           demand_backfill_requested_count?: number;
           demand_backfill_count?: number;
+          catalog_backfill_requested_count?: number;
+          catalog_backfill_count?: number;
           created_at?: string;
         };
         Update: Partial<Database['public']['Tables']['qa_poll_runs']['Insert']>;
@@ -2448,6 +2452,14 @@ export interface Database {
         Returns: boolean;
       };
       qa_missing_demand_backfill_ids: {
+        Args: {
+          p_limit?: number;
+        };
+        Returns: Array<{
+          winget_id: string;
+        }>;
+      };
+      qa_idle_catalog_backfill_ids: {
         Args: {
           p_limit?: number;
         };


### PR DESCRIPTION
## Summary
- select up to three popularity-ranked verified Win32 catalog apps when QA has no queued or active work
- keep customer/deployed demand at higher dispatch priority while using the same PSADT candidate and packager path
- record catalog-backfill poll metrics and restrict the selector RPC to service_role

## Safety
- preserves package eligibility blocks, QA package blocks, current-version candidate coverage, and current-head catalog reconciliations
- the dispatcher remains serialized to one Windows VM run at a time

## Validation
- npx vitest run (85 files, 1456 tests passed)
- npm run lint
- npm run build