### PR TITLE
fix(packaging): automate reviewed IDM uninstall dialogs

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -331,6 +331,80 @@ $reviewedUninstallArgumentsLiteral = @(
     $reviewedUninstallArguments | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }
 ) -join ', '
 
+$reviewedUninstallWindowAutomationConfigured = $false
+$reviewedUninstallWindowAutomation = $null
+if ($psadtConfig.Contains('reviewedUninstallWindowAutomation') -and
+    $null -ne $psadtConfig['reviewedUninstallWindowAutomation']) {
+    $rawWindowAutomation = $psadtConfig['reviewedUninstallWindowAutomation']
+    if ($rawWindowAutomation -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedUninstallWindowAutomation must be an object.'
+    }
+    foreach ($windowAutomationKey in $rawWindowAutomation.Keys) {
+        if ([string]$windowAutomationKey -notin @('processName', 'steps')) {
+            throw "PSADT reviewedUninstallWindowAutomation contains an unsupported property: $windowAutomationKey"
+        }
+    }
+    $windowAutomationProcessName = ([string]$rawWindowAutomation['processName']).Trim()
+    if ($windowAutomationProcessName -notmatch '^[A-Za-z0-9 _().-]+\.exe$' -or
+        $windowAutomationProcessName.Length -gt 128 -or
+        [System.IO.Path]::GetFileName($windowAutomationProcessName) -ne $windowAutomationProcessName) {
+        throw 'PSADT reviewedUninstallWindowAutomation.processName must be a bounded executable leaf name.'
+    }
+    $rawWindowAutomationSteps = $rawWindowAutomation['steps']
+    if ($rawWindowAutomationSteps -is [string] -or
+        $rawWindowAutomationSteps -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedUninstallWindowAutomation.steps must be an array.'
+    }
+    $windowAutomationSteps = @()
+    foreach ($rawWindowAutomationStep in @($rawWindowAutomationSteps)) {
+        if ($rawWindowAutomationStep -isnot [System.Collections.IDictionary]) {
+            throw 'Every PSADT reviewed uninstall window-automation step must be an object.'
+        }
+        foreach ($windowAutomationStepKey in $rawWindowAutomationStep.Keys) {
+            if ([string]$windowAutomationStepKey -notin @('windowText', 'buttonIndex', 'timeoutSeconds')) {
+                throw "PSADT reviewed uninstall window-automation step contains an unsupported property: $windowAutomationStepKey"
+            }
+        }
+        $windowText = if ($rawWindowAutomationStep.Contains('windowText')) {
+            [string]$rawWindowAutomationStep['windowText']
+        } else {
+            ''
+        }
+        if ($windowText.Length -gt 128 -or [regex]::IsMatch($windowText, '[\x00-\x1F\x7F]')) {
+            throw 'Every PSADT reviewed uninstall windowText must be a bounded, single-line string.'
+        }
+        $rawButtonIndex = $rawWindowAutomationStep['buttonIndex']
+        if (($rawButtonIndex -isnot [byte] -and
+             $rawButtonIndex -isnot [int16] -and
+             $rawButtonIndex -isnot [int32] -and
+             $rawButtonIndex -isnot [int64]) -or
+            [int]$rawButtonIndex -lt 1 -or [int]$rawButtonIndex -gt 20) {
+            throw 'Every PSADT reviewed uninstall buttonIndex must be an integer from 1 to 20.'
+        }
+        $rawTimeoutSeconds = $rawWindowAutomationStep['timeoutSeconds']
+        if (($rawTimeoutSeconds -isnot [byte] -and
+             $rawTimeoutSeconds -isnot [int16] -and
+             $rawTimeoutSeconds -isnot [int32] -and
+             $rawTimeoutSeconds -isnot [int64]) -or
+            [int]$rawTimeoutSeconds -lt 1 -or [int]$rawTimeoutSeconds -gt 120) {
+            throw 'Every PSADT reviewed uninstall timeoutSeconds must be an integer from 1 to 120.'
+        }
+        $windowAutomationSteps += [ordered]@{
+            windowText = $windowText
+            buttonIndex = [int]$rawButtonIndex
+            timeoutSeconds = [int]$rawTimeoutSeconds
+        }
+    }
+    if ($windowAutomationSteps.Count -lt 1 -or $windowAutomationSteps.Count -gt 10) {
+        throw 'PSADT reviewedUninstallWindowAutomation.steps must contain from 1 to 10 entries.'
+    }
+    $reviewedUninstallWindowAutomation = [ordered]@{
+        processName = $windowAutomationProcessName
+        steps = $windowAutomationSteps
+    }
+    $reviewedUninstallWindowAutomationConfigured = $true
+}
+
 $reviewedUninstallServiceNames = @()
 if ($psadtConfig.Contains('reviewedUninstallServiceNames') -and
     $null -ne $psadtConfig['reviewedUninstallServiceNames']) {
@@ -1446,6 +1520,30 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
         throw 'PSADT reviewedInstallShieldAdministrativeImage cannot be combined with a custom install command.'
     }
     Write-Host "Using reviewed InstallShield administrative-image lifecycle: $reviewedInstallShieldMsiExpectedFileName"
+}
+
+if ($reviewedUninstallWindowAutomationConfigured) {
+    if ($IsUserScope -or
+        -not $useRegistryUninstall -or
+        $registeredInstallerTypeLower -in @('msi', 'wix', 'burn') -or
+        -not [string]::IsNullOrWhiteSpace($customUninstallCommand) -or
+        $preserveVendorInstallationOnUninstall) {
+        throw 'PSADT reviewedUninstallWindowAutomation requires a machine-scope registry EXE uninstall lifecycle.'
+    }
+
+    $supportFilesDir = Join-Path $packageDir 'SupportFiles'
+    $null = New-Item -ItemType Directory -Path $supportFilesDir -Force
+    $windowAutomationConfigPath = Join-Path $supportFilesDir 'ReviewedUninstallWindowAutomation.json'
+    $reviewedUninstallWindowAutomation |
+        ConvertTo-Json -Depth 5 |
+        Set-Content -LiteralPath $windowAutomationConfigPath -Encoding UTF8
+
+    $windowAutomationHelperSource = Join-Path $PSScriptRoot 'Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1'
+    if (-not (Test-Path -LiteralPath $windowAutomationHelperSource -PathType Leaf)) {
+        throw 'The reviewed uninstall window-automation helper source is missing.'
+    }
+    Copy-Item -LiteralPath $windowAutomationHelperSource -Destination (Join-Path $supportFilesDir 'Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1') -Force
+    Write-Host "Embedded reviewed uninstall window automation for: $windowAutomationProcessName"
 }
 
 if ($useRegistryUninstall) {
@@ -3209,6 +3307,24 @@ if ($reviewedExactUninstallConfigured) {
         '    Write-ADTLogEntry -Message "Using the reviewed exact vendor uninstall command [$registeredUninstallFile]." -Source ''Uninstall-ADTDeployment'''
     )
 }
+$reviewedUninstallWindowAutomationLines = @(
+    '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
+)
+if ($reviewedUninstallWindowAutomationConfigured) {
+    $reviewedUninstallWindowAutomationLines = @(
+        '        $uninstallInvocationStartedAt = [DateTime]::UtcNow.AddSeconds(-2)'
+        '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
+        '        $windowAutomationScript = Join-Path $adtSession.DirSupportFiles ''Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1'''
+        '        if (-not (Test-Path -LiteralPath $windowAutomationScript -PathType Leaf)) {'
+        '            throw "The reviewed uninstall window-automation helper was not found: $windowAutomationScript"'
+        '        }'
+        '        Write-ADTLogEntry -Message "Starting reviewed window automation for the exact vendor uninstaller." -Source ''Uninstall-ADTDeployment'''
+        '        $windowAutomationEvents = @(& $windowAutomationScript -ExpectedProcessPath $registeredUninstallFile -MinimumStartTimeUtc $uninstallInvocationStartedAt)'
+        '        foreach ($windowAutomationEvent in $windowAutomationEvents) {'
+        '            Write-ADTLogEntry -Message $windowAutomationEvent -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
+        '        }'
+    )
+}
 if ($useManagedDirectoryLifecycle) {
     Write-Host 'Using reviewed managed-directory removal'
     $lines += @('', "    `$managedInstallDirectory = [Environment]::ExpandEnvironmentVariables('$reviewedManagedInstallDirectoryEscaped')")
@@ -3655,7 +3771,7 @@ if ($useManagedDirectoryLifecycle) {
             '        }'
             "        `$effectiveUninstallCompletionTimeoutMinutes = if (`$useReviewedExactUninstall) { $reviewedExactUninstallTimeoutMinutes } else { $uninstallCompletionTimeoutMinutes }"
             '        $uninstallDeadline = [DateTime]::UtcNow.AddMinutes($effectiveUninstallCompletionTimeoutMinutes)'
-            '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
+            $reviewedUninstallWindowAutomationLines
             '        $uninstallProcessExitLogged = $false'
             '        $nextUninstallProgressLog = [DateTime]::UtcNow'
             '        do {'

--- a/.github/scripts/Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1
+++ b/.github/scripts/Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1
@@ -1,0 +1,299 @@
+<#
+.SYNOPSIS
+    Drives a bounded, reviewed vendor-uninstaller dialog sequence.
+.DESCRIPTION
+    This helper is copied only into packages with an internal
+    reviewedUninstallWindowAutomation adapter. It restricts window discovery to
+    the exact uninstaller path and to processes started by the current uninstall
+    invocation. The deployment script still treats removal of the exact captured
+    ARP registration as the authoritative completion signal.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ExpectedProcessPath,
+
+    [Parameter(Mandatory = $true)]
+    [datetime]$MinimumStartTimeUtc
+)
+
+$ErrorActionPreference = 'Stop'
+
+$configPath = Join-Path $PSScriptRoot 'ReviewedUninstallWindowAutomation.json'
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw 'The reviewed uninstall window-automation configuration is missing.'
+}
+
+$config = Get-Content -LiteralPath $configPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+$configuredProcessName = ([string]$config.processName).Trim()
+if ($configuredProcessName -notmatch '^[A-Za-z0-9 _().-]+\.exe$' -or
+    $configuredProcessName.Length -gt 128 -or
+    [System.IO.Path]::GetFileName($configuredProcessName) -ne $configuredProcessName) {
+    throw 'The reviewed uninstall window-automation process name is invalid.'
+}
+
+$expectedProcess = Get-Item -LiteralPath $ExpectedProcessPath -ErrorAction Stop
+if ($expectedProcess.PSIsContainer -or $expectedProcess.Name -ine $configuredProcessName) {
+    throw 'The registered uninstaller does not match the reviewed window-automation process.'
+}
+$expectedFullPath = [System.IO.Path]::GetFullPath($expectedProcess.FullName)
+$minimumStartUtc = $MinimumStartTimeUtc.ToUniversalTime()
+
+$steps = @($config.steps)
+if ($steps.Count -lt 1 -or $steps.Count -gt 10) {
+    throw 'The reviewed uninstall window-automation step count is invalid.'
+}
+
+if (-not ('IntuneGetReviewedUninstallWindowAutomationNative' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class IntuneGetReviewedUninstallWindowAutomationNative
+{
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    private const uint BM_CLICK = 0x00F5;
+    private const uint WM_GETTEXT = 0x000D;
+    private const uint WM_GETTEXTLENGTH = 0x000E;
+    private const uint SMTO_ABORTIFHUNG = 0x0002;
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumChildWindows(IntPtr parent, EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextLengthW(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextW(IntPtr hWnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassNameW(IntPtr hWnd, StringBuilder className, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint message,
+        IntPtr wParam,
+        IntPtr lParam,
+        uint flags,
+        uint timeout,
+        out IntPtr result);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint message,
+        IntPtr wParam,
+        StringBuilder lParam,
+        uint flags,
+        uint timeout,
+        out IntPtr result);
+
+    public static IntPtr[] GetTopLevelWindows(uint processId)
+    {
+        List<IntPtr> windows = new List<IntPtr>();
+        EnumWindows(delegate(IntPtr hWnd, IntPtr unused)
+        {
+            uint ownerProcessId;
+            GetWindowThreadProcessId(hWnd, out ownerProcessId);
+            if (ownerProcessId == processId)
+            {
+                windows.Add(hWnd);
+            }
+            return true;
+        }, IntPtr.Zero);
+        return windows.ToArray();
+    }
+
+    public static bool WindowContainsText(IntPtr topLevelWindow, string expectedText)
+    {
+        if (String.IsNullOrEmpty(expectedText))
+        {
+            return true;
+        }
+
+        if (ContainsText(ReadWindowText(topLevelWindow), expectedText))
+        {
+            return true;
+        }
+
+        bool found = false;
+        EnumChildWindows(topLevelWindow, delegate(IntPtr hWnd, IntPtr unused)
+        {
+            if (ContainsText(ReadWindowText(hWnd), expectedText))
+            {
+                found = true;
+                return false;
+            }
+            return true;
+        }, IntPtr.Zero);
+        return found;
+    }
+
+    public static int GetButtonCount(IntPtr topLevelWindow)
+    {
+        return GetButtons(topLevelWindow).Count;
+    }
+
+    public static bool ClickButton(IntPtr topLevelWindow, int oneBasedIndex)
+    {
+        List<IntPtr> buttons = GetButtons(topLevelWindow);
+        if (oneBasedIndex < 1 || oneBasedIndex > buttons.Count)
+        {
+            return false;
+        }
+
+        IntPtr result;
+        return SendMessageTimeout(
+            buttons[oneBasedIndex - 1],
+            BM_CLICK,
+            IntPtr.Zero,
+            IntPtr.Zero,
+            SMTO_ABORTIFHUNG,
+            5000,
+            out result) != IntPtr.Zero;
+    }
+
+    private static List<IntPtr> GetButtons(IntPtr topLevelWindow)
+    {
+        List<IntPtr> buttons = new List<IntPtr>();
+        EnumChildWindows(topLevelWindow, delegate(IntPtr hWnd, IntPtr unused)
+        {
+            StringBuilder className = new StringBuilder(64);
+            GetClassNameW(hWnd, className, className.Capacity);
+            if (String.Equals(className.ToString(), "Button", StringComparison.Ordinal))
+            {
+                buttons.Add(hWnd);
+            }
+            return true;
+        }, IntPtr.Zero);
+        return buttons;
+    }
+
+    private static bool ContainsText(string value, string expectedText)
+    {
+        return !String.IsNullOrEmpty(value) &&
+            value.IndexOf(expectedText, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string ReadWindowText(IntPtr hWnd)
+    {
+        int length = GetWindowTextLengthW(hWnd);
+        if (length > 0)
+        {
+            StringBuilder directText = new StringBuilder(length + 1);
+            if (GetWindowTextW(hWnd, directText, directText.Capacity) > 0)
+            {
+                return directText.ToString();
+            }
+        }
+
+        IntPtr textLengthResult;
+        if (SendMessageTimeout(
+                hWnd,
+                WM_GETTEXTLENGTH,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                SMTO_ABORTIFHUNG,
+                1000,
+                out textLengthResult) == IntPtr.Zero)
+        {
+            return String.Empty;
+        }
+
+        int messageLength = textLengthResult.ToInt32();
+        if (messageLength <= 0 || messageLength > 4096)
+        {
+            return String.Empty;
+        }
+
+        StringBuilder messageText = new StringBuilder(messageLength + 1);
+        IntPtr textResult;
+        if (SendMessageTimeout(
+                hWnd,
+                WM_GETTEXT,
+                new IntPtr(messageText.Capacity),
+                messageText,
+                SMTO_ABORTIFHUNG,
+                1000,
+                out textResult) == IntPtr.Zero)
+        {
+            return String.Empty;
+        }
+        return messageText.ToString();
+    }
+}
+'@
+}
+
+$processNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($configuredProcessName)
+for ($stepIndex = 0; $stepIndex -lt $steps.Count; $stepIndex++) {
+    $step = $steps[$stepIndex]
+    $windowText = [string]$step.windowText
+    $buttonIndex = 0
+    $timeoutSeconds = 0
+    if (-not [int]::TryParse([string]$step.buttonIndex, [ref]$buttonIndex) -or
+        $buttonIndex -lt 1 -or $buttonIndex -gt 20 -or
+        -not [int]::TryParse([string]$step.timeoutSeconds, [ref]$timeoutSeconds) -or
+        $timeoutSeconds -lt 1 -or $timeoutSeconds -gt 120 -or
+        $windowText.Length -gt 128 -or
+        [regex]::IsMatch($windowText, '[\x00-\x1F\x7F]')) {
+        throw 'A reviewed uninstall window-automation step is invalid.'
+    }
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSeconds)
+    $clicked = $false
+    do {
+        $candidateProcesses = @(Get-Process -Name $processNameWithoutExtension -ErrorAction SilentlyContinue | Where-Object {
+            try {
+                $_.StartTime.ToUniversalTime() -ge $minimumStartUtc -and
+                    [System.IO.Path]::GetFullPath($_.Path) -ieq $expectedFullPath
+            } catch {
+                $false
+            }
+        })
+
+        foreach ($candidateProcess in $candidateProcesses) {
+            $windows = [IntuneGetReviewedUninstallWindowAutomationNative]::GetTopLevelWindows(
+                [uint32]$candidateProcess.Id
+            )
+            foreach ($window in $windows) {
+                if (-not [IntuneGetReviewedUninstallWindowAutomationNative]::WindowContainsText(
+                    $window,
+                    $windowText
+                )) {
+                    continue
+                }
+                if ([IntuneGetReviewedUninstallWindowAutomationNative]::GetButtonCount($window) -lt $buttonIndex) {
+                    continue
+                }
+                if ([IntuneGetReviewedUninstallWindowAutomationNative]::ClickButton($window, $buttonIndex)) {
+                    $clicked = $true
+                    break
+                }
+            }
+            if ($clicked) { break }
+        }
+
+        if (-not $clicked) {
+            Start-Sleep -Milliseconds 250
+        }
+    } while (-not $clicked -and [DateTime]::UtcNow -lt $deadline)
+
+    if (-not $clicked) {
+        throw "Reviewed uninstall window-automation step [$($stepIndex + 1)] did not find its exact process window and button before the deadline."
+    }
+
+    Write-Output "Reviewed uninstall window-automation clicked button [$buttonIndex] for step [$($stepIndex + 1)]."
+}

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -167,6 +167,46 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
       .toMatchObject({ reviewedUninstallArguments: ['/headless'] });
   });
 
+  it('dispatches IDM reviewed window automation through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Tonec.InternetDownloadManager',
+      displayName: 'Internet Download Manager',
+      publisher: 'Tonec Inc.',
+      version: '6.43.10',
+      architecture: 'x86',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'exe',
+      silentSwitches: '/skipdlgs',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Internet Download Manager',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    const psadtConfig = JSON.parse(payload.client_payload.config.psadtConfig);
+    expect(psadtConfig.reviewedUninstallArguments).toEqual([]);
+    expect(psadtConfig.reviewedUninstallWindowAutomation).toEqual({
+      processName: 'Uninstall.exe',
+      steps: [
+        {
+          windowText: 'Internet Download Manager',
+          buttonIndex: 2,
+          timeoutSeconds: 60,
+        },
+        { buttonIndex: 3, timeoutSeconds: 15 },
+        {
+          windowText: 'Internet protocol options',
+          buttonIndex: 2,
+          timeoutSeconds: 15,
+        },
+      ],
+    });
+  });
+
   it('dispatches the reviewed Postgres Pro lifecycle through the customer packager', async () => {
     reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
       item: {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -356,12 +356,6 @@ describe('application packaging adapters', () => {
         .reviewedUninstallArguments
     ).toEqual(['/S']);
     expect(
-      applyApplicationPackagingAdapter(
-        'Tonec.InternetDownloadManager',
-        DEFAULT_PSADT_CONFIG
-      ).reviewedUninstallArguments
-    ).toEqual(['/S']);
-    expect(
       applyApplicationPackagingAdapter('Cockos.REAPER', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['/S']);
@@ -828,6 +822,32 @@ describe('application packaging adapters', () => {
       reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
       uninstallCompletionTimeoutMinutes: 15,
     });
+  });
+
+  it('drives only IDM reviewed uninstaller windows and keeps ARP removal authoritative', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Tonec.InternetDownloadManager',
+      { ...DEFAULT_PSADT_CONFIG, reviewedUninstallArguments: ['/S'] }
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+    expect(adapted.reviewedUninstallWindowAutomation).toEqual({
+      processName: 'Uninstall.exe',
+      steps: [
+        {
+          windowText: 'Internet Download Manager',
+          buttonIndex: 2,
+          timeoutSeconds: 60,
+        },
+        { buttonIndex: 3, timeoutSeconds: 15 },
+        {
+          windowText: 'Internet protocol options',
+          buttonIndex: 2,
+          timeoutSeconds: 15,
+        },
+      ],
+    });
+    expect(adapted.uninstallCompletionTimeoutMinutes).toBe(3);
   });
 
   it('uses ZeeDrive\'s documented no-ARP Intune lifecycle', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -16,6 +16,14 @@ interface ApplicationPackagingAdapter {
     expectedMsiFileName: string;
   }>;
   reviewedUninstallArguments?: readonly string[];
+  reviewedUninstallWindowAutomation?: Readonly<{
+    processName: string;
+    steps: readonly Readonly<{
+      windowText?: string;
+      buttonIndex: number;
+      timeoutSeconds: number;
+    }>[];
+  }>;
   reviewedUninstallProcessGuard?: Readonly<{
     processName: string;
     argumentsPattern: string;
@@ -654,13 +662,21 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
-    // Internet Download Manager registers Uninstall.exe without a quiet
-    // command. Replaying that bare ARP command under Intune's non-interactive
-    // SYSTEM session leaves the uninstall wizard hidden and the exact product
-    // registration intact. Its uninstaller accepts the case-sensitive /S
-    // switch used by the product's unattended executable lifecycle.
+    // Internet Download Manager 6.43.10 ignores /S and leaves its ARP entry
+    // intact. Its vendor uninstaller requires three deterministic wizard
+    // control actions. Drive only the exact newly-started Uninstall.exe window
+    // on the SYSTEM desktop, then keep exact ARP removal as the completion
+    // signal. This same adapter is emitted into QA and customer PSADT packages.
     wingetId: 'Tonec.InternetDownloadManager',
-    reviewedUninstallArguments: ['/S'],
+    reviewedUninstallWindowAutomation: {
+      processName: 'Uninstall.exe',
+      steps: [
+        { windowText: 'Internet Download Manager', buttonIndex: 2, timeoutSeconds: 60 },
+        { buttonIndex: 3, timeoutSeconds: 15 },
+        { windowText: 'Internet protocol options', buttonIndex: 2, timeoutSeconds: 15 },
+      ],
+    },
+    uninstallCompletionTimeoutMinutes: 3,
   },
   {
     // REAPER registers an interactive uninstall command without a separate
@@ -1482,6 +1498,7 @@ export function applyApplicationPackagingAdapter(
       reviewedMultiProductInstallMinimumCount: undefined,
       reviewedRegistryInstallEvidence: undefined,
       reviewedAppxInstallEvidence: undefined,
+      reviewedUninstallWindowAutomation: undefined,
       reviewedUninstallProcessGuard: undefined,
       reviewedUninstallServiceNames: undefined,
       reviewedManagedInstallDirectory: undefined,
@@ -1533,9 +1550,14 @@ export function applyApplicationPackagingAdapter(
       )
     : undefined;
 
-  const reviewedUninstallArguments = (config.reviewedUninstallArguments || []).map(
-    (argument) => normalizeReviewedArgument(argument, adapter.wingetId)
-  );
+  // A reviewed window sequence replaces a previously learned command-line
+  // contract. This deliberately clears stale arguments (such as IDM's former
+  // /S adapter) when a failed candidate is regenerated from an older profile.
+  const reviewedUninstallArguments = (
+    adapter.reviewedUninstallWindowAutomation
+      ? []
+      : config.reviewedUninstallArguments || []
+  ).map((argument) => normalizeReviewedArgument(argument, adapter.wingetId));
   const configuredArguments = new Set(
     reviewedUninstallArguments.map((argument) => argument.toLowerCase())
   );
@@ -1568,6 +1590,14 @@ export function applyApplicationPackagingAdapter(
       ? { ...adapter.reviewedInstallShieldAdministrativeImage }
       : undefined,
     reviewedUninstallArguments,
+    reviewedUninstallWindowAutomation: adapter.reviewedUninstallWindowAutomation
+      ? {
+          processName: adapter.reviewedUninstallWindowAutomation.processName,
+          steps: adapter.reviewedUninstallWindowAutomation.steps.map((step) => ({
+            ...step,
+          })),
+        }
+      : undefined,
     reviewedUninstallProcessGuard: adapter.reviewedUninstallProcessGuard
       ? { ...adapter.reviewedUninstallProcessGuard }
       : undefined,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -210,6 +210,49 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/S']);
   });
 
+  it('binds IDM reviewed window automation to customer and QA package identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Tonec.InternetDownloadManager',
+      displayName: 'Internet Download Manager',
+      publisher: 'Tonec Inc.',
+      version: '6.43.10',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/skipdlgs',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Internet Download Manager',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        reviewedUninstallArguments?: string[];
+        reviewedUninstallWindowAutomation?: unknown;
+      };
+    };
+    const expected = {
+      processName: 'Uninstall.exe',
+      steps: [
+        {
+          windowText: 'Internet Download Manager',
+          buttonIndex: 2,
+          timeoutSeconds: 60,
+        },
+        { buttonIndex: 3, timeoutSeconds: 15 },
+        {
+          windowText: 'Internet protocol options',
+          buttonIndex: 2,
+          timeoutSeconds: 15,
+        },
+      ],
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual([]);
+    expect(profile.psadtConfig.reviewedUninstallWindowAutomation).toEqual(expected);
+    expect(
+      JSON.parse(normalized.psadtConfigJson).reviewedUninstallWindowAutomation
+    ).toEqual(expected);
+  });
+
   it('binds FSLogix restart suppression to customer and QA package identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.FSLogix',

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -901,6 +901,14 @@ export function normalizeQaPsadtConfig(
     reviewedInstallArgumentsOverride: value?.reviewedInstallArgumentsOverride,
     reviewedArgumentlessInstall: value?.reviewedArgumentlessInstall,
     reviewedUninstallArguments: value?.reviewedUninstallArguments || [],
+    reviewedUninstallWindowAutomation: value?.reviewedUninstallWindowAutomation
+      ? {
+          processName: value.reviewedUninstallWindowAutomation.processName,
+          steps: value.reviewedUninstallWindowAutomation.steps.map((step) => ({
+            ...step,
+          })),
+        }
+      : undefined,
     reviewedUninstallServiceNames: value?.reviewedUninstallServiceNames,
   };
 }

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -18,6 +19,14 @@ const packager = readFileSync(
 
 const hostedPackager = readFileSync(
   resolve(process.cwd(), 'packager/src/job-processor.ts'),
+  'utf8'
+);
+
+const reviewedWindowAutomationHelper = readFileSync(
+  resolve(
+    process.cwd(),
+    '.github/scripts/Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1'
+  ),
   'utf8'
 );
 
@@ -47,7 +56,8 @@ function generateRegistryUninstallPackage(
   silentSwitches = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
   installScope: 'machine' | 'user' = 'machine',
   nestedInstallerType = '',
-  nestedInstallerPath = ''
+  nestedInstallerPath = '',
+  verifyPackage?: (packageDirectory: string) => void
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -140,6 +150,8 @@ function generateRegistryUninstallPackage(
         `Generated deployment script did not parse:\n${parseResult.stdout}\n${parseResult.stderr}`
       );
     }
+
+    verifyPackage?.(join(fixtureRoot, 'package'));
 
     return readFileSync(generatedPath, 'utf8');
   } finally {
@@ -245,6 +257,161 @@ describe('PSADT Inno packaging contract', () => {
 });
 
 describe('PSADT vendor argument contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'loads the reviewed window-control native helper and fails closed without a matching button',
+    () => {
+      const fixtureRoot = mkdtempSync(
+        join(tmpdir(), 'intuneget-window-automation-helper-')
+      );
+      try {
+        const helperPath = join(
+          fixtureRoot,
+          'Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1'
+        );
+        writeFileSync(helperPath, reviewedWindowAutomationHelper);
+        writeFileSync(
+          join(fixtureRoot, 'ReviewedUninstallWindowAutomation.json'),
+          JSON.stringify({
+            processName: 'pwsh.exe',
+            steps: [{ windowText: '', buttonIndex: 1, timeoutSeconds: 1 }],
+          })
+        );
+        const pwshPath = spawnSync(
+          'pwsh',
+          ['-NoProfile', '-Command', '(Get-Process -Id $PID).Path'],
+          { encoding: 'utf8' }
+        ).stdout.trim();
+        const result = spawnSync(
+          'pwsh',
+          [
+            '-NoProfile',
+            '-File',
+            helperPath,
+            '-ExpectedProcessPath',
+            pwshPath,
+            '-MinimumStartTimeUtc',
+            '1970-01-01T00:00:00Z',
+          ],
+          { encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(1);
+        expect(`${result.stdout}\n${result.stderr}`).toContain(
+          'Reviewed uninstall window-automation step [1] did not find its exact process window'
+        );
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'rejects unsafe reviewed uninstall window automation',
+    () => {
+      expect(() =>
+        generateRegistryUninstallPackage(
+          'exe',
+          'Unsafe Window Automation',
+          [],
+          {
+            reviewedUninstallWindowAutomation: {
+              processName: '..\\Uninstall.exe',
+              steps: [{ buttonIndex: 0, timeoutSeconds: 500 }],
+            },
+          }
+        )
+      ).toThrow(
+        'reviewedUninstallWindowAutomation.processName must be a bounded executable leaf name'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'embeds and invokes bounded IDM window automation while retaining exact ARP verification',
+    () => {
+      let embeddedConfig: unknown;
+      let embeddedHelper = '';
+      const automation = {
+        processName: 'Uninstall.exe',
+        steps: [
+          {
+            windowText: 'Internet Download Manager',
+            buttonIndex: 2,
+            timeoutSeconds: 60,
+          },
+          { buttonIndex: 3, timeoutSeconds: 15 },
+          {
+            windowText: 'Internet protocol options',
+            buttonIndex: 2,
+            timeoutSeconds: 15,
+          },
+        ],
+      };
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Internet Download Manager',
+        [],
+        {
+          reviewedUninstallWindowAutomation: automation,
+          uninstallCompletionTimeoutMinutes: 3,
+        },
+        [],
+        'Tonec.InternetDownloadManager',
+        'Internet Download Manager',
+        '6.43.10',
+        'REGISTRY_UNINSTALL:Internet Download Manager',
+        '/skipdlgs',
+        'machine',
+        '',
+        '',
+        (packageDirectory) => {
+          const supportDirectory = join(packageDirectory, 'SupportFiles');
+          const configPath = join(
+            supportDirectory,
+            'ReviewedUninstallWindowAutomation.json'
+          );
+          const helperPath = join(
+            supportDirectory,
+            'Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1'
+          );
+          expect(existsSync(configPath)).toBe(true);
+          expect(existsSync(helperPath)).toBe(true);
+          embeddedConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+          embeddedHelper = readFileSync(helperPath, 'utf8');
+        }
+      );
+
+      expect(embeddedConfig).toEqual({
+        processName: automation.processName,
+        steps: [
+          automation.steps[0],
+          { windowText: '', ...automation.steps[1] },
+          automation.steps[2],
+        ],
+      });
+      expect(embeddedHelper).toContain(
+        '[System.IO.Path]::GetFullPath($_.Path) -ieq $expectedFullPath'
+      );
+      expect(embeddedHelper).toContain(
+        '$_.StartTime.ToUniversalTime() -ge $minimumStartUtc'
+      );
+      expect(embeddedHelper).toContain('private const uint BM_CLICK = 0x00F5;');
+      expect(embeddedHelper).toContain('private const uint SMTO_ABORTIFHUNG = 0x0002;');
+      expect(generated).toContain(
+        '$uninstallInvocationStartedAt = [DateTime]::UtcNow.AddSeconds(-2)'
+      );
+      expect(generated).toContain(
+        '& $windowAutomationScript -ExpectedProcessPath $registeredUninstallFile -MinimumStartTimeUtc $uninstallInvocationStartedAt'
+      );
+      expect(generated).toContain(
+        'Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey }'
+      );
+      expect(generated).toContain(
+        'The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline.'
+      );
+    }
+  );
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'appends NeoLoad unattended removal to the exact captured install4j command',
     () => {

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -229,6 +229,19 @@ export interface PSADTConfig {
   // not exposed as a customer-facing free-form command surface.
   reviewedUninstallArguments?: string[];
 
+  // Internal window-control contract for a reviewed vendor uninstaller that
+  // exposes no reliable silent command line. The generated package restricts
+  // automation to a newly started exact process name and fixed Button class
+  // indices. Application adapters are the only trusted source.
+  reviewedUninstallWindowAutomation?: {
+    processName: string;
+    steps: Array<{
+      windowText?: string;
+      buttonIndex: number;
+      timeoutSeconds: number;
+    }>;
+  };
+
   // Internal guard for a reviewed vendor MSI custom-action helper that can
   // remain alive indefinitely during removal. The packager only accepts this
   // value from an application adapter and matches both the executable name and
@@ -397,6 +410,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   reviewedInstallCompletionTimeoutMinutes: undefined,
   reviewedInstallShieldAdministrativeImage: undefined,
   reviewedUninstallArguments: [],
+  reviewedUninstallWindowAutomation: undefined,
   reviewedUninstallProcessGuard: undefined,
   reviewedUninstallServiceNames: undefined,
   reviewedPreferVisiblePrimaryUninstallRegistration: undefined,


### PR DESCRIPTION
## Summary
- replace IDM's ineffective /S uninstall adapter with a reviewed three-step Button-control sequence
- scope automation to the exact newly started Uninstall.exe path and retain exact ARP removal as authoritative completion
- embed the same helper/config in QA and customer PSADT packages and clear stale /S profiles

## Verification
- 290 focused tests passed
- ESLint passed on all touched TypeScript files
- both PowerShell scripts parse; native window helper compiles and fails closed without a matching button