### PR TITLE
release(qa): activate IDM window automation

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c649792a94f23b4c3fc04e07b81c4aa655887301',
+  packagerCommit: '943851a66f72cf115e2d97058a6415ee71e3f50f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -353,6 +353,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Internet Download Manager now supplies /S to its otherwise interactive
   // registered uninstaller. Preserve every unrelated pass from Playnite.
   'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
+  // IDM's reviewed window sequence replaces its ineffective /S argument and
+  // changes only that adapter's canonical profile. Preserve unrelated passes.
+  'c649792a94f23b4c3fc04e07b81c4aa655887301',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -204,7 +204,15 @@ const IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...PLAYNITE_PROCESS_CLOSE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS = [
+  // Replace IDM's ineffective /S attempt with the reviewed, exact-process
+  // window sequence, then carry every still-unconsumed bounded target.
+  ...IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '943851a66f72cf115e2d97058a6415ee71e3f50f':
+    IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS,
   'c649792a94f23b4c3fc04e07b81c4aa655887301':
     IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5':


### PR DESCRIPTION
## Summary
- pin QA/customer profile generation to the merged reviewed IDM window-automation packager
- retain compatible passing profiles from the prior release
- target IDM and the bounded carried retry set for the new toolchain

## Verification
- 190 package-profile and toolchain-backfill tests passed
- ESLint passed on the touched files