### PR TITLE
release(qa): activate IDM silent uninstall

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
+  packagerCommit: 'c649792a94f23b4c3fc04e07b81c4aa655887301',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -350,6 +350,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Playnite now closes its two reviewed desktop frontends before the exact
   // Inno uninstall. Preserve every unrelated compatible pass from Waterfox.
   '937a4d51d8c62885f76cb896fa3d742069436ee2',
+  // Internet Download Manager now supplies /S to its otherwise interactive
+  // registered uninstaller. Preserve every unrelated pass from Playnite.
+  'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -163,6 +163,7 @@ describe('QA toolchain targeted retries', () => {
       'Surfshark.Surfshark',
       'Waterfox.Waterfox',
       'Playnite.Playnite',
+      'Tonec.InternetDownloadManager',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -218,6 +219,7 @@ describe('QA toolchain targeted retries', () => {
         'Microsoft.VisualStudio.2022.BuildTools',
         'Waterfox.Waterfox',
         'Playnite.Playnite',
+        'Tonec.InternetDownloadManager',
       ])
     );
     expect(
@@ -247,6 +249,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '937a4d51d8c62885f76cb896fa3d742069436ee2',
       { wingetId: 'Playnite.Playnite', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Internet Download Manager only after activating its silent uninstall contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' tonec.internetdownloadmanager ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
+      { wingetId: 'Tonec.InternetDownloadManager', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -197,7 +197,16 @@ const PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS = [
   ...WATERFOX_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Re-run the exact failed IDM release with its unattended /S uninstall
+  // switch, then carry every still-unconsumed bounded target.
+  'Tonec.InternetDownloadManager',
+  ...PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'c649792a94f23b4c3fc04e07b81c4aa655887301':
+    IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5':
     PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS,
   '937a4d51d8c62885f76cb896fa3d742069436ee2':


### PR DESCRIPTION
## Summary
- pin shared QA and customer package profiles to c649792a94f23b4c3fc04e07b81c4aa655887301
- preserve compatible passes from the Playnite release
- add Tonec.InternetDownloadManager to the bounded terminal retry set

## Verification
- focused activation suite: 5 files, 408 tests passed
- focused ESLint passed
- git diff --check passed