### PR TITLE
Activate DesktopOK safety block in QA toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'fe8a13f4473a3528368d7a97ff410df1961c594a',
+  packagerCommit: 'd64f6815b43c16428d83cde1b909e6503d7cc40f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -338,6 +338,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // RedisInsight's reviewed per-user scope changes only its Electron NSIS
   // lifecycle. Preserve every unrelated compatible pass from the prior release.
   '2eaa857bc5a1297ec7e7b521307079de4622b0b7',
+  // DesktopOK is now blocked because it has no verified unattended removal
+  // contract. Preserve every compatible pass for the remaining eligible apps.
+  'fe8a13f4473a3528368d7a97ff410df1961c594a',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('does not replay DesktopOK after activating its managed-uninstall block', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' softwareok.desktopok ', status: 'failed' }
+    )).toBe(false);
+    expect(
+      terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
+        .map((wingetId) => wingetId.toLowerCase())
+    ).not.toContain('softwareok.desktopok');
+  });
+
   it('retries RedisInsight only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -120,7 +131,6 @@ describe('QA toolchain targeted retries', () => {
       'Microsoft.FSLogix',
       'AvaCC.AvaDesktop',
       'Microsoft.RMSClient',
-      'SoftwareOK.DesktopOK',
       'Movavi.MovaviPhotoFocus',
       'RedHat.Podman-Desktop',
       'PDFsam.PDFsam',
@@ -176,7 +186,6 @@ describe('QA toolchain targeted retries', () => {
         'Microsoft.FSLogix',
         'Google.Chrome.Beta.EXE',
         'Microsoft.RMSClient',
-        'SoftwareOK.DesktopOK',
         'Movavi.MovaviPhotoFocus',
         'RedHat.Podman-Desktop',
         'PDFsam.PDFsam',
@@ -393,10 +402,14 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries DesktopOK only after activating its exact silent removal command', () => {
+  it('keeps DesktopOK retries confined to its retired repair releases', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'softwareok.desktopok', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f79b14647328d39bca04dada822a07f70573aa49',
+      { wingetId: 'SoftwareOK.DesktopOK', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '0a3741207b9fbab73f108b0b6f214ab9d2ffedfa',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -173,7 +173,16 @@ const REDISINSIGHT_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...ATLASSIAN_QUIET_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const DESKTOPOK_BLOCK_RELEASE_RETRY_TARGETS =
+  REDISINSIGHT_USER_SCOPE_RELEASE_RETRY_TARGETS.filter(
+    (wingetId) => wingetId.toLowerCase() !== 'softwareok.desktopok'
+  );
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  // DesktopOK is eligibility-blocked, so this release carries the prior
+  // bounded retry set without replaying its unsupported removal lifecycle.
+  'd64f6815b43c16428d83cde1b909e6503d7cc40f':
+    DESKTOPOK_BLOCK_RELEASE_RETRY_TARGETS,
   'fe8a13f4473a3528368d7a97ff410df1961c594a':
     REDISINSIGHT_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '2eaa857bc5a1297ec7e7b521307079de4622b0b7':


### PR DESCRIPTION
## Summary
- activate merged packager commit `d64f6815b43c16428d83cde1b909e6503d7cc40f`
- preserve compatible QA passes for every still-eligible app
- explicitly remove eligibility-blocked DesktopOK from the inherited terminal retry set

## Validation
- `npm test`: 85 files, 1,463 tests passed
- focused package-profile/toolchain tests: 187 passed
- ESLint passed
- `git diff --check` passed