### PR TITLE
release(qa): activate IObit detain uninstall

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f7be39a95d529bc613f0ec8d4f2483762a5e02a2',
+  packagerCommit: '3400509334e29c78e960ba3b05ba3e4bec408b87',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -356,6 +356,13 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // IDM's reviewed window sequence replaces its ineffective /S argument and
   // changes only that adapter's canonical profile. Preserve unrelated passes.
   'c649792a94f23b4c3fc04e07b81c4aa655887301',
+  // IDM's exact-process window automation changes only its previously failed
+  // lifecycle. Preserve every unrelated compatible pass from that release.
+  '943851a66f72cf115e2d97058a6415ee71e3f50f',
+  // IObit's first Inno-only correction changes only that app's failed removal
+  // path. Preserve every unrelated compatible pass while its vendor-specific
+  // detain switch becomes the current exact profile.
+  'f7be39a95d529bc613f0ec8d4f2483762a5e02a2',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -217,7 +217,15 @@ const IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...IDM_WINDOW_AUTOMATION_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Replace IObit's ineffective standard-only Inno attempt with the reviewed
+  // vendor-specific detain switch, then carry every unconsumed bounded target.
+  ...IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3400509334e29c78e960ba3b05ba3e4bec408b87':
+    IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS,
   'f7be39a95d529bc613f0ec8d4f2483762a5e02a2':
     IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS,
   '943851a66f72cf115e2d97058a6415ee71e3f50f':


### PR DESCRIPTION
## Summary
- pin production catalog packaging to exact packager commit 3400509334e29c78e960ba3b05ba3e4bec408b87`n- queue a bounded IObit proof retry on the new canonical profile
- preserve compatible passes from the IDM and first IObit releases

## Verification
- 258 profile, backfill, and adapter tests passed
- ESLint passed for changed files
- git diff --check passed