### PR TITLE
fix(packaging): silence IObit Inno uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -850,6 +850,19 @@ describe('application packaging adapters', () => {
     expect(adapted.uninstallCompletionTimeoutMinutes).toBe(3);
   });
 
+  it('uses Inno Setup silent removal with the exact IObit ARP command', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'iobit.uninstaller',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual([
+      '/VERYSILENT',
+      '/SUPPRESSMSGBOXES',
+      '/NORESTART',
+    ]);
+  });
+
   it('uses ZeeDrive\'s documented no-ARP Intune lifecycle', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -679,6 +679,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     uninstallCompletionTimeoutMinutes: 3,
   },
   {
+    // IObit Uninstaller is published as an Inno Setup package, but its ARP
+    // command contains only the uninstaller path. Invoking that command
+    // unchanged leaves the confirmation flow waiting under LocalSystem and the
+    // exact IObitUninstall registration present. Append Inno Setup's documented
+    // unattended removal switches to the captured product-specific command for
+    // both QA and customer Intune packages.
+    wingetId: 'IObit.Uninstaller',
+    reviewedUninstallArguments: [
+      '/VERYSILENT',
+      '/SUPPRESSMSGBOXES',
+      '/NORESTART',
+    ],
+  },
+  {
     // REAPER registers an interactive uninstall command without a separate
     // QuietUninstallString. Its vendor installer and uninstaller both accept
     // the manifest's case-sensitive /S switch; without it, a SYSTEM removal


### PR DESCRIPTION
## Summary
- append Inno Setup's documented unattended uninstall switches to the exact captured IObit ARP command
- keep exact IObitUninstall registration removal as the authoritative completion signal
- apply the adapter to the shared QA and customer PSADT packaging path

## Production QA evidence
- run 32845706989 installed and detected IObit Uninstaller 15.6.0.6 successfully
- the bare registered uninstaller left IObitUninstall present for the full five-minute deadline
- PSADT returned 60001 after 310 seconds, matching the hidden confirmation-flow failure

## Verification
- 271 packaging adapter, package-profile, and PSADT contract tests passed
- ESLint passed for both touched files
- git diff --check passed

Official Inno Setup uninstall contract: https://jrsoftware.org/ishelp/topic_uninstcmdline.htm