### PR TITLE
Fix targeted QA retries and manifest-change deduplication

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -728,6 +728,48 @@ describe('GET /api/cron/qa-enqueue', () => {
     expect(resolveManifestMock).not.toHaveBeenCalled();
   });
 
+  it('allows a protected targeted rerun for a prior failed catalog package', async () => {
+    const { client, candidateInserts } = createSupabaseStub({
+      supportedApps: [{
+        winget_id: 'Failed.CatalogApp',
+        name: 'Failed Catalog App',
+        publisher: 'Contoso',
+        latest_version: '1.0.0',
+      }],
+      deployedApps: [],
+      packageResults: [{
+        winget_id: 'Failed.CatalogApp',
+        tested_version: '1.0.0',
+        architecture: 'x64',
+        installer_sha256: 'A'.repeat(64),
+        outcome: 'Failed',
+        tested_at_utc: '2026-08-25T10:00:00.000Z',
+        package_profile_sha256: 'B'.repeat(64),
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest('?id=Failed.CatalogApp'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      queued: 1,
+      targetedRequestedCount: 1,
+      targetedCount: 1,
+    });
+    expect(candidateInserts).toEqual([
+      expect.objectContaining({
+        winget_id: 'Failed.CatalogApp',
+        status: 'queued',
+        priority: 1_000,
+        demand_source: 'operator',
+      }),
+    ]);
+  });
+
   it('records a current-head reconciliation when the live installer manifest is unavailable', async () => {
     const { client, candidateInserts, catalogReconciliations } = createSupabaseStub({
       demandBackfillApps: ['Unavailable.App'],
@@ -812,6 +854,7 @@ describe('GET /api/cron/qa-enqueue', () => {
         architecture: 'x64',
         installer_url: 'https://example.com/setup.exe',
         expected_sha256: 'A'.repeat(64),
+        status: 'quarantined',
       }],
     });
     createServerClientMock.mockReturnValue(client);
@@ -829,6 +872,43 @@ describe('GET /api/cron/qa-enqueue', () => {
         catalog_version: '1.0.0',
         observed_live_version: '1.0.0',
         observed_head_sha: 'b'.repeat(40),
+        reason_code: 'installer_hash_quarantined',
+      }),
+    ]);
+  });
+
+  it('keeps a fresh manifest-changed installer tuple out of the queue', async () => {
+    const { client, candidateInserts, catalogReconciliations } = createSupabaseStub({
+      demandBackfillApps: ['Changed.ManifestApp'],
+      supportedApps: [{
+        winget_id: 'Changed.ManifestApp',
+        name: 'Changed Manifest App',
+        publisher: 'Contoso',
+        latest_version: '1.0.0',
+      }],
+      installerHealth: [{
+        winget_id: 'Changed.ManifestApp',
+        version: '1.0.0',
+        architecture: 'x64',
+        installer_url: 'https://example.com/setup.exe',
+        expected_sha256: 'A'.repeat(64),
+        status: 'error',
+        reason_code: 'MANIFEST_CHANGED',
+        expires_at: '2099-01-01T00:00:00.000Z',
+      }],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 1, queued: 0, unavailable: 1, errorCount: 0 });
+    expect(candidateInserts).toHaveLength(0);
+    expect(catalogReconciliations).toEqual([
+      expect.objectContaining({
+        winget_id: 'Changed.ManifestApp',
         reason_code: 'installer_hash_quarantined',
       }),
     ]);

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -718,7 +718,10 @@ export async function GET(request: Request) {
       tested_at_utc: string;
       package_profile_sha256: string | null;
     }> = [];
-    let quarantinedInstallerTuples = new Set<string>();
+    let unavailableInstallerTuples = new Map<
+      string,
+      'HASH_MISMATCH' | 'MANIFEST_CHANGED'
+    >();
     if (supportedIds.length > 0) {
       const [recipeResult, policyResult, deployedResult, resultResult, healthResult] = await Promise.all([
         supabase
@@ -744,9 +747,11 @@ export async function GET(request: Request) {
           .in('winget_id', supportedIds),
         supabase
           .from('installer_health')
-          .select('winget_id, version, architecture, installer_url, expected_sha256')
+          .select(
+            'winget_id, version, architecture, installer_url, expected_sha256, status, reason_code, expires_at'
+          )
           .in('winget_id', supportedIds)
-          .eq('status', 'quarantined'),
+          .in('status', ['quarantined', 'error']),
       ]);
       if (recipeResult.error) {
         throw new Error(`Could not read optional QA recipes: ${recipeResult.error.message}`);
@@ -767,15 +772,25 @@ export async function GET(request: Request) {
       policies = policyResult.data || [];
       deployedApps = deployedResult.data || [];
       results = resultResult.data || [];
-      quarantinedInstallerTuples = new Set((healthResult.data || []).map((row) =>
-        installerTupleKey({
+      const observedAtMs = Date.parse(startedAt);
+      unavailableInstallerTuples = new Map((healthResult.data || []).flatMap((row) => {
+        const reasonCode = row.status === 'quarantined'
+          ? 'HASH_MISMATCH' as const
+          : row.status === 'error' &&
+              row.reason_code === 'MANIFEST_CHANGED' &&
+              typeof row.expires_at === 'string' &&
+              Date.parse(row.expires_at) > observedAtMs
+            ? 'MANIFEST_CHANGED' as const
+            : null;
+        if (!reasonCode) return [];
+        return [[installerTupleKey({
           wingetId: row.winget_id,
           version: row.version,
           architecture: row.architecture,
           installerUrl: row.installer_url,
           installerSha256: row.expected_sha256,
-        })
-      ));
+        }), reasonCode]];
+      }));
     }
 
     const priorities = new Map<string, number>();
@@ -792,10 +807,16 @@ export async function GET(request: Request) {
         priorities.set(wingetId, Math.max(priorities.get(wingetId) || 0, TARGETED_QA_PRIORITY));
       }
     }
+    const failedCatalogQaIds = new Set(
+      results
+        .filter((result) => result.outcome === 'Failed')
+        .map((result) => result.winget_id)
+    );
     supportedApps = supportedApps.filter((app) =>
       demandedIds.has(app.winget_id) ||
       backfillIds.has(app.winget_id) ||
-      catalogBackfillIdSet.has(app.winget_id)
+      catalogBackfillIdSet.has(app.winget_id) ||
+      (targetedIdSet.has(app.winget_id) && failedCatalogQaIds.has(app.winget_id))
     );
     targetedCount = supportedApps.filter((app) => targetedIdSet.has(app.winget_id)).length;
     for (const app of supportedApps) {
@@ -923,13 +944,14 @@ export async function GET(request: Request) {
             }
 
             const architecture = selectedForVm.architecture;
-            if (quarantinedInstallerTuples.has(installerTupleKey({
+            const unavailableReasonCode = unavailableInstallerTuples.get(installerTupleKey({
               wingetId: app.winget_id,
               version: resolution.version,
               architecture,
               installerUrl,
               installerSha256,
-            }))) {
+            }));
+            if (unavailableReasonCode) {
               await persistQaCatalogReconciliation(supabase!, {
                 wingetId: app.winget_id,
                 catalogVersion: app.latest_version!,
@@ -938,11 +960,12 @@ export async function GET(request: Request) {
                 observedLiveVersion: resolution.version,
               });
               summary.unavailable++;
-              structuredQaPollLog('info', 'qa_installer_hash_quarantined', {
+              structuredQaPollLog('info', 'qa_installer_source_quarantined', {
                 runId,
                 wingetId: app.winget_id,
                 version: resolution.version,
                 architecture,
+                preflightReasonCode: unavailableReasonCode,
               });
               return;
             }


### PR DESCRIPTION
## Summary
- allow the protected targeted enqueue path to rebuild prior failed catalog packages without expanding to arbitrary undeployed apps
- consult fresh MANIFEST_CHANGED installer-health errors alongside hash quarantines
- keep those exact source tuples dormant until their health record expires

## Why
- Tonec.InternetDownloadManager could not be rerun immediately after its adapter fix because the final target filter dropped catalog-only failures
- Rakuten.Viber was recreated after every packager activation even though the shared preflight cache still marked its tuple MANIFEST_CHANGED

## Verification
- qa-enqueue route: 36 tests passed
- focused ESLint passed
- git diff --check passed
- repository-wide tsc still reports pre-existing test-global typing errors; no qa-enqueue route errors remain