### PR TITLE
feat(seo): catalog polish - QA detection and VirusTotal surfacing, OG images, sitemap fixes, hub intros, deep links

### DIFF
--- a/app/(marketing)/apps/[wingetId]/opengraph-image.tsx
+++ b/app/(marketing)/apps/[wingetId]/opengraph-image.tsx
@@ -1,0 +1,132 @@
+import { ImageResponse } from 'next/og';
+import { getCatalogSource } from '@/lib/catalog';
+import { resolveCatalogIconUrl } from '@/lib/catalog/seo';
+
+export const revalidate = 86400;
+export const alt = 'Deploy this app to Microsoft Intune with IntuneGet';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+async function loadIconDataUri(iconUrl: string): Promise<string | null> {
+  try {
+    const res = await fetch(iconUrl);
+    if (!res.ok) return null;
+    const type = res.headers.get('content-type') || 'image/png';
+    if (!type.startsWith('image/')) return null;
+    const buffer = Buffer.from(await res.arrayBuffer());
+    if (buffer.byteLength === 0 || buffer.byteLength > 1024 * 1024) return null;
+    return `data:${type};base64,${buffer.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}
+
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ wingetId: string }>;
+}) {
+  const { wingetId } = await params;
+  let id = wingetId;
+  try {
+    id = decodeURIComponent(wingetId);
+  } catch {
+    // keep the raw segment
+  }
+
+  const details = await getCatalogSource()
+    .getAppByWingetId(id)
+    .catch(() => null);
+  const app = details?.app ?? null;
+  const name = app?.name ?? 'Windows apps';
+  const publisher = app?.publisher ?? '';
+  const icon = app ? await loadIconDataUri(resolveCatalogIconUrl(app)) : null;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 72,
+          backgroundColor: '#080d17',
+          backgroundImage:
+            'radial-gradient(circle at 85% 15%, rgba(34, 211, 238, 0.18) 0%, rgba(8, 13, 23, 0) 55%)',
+          color: '#f8fafc',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 40 }}>
+          {icon ? (
+            <img
+              src={icon}
+              alt=""
+              width={140}
+              height={140}
+              style={{ borderRadius: 28, backgroundColor: '#ffffff', padding: 14 }}
+            />
+          ) : (
+            <div
+              style={{
+                width: 140,
+                height: 140,
+                borderRadius: 28,
+                backgroundColor: 'rgba(34, 211, 238, 0.15)',
+                border: '2px solid rgba(34, 211, 238, 0.5)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 72,
+                fontWeight: 700,
+                color: '#22d3ee',
+              }}
+            >
+              {name.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ fontSize: 30, color: '#22d3ee', fontWeight: 600 }}>Deploy</div>
+            <div
+              style={{
+                fontSize: name.length > 28 ? 52 : 64,
+                fontWeight: 700,
+                lineHeight: 1.1,
+                maxWidth: 850,
+              }}
+            >
+              {name}
+            </div>
+            <div style={{ fontSize: 34, color: '#94a3b8' }}>to Microsoft Intune</div>
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            fontSize: 28,
+            color: '#94a3b8',
+          }}
+        >
+          <div style={{ display: 'flex' }}>{publisher ? `by ${publisher}` : ''}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+            <div
+              style={{
+                width: 18,
+                height: 18,
+                borderRadius: 6,
+                backgroundColor: '#22d3ee',
+              }}
+            />
+            <div style={{ fontWeight: 700, color: '#f8fafc' }}>IntuneGet</div>
+            <div>packaged and uploaded automatically</div>
+          </div>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/(marketing)/apps/[wingetId]/page.tsx
+++ b/app/(marketing)/apps/[wingetId]/page.tsx
@@ -166,7 +166,31 @@ export default async function AppDetailPage({ params }: PageProps) {
   if (installCommand) deploymentRows.push({ label: <T>Install command</T>, value: installCommand, code: true });
   if (uninstallCommand) deploymentRows.push({ label: <T>Uninstall command</T>, value: uninstallCommand, code: true });
   if (usesRegisteredUninstaller) deploymentRows.push({ label: <T>Uninstall</T>, value: <T>Uses the app&apos;s own registered uninstaller</T> });
+  const detection = qaVerified ? qa.detection : null;
+  if (detection?.type === 'fileVersion' && detection.path) {
+    deploymentRows.push({
+      label: <T>Detection rule</T>,
+      value: (
+        <T>
+          File version at <Var><code className="rounded bg-bg-deepest px-1.5 py-0.5 text-sm">{detection.path}</code></Var> must be at least <Var>{detection.minimumVersion}</Var>
+        </T>
+      ),
+    });
+  } else if (detection?.description) {
+    deploymentRows.push({ label: <T>Detection rule</T>, value: <Var>{detection.description}</Var> });
+  }
   if (appSource) deploymentRows.push({ label: <T>App source</T>, value: appSource });
+
+  // Hash-only VirusTotal verdict recorded alongside the QA run. Informational;
+  // only surface the states that mean something to a reader.
+  const virusTotal =
+    qa?.virustotal_status && ['clean', 'suspicious', 'flagged'].includes(qa.virustotal_status)
+      ? {
+          status: qa.virustotal_status,
+          flagged: (qa.virustotal_malicious ?? 0) + (qa.virustotal_suspicious ?? 0),
+          engines: qa.virustotal_total_engines ?? null,
+        }
+      : null;
 
   return (
     <div className="flex min-h-screen flex-col bg-bg-deepest">
@@ -202,7 +226,7 @@ export default async function AppDetailPage({ params }: PageProps) {
 
         {deploymentRows.length > 0 && <section className="space-y-5"><h2 className="text-2xl font-semibold text-text-primary"><T>Deployment details</T></h2><dl className="divide-y divide-overlay/10 rounded-2xl border border-overlay/10 bg-bg-elevated px-6">{deploymentRows.map((row, index) => <div key={index} className="grid gap-1 py-4 sm:grid-cols-3"><dt className="text-text-muted">{row.label}</dt><dd className="sm:col-span-2 text-text-primary">{row.code ? <code className="rounded bg-bg-deepest px-2 py-1 text-sm"><Var>{row.value}</Var></code> : <Var>{row.value}</Var>}</dd></div>)}</dl>{qaVerified ? <p className="flex items-center gap-2 text-sm text-text-muted"><CheckCircle2 className="h-4 w-4 shrink-0 text-green-400" aria-hidden="true" /><T>Commands and arguments were captured during an automated QA install of version <Var>{qa.tested_version}</Var> in an isolated Windows VM.</T></p> : <p className="text-sm text-text-muted">{qa ? <T>Values come from the WinGet community manifest.</T> : <T>Values come from the WinGet community manifest. This app has not completed an IntuneGet QA run yet.</T>}</p>}{changelog?.install_path && <p className="text-sm text-text-muted"><T>Observed install path: <Var>{changelog.install_path}</Var></T></p>}</section>}
 
-        {qa && <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-6"><h2 className="text-2xl font-semibold text-text-primary"><T>Tested by IntuneGet QA</T></h2><div className="flex items-center gap-2">{qa.outcome === 'Passed' ? <CheckCircle2 className="h-5 w-5 text-green-400" /> : <XCircle className="h-5 w-5 text-red-400" />}<span className="font-medium text-text-primary"><Var>{qa.outcome}</Var></span></div><p className="text-sm text-text-secondary"><T>Version <Var>{qa.tested_version}</Var> tested on <Var>{new Date(qa.tested_at_utc).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</Var>.</T></p></section>}
+        {qa && <section className="space-y-4 rounded-2xl border border-overlay/10 bg-bg-elevated p-6"><h2 className="text-2xl font-semibold text-text-primary"><T>Tested by IntuneGet QA</T></h2><div className="flex items-center gap-2">{qa.outcome === 'Passed' ? <CheckCircle2 className="h-5 w-5 text-green-400" /> : <XCircle className="h-5 w-5 text-red-400" />}<span className="font-medium text-text-primary"><Var>{qa.outcome}</Var></span></div><p className="text-sm text-text-secondary"><T>Version <Var>{qa.tested_version}</Var> tested on <Var>{new Date(qa.tested_at_utc).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</Var>.</T></p>{virusTotal && <p className="text-sm text-text-secondary">{virusTotal.status === 'clean' ? <T>VirusTotal scan of the installer hash: clean{virusTotal.engines ? <>. 0 of <Var>{virusTotal.engines}</Var> engines flagged it</> : null}.</T> : <T>VirusTotal scan of the installer hash: <Var>{virusTotal.flagged}</Var> of <Var>{virusTotal.engines ?? 'the'}</Var> engines flagged it.</T>}</p>}</section>}
 
         {recentVersions.length > 0 && <section className="space-y-4"><h2 className="text-2xl font-semibold text-text-primary"><T>Recent versions</T></h2><ol className="flex flex-wrap gap-2">{recentVersions.map((version) => <li key={version} className="rounded-lg border border-overlay/10 bg-bg-elevated px-3 py-1.5 font-mono text-sm text-text-secondary"><Var>{version}</Var></li>)}</ol></section>}
 

--- a/app/(marketing)/apps/category/[slug]/page.tsx
+++ b/app/(marketing)/apps/category/[slug]/page.tsx
@@ -39,6 +39,37 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
+/**
+ * Hand-written intros for the largest categories so the hubs read as curated
+ * pages rather than templated listings. Everything else gets the generic copy.
+ */
+function CategoryIntro({ slug, name }: { slug: string; name: string }) {
+  switch (slug) {
+    case 'browser':
+      return <T>Browsers are usually the first app every managed Windows device needs. IntuneGet packages Chrome, Firefox, Edge and the alternatives as Win32 apps with silent installs, so you can assign a standard browser to your whole tenant in minutes.</T>;
+    case 'security':
+      return <T>Security tooling has to install silently and predictably on every endpoint. These packages ship with verified silent switches and detection rules so agents, scanners and VPN clients deploy cleanly through Intune without user interaction.</T>;
+    case 'developer-tools':
+      return <T>Developer machines need editors, runtimes, SDKs and command line tools that install without prompts. IntuneGet turns these WinGet packages into Win32 apps you can assign to engineering groups instead of asking developers to install everything by hand.</T>;
+    case 'utilities':
+      return <T>Everyday utilities like archivers, viewers and small system helpers round out most Windows baselines. Each one here can be packaged and uploaded to Intune automatically, silent install arguments included.</T>;
+    case 'system':
+      return <T>System tools often ship as vendor installers with awkward switches. IntuneGet normalizes them into Win32 packages with tested silent installs so platform tools and agents deploy reliably across your fleet.</T>;
+    case 'communication':
+      return <T>Meeting and messaging clients are among the most requested Intune deployments. These packages install silently and machine wide, so users are ready for their first call as soon as they sign in.</T>;
+    case 'runtime':
+      return <T>Runtimes and redistributables such as .NET, Visual C++ and Java are prerequisites for countless line of business apps. Deploy them once through Intune and stop chasing missing dependency errors on end user devices.</T>;
+    case 'productivity':
+      return <T>Productivity apps are the core of most software baselines. From note taking to PDF tools, these packages deploy silently through Intune so a new device is a working machine on day one.</T>;
+    case 'networking':
+      return <T>Network clients, VPNs and remote access tools need consistent machine wide installs. These packages carry verified silent arguments so they roll out through Intune without a single prompt.</T>;
+    case 'office':
+      return <T>Office suites, PDF editors and document tools are staple deployments in every tenant. IntuneGet packages them with the right silent switches and detection rules for dependable rollouts.</T>;
+    default:
+      return <T>Explore <Var>{name}</Var> tools that your organization can package as Win32 apps and upload to Microsoft Intune. IntuneGet keeps the deployment workflow consistent while you choose assignments for each app.</T>;
+  }
+}
+
 export default async function CategoryPage({ params }: PageProps) {
   const { slug } = await params;
   const categoryInfo = await resolveCategory(slug);
@@ -81,7 +112,7 @@ export default async function CategoryPage({ params }: PageProps) {
         </nav>
         <header className="space-y-4">
           <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>Deploy <Var>{categoryInfo.name}</Var> apps to Microsoft Intune</T></h1>
-          <p className="max-w-3xl text-lg text-text-secondary"><T>Explore <Var>{categoryInfo.name}</Var> tools that your organization can package as Win32 apps and upload to Microsoft Intune. IntuneGet keeps the deployment workflow consistent while you choose assignments for each app.</T></p>
+          <p className="max-w-3xl text-lg text-text-secondary"><CategoryIntro slug={slug} name={categoryInfo.name} /></p>
           <p className="text-sm text-text-muted"><T><Var>{categoryInfo.count.toLocaleString('en-US')}</Var> apps are available in this category. Showing up to 60 verified apps.</T></p>
         </header>
         <section aria-label="Category apps">

--- a/app/(marketing)/blog/deploy-winget-apps-to-intune/page.tsx
+++ b/app/(marketing)/blog/deploy-winget-apps-to-intune/page.tsx
@@ -1,3 +1,4 @@
+import { PopularAppLinks } from "@/components/catalog/PopularAppLinks";
 import { Metadata } from "next";
 import Link from "next/link";
 import { getBlogPost } from "@/lib/data/blog-data";
@@ -865,6 +866,9 @@ IntuneWinAppUtil.exe -c C:\\IntunePackaging\\Chrome -s ChromeSetup.msi -o C:\\In
                 </Link>
                 .</T>
               </p>
+
+              <div className="mt-10"><PopularAppLinks /></div>
+
 
               {/* CTA */}
               <div className="mt-10 p-6 rounded-2xl bg-accent-cyan/5 border border-accent-cyan/20">

--- a/app/(marketing)/blog/intune-winget-integration-guide/page.tsx
+++ b/app/(marketing)/blog/intune-winget-integration-guide/page.tsx
@@ -1,3 +1,4 @@
+import { PopularAppLinks } from "@/components/catalog/PopularAppLinks";
 import { Metadata } from "next";
 import Link from "next/link";
 import { getBlogPost } from "@/lib/data/blog-data";
@@ -878,6 +879,9 @@ winget upgrade --all --silent`}</code>
                 </Link>
                 .</T>
               </p>
+
+              <div className="mt-10"><PopularAppLinks /></div>
+
 
               {/* CTA */}
               <div className="mt-10 p-6 rounded-2xl bg-accent-cyan/5 border border-accent-cyan/20">

--- a/app/(marketing)/blog/sccm-to-intune-migration-winget/page.tsx
+++ b/app/(marketing)/blog/sccm-to-intune-migration-winget/page.tsx
@@ -1,3 +1,4 @@
+import { PopularAppLinks } from "@/components/catalog/PopularAppLinks";
 import { Metadata } from "next";
 import Link from "next/link";
 import { getBlogPost } from "@/lib/data/blog-data";
@@ -899,6 +900,9 @@ Write-Host "Results saved to C:\\Migration\\WingetMatchResults.csv"`}</code>
                 </Link>
                 .</T>
               </p>
+
+              <div className="mt-10"><PopularAppLinks /></div>
+
 
               {/* CTA */}
               <div className="mt-10 p-6 rounded-2xl bg-accent-cyan/5 border border-accent-cyan/20">

--- a/app/(marketing)/blog/winget-vs-manual-intune-deployment/page.tsx
+++ b/app/(marketing)/blog/winget-vs-manual-intune-deployment/page.tsx
@@ -1,3 +1,4 @@
+import { PopularAppLinks } from "@/components/catalog/PopularAppLinks";
 import { Metadata } from "next";
 import Link from "next/link";
 import { getBlogPost } from "@/lib/data/blog-data";
@@ -722,6 +723,9 @@ export default function WingetVsManualIntuneDeploymentPage() {
                 </Link>
                 .</T>
               </p>
+
+              <div className="mt-10"><PopularAppLinks /></div>
+
 
               {/* CTA */}
               <div className="mt-10 p-6 rounded-2xl bg-accent-cyan/5 border border-accent-cyan/20">

--- a/app/(marketing)/docs/getting-started/page.tsx
+++ b/app/(marketing)/docs/getting-started/page.tsx
@@ -1,3 +1,4 @@
+import { PopularAppLinks } from "@/components/catalog/PopularAppLinks";
 import { Metadata } from "next";
 import Link from "next/link";
 import { T } from "gt-next";
@@ -504,6 +505,8 @@ nssm start IntuneGetPackager`}
           </li>
         </ul>
       </section>
+
+      <PopularAppLinks />
     </div>
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,16 +11,21 @@ export function generateSitemaps() {
 
 export default async function sitemap({ id }: { id: Promise<number> }): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
-  const sitemapId = await id;
+  // At request time Next resolves the [id] URL segment as a string, so coerce
+  // before comparing; otherwise every segment falls through to the static set.
+  const sitemapId = Number(await id);
 
   if (sitemapId === 1) {
     const apps = await getCatalogSource().getVerifiedAppIds().catch(() => []);
-    return apps.map((app) => ({
-      url: absoluteAppCatalogUrl(app.winget_id),
-      lastModified: now,
-      changeFrequency: "daily" as const,
-      priority: 0.8,
-    }));
+    return apps.map((app) => {
+      const updated = app.updated_at ? new Date(app.updated_at) : null;
+      return {
+        url: absoluteAppCatalogUrl(app.winget_id),
+        lastModified: updated && !Number.isNaN(updated.getTime()) ? updated : now,
+        changeFrequency: "weekly" as const,
+        priority: 0.8,
+      };
+    });
   }
 
   if (sitemapId === 2) {

--- a/components/catalog/PopularAppLinks.tsx
+++ b/components/catalog/PopularAppLinks.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { T, Var } from 'gt-next';
+import { appCatalogHref } from '@/lib/catalog/seo';
+
+/**
+ * Static strip of flagship app detail pages. Used on blog posts and docs to
+ * deep-link the catalog's strongest pages; kept static so the strip renders
+ * even when the catalog source is unavailable.
+ */
+const FLAGSHIP_APPS: { wingetId: string; name: string }[] = [
+  { wingetId: 'Google.Chrome', name: 'Google Chrome' },
+  { wingetId: 'Adobe.Acrobat.Reader.64-bit', name: 'Adobe Acrobat Reader' },
+  { wingetId: 'Mozilla.Firefox', name: 'Mozilla Firefox' },
+  { wingetId: 'Microsoft.VisualStudioCode', name: 'Visual Studio Code' },
+  { wingetId: '7zip.7zip', name: '7-Zip' },
+  { wingetId: 'VideoLAN.VLC', name: 'VLC media player' },
+  { wingetId: 'Zoom.Zoom', name: 'Zoom Workplace' },
+  { wingetId: 'Notepad++.Notepad++', name: 'Notepad++' },
+];
+
+export function PopularAppLinks() {
+  return (
+    <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6 space-y-4">
+      <h2 className="text-xl font-semibold text-text-primary">
+        <T>Deploy these apps with IntuneGet</T>
+      </h2>
+      <p className="text-sm text-text-secondary">
+        <T>
+          Each page shows the verified silent install commands, detection rules,
+          and QA results for that app.
+        </T>
+      </p>
+      <div className="flex flex-wrap gap-2.5">
+        {FLAGSHIP_APPS.map((app) => (
+          <Link
+            key={app.wingetId}
+            href={appCatalogHref(app.wingetId)}
+            className="rounded-lg border border-overlay/10 bg-bg-surface px-3.5 py-2 text-sm font-medium text-text-primary transition-colors hover:border-accent-cyan/40 hover:text-accent-cyan"
+          >
+            <Var>{app.name}</Var>
+          </Link>
+        ))}
+        <Link
+          href="/apps"
+          className="rounded-lg px-3.5 py-2 text-sm font-medium text-accent-cyan hover:underline"
+        >
+          <T>Browse the full catalog</T>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -246,10 +246,8 @@ describe('SnapshotCatalogSource', () => {
   });
 
   it('getVerifiedAppIds returns canonical apps in popularity order', async () => {
-    await expect(source.getVerifiedAppIds(2)).resolves.toEqual([
-      { winget_id: 'Google.Chrome' },
-      { winget_id: 'Mozilla.Firefox' },
-    ]);
+    const ids = await source.getVerifiedAppIds(2);
+    expect(ids.map((row) => row.winget_id)).toEqual(['Google.Chrome', 'Mozilla.Firefox']);
   });
 
   it('getCategories returns per-category counts', async () => {

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -369,18 +369,25 @@ export class SnapshotCatalogSource implements CatalogSource {
     );
   }
 
-  async getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]> {
+  async getVerifiedAppIds(
+    limit?: number
+  ): Promise<{ winget_id: string; updated_at?: string | null }[]> {
     return withDb(
       (db) => {
         const limitClause = limit === undefined ? '' : 'LIMIT @limit';
+        // The snapshot schema has no updated_at; created_at is the closest
+        // last-changed signal it carries.
         return db
           .prepare(
-            `SELECT winget_id FROM curated_apps
+            `SELECT winget_id, created_at AS updated_at FROM curated_apps
              WHERE is_verified = 1 AND is_locale_variant = 0 AND latest_version IS NOT NULL
              ORDER BY popularity_rank IS NULL, popularity_rank ASC, winget_id ASC
              ${limitClause}`
           )
-          .all(limit === undefined ? {} : { limit }) as { winget_id: string }[];
+          .all(limit === undefined ? {} : { limit }) as {
+          winget_id: string;
+          updated_at: string | null;
+        }[];
       },
       () => []
     );

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -209,19 +209,21 @@ export class SupabaseCatalogSource implements CatalogSource {
     }));
   }
 
-  async getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]> {
+  async getVerifiedAppIds(
+    limit?: number
+  ): Promise<{ winget_id: string; updated_at?: string | null }[]> {
     const supabase = serviceOrAnonClient();
     if (!supabase) return [];
 
     const pageSize = limit === undefined ? 1000 : Math.min(limit, 1000);
-    const rows: { winget_id: string }[] = [];
+    const rows: { winget_id: string; updated_at?: string | null }[] = [];
     let offset = 0;
 
     while (limit === undefined || rows.length < limit) {
       const requested = limit === undefined ? pageSize : Math.min(pageSize, limit - rows.length);
       const { data, error } = await supabase
         .from('curated_apps')
-        .select('winget_id')
+        .select('winget_id, updated_at')
         .eq('is_verified', true)
         .eq('is_locale_variant', false)
         .not('latest_version', 'is', null)
@@ -233,7 +235,7 @@ export class SupabaseCatalogSource implements CatalogSource {
         console.error('Failed to list verified catalog apps:', error.message);
         return rows;
       }
-      const page = (data || []) as { winget_id: string }[];
+      const page = (data || []) as { winget_id: string; updated_at: string | null }[];
       rows.push(...page);
       if (page.length < requested) break;
       offset += page.length;

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -183,8 +183,12 @@ export interface CatalogSource {
   /** RPC get_curated_categories. */
   getCategories(): Promise<CategoryCount[]>;
 
-  /** Verified, canonical app ids for prerendering and segmented sitemaps. */
-  getVerifiedAppIds(limit?: number): Promise<{ winget_id: string }[]>;
+  /** Verified, canonical app ids for prerendering and segmented sitemaps.
+   *  updated_at carries the row's last catalog update when the store has one
+   *  (the snapshot only records created_at). */
+  getVerifiedAppIds(
+    limit?: number
+  ): Promise<{ winget_id: string; updated_at?: string | null }[]>;
 
   /** curated_apps count(head) with optional is_verified filter. */
   getCategoryCount(opts: { verifiedOnly: boolean }): Promise<number | null>;

--- a/supabase/migrations/20260824153000_normalize_curated_app_categories.sql
+++ b/supabase/migrations/20260824153000_normalize_curated_app_categories.sql
@@ -1,0 +1,14 @@
+-- Normalize curated_apps.category to lowercase slug form.
+--
+-- The catalog accumulated mixed-case category values ("Business" next to
+-- "business", counts of 1 to 4 per stray variant), which duplicated category
+-- listings and split hub pages until the UI started merging them case
+-- insensitively. Normalize the stored values to the canonical slug form
+-- (lowercase, whitespace collapsed to hyphens) so every consumer sees one
+-- value per category. The UI keeps its case-insensitive merge as a guard for
+-- future strays.
+
+update curated_apps
+set category = regexp_replace(lower(btrim(category)), '\s+', '-', 'g')
+where category is not null
+  and category <> regexp_replace(lower(btrim(category)), '\s+', '-', 'g');


### PR DESCRIPTION
## Summary

Follow-up polish round for the app catalog (#877), implementing the remaining SEO and content improvements plus one important fix found while verifying:

- **Fix: sitemap segments were all serving the static set.** Next resolves the sitemap `[id]` URL segment as a string at request time, so the strict numeric comparisons never matched and app/category URLs were missing from every sitemap. Now coerced; verified locally: segment 1 serves 13,426 app URLs, segment 2 serves 31 category hubs.
- **Real `lastModified` dates** in the app sitemap from `curated_apps.updated_at` (snapshot: `created_at`) instead of stamping every URL with the generation time.
- **Detection rules and VirusTotal on detail pages**: QA-verified pages now show the Intune detection rule in deployment details and the hash-only VirusTotal verdict in the QA section.
- **Generated OG images** at `/apps/[wingetId]/opengraph-image`: app icon on a branded 1200x630 card with letter-tile and generic fallbacks.
- **Hand-written intros** for the ten largest category hubs (browsers, security, developer tools, ...), generic template for the rest.
- **Deep links**: a static flagship-apps strip added to all four blog posts and the getting-started doc, so catalog pages inherit internal links from the site's strongest pages.
- **DB migration** normalizing `curated_apps.category` to lowercase slug form, removing the mixed-case duplicates at the source (UI keeps its case-insensitive merge as a guard).

## Verification

- Lint passes, all 53 catalog tests pass.
- `npm run build:ci` succeeds.
- Verified against the real catalog snapshot locally: sitemap segments correct with real lastmod dates, OG image renders (Chrome card checked visually), blog and category pages 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)