### PR TITLE
release(qa): activate IObit silent uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '943851a66f72cf115e2d97058a6415ee71e3f50f',
+  packagerCommit: 'f7be39a95d529bc613f0ec8d4f2483762a5e02a2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -164,6 +164,7 @@ describe('QA toolchain targeted retries', () => {
       'Waterfox.Waterfox',
       'Playnite.Playnite',
       'Tonec.InternetDownloadManager',
+      'IObit.Uninstaller',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -220,6 +221,7 @@ describe('QA toolchain targeted retries', () => {
         'Waterfox.Waterfox',
         'Playnite.Playnite',
         'Tonec.InternetDownloadManager',
+        'IObit.Uninstaller',
       ])
     );
     expect(
@@ -260,6 +262,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'd8642e4a6e3ee867fd8dfaf5bae632fbe24200f5',
       { wingetId: 'Tonec.InternetDownloadManager', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries IObit only after activating its Inno silent uninstall contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' iobit.uninstaller ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '943851a66f72cf115e2d97058a6415ee71e3f50f',
+      { wingetId: 'IObit.Uninstaller', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -210,7 +210,16 @@ const IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS = [
   ...IDM_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Re-run the exact failed IObit release with Inno Setup's documented silent
+  // removal contract, then carry every still-unconsumed bounded target.
+  'IObit.Uninstaller',
+  ...IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f7be39a95d529bc613f0ec8d4f2483762a5e02a2':
+    IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS,
   '943851a66f72cf115e2d97058a6415ee71e3f50f':
     IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS,
   'c649792a94f23b4c3fc04e07b81c4aa655887301':


### PR DESCRIPTION
## Summary
- pin the shared customer and QA package profile to packager commit f7be39a95d529bc613f0ec8d4f2483762a5e02a2
- retry IObit.Uninstaller after its verified bare-ARP uninstall failure
- carry the prior bounded retry set forward

## Verification
- 227 package-profile, backfill, and enqueue tests passed
- ESLint passed for all touched files
- git diff --check passed