### PR TITLE
fix(packaging): silence Waterfox uninstall helper

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -979,6 +979,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('uses Mozilla NSIS silent mode with the exact Waterfox ARP command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'waterfox.waterfox',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/S']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('uses JetBrains Toolbox\'s documented headless uninstall mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'jetbrains.toolbox',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -408,6 +408,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // Waterfox uses Mozilla's NSIS helper.exe lifecycle. Its captured ARP
+    // command contains only the helper path, so invoking it unchanged opens an
+    // uninstall wizard that is invisible under SYSTEM and leaves the exact
+    // registration present. Append the Mozilla-family /S contract to that
+    // captured, version-specific command for both QA and customer packages.
+    wingetId: 'Waterfox.Waterfox',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     // MEGA's installer source makes silent installs current-user by default.
     // Its reviewed /MULTIUSER option selects the AllUsers path required for
     // non-interactive LocalSystem deployment and machine-wide detection.


### PR DESCRIPTION
## Summary
- append Waterfox's reviewed Mozilla-family /S switch to its exact captured ARP helper command
- keep registry identity and version-specific uninstall path authoritative
- apply the adapter to both QA and customer portal PSADT packages

## QA evidence
- run 32766024831 installed and detected Waterfox 6.6.17 successfully under LocalSystem
- the captured helper.exe command opened the non-interactive wizard without /S and left Waterfox 140.13.0 (x64 en-US) registered until the five-minute fail-closed deadline
- reconciled result: install 0, detection 0, uninstall 60001, removal verification 0

## Verification
- 85 Vitest files / 1,462 tests passed
- focused ESLint passed
- TypeScript's standalone 	sc --noEmit remains red on pre-existing Vitest-global and unrelated test-fixture errors