### PR TITLE
Run RedisInsight PSADT packages in user context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -247,6 +247,12 @@ describe('application packaging adapters', () => {
       ' ultimategadgetlaboratories.uhkagent ',
       undefined
     )).toBe('user');
+    expect(
+      resolveApplicationInstallScope('RedisInsight.RedisInsight', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' redisinsight.redisinsight ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('Rakuten.Viber', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' rakuten.viber ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('TorProject.TorBrowser', 'machine')).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -206,6 +206,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // RedisInsight 3.4.2's tagged Electron Builder configuration explicitly
+    // sets NSIS perMachine=false. WinGet omits Scope, so the generic machine
+    // default installs below LocalSystem's disposable systemprofile and records
+    // an uninstaller that is gone by the removal cycle. Keep the shared customer
+    // package and QA lifecycle in the vendor's intended signed-in user context.
+    // https://github.com/RedisInsight/RedisInsight/blob/3.4.2/electron-builder.json
+    wingetId: 'RedisInsight.RedisInsight',
+    requiredInstallScope: 'user',
+  },
+  {
     // Viber's MSI is declared machine-scope by WinGet, but its Directory
     // table targets LocalAppData. Under LocalSystem that resolves to the
     // system profile and the vendor's VerifyInstalledFiles action rolls the

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -651,6 +651,35 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
+  it('tests RedisInsight in user context when its NSIS manifest omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'RedisInsight.RedisInsight',
+        name: 'Redis Insight',
+        publisher: 'Redis Ltd.',
+        version: '3.4.2',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        ProductCode: '35443657-9fe0-5c86-a3fe-135cfbd99cbb',
+        AppsAndFeaturesEntries: [{ DisplayName: 'Redis Insight' }],
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\RedisInsight_RedisInsight',
+      }),
+    ]);
+  });
+
   it('tests Youdao in user context when its NSIS manifest omits scope', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- add a reviewed user-scope adapter for RedisInsight.RedisInsight
- keep QA detection in HKCU and customer Intune execution in the signed-in user context
- add adapter and catalog QA regression coverage

## Root cause
RedisInsight 3.4.2 installs and detects successfully under LocalSystem, but its per-user NSIS package writes an uninstall registration below systemprofile and the registered executable is unavailable by managed removal. The vendor's tagged Electron Builder configuration explicitly sets perMachine=false.

## Evidence
- QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32740181400
- Vendor build config: https://github.com/RedisInsight/RedisInsight/blob/3.4.2/electron-builder.json

## Validation
- npm test -- lib/packaging-adapters.test.ts lib/qa/test-config.test.ts (93 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/test-config.test.ts
- git diff --check