### PR TITLE
release(qa): activate RedisInsight user scope

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '2eaa857bc5a1297ec7e7b521307079de4622b0b7',
+  packagerCommit: 'fe8a13f4473a3528368d7a97ff410df1961c594a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -335,6 +335,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // The reviewed -q argument changes only Atlassian Service Management LTS.
   // Preserve every unrelated compatible pass from the parser release.
   '326eafef044af8579bc0089c9556a3d59e26cbe0',
+  // RedisInsight's reviewed per-user scope changes only its Electron NSIS
+  // lifecycle. Preserve every unrelated compatible pass from the prior release.
+  '2eaa857bc5a1297ec7e7b521307079de4622b0b7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries RedisInsight only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' redisinsight.redisinsight ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '2eaa857bc5a1297ec7e7b521307079de4622b0b7',
+      { wingetId: 'RedisInsight.RedisInsight', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Atlassian only after activating its documented quiet uninstall', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -166,7 +166,16 @@ const ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...LEAF_ONLY_UNINSTALL_PATH_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const REDISINSIGHT_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // RedisInsight's NSIS installer is explicitly per-user. Re-run the failed
+  // release in user context, then carry every still-unconsumed bounded target.
+  'RedisInsight.RedisInsight',
+  ...ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'fe8a13f4473a3528368d7a97ff410df1961c594a':
+    REDISINSIGHT_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '2eaa857bc5a1297ec7e7b521307079de4622b0b7':
     ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS,
   '326eafef044af8579bc0089c9556a3d59e26cbe0':


### PR DESCRIPTION
## Summary
- pin QA packaging to the merged RedisInsight user-scope adapter commit
- retry the failed RedisInsight terminal candidate on this release
- retain all unrelated compatible passing QA profiles

## Validation
- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts (186 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check