### PR TITLE
release(qa): activate Desktop Connector ODIS wait

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3400509334e29c78e960ba3b05ba3e4bec408b87',
+  packagerCommit: 'b798917a85465cb2fe7b55582322d1e30b20e088',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -363,6 +363,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // path. Preserve every unrelated compatible pass while its vendor-specific
   // detain switch becomes the current exact profile.
   'f7be39a95d529bc613f0ec8d4f2483762a5e02a2',
+  // Desktop Connector now waits for its detached ODIS registration. Preserve
+  // every package that already passed on the prior IObit detain release.
+  '3400509334e29c78e960ba3b05ba3e4bec408b87',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -165,6 +165,7 @@ describe('QA toolchain targeted retries', () => {
       'Playnite.Playnite',
       'Tonec.InternetDownloadManager',
       'IObit.Uninstaller',
+      'Autodesk.DesktopConnector',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -222,6 +223,7 @@ describe('QA toolchain targeted retries', () => {
         'Playnite.Playnite',
         'Tonec.InternetDownloadManager',
         'IObit.Uninstaller',
+        'Autodesk.DesktopConnector',
       ])
     );
     expect(
@@ -273,6 +275,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '943851a66f72cf115e2d97058a6415ee71e3f50f',
       { wingetId: 'IObit.Uninstaller', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Desktop Connector only after activating its ODIS registration wait', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' autodesk.desktopconnector ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '3400509334e29c78e960ba3b05ba3e4bec408b87',
+      { wingetId: 'Autodesk.DesktopConnector', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -223,7 +223,16 @@ const IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...IOBIT_INNO_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS = [
+  // Re-run Desktop Connector with a bounded wait for its detached ODIS product
+  // registration, then carry every still-unconsumed targeted retry.
+  'Autodesk.DesktopConnector',
+  ...IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b798917a85465cb2fe7b55582322d1e30b20e088':
+    AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS,
   '3400509334e29c78e960ba3b05ba3e4bec408b87':
     IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS,
   'f7be39a95d529bc613f0ec8d4f2483762a5e02a2':


### PR DESCRIPTION
## Summary
- activate exact customer and QA PSADT packager commit \798917a85465cb2fe7b55582322d1e30b20e088\`n- preserve passes from \3400509334e29c78e960ba3b05ba3e4bec408b87\ because the new wait changes only detached-bootstrapper registration failure behavior
- add Autodesk.DesktopConnector to the bounded terminal retry targets while carrying prior unconsumed targets

## Verification
- 384 relevant adapter, package-profile, packager, and toolchain retry tests passed
- ESLint passed for all changed files
- git diff --check passed