### PR TITLE
Activate Speek safety block in QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd64f6815b43c16428d83cde1b909e6503d7cc40f',
+  packagerCommit: '44c38ddec97b546c7423374e09387d812e2386cc',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -341,6 +341,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // DesktopOK is now blocked because it has no verified unattended removal
   // contract. Preserve every compatible pass for the remaining eligible apps.
   'fe8a13f4473a3528368d7a97ff410df1961c594a',
+  // Speek is now blocked after its reviewed non-ARP adapter failed to produce a
+  // stable machine payload. Preserve compatible passes for all eligible apps.
+  'd64f6815b43c16428d83cde1b909e6503d7cc40f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1057,23 +1057,23 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'verifies and removes Speek from its reviewed non-ARP directory',
+    'verifies and removes a reviewed non-ARP machine directory',
     () => {
       const generated = generateRegistryUninstallPackage(
         'nullsoft',
-        'Speek',
+        'Managed Payload Example',
         [],
         {
-          reviewedManagedInstallDirectory: '%ProgramFiles(x86)%\\Speek',
+          reviewedManagedInstallDirectory: '%ProgramFiles%\\ManagedPayloadExample',
           reviewedManagedInstallEvidenceFile:
-            '%ProgramFiles(x86)%\\Speek\\Speek.exe',
+            '%ProgramFiles%\\ManagedPayloadExample\\ManagedPayloadExample.exe',
           reviewedManagedInstallCompletionTimeoutMinutes: 2,
         },
         [],
-        'Speek.Speek',
-        'Speek',
-        '1.7.0',
-        'REGISTRY_UNINSTALL:Speek',
+        'Example.ManagedPayload',
+        'Managed Payload Example',
+        '1.0.0',
+        'REGISTRY_UNINSTALL:Managed Payload Example',
         '/S',
         'machine'
       );
@@ -1087,10 +1087,10 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(installFunction).toContain(
-        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Speek')"
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\ManagedPayloadExample')"
       );
       expect(installFunction).toContain(
-        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Speek\\Speek.exe')"
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\ManagedPayloadExample\\ManagedPayloadExample.exe')"
       );
       expect(installFunction).toContain(
         'Verified stable managed installation evidence'

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -126,7 +126,6 @@ describe('QA toolchain targeted retries', () => {
       'ABB.RobotStudio',
       'Microsoft.msodbcsql.13',
       'Microsoft.WindowsAppRuntime.1.8',
-      'Speek.Speek',
       '8x8.Work',
       'Microsoft.FSLogix',
       'AvaCC.AvaDesktop',
@@ -166,6 +165,7 @@ describe('QA toolchain targeted retries', () => {
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
     expect(targets).not.toContain('Webroot.SecureAnywhere');
+    expect(targets).not.toContain('Speek.Speek');
 
     targets.length = 0;
 
@@ -181,7 +181,6 @@ describe('QA toolchain targeted retries', () => {
         'ABB.RobotStudio',
         'Microsoft.msodbcsql.13',
         'Microsoft.WindowsAppRuntime.1.8',
-        'Speek.Speek',
         '8x8.Work',
         'Microsoft.FSLogix',
         'Google.Chrome.Beta.EXE',
@@ -377,15 +376,15 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Speek only after activating its reviewed non-ARP lifecycle', () => {
+  it('does not replay Speek after activating its managed-install block', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'speek.speek', status: 'failed' }
-    )).toBe(true);
-    expect(shouldRetryTerminalToolchainCandidate(
-      '9aaebb8f2af8bf3144fb5358b8b34e99195c088e',
-      { wingetId: 'Speek.Speek', status: 'failed' }
     )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd64f6815b43c16428d83cde1b909e6503d7cc40f',
+      { wingetId: 'Speek.Speek', status: 'failed' }
+    )).toBe(true);
   });
 
   it.each([

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -178,7 +178,16 @@ const DESKTOPOK_BLOCK_RELEASE_RETRY_TARGETS =
     (wingetId) => wingetId.toLowerCase() !== 'softwareok.desktopok'
   );
 
+const SPEEK_BLOCK_RELEASE_RETRY_TARGETS =
+  DESKTOPOK_BLOCK_RELEASE_RETRY_TARGETS.filter(
+    (wingetId) => wingetId.toLowerCase() !== 'speek.speek'
+  );
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  // Speek is eligibility-blocked after its reviewed machine install contract
+  // failed, so carry the bounded set without replaying Speek or DesktopOK.
+  '44c38ddec97b546c7423374e09387d812e2386cc':
+    SPEEK_BLOCK_RELEASE_RETRY_TARGETS,
   // DesktopOK is eligibility-blocked, so this release carries the prior
   // bounded retry set without replaying its unsupported removal lifecycle.
   'd64f6815b43c16428d83cde1b909e6503d7cc40f':


### PR DESCRIPTION
## Summary
- activate the merged Speek safety block as the current QA/customer packager commit
- preserve compatible pass history from the prior DesktopOK-block release
- exclude both Speek and DesktopOK from inherited terminal retry targets
- keep the managed-directory generator coverage app-neutral

## Verification
- npm run lint
- npm test (85 files, 1461 tests)