### PR TITLE
release(qa): activate Playnite process-close adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '937a4d51d8c62885f76cb896fa3d742069436ee2',
+  packagerCommit: 'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -347,6 +347,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Waterfox now appends the reviewed Mozilla-family /S switch only to its
   // captured ARP helper command. Preserve every unrelated compatible pass.
   '44c38ddec97b546c7423374e09387d812e2386cc',
+  // Playnite now closes its two reviewed desktop frontends before the exact
+  // Inno uninstall. Preserve every unrelated compatible pass from Waterfox.
+  '937a4d51d8c62885f76cb896fa3d742069436ee2',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -162,6 +162,7 @@ describe('QA toolchain targeted retries', () => {
       'Microsoft.VisualStudio.2022.BuildTools',
       'Surfshark.Surfshark',
       'Waterfox.Waterfox',
+      'Playnite.Playnite',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -216,6 +217,7 @@ describe('QA toolchain targeted retries', () => {
         'Microsoft.VisualStudio.2019.BuildTools',
         'Microsoft.VisualStudio.2022.BuildTools',
         'Waterfox.Waterfox',
+        'Playnite.Playnite',
       ])
     );
     expect(
@@ -234,6 +236,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '44c38ddec97b546c7423374e09387d812e2386cc',
       { wingetId: 'Waterfox.Waterfox', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Playnite only after activating its process-close contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' playnite.playnite ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '937a4d51d8c62885f76cb896fa3d742069436ee2',
+      { wingetId: 'Playnite.Playnite', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -190,7 +190,16 @@ const WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...SPEEK_BLOCK_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS = [
+  // Re-run Playnite with both vendor-published desktop frontends closed before
+  // its exact Inno removal, then carry every still-unconsumed bounded target.
+  'Playnite.Playnite',
+  ...WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5':
+    PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS,
   '937a4d51d8c62885f76cb896fa3d742069436ee2':
     WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   // Speek is eligibility-blocked after its reviewed machine install contract


### PR DESCRIPTION
## Summary
- pin the shared QA and customer package profile to d8642e4a6e3ee867fd8dfaf5bae632fbe24200f5
- preserve compatible passes from the previous packager release
- include Playnite in the bounded terminal retry set for this release

## Verification
- focused activation suite: 5 files, 301 tests passed
- full Vitest suite: 85 files, 1465 tests passed
- focused ESLint and git diff --check passed