### PR TITLE
Block unsupported Speek managed lifecycle

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -742,42 +742,6 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
-  it('applies the reviewed Speek non-ARP lifecycle to QA and customer packaging', async () => {
-    const request = new NextRequest('http://localhost:3000/api/package', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer test-token',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        items: [makeWin32Item({
-          wingetId: 'Speek.Speek',
-          displayName: 'Speek',
-          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
-        })],
-      }),
-    });
-
-    const response = await POST(request);
-
-    expect(response.status).toBe(200);
-    const expectedAdapter = {
-      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
-      reviewedManagedInstallEvidenceFile:
-        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
-      reviewedManagedInstallCompletionTimeoutMinutes: 2,
-    };
-    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
-      expectedAdapter
-    );
-    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
-      expectedAdapter
-    );
-    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
-      psadtConfig: expectedAdapter,
-    });
-  });
-
   it('adds a usable Build Tools workload to QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -322,17 +322,6 @@ describe('application packaging adapters', () => {
     });
   });
 
-  it('models Speek as the reviewed non-ARP Program Files payload', () => {
-    expect(
-      applyApplicationPackagingAdapter('Speek.Speek', DEFAULT_PSADT_CONFIG)
-    ).toMatchObject({
-      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
-      reviewedManagedInstallEvidenceFile:
-        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
-      reviewedManagedInstallCompletionTimeoutMinutes: 2,
-    });
-  });
-
   it('keeps the darktable NSIS extraction observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter('darktable.darktable', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -237,20 +237,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
   },
   {
-    // Speek 1.7.0's reviewed NSIS source installs the complete application to
-    // `$PROGRAMFILES\Speek`, writes Speek.exe plus uninstall.exe there, and
-    // never creates an Add/Remove Programs entry. NSIS resolves $PROGRAMFILES
-    // to Program Files (x86) on 64-bit Windows unless the script explicitly
-    // selects the 64-bit view, which Speek does not. Verify and own only that
-    // dedicated vendor directory instead of waiting for an ARP identity that
-    // the package intentionally omits. Direct managed-directory removal also
-    // avoids relying on the vendor uninstaller's incomplete cleanup section.
-    wingetId: 'Speek.Speek',
-    reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
-    reviewedManagedInstallEvidenceFile: '%ProgramFiles(x86)%\\Speek\\Speek.exe',
-    reviewedManagedInstallCompletionTimeoutMinutes: 2,
-  },
-  {
     // darktable's official CPack/NSIS installer writes its ARP registration
     // only after the complete application tree has been extracted. The signed
     // 5.6.0 package can therefore remain quiet longer than the generic QA

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1424,3 +1424,26 @@ describe('DesktopOK managed uninstall block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Speek managed lifecycle block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260824165000_block_speek_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the disproven non-ARP adapter across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Speek.Speek'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32752063718'
+    );
+    expect(sql).toContain('requests user-level execution');
+    expect(sql).toContain('zero new uninstall entries');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1101,35 +1101,6 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
-  it('binds the Speek non-ARP directory lifecycle to customer and QA packaging', () => {
-    const normalized = normalizeQaWorkflowPackageInput({
-      wingetId: 'Speek.Speek',
-      displayName: 'Speek',
-      publisher: 'Speek App',
-      version: '1.7.0',
-      architecture: 'x64',
-      installerSha256: 'b'.repeat(64),
-      installerType: 'nullsoft',
-      silentSwitches: '/S',
-      uninstallCommand: 'REGISTRY_UNINSTALL:Speek',
-      installScope: 'machine',
-      detectionRules: '[]',
-      psadtConfig: JSON.stringify({ detectionRules: [] }),
-    });
-    const expectedConfig = {
-      reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
-      reviewedManagedInstallEvidenceFile:
-        '%ProgramFiles(x86)%\\Speek\\Speek.exe',
-      reviewedManagedInstallCompletionTimeoutMinutes: 2,
-    };
-    const profile = normalized.identity.profile as {
-      psadtConfig: typeof expectedConfig;
-    };
-
-    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
-    expect(profile.psadtConfig).toMatchObject(expectedConfig);
-  });
-
   it('binds the Visual Studio 2022 Build Tools x86 instance root to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2022.BuildTools',

--- a/supabase/migrations/20260824165000_block_speek_unsupported_managed_install.sql
+++ b/supabase/migrations/20260824165000_block_speek_unsupported_managed_install.sql
@@ -1,0 +1,40 @@
+-- Speek 1.7.0's official NSIS source requests user-level execution, writes no
+-- Add/Remove Programs registration, and provides an uninstall section that
+-- does not recursively remove the installed application directory:
+-- https://github.com/Speek-App/Speek/blob/v1.7.0-release/packaging/windows_nsis/installer.nsi
+-- The exact WinGet /S command returned zero under LocalSystem in two isolated
+-- lifecycle runs, but produced zero new uninstall entries and no stable
+-- reviewed machine payload. The first run also retained essentially its full
+-- post-install file delta after the generic uninstall attempt. Remove the
+-- disproven managed-directory adapter and do not publish a PSADT package whose
+-- unattended machine install and removal lifecycle cannot be verified.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Speek.Speek',
+  'unsupported_managed_install',
+  'Speek 1.7.0 requests user-level execution, creates no standard uninstall registration, and does not expose a reliable unattended machine lifecycle. Two isolated LocalSystem runs produced zero new uninstall entries, and the reviewed adapter could not find a stable installed payload after the exact /S command returned success.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32752063718'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Speek.Speek';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Speek.Speek'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- remove the disproven Speek non-ARP managed-directory adapter from the shared customer/QA packager
- block Speek.Speek as an unsupported unattended managed install
- supersede stale failed/queued QA candidates and remove catalog verification

## Evidence
- isolated QA run 32752063718: exact /S invocation returned 0 but no stable managed payload appeared, install outcome 60001, and zero new uninstall entries
- prior isolated run 32414327876 also failed the full lifecycle
- official Speek 1.7.0 NSIS source requests user execution, writes no ARP registration, and does not recursively remove the installed directory

## Verification
- npm run lint
- npm test (85 files, 1461 tests)