### PR TITLE
Block unsupported SQL Server 2019 Express lifecycle

### DIFF
--- a/supabase/migrations/20260824144000_block_sql_server_2019_express_unsupported_managed_install.sql
+++ b/supabase/migrations/20260824144000_block_sql_server_2019_express_unsupported_managed_install.sql
@@ -1,0 +1,40 @@
+-- SQL Server Express is a configurable server workload rather than a generic
+-- desktop application. Microsoft requires unattended setup to choose the
+-- features or role, instance identity, and SQL sysadmin accounts explicitly:
+-- https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt
+-- The current WinGet bootstrapper omits that deployment-specific contract. In
+-- isolated LocalSystem lifecycle QA its exact manifest command exited -1,
+-- continued changing the machine after the launcher returned, created no
+-- unambiguous ARP identity, and therefore exposed no bounded install or safe
+-- generic uninstall target. Do not guess customer SQL security or instance
+-- settings in automated packaging.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Microsoft.SQLServer.2019.Express',
+  'unsupported_managed_install',
+  'SQL Server 2019 Express requires deployment-specific feature, instance, and SQL administrator configuration. Its exact WinGet bootstrapper command exits -1 under LocalSystem, continues changing the machine after the launcher returns, creates no unambiguous uninstall identity, and cannot provide a safe generic managed lifecycle.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32736168966'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.SQLServer.2019.Express';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Microsoft.SQLServer.2019.Express'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Microsoft.SQLServer.2019.Express from automated customer packaging and QA backfill
- clear catalog verification and supersede obsolete failed/queued/error candidates
- document the isolated LocalSystem evidence and Microsoft deployment-specific setup requirement

## Evidence
- QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32736168966
- Microsoft requires explicit SQL features/role, instance identity, and administrator configuration for unattended setup: https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt
- exact WinGet bootstrapper returned -1, continued machine changes after return, and created no unambiguous uninstall identity

## Validation
- git diff --check
- migration follows the already-deployed SQL Server 2017/2025 Express eligibility-block pattern