### PR TITLE
release(qa): activate Waterfox silent uninstall

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '44c38ddec97b546c7423374e09387d812e2386cc',
+  packagerCommit: '937a4d51d8c62885f76cb896fa3d742069436ee2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -344,6 +344,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Speek is now blocked after its reviewed non-ARP adapter failed to produce a
   // stable machine payload. Preserve compatible passes for all eligible apps.
   'd64f6815b43c16428d83cde1b909e6503d7cc40f',
+  // Waterfox now appends the reviewed Mozilla-family /S switch only to its
+  // captured ARP helper command. Preserve every unrelated compatible pass.
+  '44c38ddec97b546c7423374e09387d812e2386cc',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -161,6 +161,7 @@ describe('QA toolchain targeted retries', () => {
       'Microsoft.VisualStudio.2019.BuildTools',
       'Microsoft.VisualStudio.2022.BuildTools',
       'Surfshark.Surfshark',
+      'Waterfox.Waterfox',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -214,6 +215,7 @@ describe('QA toolchain targeted retries', () => {
         'Microsoft.VisualStudio.2017.BuildTools',
         'Microsoft.VisualStudio.2019.BuildTools',
         'Microsoft.VisualStudio.2022.BuildTools',
+        'Waterfox.Waterfox',
       ])
     );
     expect(
@@ -222,6 +224,17 @@ describe('QA toolchain targeted retries', () => {
     expect(
       terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
     ).not.toContain('Tencent.QQ.NT');
+  });
+
+  it('retries Waterfox only after activating its silent helper contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' waterfox.waterfox ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '44c38ddec97b546c7423374e09387d812e2386cc',
+      { wingetId: 'Waterfox.Waterfox', status: 'failed' }
+    )).toBe(false);
   });
 
   it('retries ElegantClipboard only after activating its reviewed user scope', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -183,7 +183,16 @@ const SPEEK_BLOCK_RELEASE_RETRY_TARGETS =
     (wingetId) => wingetId.toLowerCase() !== 'speek.speek'
   );
 
+const WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Re-run the exact failed Waterfox release with Mozilla's unattended /S
+  // helper contract, then carry every still-unconsumed bounded target.
+  'Waterfox.Waterfox',
+  ...SPEEK_BLOCK_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '937a4d51d8c62885f76cb896fa3d742069436ee2':
+    WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   // Speek is eligibility-blocked after its reviewed machine install contract
   // failed, so carry the bounded set without replaying Speek or DesktopOK.
   '44c38ddec97b546c7423374e09387d812e2386cc':


### PR DESCRIPTION
## Summary
- activate packager commit 937a4d51d8c62885f76cb896fa3d742069436ee2 for QA and portal package profiles
- preserve all compatible passes from 44c38ddec97b546c7423374e09387d812e2386cc`n- target the failed Waterfox candidate for exactly one new-toolchain replay

## Verification
- 85 Vitest files / 1,463 tests passed
- activation-focused package-profile, retry-map, and generated-PSADT contracts passed (307 tests)