### PR TITLE
fix(packaging): close Playnite before uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1147,6 +1147,18 @@ describe('application packaging adapters', () => {
     ]);
   });
 
+  it('closes both Playnite frontends before its exact Inno removal', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'playnite.playnite',
+        DEFAULT_PSADT_CONFIG
+      ).processesToClose
+    ).toEqual([
+      { name: 'Playnite.DesktopApp', description: 'Playnite Desktop' },
+      { name: 'Playnite.FullscreenApp', description: 'Playnite Fullscreen' },
+    ]);
+  });
+
   it.each([
     'Microsoft.SQLServerManagementStudio.21',
     'Microsoft.SQLServerManagementStudio.22',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1083,6 +1083,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Playnite can keep either of its signed desktop frontends running after
+    // installation. Its Inno uninstaller then exits with code 1 even with the
+    // full unattended switch set and leaves the exact Playnite_is1 registration
+    // installed. Close only the executable identities published by Playnite so
+    // QA and customer Intune packages share the same reliable removal path.
+    wingetId: 'Playnite.Playnite',
+    requiredProcessesToClose: [
+      { name: 'Playnite.DesktopApp', description: 'Playnite Desktop' },
+      { name: 'Playnite.FullscreenApp', description: 'Playnite Fullscreen' },
+    ],
+  },
+  {
     // Qfinder Pro starts its desktop process after a silent install. Close it
     // before removal so the NSIS uninstaller can delete the product instead
     // of waiting behind the running application or its startup-error dialog.


### PR DESCRIPTION
## Summary
- close Playnite Desktop and Fullscreen processes through the shared PSADT adapter
- preserve the exact captured Playnite_is1 Inno uninstall identity and existing unattended switches
- apply the same behavior to QA and customer portal/catalog packages

## Evidence
Production QA run 32775006426 installed and detected Playnite 10.55 successfully, then unins000.exe exited 1 and the exact Playnite_is1 registration survived the 310-second removal deadline. The failed profile had zero processes to close. Playnite's official source publishes the executable identities Playnite.DesktopApp and Playnite.FullscreenApp.

## Verification
- focused packaging/profile/PSADT contracts: 294 passed
- full Vitest suite: 85 files, 1464 tests passed
- focused ESLint passed
- git diff --check passed