### PR TITLE
fix(app-requests): fully automated, honest request resolution

### DIFF
--- a/.github/workflows/resolve-app-requests.yml
+++ b/.github/workflows/resolve-app-requests.yml
@@ -1,11 +1,23 @@
 name: Resolve App Requests
 
-# Community app suggestions create app-request issues, but the catalog
-# ingests every package in the winget community repository automatically,
-# so a request is either already fulfilled (the id exists and will appear
-# within a day) or unfulfillable (the id does not exist in winget). This
-# workflow checks every open app-request issue against winget-pkgs and
-# resolves it either way, keeping the suggestion status in Supabase in sync.
+# Community app suggestions create app-request issues. This workflow keeps
+# them resolved without manual review by checking each open issue against
+# the actual state of the system, in precedence order:
+#
+#   1. curated_excluded_apps (permanent denylist, e.g. SourceForge
+#      installers that get rate limited in CI): close as rejected with
+#      the recorded reason.
+#   2. curated_apps: the app is in the catalog. If it also has a
+#      package_eligibility_blocks row it cannot be deployed, so close as
+#      rejected; otherwise close as fulfilled.
+#   3. winget-pkgs: the id exists upstream but has not been imported yet.
+#      Leave the issue open with a one-time "queued" comment; the weekly
+#      catalog sync imports the full winget index, after which the next
+#      run of this workflow closes the issue as fulfilled.
+#   4. Otherwise the id does not exist in winget, so the request is
+#      unfulfillable: close as rejected with correction guidance.
+#
+# Every resolution is synced back to the suggestion status in Supabase.
 
 on:
   schedule:
@@ -36,6 +48,26 @@ jobs:
             });
 
             core.info(`Found ${issues.length} open app-request issue(s)`);
+
+            const supabaseGet = async (path) => {
+              const url = process.env.SUPABASE_URL;
+              const key = process.env.SUPABASE_SERVICE_KEY;
+              if (!url || !key) {
+                throw new Error('Supabase secrets not configured');
+              }
+              for (let attempt = 1; attempt <= 3; attempt += 1) {
+                const response = await fetch(`${url}/rest/v1/${path}`, {
+                  signal: AbortSignal.timeout(15_000),
+                  headers: {
+                    apikey: key,
+                    Authorization: `Bearer ${key}`,
+                  },
+                });
+                if (response.ok) return response.json();
+                if (attempt === 3) throw new Error(`Supabase query failed with status ${response.status}`);
+                await new Promise(resolve => setTimeout(resolve, attempt * 1000));
+              }
+            };
 
             const updateSuggestion = async (issueNumber, status) => {
               const url = process.env.SUPABASE_URL;
@@ -69,89 +101,146 @@ jobs:
               }
             };
 
+            // Post a comment only if no earlier comment carries the marker,
+            // so re-runs never spam the issue.
+            const commentOnce = async (issueNumber, marker, body) => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              if (comments.some(item => item.body?.includes(marker))) return;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `<!-- ${marker} -->\n${body}`,
+              });
+            };
+
+            const RESOLUTION_MARKER = 'intuneget-app-request-resolution';
+            const QUEUED_MARKER = 'intuneget-app-request-queued';
+
+            const resolveIssue = async (issue, { status, stateReason, comment }) => {
+              await updateSuggestion(issue.number, status);
+              await commentOnce(issue.number, RESOLUTION_MARKER, comment);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: stateReason,
+              });
+            };
+
             let resolutionFailures = 0;
             for (const issue of issues) {
               try {
-              const bodyMatch = (issue.body || '').match(/\*\*WinGet ID:\*\*\s*`([^`]+)`/);
-              const titleMatch = (issue.title || '').match(/^App Request:\s*(.+)$/);
-              const wingetId = (bodyMatch?.[1] || titleMatch?.[1] || '').trim();
+                const bodyMatch = (issue.body || '').match(/\*\*WinGet ID:\*\*\s*`([^`]+)`/);
+                const titleMatch = (issue.title || '').match(/^App Request:\s*(.+)$/);
+                const wingetId = (bodyMatch?.[1] || titleMatch?.[1] || '').trim();
 
-              if (!wingetId || !/^[A-Za-z0-9][A-Za-z0-9._-]*\.[A-Za-z0-9][A-Za-z0-9._-]*$/.test(wingetId)) {
-                core.info(`#${issue.number}: could not extract a WinGet id, skipping`);
-                continue;
-              }
-
-              // Check the manifest directory in microsoft/winget-pkgs
-              const firstLetter = wingetId[0].toLowerCase();
-              const manifestPath = wingetId.split('.').join('/');
-              let exists = null;
-              try {
-                await github.rest.repos.getContent({
-                  owner: 'microsoft',
-                  repo: 'winget-pkgs',
-                  path: `manifests/${firstLetter}/${manifestPath}`,
-                });
-                exists = true;
-              } catch (error) {
-                if (error.status === 404) {
-                  exists = false;
-                } else {
-                  core.warning(`#${issue.number}: winget-pkgs check failed (${error.status}), skipping`);
+                if (!wingetId || !/^[A-Za-z0-9][A-Za-z0-9._-]*\.[A-Za-z0-9][A-Za-z0-9._-]*$/.test(wingetId)) {
+                  core.info(`#${issue.number}: could not extract a WinGet id, skipping`);
                   continue;
                 }
-              }
+                const encodedId = encodeURIComponent(wingetId);
 
-              if (exists) {
-                const comment = [
-                  '<!-- intuneget-app-request-resolution -->',
-                  `\`${wingetId}\` exists in the winget community repository, and the IntuneGet catalog ingests every winget package automatically - new packages appear within a day of being added upstream. Search the catalog for it; if it is not there yet, it will be after the next sync.`,
-                  '',
-                  'Closing as fulfilled. If the app is still missing from the catalog after a couple of days, comment here and the issue can be reopened.',
-                ].join('\n');
-                await updateSuggestion(issue.number, 'implemented');
-                const comments = await github.paginate(github.rest.issues.listComments, {
-                  owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, per_page: 100,
-                });
-                if (!comments.some(item => item.body?.includes('intuneget-app-request-resolution'))) {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body: comment,
+                // 1. Permanent denylist: the package can never enter the catalog.
+                const excludedRows = await supabaseGet(
+                  `curated_excluded_apps?select=winget_id,reason&winget_id=ilike.${encodedId}&limit=1`
+                );
+                if (excludedRows.length > 0) {
+                  const excluded = excludedRows[0];
+                  await resolveIssue(issue, {
+                    status: 'rejected',
+                    stateReason: 'not_planned',
+                    comment: [
+                      `IntuneGet cannot offer \`${excluded.winget_id}\`: ${excluded.reason}.`,
+                      '',
+                      'This package is permanently excluded from the catalog, so this request cannot be fulfilled. Closing as not planned.',
+                    ].join('\n'),
                   });
+                  core.info(`#${issue.number}: ${wingetId} is on the exclusion list, closed as not planned`);
+                  continue;
                 }
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  state: 'closed',
-                  state_reason: 'completed',
-                });
-                core.info(`#${issue.number}: ${wingetId} exists - closed as fulfilled`);
-              } else {
-                const comment = [
-                  '<!-- intuneget-app-request-resolution -->',
-                  `No package with the id \`${wingetId}\` exists in the winget community repository (ids are case sensitive), so IntuneGet cannot package it - the catalog can only offer what winget provides.`,
-                  '',
-                  'To get this app into IntuneGet:',
-                  `1. Find the exact id with \`winget search <app name>\` and submit a new suggestion with that id, or`,
-                  '2. If the app is not in winget at all, submit a manifest to https://github.com/microsoft/winget-pkgs first - IntuneGet picks it up automatically once merged.',
-                ].join('\n');
-                await updateSuggestion(issue.number, 'rejected');
-                const comments = await github.paginate(github.rest.issues.listComments, {
-                  owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, per_page: 100,
-                });
-                if (!comments.some(item => item.body?.includes('intuneget-app-request-resolution'))) {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body: comment,
+
+                // 2. Already in the catalog: fulfilled, unless deployment is blocked.
+                const catalogRows = await supabaseGet(
+                  `curated_apps?select=winget_id&winget_id=ilike.${encodedId}&limit=1`
+                );
+                if (catalogRows.length > 0) {
+                  const canonicalId = catalogRows[0].winget_id;
+                  const blockRows = await supabaseGet(
+                    `package_eligibility_blocks?select=winget_id&winget_id=eq.${encodeURIComponent(canonicalId)}&limit=1`
+                  );
+                  if (blockRows.length > 0) {
+                    await resolveIssue(issue, {
+                      status: 'rejected',
+                      stateReason: 'not_planned',
+                      comment: [
+                        `\`${canonicalId}\` is listed in the IntuneGet catalog but is not available for automated deployment, so this request cannot be fulfilled. Closing as not planned.`,
+                      ].join('\n'),
+                    });
+                    core.info(`#${issue.number}: ${canonicalId} is deployment blocked, closed as not planned`);
+                  } else {
+                    await resolveIssue(issue, {
+                      status: 'implemented',
+                      stateReason: 'completed',
+                      comment: [
+                        `\`${canonicalId}\` is available in the IntuneGet catalog now. Closing as fulfilled.`,
+                      ].join('\n'),
+                    });
+                    core.info(`#${issue.number}: ${canonicalId} is in the catalog, closed as fulfilled`);
+                  }
+                  continue;
+                }
+
+                // 3./4. Not in the catalog: does the id exist upstream at all?
+                const firstLetter = wingetId[0].toLowerCase();
+                const manifestPath = wingetId.split('.').join('/');
+                let existsUpstream = null;
+                try {
+                  await github.rest.repos.getContent({
+                    owner: 'microsoft',
+                    repo: 'winget-pkgs',
+                    path: `manifests/${firstLetter}/${manifestPath}`,
                   });
+                  existsUpstream = true;
+                } catch (error) {
+                  if (error.status === 404) {
+                    existsUpstream = false;
+                  } else {
+                    core.warning(`#${issue.number}: winget-pkgs check failed (${error.status}), skipping`);
+                    continue;
+                  }
                 }
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  state: 'closed',
-                  state_reason: 'not_planned',
-                });
-                core.info(`#${issue.number}: ${wingetId} not found in winget-pkgs - closed as not planned`);
-              }
+
+                if (existsUpstream) {
+                  // Queued: the weekly catalog sync imports the full winget
+                  // index, so the app appears within a week. Leave the issue
+                  // open; a later run closes it once the app is in the catalog.
+                  await commentOnce(issue.number, QUEUED_MARKER, [
+                    `\`${wingetId}\` exists in the winget community repository and is queued for the IntuneGet catalog, which imports the full winget index on a weekly sync.`,
+                    '',
+                    'This issue stays open and closes automatically once the app is available in the catalog.',
+                  ].join('\n'));
+                  core.info(`#${issue.number}: ${wingetId} exists upstream, waiting for the next catalog sync`);
+                } else {
+                  await resolveIssue(issue, {
+                    status: 'rejected',
+                    stateReason: 'not_planned',
+                    comment: [
+                      `No package with the id \`${wingetId}\` exists in the winget community repository (ids are case sensitive), so IntuneGet cannot package it. The catalog can only offer what winget provides.`,
+                      '',
+                      'To get this app into IntuneGet:',
+                      `1. Find the exact id with \`winget search <app name>\` and submit a new suggestion with that id, or`,
+                      '2. If the app is not in winget at all, submit a manifest to https://github.com/microsoft/winget-pkgs first. IntuneGet picks it up automatically once merged.',
+                    ].join('\n'),
+                  });
+                  core.info(`#${issue.number}: ${wingetId} not found in winget-pkgs, closed as not planned`);
+                }
               } catch (error) {
                 core.warning(`#${issue.number}: resolution failed: ${error.message}`);
                 resolutionFailures += 1;

--- a/app/api/community/suggestions/route.eligibility.test.ts
+++ b/app/api/community/suggestions/route.eligibility.test.ts
@@ -7,8 +7,10 @@ const h = vi.hoisted(() => {
   // A blocked id is still present in curated_apps, because the block row
   // references it, so the catalog lookup would otherwise answer
   // "already available in IntuneGet".
-  const state: { blockRows: Array<{ winget_id: string; block_code: string }> } =
-    { blockRows: [] };
+  const state: {
+    blockRows: Array<{ winget_id: string; block_code: string }>;
+    excludedRow: { winget_id: string; reason: string } | null;
+  } = { blockRows: [], excludedRow: null };
 
   const catalogAppExists = vi.fn();
   const wingetExists = vi.fn();
@@ -30,12 +32,24 @@ const h = vi.hoisted(() => {
         };
         return builder;
       }
+      if (table === 'curated_excluded_apps') {
+        const builder: Record<string, unknown> = {
+          select: () => builder,
+          ilike: () => builder,
+          limit: () => builder,
+          maybeSingle: () =>
+            Promise.resolve({ data: state.excludedRow, error: null }),
+        };
+        return builder;
+      }
       // app_suggestions duplicate lookup: no existing suggestion
       const builder: Record<string, unknown> = {
         select: () => builder,
         eq: () => builder,
         in: () => builder,
+        limit: () => builder,
         single: () => Promise.resolve({ data: null, error: null }),
+        maybeSingle: () => Promise.resolve({ data: null, error: null }),
       };
       return builder;
     },
@@ -90,7 +104,29 @@ function request(wingetId: string) {
 }
 
 describe('POST /api/community/suggestions eligibility gate', () => {
+  it('refuses a request for a denylisted package with the recorded reason', async () => {
+    h.state.blockRows = [];
+    h.state.excludedRow = {
+      winget_id: 'WinSCP.WinSCP',
+      reason: 'SourceForge installers fail to download in CI',
+    };
+    h.catalogAppExists.mockReset().mockResolvedValue(null);
+    h.wingetExists.mockReset().mockResolvedValue('exists');
+
+    const response = await POST(request('winscp.winscp'));
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.code).toBe('PACKAGE_EXCLUDED');
+    expect(body.wingetId).toBe('WinSCP.WinSCP');
+    expect(body.error).toContain('SourceForge installers fail to download in CI');
+    // The denylist must short-circuit before the catalog and winget checks,
+    // otherwise the caller is sent down the request path again.
+    expect(h.catalogAppExists).not.toHaveBeenCalled();
+  });
+
   it('refuses a request for an app blocked from automated deployment', async () => {
+    h.state.excludedRow = null;
     h.state.blockRows = [
       {
         winget_id: 'WinSCP.WinSCP.Beta',
@@ -115,6 +151,7 @@ describe('POST /api/community/suggestions eligibility gate', () => {
 
   it('leaves unblocked ids to the existing catalog and winget checks', async () => {
     h.state.blockRows = [];
+    h.state.excludedRow = null;
     h.catalogAppExists.mockReset().mockResolvedValue({
       winget_id: 'Google.Chrome',
     });

--- a/app/api/community/suggestions/route.ts
+++ b/app/api/community/suggestions/route.ts
@@ -24,6 +24,7 @@ import { createAppSuggestionIssue } from '@/lib/github-issues';
 import { checkWingetPackageExists } from '@/lib/winget-existence';
 import { getCatalogSource } from '@/lib/catalog';
 import {
+  getCatalogExclusion,
   getPackageEligibilityBlocks,
   PACKAGE_UNAVAILABLE_MESSAGE,
 } from '@/lib/package-eligibility';
@@ -187,7 +188,8 @@ export async function POST(request: NextRequest) {
       .select('id, status')
       .eq('winget_id', winget_id)
       .in('status', ['pending', 'approved'])
-      .single();
+      .limit(1)
+      .maybeSingle();
 
     if (existing) {
       return NextResponse.json(
@@ -215,6 +217,23 @@ export async function POST(request: NextRequest) {
           wingetId: eligibilityBlocks[0].wingetId,
         },
         { status: 409 }
+      );
+    }
+
+    // Refuse ids on the permanent catalog denylist. Excluded packages never
+    // enter curated_apps (e.g. SourceForge installers that get rate limited
+    // in CI), so a request for one can never be fulfilled: without this check
+    // it would pass the winget existence check below and later be closed as
+    // fulfilled with a promise the catalog cannot keep.
+    const exclusion = await getCatalogExclusion(supabase, winget_id);
+    if (exclusion) {
+      return NextResponse.json(
+        {
+          error: `IntuneGet cannot offer ${exclusion.wingetId}: ${exclusion.reason}. This package is permanently excluded from the catalog, so requests for it cannot be fulfilled.`,
+          code: 'PACKAGE_EXCLUDED',
+          wingetId: exclusion.wingetId,
+        },
+        { status: 422 }
       );
     }
 

--- a/lib/package-eligibility.test.ts
+++ b/lib/package-eligibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getPackageEligibilityBlocks } from '@/lib/package-eligibility';
+import {
+  getCatalogExclusion,
+  getPackageEligibilityBlocks,
+} from '@/lib/package-eligibility';
 
 function query(result: { data: unknown; error: { message: string } | null }) {
   const builder: Record<string, ReturnType<typeof vi.fn>> & {
@@ -14,6 +17,66 @@ function query(result: { data: unknown; error: { message: string } | null }) {
     Promise.resolve(result).then(onFulfilled, onRejected);
   return builder;
 }
+
+function singleRowQuery(result: { data: unknown; error: { message: string } | null }) {
+  const builder = {
+    select: vi.fn(),
+    ilike: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+  builder.select.mockReturnValue(builder);
+  builder.ilike.mockReturnValue(builder);
+  builder.limit.mockReturnValue(builder);
+  return builder;
+}
+
+describe('getCatalogExclusion', () => {
+  it('returns the canonical id and reason for a denylisted package', async () => {
+    const builder = singleRowQuery({
+      data: {
+        winget_id: 'WinSCP.WinSCP',
+        reason: 'SourceForge installers fail to download in CI',
+      },
+      error: null,
+    });
+    const client = { from: vi.fn(() => builder) };
+
+    const result = await getCatalogExclusion(client as never, ' winscp.winscp ');
+
+    expect(client.from).toHaveBeenCalledWith('curated_excluded_apps');
+    expect(builder.ilike).toHaveBeenCalledWith('winget_id', 'winscp.winscp');
+    expect(result).toEqual({
+      wingetId: 'WinSCP.WinSCP',
+      reason: 'SourceForge installers fail to download in CI',
+    });
+  });
+
+  it('returns null for packages that are not excluded', async () => {
+    const client = {
+      from: vi.fn(() => singleRowQuery({ data: null, error: null })),
+    };
+
+    await expect(getCatalogExclusion(client as never, 'Example.App')).resolves.toBeNull();
+  });
+
+  it('does not query Supabase for a blank id', async () => {
+    const client = { from: vi.fn() };
+
+    await expect(getCatalogExclusion(client as never, '  ')).resolves.toBeNull();
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the denylist cannot be read', async () => {
+    const client = {
+      from: vi.fn(() => singleRowQuery({ data: null, error: { message: 'database unavailable' } })),
+    };
+
+    await expect(getCatalogExclusion(client as never, 'Example.App')).rejects.toThrow(
+      'Could not verify package availability: database unavailable'
+    );
+  });
+});
 
 describe('getPackageEligibilityBlocks', () => {
   it('deduplicates requested IDs and returns only application-level blocks', async () => {

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -16,6 +16,38 @@ export interface PackageEligibilityBlock {
 export const PACKAGE_UNAVAILABLE_MESSAGE =
   'This app is not available for automated deployment.';
 
+export interface CatalogExclusion {
+  wingetId: string;
+  reason: string;
+}
+
+/**
+ * Look up a winget ID on the permanent catalog denylist
+ * (public.curated_excluded_apps). Excluded packages never enter
+ * curated_apps, so app requests for them can never be fulfilled and
+ * must be refused with the recorded reason instead of accepted.
+ * Case-insensitive because users often type a differently-cased id.
+ */
+export async function getCatalogExclusion(
+  supabase: SupabaseClient<Database>,
+  wingetId: string
+): Promise<CatalogExclusion | null> {
+  const id = wingetId.trim();
+  if (!id) return null;
+
+  const { data, error } = await supabase
+    .from('curated_excluded_apps')
+    .select('winget_id, reason')
+    .ilike('winget_id', id)
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Could not verify package availability: ${error.message}`);
+  }
+
+  return data ? { wingetId: data.winget_id, reason: data.reason } : null;
+}
+
 export async function getPackageEligibilityBlocks(
   supabase: SupabaseClient<Database>,
   wingetIds: readonly string[]

--- a/types/database.ts
+++ b/types/database.ts
@@ -372,6 +372,29 @@ export interface Database {
         >;
         Relationships: GenericRelationship[];
       };
+      curated_excluded_apps: {
+        Row: {
+          winget_id: string;
+          reason: string;
+          source: string;
+          excluded_at: string;
+          excluded_by: string | null;
+          notes: string | null;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['curated_excluded_apps']['Row'],
+          'source' | 'excluded_at' | 'excluded_by' | 'notes'
+        > & {
+          source?: string;
+          excluded_at?: string;
+          excluded_by?: string | null;
+          notes?: string | null;
+        };
+        Update: Partial<
+          Database['public']['Tables']['curated_excluded_apps']['Insert']
+        >;
+        Relationships: GenericRelationship[];
+      };
       package_eligibility_blocks: {
         Row: {
           winget_id: string;


### PR DESCRIPTION
## Problem

The app request pipeline is automated but dishonest for denylisted packages. The daily resolver assumes every id that exists in winget-pkgs lands in the catalog within a day, but the weekly import skips everything on the `curated_excluded_apps` denylist (SourceForge installers that get rate limited in CI, per #163/#208/#314). Requests for WinSCP.WinSCP were closed as "implemented" three times with a promise the catalog can never keep, and nothing blocked resubmission, so the loop kept repeating. KeePass hit the same path once.

## Changes

**Submit API** (`app/api/community/suggestions/route.ts`)
- Refuses denylisted ids up front with a 422 and the recorded exclusion reason (new `getCatalogExclusion` helper in `lib/package-eligibility.ts`), so doomed requests never create an issue.
- Dedupe lookup switched from `.single()` to `.limit(1).maybeSingle()` so pre-existing duplicates no longer error into a false "no existing suggestion".

**Resolver** (`.github/workflows/resolve-app-requests.yml`) now decides from actual state instead of assumptions, in precedence order:
1. On the denylist: close as rejected with the recorded reason.
2. In the catalog with a `package_eligibility_blocks` row: close as rejected (not deployable).
3. In the catalog: close as fulfilled ("available now", no more "within a day" promise).
4. Exists in winget but not imported yet: leave open with a one-time "queued" comment; the next run after the weekly catalog sync closes it as fulfilled.
5. Not in winget: close as rejected with correction guidance (unchanged behavior).

All comments are marker-guarded so re-runs never spam issues, and every resolution still syncs the suggestion status to Supabase. With this, no request state requires manual review; the `/implemented` and `/declined` webhook commands remain as a manual override only.

## Data correction (already applied)

The five wrongly "implemented" rows in `app_suggestions` (WinSCP #163/#208/#314, KeePass #108/#123) have been set to `rejected` in production.

## Testing

- `vitest`: 8 tests pass, including 4 new tests for `getCatalogExclusion` (denylisted, not excluded, blank id, fail closed).
- `eslint` clean on touched files; `tsc` shows no errors in touched files (pre-existing errors in unrelated test files unchanged).
- Workflow YAML parses and the github-script body compiles as an async function.
- Not yet exercised in production: the new resolver paths run on the next scheduled run (04:30 UTC daily) or via `workflow_dispatch` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)