### PR TITLE
fix(packager): await Desktop Connector ODIS registration

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2283,6 +2283,15 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         ''
     )
 } elseif ($useRegistryUninstall) {
+    # A reviewed long-running bootstrapper can hand work to a detached child
+    # before its own process handle completes. Reuse the reviewed completion
+    # ceiling for exact ARP registration instead of reverting to the generic
+    # one-minute capture window after the parent exits.
+    $registryUninstallVerificationAttempts = if ($reviewedInstallCompletionTimeoutMinutes -gt 0) {
+        [Math]::Max(30, $reviewedInstallCompletionTimeoutMinutes * 30)
+    } else {
+        30
+    }
     $lines += @(
         '    # Snapshot uninstall entries so the exact vendor entry created or updated by this installer can be reused later.'
         '    $preInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
@@ -2906,7 +2915,7 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         '    $candidateLocaleSuffixPattern = if ($configuredUninstallLocaleAgnosticName) {'
         '        ''\(\s*(?:(?:x86_64|aarch64|amd64|arm64|x64|x86|win64|win32|64-bit|32-bit)\s+)?'' + [regex]::Escape($configuredUninstallLocaleHint) + ''\s*\)$'''
         '    } else { $null }'
-        '    foreach ($verificationAttempt in 1..30) {'
+        "    foreach (`$verificationAttempt in 1..$registryUninstallVerificationAttempts) {"
         '        $postInstallApplications = @(Get-ADTApplication -ErrorAction SilentlyContinue)'
         '        $changedApplications = @($postInstallApplications | Where-Object {'
         '            $candidateApplication = $_'
@@ -3090,7 +3099,7 @@ if ($reviewedAppxInstallEvidenceConfigured) {
     $lines += @(
         '        if ($selectedApplications.Count -eq 1) { break }'
         '        if ($multiProductInstallationVerified) { break }'
-        '        if ($verificationAttempt -lt 30) { Start-Sleep -Seconds 2 }'
+        "        if (`$verificationAttempt -lt $registryUninstallVerificationAttempts) { Start-Sleep -Seconds 2 }"
         '    }'
         '    if ($selectedApplications.Count -eq 1) {'
         '        $capturedUninstallKey = [string]$selectedApplications[0].PSChildName'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -560,6 +560,20 @@ describe('application packaging adapters', () => {
     ).toBe('%SystemDrive%\\SWSetup\\HPImageAssistant');
     expect(
       applyApplicationPackagingAdapter(
+        'Autodesk.DesktopConnector',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      processesToClose: [
+        {
+          name: 'DesktopConnector.Applications.Tray',
+          description: 'Autodesk Desktop Connector',
+        },
+      ],
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Autodesk.LicensingService',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -797,6 +797,23 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%SystemDrive%\\SWSetup\\HPImageAssistant',
   },
   {
+    // Desktop Connector is delivered by Autodesk ODIS. The signed bootstrapper
+    // can exit before ODIS creates the exact product registration, so the
+    // ordinary one-minute ARP capture races a still-running installation.
+    // Autodesk's current administrator sample also closes this exact tray
+    // process before install and removal. Keep the dynamic manifest product
+    // identity and registered ODIS uninstall command, but give registration
+    // the same reviewed completion window as the vendor installer.
+    wingetId: 'Autodesk.DesktopConnector',
+    requiredProcessesToClose: [
+      {
+        name: 'DesktopConnector.Applications.Tray',
+        description: 'Autodesk Desktop Connector',
+      },
+    ],
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // Autodesk documents Desktop Licensing Service as a shared component that
     // does not appear in Programs and Features. Verify its dedicated payload
     // instead of trying to select one of the unrelated Autodesk ARP changes,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -650,6 +650,39 @@ describe('PSADT QA package identity', () => {
     });
   });
 
+  it('binds the reviewed Autodesk Desktop Connector ODIS wait to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Autodesk.DesktopConnector',
+      displayName: 'Autodesk Desktop Connector',
+      publisher: 'Autodesk',
+      version: '2027.2.0.85',
+      architecture: 'x64',
+      installerSha256: 'f'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{0D3EBA46-5179-3ECC-9E63-8A0221EBFA9F}:Autodesk Desktop Connector',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+      psadtConfig: {
+        processesToClose: Array<{ name: string }>;
+        reviewedInstallCompletionTimeoutMinutes?: number;
+      };
+    };
+
+    expect(profile.psadtConfig.processesToClose.map(({ name }) => name)).toEqual([
+      'DesktopConnector.Applications.Tray',
+    ]);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.installer.uninstallCommand).toContain(
+      '{0D3EBA46-5179-3ECC-9E63-8A0221EBFA9F}'
+    );
+  });
+
   it('binds the bounded darktable installer wait to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'darktable.darktable',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2002,6 +2002,35 @@ describe('PSADT registry uninstall identity contract', () => {
     30_000
   );
 
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'uses a reviewed bootstrapper completion window for exact ARP registration',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Autodesk Desktop Connector',
+        [],
+        { reviewedInstallCompletionTimeoutMinutes: 15 },
+        [],
+        'Autodesk.DesktopConnector',
+        'Autodesk Desktop Connector',
+        '2027.2.0.85',
+        'REGISTRY_UNINSTALL_PRODUCT:{0D3EBA46-5179-3ECC-9E63-8A0221EBFA9F}:Autodesk Desktop Connector',
+        '--quiet'
+      );
+
+      expect(generated).toContain(
+        'foreach ($verificationAttempt in 1..450)'
+      );
+      expect(generated).toContain(
+        'if ($verificationAttempt -lt 450) { Start-Sleep -Seconds 2 }'
+      );
+      expect(generated).toContain(
+        '$configuredMatches = @($postInstallApplications'
+      );
+    },
+    30_000
+  );
+
   it('parses and persists a manifest product code for multi-entry installers', () => {
     expect(packager).toContain(
       "^REGISTRY_UNINSTALL_PRODUCT:(\\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\\}):(.+)$"


### PR DESCRIPTION
## Summary
- add an Autodesk Desktop Connector adapter that closes the vendor tray process and enables a reviewed 15-minute installer-completion window
- reuse reviewed bootstrapper completion windows while waiting for the exact ARP registration, covering ODIS processes that continue after the signed parent exits
- preserve the manifest product-code identity and existing fail-closed registry-driven Autodesk ODIS uninstall path for customer and QA PSADT packages

## Evidence
- protected QA run 32856550072: installer parent returned, exact ARP registration was still absent after the generic 60-second window, and ODIS continued creating payload afterward
- Autodesk administrator deployment guidance identifies DesktopConnector.Applications.Tray and registry-driven quiet ODIS removal

## Verification
- 382 relevant adapter/package-profile/packager/toolchain tests passed before the final focused profile assertion
- new Autodesk profile test passed
- ESLint passed for all changed TypeScript test/source files
- git diff --check passed