### PR TITLE
fix(packaging): survive transient Graph errors in the duplicate check

### DIFF
--- a/.github/scripts/Check-DuplicateApp.ps1
+++ b/.github/scripts/Check-DuplicateApp.ps1
@@ -8,7 +8,9 @@
     DUPLICATE_FOUND=true in the environment. If forceCreate is enabled, skips the check.
 
     API errors stop the deployment before app creation so a transient duplicate
-    check failure cannot create a second app.
+    check failure cannot create a second app. Requests go through
+    Invoke-GraphRequest so a genuinely transient 401/429/5xx is retried (and the
+    token refreshed) before the run is failed.
 
 .NOTES
     Env vars consumed:
@@ -21,6 +23,12 @@
 
 # Load Send-Callback helper
 . "$env:GITHUB_WORKSPACE\Send-Callback.ps1"
+
+# Graph helpers. Invoke-GraphRequest owns token refresh on 401, Retry-After on
+# 429 and backoff on 5xx; calling Invoke-RestMethod directly here meant a single
+# transient response failed the whole deployment.
+. "$env:GITHUB_WORKSPACE\Get-GraphToken.ps1"
+. "$env:GITHUB_WORKSPACE\Invoke-GraphRequest.ps1"
 
 # If forceCreate is enabled, skip the duplicate check entirely
 if ($env:INPUT_FORCE_CREATE -eq 'true') {
@@ -48,31 +56,52 @@ if (-not $graphToken) {
 Write-Host "Checking for duplicate app: '$displayName' (Winget: $wingetId)"
 
 try {
-    $headers = @{
-        "Authorization" = "Bearer $graphToken"
-        "Content-Type"  = "application/json"
-    }
-
-    # Query Win32 apps from Graph API
-    $filter = "isof('microsoft.graph.win32LobApp')"
     # Keep the collection projection limited to mobileApp base properties.
     # Graph rejects Win32-only fields in $select against this base collection.
     $select = "id,displayName,description"
     $baseUrl = "https://graph.microsoft.com/v1.0/deviceAppManagement/mobileApps"
-    $url = "${baseUrl}?`$filter=${filter}&`$select=${select}"
+    $escapedDisplayName = $displayName.Replace("'", "''")
 
-    $allApps = @()
+    # Pull only the candidates that can possibly match. Enumerating every Win32
+    # app in the tenant page by page is what produced 504 Gateway Timeout on
+    # large tenants; the name filter usually reduces this to a single page.
+    $typeFilter = "isof('microsoft.graph.win32LobApp')"
+    $nameFilter = "displayName eq '${escapedDisplayName}'"
+    $maxPages = 200
 
-    # Handle pagination
-    while ($url) {
-        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get -ErrorAction Stop
-        if ($response.value) {
-            $allApps += $response.value
+    function Get-CandidateApps {
+        param([string]$Filter)
+
+        $apps = @()
+        $pageCount = 0
+        $url = "${baseUrl}?`$filter=$([Uri]::EscapeDataString($Filter))&`$select=${select}&`$top=999"
+        while ($url -and $pageCount -lt $maxPages) {
+            $pageCount++
+            $response = Invoke-GraphRequest -Uri $url -MaxRetries 4
+            if ($response.value) { $apps += $response.value }
+            $url = $response.'@odata.nextLink'
         }
-        $url = $response.'@odata.nextLink'
+        if ($url) {
+            throw "Duplicate check stopped after $maxPages pages without reaching the end of the app list"
+        }
+        return , $apps
     }
 
-    Write-Host "Found $($allApps.Count) Win32 app(s) in tenant"
+    $allApps = $null
+    try {
+        $allApps = Get-CandidateApps -Filter "$typeFilter and $nameFilter"
+        Write-Host "Found $($allApps.Count) Win32 app(s) matching '$displayName'"
+    }
+    catch {
+        # Intune's $filter support on this collection is uneven. If the combined
+        # filter is rejected, fall back to the type-only enumeration rather than
+        # failing a deployment over a query-shape limitation.
+        $filterStatus = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+        if ($filterStatus -ne 400) { throw }
+        Write-Host "::warning::Graph rejected the combined duplicate-check filter; falling back to a full Win32 enumeration"
+        $allApps = Get-CandidateApps -Filter $typeFilter
+        Write-Host "Found $($allApps.Count) Win32 app(s) in tenant"
+    }
 
     $nameMatches = @($allApps | Where-Object { $_.displayName -ieq $displayName })
 
@@ -105,7 +134,7 @@ try {
         # Fetch the polymorphic resource without $select before reading
         # Win32-only properties such as displayVersion and committedContentVersion.
         $detailUrl = "$baseUrl/$($app.id)"
-        $appDetails = Invoke-RestMethod -Uri $detailUrl -Headers $headers -Method Get -ErrorAction Stop
+        $appDetails = Invoke-GraphRequest -Uri $detailUrl -MaxRetries 3
 
         # Only committed, published apps are deployable duplicates. Failed or
         # partially-created apps from an earlier upload must not block a safe retry.


### PR DESCRIPTION
## Why

`Check-DuplicateApp.ps1` gates every deployment, but it called `Invoke-RestMethod` directly instead of `Invoke-GraphRequest`. It therefore had none of the retry behaviour the rest of the pipeline relies on, and a single transient response failed the whole run before app creation.

From the last few weeks of `package-intunewin.yml` failures, this step accounted for 5 of them:

| Date | Runs | Failure |
|---|---|---|
| 2026-08-13 | 4 | `Duplicate check failed: 401 (Unauthorized)` |
| 2026-08-14 | 1 | `Duplicate check failed: 504 (Gateway Timeout)` |

The 401s are the transient Intune backend response that `Invoke-GraphRequest` already has explicit handling for. The 504 is the full-tenant enumeration timing out.

## What changed

- Both Graph calls now go through `Invoke-GraphRequest`, inheriting token refresh on 401, `Retry-After` on 429 and backoff on 5xx. This also drops the reliance on a single token captured before a whole-tenant walk, which could expire midway.
- The candidate query filters on `displayName` server side with `$top=999` instead of paginating every Win32 app and matching client side. The unbounded enumeration is what produced the 504.
- Intune's `$filter` support on this collection is uneven, so a 400 on the combined filter falls back to the previous type-only enumeration rather than failing a deployment over a query-shape limitation. Pagination is capped at 200 pages.

## What did not change

The check still fails closed. A genuinely persistent Graph error stops the run before app creation, so a transient failure can never create a duplicate app. That property is what the existing `.NOTES` block describes and it is preserved.

## Verification

- Parses clean.
- Functional test with stubbed Graph covering three cases: filtered query succeeds; Graph rejects the combined filter with 400 and the fallback runs; a persistent 504 still fails closed with `DUPLICATE_CHECK_FAILED`. All pass.

## Follow-up

`package-intunewin.yml` pins this repo at `44c38ddec97b546c7423374e09387d812e2386cc`, so this change has no effect until that pin is bumped in `ugurkocde/IntuneGet-Workflows`. The pin lives in three places kept in sync by `Test-IntuneQAPackageToolchain.ps1`:

- `qa/config/IntuneQAPackageToolchain.psd1` → `PackagerCommit`
- `.github/workflows/intune-qa.yml` → `QA_PACKAGER_COMMIT`
- `.github/workflows/package-intunewin.yml` → `ref:`

That bump follows once this merges and the squashed commit SHA on `main` is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)