### PR TITLE
Block DesktopOK unsupported managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -384,14 +384,10 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter(
         'SoftwareOK.DesktopOK',
         DEFAULT_PSADT_CONFIG
-      ).reviewedExactUninstall
-    ).toEqual({
-      executablePath: '%ProgramFiles%\\DesktopOK\\DesktopOK_x64.exe',
-      arguments: ['/silent', '-?uninstall'],
-      completionTimeoutMinutes: 5,
-    });
+      )
+    ).not.toHaveProperty('reviewedExactUninstall');
     expect(resolveApplicationInstallScope('SoftwareOK.DesktopOK', 'user')).toBe(
-      'machine'
+      'user'
     );
     expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -667,20 +667,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
-    // DesktopOK publishes both user- and machine-scope installers. Intune runs
-    // Win32 packages as SYSTEM, and the reviewed exact uninstaller lives below
-    // Program Files, so keep package creation on the machine-scope variant.
-    // Reuse the vendor's documented /silent mode ahead of the registered
-    // -?uninstall verb so removal never waits for interactive UI.
-    wingetId: 'SoftwareOK.DesktopOK',
-    requiredInstallScope: 'machine',
-    reviewedExactUninstall: {
-      executablePath: '%ProgramFiles%\\DesktopOK\\DesktopOK_x64.exe',
-      arguments: ['/silent', '-?uninstall'],
-      completionTimeoutMinutes: 5,
-    },
-  },
-  {
     wingetId: 'SoftwareOK.Q-Dir',
     reviewedUninstallArguments: ['/silent', 'forall'],
   },

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1401,3 +1401,26 @@ describe('QA idle catalog backfill migration contract', () => {
     expect(sql).toContain('poll_state.head_sha = reconciliation.observed_head_sha');
   });
 });
+
+describe('DesktopOK managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260824163000_block_desktopok_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unsupported vendor removal lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'SoftwareOK.DesktopOK'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32747225410'
+    );
+    expect(sql).toContain('exact DesktopOK registration');
+    expect(sql).toContain('three isolated lifecycle runs');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260824163000_block_desktopok_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260824163000_block_desktopok_unsupported_managed_uninstall.sql
@@ -1,0 +1,41 @@
+-- DesktopOK documents unattended installation with /silent -?install, but its
+-- removal guidance only covers interactive Control Panel/application-menu
+-- removal or manually deleting the portable executable:
+-- https://www.softwareok.com/?faq=37&seite=faq-DesktopOK
+-- https://www.softwareok.com/?page=Windows%2FInfo%2FDesktopOK%2F23
+-- https://www.softwareok.com/?faq=11&seite=faq-DesktopOK
+-- The registered -?uninstall command failed generically under LocalSystem. A
+-- guessed /silent -?uninstall adapter then failed under both user and machine
+-- scopes. Across all three isolated lifecycle runs, installation and detection
+-- succeeded but the exact DesktopOK registration remained after uninstall.
+-- Do not publish a PSADT package whose managed removal contract is unsupported.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'SoftwareOK.DesktopOK',
+  'unsupported_managed_uninstall',
+  'DesktopOK installs unattended, but the registered vendor removal command and the guessed silent variant failed in three isolated lifecycle runs across user and machine scopes. The exact DesktopOK registration remained after every uninstall attempt, and the vendor does not document an unattended removal contract.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32747225410'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'SoftwareOK.DesktopOK';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'SoftwareOK.DesktopOK'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- remove the guessed DesktopOK `/silent -?uninstall` adapter after repeat isolated lifecycle failure
- block DesktopOK across portal/customer packaging and QA with `unsupported_managed_uninstall`
- supersede retryable DesktopOK candidates and clear catalog verification

## Evidence
- run 32747225410 installed and detected DesktopOK 12.71, but the exact ARP registration remained after the five-minute uninstall deadline
- prior user-scope run 32291196774 failed with the same adapter
- prior generic machine-scope run 32287628675 also failed
- vendor documentation covers silent install and interactive/manual removal, not an unattended uninstall contract

## Validation
- `npm test`: 85 files, 1,462 tests passed
- focused adapter/migration tests: 152 passed
- ESLint passed
- `git diff --check` passed