### PR TITLE
chore(catalog): block WinSCP Beta and refuse requests for blocked apps

### DIFF
--- a/app/api/community/suggestions/route.eligibility.test.ts
+++ b/app/api/community/suggestions/route.eligibility.test.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// vi.mock factories are hoisted, so everything they close over has to be
+// created inside vi.hoisted.
+const h = vi.hoisted(() => {
+  // A blocked id is still present in curated_apps, because the block row
+  // references it, so the catalog lookup would otherwise answer
+  // "already available in IntuneGet".
+  const state: { blockRows: Array<{ winget_id: string; block_code: string }> } =
+    { blockRows: [] };
+
+  const catalogAppExists = vi.fn();
+  const wingetExists = vi.fn();
+
+  const client = {
+    from(table: string) {
+      if (table === 'package_eligibility_blocks') {
+        const builder: Record<string, unknown> = {
+          select: () => builder,
+          in: () => builder,
+          then: (
+            onFulfilled: (value: unknown) => unknown,
+            onRejected?: (reason: unknown) => unknown
+          ) =>
+            Promise.resolve({ data: state.blockRows, error: null }).then(
+              onFulfilled,
+              onRejected
+            ),
+        };
+        return builder;
+      }
+      // app_suggestions duplicate lookup: no existing suggestion
+      const builder: Record<string, unknown> = {
+        select: () => builder,
+        eq: () => builder,
+        in: () => builder,
+        single: () => Promise.resolve({ data: null, error: null }),
+      };
+      return builder;
+    },
+  };
+
+  return { state, catalogAppExists, wingetExists, client };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  createServerClient: () => h.client,
+  isSupabaseServerConfigured: () => true,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  applyRateLimit: vi.fn().mockResolvedValue(null),
+  getIpKey: vi.fn(),
+  getUserKey: vi.fn(),
+  SUGGESTION_RATE_LIMIT: {},
+  PUBLIC_RATE_LIMIT: {},
+}));
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: vi
+    .fn()
+    .mockResolvedValue({ userId: 'user-1', userEmail: 'user@example.com' }),
+}));
+vi.mock('@/lib/catalog', () => ({
+  getCatalogSource: () => ({
+    appExistsCaseInsensitive: h.catalogAppExists,
+    findSimilarVerifiedApps: vi.fn().mockResolvedValue([]),
+  }),
+}));
+vi.mock('@/lib/winget-existence', () => ({
+  checkWingetPackageExists: h.wingetExists,
+}));
+vi.mock('@/lib/github-issues', () => ({
+  createAppSuggestionIssue: vi.fn().mockResolvedValue(null),
+}));
+
+import { POST } from './route';
+
+function request(wingetId: string) {
+  return new NextRequest('http://localhost/api/community/suggestions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer token',
+    },
+    body: JSON.stringify({
+      winget_id: wingetId,
+      reason: 'We need this application for our standard desktop image.',
+    }),
+  });
+}
+
+describe('POST /api/community/suggestions eligibility gate', () => {
+  it('refuses a request for an app blocked from automated deployment', async () => {
+    h.state.blockRows = [
+      {
+        winget_id: 'WinSCP.WinSCP.Beta',
+        block_code: 'unsupported_installer_source',
+      },
+    ];
+    h.catalogAppExists.mockReset().mockResolvedValue({
+      winget_id: 'WinSCP.WinSCP.Beta',
+    });
+    h.wingetExists.mockReset().mockResolvedValue('found');
+
+    const response = await POST(request('WinSCP.WinSCP.Beta'));
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe('PACKAGE_UNAVAILABLE');
+    expect(body.wingetId).toBe('WinSCP.WinSCP.Beta');
+    // The block must short-circuit before the catalog branch, otherwise the
+    // caller is told the app is "already available".
+    expect(h.catalogAppExists).not.toHaveBeenCalled();
+  });
+
+  it('leaves unblocked ids to the existing catalog and winget checks', async () => {
+    h.state.blockRows = [];
+    h.catalogAppExists.mockReset().mockResolvedValue({
+      winget_id: 'Google.Chrome',
+    });
+    h.wingetExists.mockReset().mockResolvedValue('found');
+
+    const response = await POST(request('Google.Chrome'));
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBeUndefined();
+    expect(body.error).toContain('already available in IntuneGet');
+    expect(h.catalogAppExists).toHaveBeenCalled();
+  });
+});

--- a/app/api/community/suggestions/route.ts
+++ b/app/api/community/suggestions/route.ts
@@ -23,6 +23,10 @@ import {
 import { createAppSuggestionIssue } from '@/lib/github-issues';
 import { checkWingetPackageExists } from '@/lib/winget-existence';
 import { getCatalogSource } from '@/lib/catalog';
+import {
+  getPackageEligibilityBlocks,
+  PACKAGE_UNAVAILABLE_MESSAGE,
+} from '@/lib/package-eligibility';
 
 /**
  * GET /api/community/suggestions
@@ -191,6 +195,24 @@ export async function POST(request: NextRequest) {
           error: 'This app has already been suggested',
           existingSuggestionId: existing.id,
           status: existing.status,
+        },
+        { status: 409 }
+      );
+    }
+
+    // Refuse ids that are blocked from automated deployment. This runs before
+    // the catalog check because a blocked app stays in curated_apps (the block
+    // row references it), so the catalog branch would otherwise answer with a
+    // misleading "already available in IntuneGet".
+    const eligibilityBlocks = await getPackageEligibilityBlocks(supabase, [
+      winget_id,
+    ]);
+    if (eligibilityBlocks.length > 0) {
+      return NextResponse.json(
+        {
+          error: PACKAGE_UNAVAILABLE_MESSAGE,
+          code: 'PACKAGE_UNAVAILABLE',
+          wingetId: eligibilityBlocks[0].wingetId,
         },
         { status: 409 }
       );

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -5,7 +5,8 @@ export type PackageEligibilityBlockCode =
   | 'vendor_retired'
   | 'upstream_removed'
   | 'unsupported_managed_install'
-  | 'unsupported_managed_uninstall';
+  | 'unsupported_managed_uninstall'
+  | 'unsupported_installer_source';
 
 export interface PackageEligibilityBlock {
   wingetId: string;

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1447,3 +1447,49 @@ describe('Speek managed lifecycle block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('WinSCP Beta installer source block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260825120000_block_winscp_beta_unavailable_installer_source.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks an installer the packaging service can never fetch', () => {
+    expect(sql).toContain("'unsupported_installer_source'");
+    expect(sql).toContain("'WinSCP.WinSCP.Beta'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32475327124'
+    );
+    expect(sql).toContain('HTTP 403');
+    expect(sql).toContain('source-access restriction');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+
+  it('keeps the new code in the shared block_code constraint', () => {
+    expect(sql).toContain('package_eligibility_blocks_block_code_check');
+    for (const code of [
+      'vendor_retired',
+      'upstream_removed',
+      'unsupported_managed_install',
+      'unsupported_managed_uninstall',
+      'unsupported_installer_source',
+    ]) {
+      expect(sql).toContain(`'${code}'`);
+    }
+  });
+
+  it('closes any open community request for the blocked id', () => {
+    expect(sql).toContain('update public.app_suggestions');
+    expect(sql).toContain("status = 'rejected'");
+    expect(sql).toContain("status in ('pending', 'approved')");
+  });
+
+  it('does not block the reviewed stable WinSCP id', () => {
+    expect(sql).not.toContain("'WinSCP.WinSCP',");
+  });
+});

--- a/supabase/migrations/20260825120000_block_winscp_beta_unavailable_installer_source.sql
+++ b/supabase/migrations/20260825120000_block_winscp_beta_unavailable_installer_source.sql
@@ -1,0 +1,67 @@
+-- WinSCP.WinSCP.Beta 6.6.1.beta is hosted only on SourceForge, which refuses
+-- automated retrieval from the packaging infrastructure. Twelve consecutive
+-- package-app runs between 2026-08-06 and 2026-08-21 failed at the download
+-- stage: the primary sourceforge.net URL and every one of the seven configured
+-- dl.sourceforge.net mirrors returned HTTP 403.
+-- https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32475327124
+--
+-- The file has not been withdrawn upstream. It still returns HTTP 200 from
+-- ordinary networks, so this is a source-access restriction against the CI
+-- egress range rather than an upstream removal, and it cannot be repaired by
+-- retrying, by mirror rotation, or by any change to the packaging workflow.
+-- A package whose installer cannot be fetched can never produce a verified
+-- deployment, so remove it from the catalog and refuse it everywhere,
+-- including community requests.
+--
+-- This is a beta channel package. The reviewed stable id WinSCP.WinSCP is a
+-- different package and is not covered by this block.
+
+alter table public.package_eligibility_blocks
+  drop constraint if exists package_eligibility_blocks_block_code_check;
+alter table public.package_eligibility_blocks
+  add constraint package_eligibility_blocks_block_code_check
+  check (block_code in (
+    'vendor_retired',
+    'upstream_removed',
+    'unsupported_managed_install',
+    'unsupported_managed_uninstall',
+    'unsupported_installer_source'
+  ));
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'WinSCP.WinSCP.Beta',
+  'unsupported_installer_source',
+  'WinSCP Beta 6.6.1.beta is distributed only through SourceForge, which returns HTTP 403 to the packaging infrastructure on both the primary download URL and all seven configured mirrors. Twelve consecutive runs between 2026-08-06 and 2026-08-21 failed at the download stage. The file is still published and reachable from other networks, so this is a source-access restriction rather than an upstream removal, and no retry or mirror rotation can recover it. The installer can never be fetched, so no verified package can be produced.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32475327124'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'WinSCP.WinSCP.Beta';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'WinSCP.WinSCP.Beta'
+  and status in ('queued', 'failed', 'error');
+
+-- Close any community request for a package that can never be delivered, and
+-- keep it closed. New requests are refused by the eligibility gate in
+-- app/api/community/suggestions.
+update public.app_suggestions
+set status = 'rejected'
+where winget_id ilike 'WinSCP.WinSCP.Beta'
+  and status in ('pending', 'approved');


### PR DESCRIPTION
## Why

`WinSCP.WinSCP.Beta` 6.6.1.beta is distributed only through SourceForge, which returns **HTTP 403 to the packaging infrastructure** on the primary download URL and on all seven configured `dl.sourceforge.net` mirrors.

Twelve consecutive `package-app` runs failed at the download stage:

| Date (UTC) | Attempts |
|---|---|
| 2026-08-06 | 2 |
| 2026-08-07 | 1 |
| 2026-08-12 | 2 |
| 2026-08-13 | 2 |
| 2026-08-16 | 1 |
| 2026-08-21 | 4 (11:03, 11:05, 11:07, 11:09) |

Sixteen days, and the last day is four attempts inside seven minutes, which reads as manual retries.

**The file has not been withdrawn upstream.** I checked: the SourceForge landing page and the direct mirror URL both return HTTP 200 from an ordinary network, and WinSCP has since published `6.6.2 RC`. So this is a source-access restriction against the CI egress range, not an upstream removal. No retry, mirror rotation, or packaging-workflow change can recover it. An installer that can never be fetched can never produce a verified package.

## New eligibility code

Adds `unsupported_installer_source` as a fifth code.

None of the existing four fits. The vendor has not retired the package and nothing was removed upstream, so reusing `vendor_retired` or `upstream_removed` would record a **false reason** in a table whose `detail` and `source_url` columns exist precisely to carry evidence. The constraint has been widened this way before, when `upstream_removed`, `unsupported_managed_install` and `unsupported_managed_uninstall` were each added.

## Closing the request path

This is the part that was missing. The eligibility gate was enforced in `app/api/package/route.ts` and `lib/qa/demand.ts`, but **not** in `app/api/community/suggestions`, so a blocked app could still be requested by anyone.

The gate now runs in the suggestions `POST` handler, placed **ahead of** the catalog check. A blocked app stays in `curated_apps` (because `package_eligibility_blocks.winget_id` references it), so the catalog branch would otherwise answer with a misleading "already available in IntuneGet".

The migration also rejects any already-open suggestion for the id. There are currently none.

## Scope note

The reviewed stable id `WinSCP.WinSCP` is a different package and is **not** covered by this block. It is also not currently in the catalog, so this removes WinSCP from IntuneGet entirely until the stable id is added. Flagging that explicitly in case adding stable WinSCP is the follow-up you want.

## What "removed" means here

`is_verified = false` de-lists it from the verified catalog and sets `noindex` on the detail page, and the packaging gate refuses deployment. The detail URL still resolves. That is the established behaviour of all 52 existing blocks; making blocked apps hard-404 would be a separate change affecting all of them.

## Verification

- Full suite: 1474 tests, 86 files, all passing.
- New contract tests for the migration, matching the per-block convention already in `lib/qa/migration-contract.test.ts`.
- New tests for the request gate: a blocked id returns 409 `PACKAGE_UNAVAILABLE` and short-circuits before the catalog lookup; an unblocked id still falls through to the existing catalog and winget checks.
- ESLint clean on all touched files. `tsc --noEmit` reports zero errors in touched files (the repo has 543 pre-existing errors in other test files and does not gate on it).

## After merge

Migrations are applied manually (`supabase db push`); merging alone does not activate the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)