### PR TITLE
Fix Internet Download Manager silent uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -356,6 +356,12 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/S']);
     expect(
+      applyApplicationPackagingAdapter(
+        'Tonec.InternetDownloadManager',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['/S']);
+    expect(
       applyApplicationPackagingAdapter('Cockos.REAPER', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/S']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -654,6 +654,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // Internet Download Manager registers Uninstall.exe without a quiet
+    // command. Replaying that bare ARP command under Intune's non-interactive
+    // SYSTEM session leaves the uninstall wizard hidden and the exact product
+    // registration intact. Its uninstaller accepts the case-sensitive /S
+    // switch used by the product's unattended executable lifecycle.
+    wingetId: 'Tonec.InternetDownloadManager',
+    reviewedUninstallArguments: ['/S'],
+  },
+  {
     // REAPER registers an interactive uninstall command without a separate
     // QuietUninstallString. Its vendor installer and uninstaller both accept
     // the manifest's case-sensitive /S switch; without it, a SYSTEM removal


### PR DESCRIPTION
## Summary
- add a scoped packaging adapter for Tonec.InternetDownloadManager
- pass the vendor uninstaller's silent /S switch under Intune's non-interactive SYSTEM context
- preserve exact ARP removal verification as the lifecycle authority

## QA evidence
- failing production QA run: 32834375525
- install and detection passed; bare Uninstall.exe left the exact ARP registration and returned PSADT 60001 after the bounded deadline

## Tests
- 265 focused adapter/profile/packager tests passed
- 65 adapter tests passed again after rebasing onto current main