### PR TITLE
fix(packager): use IObit detain uninstall switch

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -850,17 +850,13 @@ describe('application packaging adapters', () => {
     expect(adapted.uninstallCompletionTimeoutMinutes).toBe(3);
   });
 
-  it('uses Inno Setup silent removal with the exact IObit ARP command', () => {
+  it('uses IObit detain removal with the exact captured ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'iobit.uninstaller',
       DEFAULT_PSADT_CONFIG
     );
 
-    expect(adapted.reviewedUninstallArguments).toEqual([
-      '/VERYSILENT',
-      '/SUPPRESSMSGBOXES',
-      '/NORESTART',
-    ]);
+    expect(adapted.reviewedUninstallArguments).toEqual(['/DetainUninstall']);
   });
 
   it('uses ZeeDrive\'s documented no-ARP Intune lifecycle', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -680,17 +680,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // IObit Uninstaller is published as an Inno Setup package, but its ARP
-    // command contains only the uninstaller path. Invoking that command
-    // unchanged leaves the confirmation flow waiting under LocalSystem and the
-    // exact IObitUninstall registration present. Append Inno Setup's documented
-    // unattended removal switches to the captured product-specific command for
-    // both QA and customer Intune packages.
+    // command contains only the uninstaller path. Standard Inno unattended
+    // switches make the launcher exit without removing the product. IObit's
+    // maintained deployment package adds the vendor-specific /DetainUninstall
+    // switch; append it to the captured product command for both QA and customer
+    // Intune packages. The shared Inno normalizer supplies the standard silent,
+    // message-box, restart, and startup-prompt suppression switches.
     wingetId: 'IObit.Uninstaller',
-    reviewedUninstallArguments: [
-      '/VERYSILENT',
-      '/SUPPRESSMSGBOXES',
-      '/NORESTART',
-    ],
+    reviewedUninstallArguments: ['/DetainUninstall'],
   },
   {
     // REAPER registers an interactive uninstall command without a separate


### PR DESCRIPTION
## Summary
- replace standard-only IObit removal arguments with the vendor-specific /DetainUninstall switch
- keep standard Inno unattended normalization in the shared PSADT packager
- apply the adapter to both QA and customer catalog package generation

## Evidence
- QA run 32848854196 proved standard Inno flags exit without removing the exact IObitUninstall registration
- the maintained IObit Chocolatey deployment script and recent package test use /VERYSILENT /NORESTART /DetainUninstall`n
## Verification
- 381 packaging/profile/toolchain tests passed
- ESLint passed for changed files
- git diff --check passed