### PR TITLE
feat(updates): choose an update policy during deployment configuration

### DIFF
--- a/app/api/package/callback/route.ts
+++ b/app/api/package/callback/route.ts
@@ -9,6 +9,7 @@ import { getDatabase } from '@/lib/db';
 import { verifyCallbackSignature } from '@/lib/callback-signature';
 import { onJobCompleted } from '@/lib/msp/batch-orchestrator';
 import { handleAutoUpdateJobCompletion } from '@/lib/auto-update/cleanup';
+import { ensureUpdatePolicy, parseCartUpdatePolicy } from '@/lib/update-policies/ensure-policy';
 import { quarantineInstaller } from '@/lib/installer-preflight';
 import {
   packageCallbackSchema,
@@ -194,6 +195,22 @@ export async function POST(request: NextRequest) {
         // The terminal job state is authoritative. Do not ask the workflow to
         // retry a callback that can no longer repeat this side effect.
         console.error(`[Callback] Failed to create upload history for ${data.jobId}:`, historyError);
+      }
+
+      // Materialize an update policy chosen in the cart, now that the
+      // upload_history row exists to anchor original_upload_history_id.
+      const chosenPolicy = parseCartUpdatePolicy(currentJob.package_config);
+      if (chosenPolicy && currentJob.tenant_id) {
+        const policyResult = await ensureUpdatePolicy({
+          userId: currentJob.user_id,
+          tenantId: currentJob.tenant_id,
+          wingetId: currentJob.winget_id,
+          policyType: chosenPolicy,
+          deployedVersion: currentJob.version,
+        });
+        if (policyResult.status !== 'saved') {
+          console.warn(`[Callback] Update policy not saved for ${data.jobId}:`, policyResult);
+        }
       }
     }
 

--- a/app/api/packager/jobs/route.ts
+++ b/app/api/packager/jobs/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, verifyPackagerApiKey } from '@/lib/db';
 import { createServerClient } from '@/lib/supabase';
 import { getFeatureFlags } from '@/lib/features';
+import { ensureUpdatePolicy, parseCartUpdatePolicy } from '@/lib/update-policies/ensure-policy';
 
 // Verify the packager auth key (API key for SQLite, service role key for Supabase)
 function verifyPackagerAuth(request: NextRequest): boolean {
@@ -218,6 +219,22 @@ export async function PATCH(request: NextRequest) {
           `[Packager Jobs API] Failed to write upload_history for job ${job.id}:`,
           historyError
         );
+      }
+
+      // Materialize an update policy chosen in the cart, now that the
+      // upload_history row exists to anchor original_upload_history_id.
+      const chosenPolicy = parseCartUpdatePolicy(job.package_config);
+      if (chosenPolicy && job.tenant_id) {
+        const policyResult = await ensureUpdatePolicy({
+          userId: job.user_id,
+          tenantId: job.tenant_id,
+          wingetId: job.winget_id,
+          policyType: chosenPolicy,
+          deployedVersion: job.version,
+        });
+        if (policyResult.status !== 'saved') {
+          console.warn(`[Packager Jobs API] Update policy not saved for job ${job.id}:`, policyResult);
+        }
       }
 
       // Clean up stale update_check_results so the Updates page no longer

--- a/components/CartItemConfig.tsx
+++ b/components/CartItemConfig.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import {
+  ArrowUpCircle,
   X,
   Settings,
   Terminal,
@@ -34,6 +35,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { cn } from '@/lib/utils';
 import { AssignmentConfig } from '@/components/AssignmentConfig';
+import { CartUpdatePolicyPicker, type CartUpdatePolicyValue } from '@/components/updates/CartUpdatePolicyPicker';
 import { CategoryConfig } from '@/components/CategoryConfig';
 import { DependencyConfig } from '@/components/DependencyConfig';
 import { EspProfileSelector } from '@/components/EspProfileSelector';
@@ -72,6 +74,7 @@ type ConfigSection =
   | 'assignment'
   | 'category'
   | 'esp'
+  | 'updates'
   | 'dependencies'
   | 'branding'
   | 'advanced';
@@ -107,6 +110,9 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   );
   const [installCommand, setInstallCommand] = useState(isWin32 ? item.installCommand : '');
   const [uninstallCommand, setUninstallCommand] = useState(isWin32 ? item.uninstallCommand : '');
+  const [updatePolicy, setUpdatePolicy] = useState<CartUpdatePolicyValue>(
+    isWin32 ? item.updatePolicy : undefined
+  );
 
   // UI state
   const [expandedSection, setExpandedSection] = useState<ConfigSection | null>(isStore ? 'assignment' : 'behavior');
@@ -119,6 +125,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   const configSnapshot = JSON.stringify({
     storeInstallExperience, selectedScope, config, assignments, categories,
     espProfiles, relationships, installCommand, uninstallCommand,
+    updatePolicy: updatePolicy ?? null,
   });
   const baselineSnapshotRef = useRef(configSnapshot);
   const requestClose = () => {
@@ -213,6 +220,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
           requirementRules,
           installCommand,
           uninstallCommand,
+          updatePolicy,
         });
       }
       onClose();
@@ -1134,6 +1142,21 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
                   hasRequiredAssignment={assignments.some((a) => a.intent === 'required')}
                 />
               </ConfigSection>
+
+              {/* App Updates (win32 only) */}
+              {isWin32 && <ConfigSection
+                title="App Updates"
+                icon={<ArrowUpCircle className="w-4 h-4" />}
+                expanded={expandedSection === 'updates'}
+                onToggle={() => toggleSection('updates')}
+              >
+                <div className="space-y-3">
+                  <p className="text-sm text-text-secondary">
+                    Choose how IntuneGet handles future versions of this app.
+                  </p>
+                  <CartUpdatePolicyPicker value={updatePolicy} onChange={setUpdatePolicy} />
+                </div>
+              </ConfigSection>}
 
               {/* Dependencies & Supersedence (win32 only) */}
               {isWin32 && <ConfigSection

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo, useId } from 'react';
 import {
+  ArrowUpCircle,
   X,
   Settings,
   Terminal,
@@ -41,6 +42,7 @@ import {
 import { cn } from '@/lib/utils';
 import { AppIcon } from '@/components/AppIcon';
 import { AssignmentConfig } from '@/components/AssignmentConfig';
+import { CartUpdatePolicyPicker, type CartUpdatePolicyValue } from '@/components/updates/CartUpdatePolicyPicker';
 import { CategoryConfig } from '@/components/CategoryConfig';
 import { DependencyConfig } from '@/components/DependencyConfig';
 import { EspProfileSelector } from '@/components/EspProfileSelector';
@@ -101,6 +103,7 @@ type ConfigSection =
   | 'assignment'
   | 'category'
   | 'esp'
+  | 'updates'
   | 'dependencies'
   | 'branding'
   | 'advanced';
@@ -204,6 +207,9 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   const [relationships, setRelationships] = useState<AppRelationship[]>(
     deployedConfig?.relationships || []
   );
+  const [updatePolicy, setUpdatePolicy] = useState<CartUpdatePolicyValue>(
+    deployedConfig?.updatePolicy
+  );
 
   // UI state
   const [expandedSection, setExpandedSection] = useState<ConfigSection | null>(isStoreApp ? 'assignment' : 'detection');
@@ -211,7 +217,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   const [addedToCartSuccess, setAddedToCartSuccess] = useState(false);
   const [configMode, setConfigMode] = useState<'quick' | 'advanced'>('quick');
 
-  const quickSections: ConfigSection[] = ['detection', 'assignment', 'category', 'esp', 'dependencies'];
+  const quickSections: ConfigSection[] = ['detection', 'assignment', 'category', 'esp', 'updates', 'dependencies'];
   const isQuickSection = (section: ConfigSection) => quickSections.includes(section);
   const visibleSections = configMode === 'quick' ? quickSections : null; // null = show all
 
@@ -464,6 +470,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
           relationships: relationships.length > 0 ? relationships : undefined,
           localeCode: selectedLocale || undefined,
           iconPath: pkg.iconPath,
+          updatePolicy,
           ...(isDeployed ? { forceCreate: true } : {}),
         });
       }
@@ -1765,6 +1772,21 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
                   mode="pre-deploy"
                   hasRequiredAssignment={assignments.some((a) => a.intent === 'required')}
                 />
+              </ConfigSection>}
+
+              {/* App Updates (quick + advanced, win32 only) */}
+              {!isStoreApp && (visibleSections === null || visibleSections.includes('updates')) && <ConfigSection
+                title="App Updates"
+                icon={<ArrowUpCircle className="w-4 h-4" />}
+                expanded={expandedSection === 'updates'}
+                onToggle={() => toggleSection('updates')}
+              >
+                <div className="space-y-3">
+                  <p className="text-sm text-text-secondary">
+                    Choose how IntuneGet handles future versions of this app.
+                  </p>
+                  <CartUpdatePolicyPicker value={updatePolicy} onChange={setUpdatePolicy} />
+                </div>
               </ConfigSection>}
 
               {/* Dependencies & Supersedence (quick + advanced, win32 only) */}

--- a/components/updates/CartUpdatePolicyPicker.tsx
+++ b/components/updates/CartUpdatePolicyPicker.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+// Cart-time update policy choice. undefined = "Notify" (default): nothing is
+// written on deploy, so a policy set earlier on the Updates page is preserved.
+// pin_version is intentionally absent; it has no meaning before deployment.
+export type CartUpdatePolicyValue = 'auto_update' | 'ignore' | undefined;
+
+interface PolicyOption {
+  value: CartUpdatePolicyValue;
+  label: string;
+  description: string;
+}
+
+const POLICY_OPTIONS: PolicyOption[] = [
+  {
+    value: undefined,
+    label: 'Notify',
+    description: 'New versions appear on the Updates page and in your notifications. You deploy them when you choose.',
+  },
+  {
+    value: 'auto_update',
+    label: 'Auto update',
+    description: 'New versions are packaged, checked by QA, and deployed to this tenant automatically. Assignments carry over based on your settings.',
+  },
+  {
+    value: 'ignore',
+    label: 'Ignore',
+    description: 'Skip update checks for this app. It will not appear on the Updates page.',
+  },
+];
+
+interface CartUpdatePolicyPickerProps {
+  value: CartUpdatePolicyValue;
+  onChange: (value: CartUpdatePolicyValue) => void;
+}
+
+export function CartUpdatePolicyPicker({ value, onChange }: CartUpdatePolicyPickerProps) {
+  const selected = POLICY_OPTIONS.find((option) => option.value === value) ?? POLICY_OPTIONS[0];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {POLICY_OPTIONS.map((option) => (
+          <button
+            key={option.label}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'flex-1 px-4 py-2.5 rounded-lg border text-sm font-medium transition-colors',
+              selected.label === option.label
+                ? 'bg-blue-600 border-blue-500 text-white'
+                : 'bg-bg-elevated border-overlay/15 text-text-primary hover:border-overlay/20'
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-text-muted">{selected.description}</p>
+      <p className="text-xs text-text-muted">
+        Applies after this deployment completes. You can change it anytime on the Updates page.
+      </p>
+    </div>
+  );
+}

--- a/lib/update-policies/__tests__/ensure-policy.test.ts
+++ b/lib/update-policies/__tests__/ensure-policy.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for deploy-time update policy creation: the cart's updatePolicy choice
+ * must materialize as a usable app_update_policies row once a deployment
+ * completes, and must never write a null-config auto_update row.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureUpdatePolicy, parseCartUpdatePolicy } from '../ensure-policy';
+
+const {
+  isSupabaseServerConfiguredMock,
+  buildDeploymentConfigForAppMock,
+  upsertMock,
+  maybeSingleMock,
+} = vi.hoisted(() => ({
+  isSupabaseServerConfiguredMock: vi.fn(),
+  buildDeploymentConfigForAppMock: vi.fn(),
+  upsertMock: vi.fn(),
+  maybeSingleMock: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  isSupabaseServerConfigured: isSupabaseServerConfiguredMock,
+  createServerClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === 'app_update_policies') {
+        return { upsert: upsertMock };
+      }
+      const builder: Record<string, unknown> = {};
+      const chain = () => builder;
+      builder.select = vi.fn(chain);
+      builder.eq = vi.fn(chain);
+      builder.maybeSingle = maybeSingleMock;
+      return builder;
+    }),
+  })),
+}));
+
+vi.mock('@/lib/update-policies/build-deployment-config', () => ({
+  buildDeploymentConfigForApp: buildDeploymentConfigForAppMock,
+}));
+
+const ARGS = {
+  userId: 'user-1',
+  tenantId: 'tenant-1',
+  wingetId: 'Publisher.App',
+  deployedVersion: '1.2.3',
+};
+
+const DEPLOYMENT_CONFIG = {
+  displayName: 'App',
+  publisher: 'Publisher',
+  architecture: 'x64',
+  installerType: 'msi',
+  installCommand: 'msiexec /i app.msi /qn',
+  uninstallCommand: 'msiexec /x {GUID} /qn',
+  installScope: 'system',
+  detectionRules: [],
+};
+
+describe('parseCartUpdatePolicy', () => {
+  it('returns the choice for valid values', () => {
+    expect(parseCartUpdatePolicy({ updatePolicy: 'auto_update' })).toBe('auto_update');
+    expect(parseCartUpdatePolicy({ updatePolicy: 'ignore' })).toBe('ignore');
+  });
+
+  it('returns null for absent, invalid, or malformed configs', () => {
+    expect(parseCartUpdatePolicy({})).toBeNull();
+    expect(parseCartUpdatePolicy({ updatePolicy: 'notify' })).toBeNull();
+    expect(parseCartUpdatePolicy({ updatePolicy: 'pin_version' })).toBeNull();
+    expect(parseCartUpdatePolicy(null)).toBeNull();
+    expect(parseCartUpdatePolicy('auto_update')).toBeNull();
+    expect(parseCartUpdatePolicy([])).toBeNull();
+  });
+});
+
+describe('ensureUpdatePolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSupabaseServerConfiguredMock.mockReturnValue(true);
+    maybeSingleMock.mockResolvedValue({ data: { settings: { carryOverAssignments: true } }, error: null });
+    upsertMock.mockResolvedValue({ error: null });
+  });
+
+  it('skips when Supabase is not configured', async () => {
+    isSupabaseServerConfiguredMock.mockReturnValue(false);
+
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'auto_update' });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'not_configured' });
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('saves an auto_update policy with config and upload history link', async () => {
+    buildDeploymentConfigForAppMock.mockResolvedValue({
+      status: 'ok',
+      deploymentConfig: DEPLOYMENT_CONFIG,
+      originalUploadHistoryId: 'history-1',
+    });
+
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'auto_update' });
+
+    expect(result).toEqual({ status: 'saved' });
+    expect(buildDeploymentConfigForAppMock).toHaveBeenCalledWith(expect.anything(), {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      wingetId: 'Publisher.App',
+      latestVersion: '1.2.3',
+      globalCarryOver: true,
+    });
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        tenant_id: 'tenant-1',
+        winget_id: 'Publisher.App',
+        policy_type: 'auto_update',
+        pinned_version: null,
+        deployment_config: DEPLOYMENT_CONFIG,
+        original_upload_history_id: 'history-1',
+        is_enabled: true,
+      }),
+      { onConflict: 'user_id,tenant_id,winget_id' }
+    );
+  });
+
+  it('skips auto_update instead of writing a null-config row when no config can be built', async () => {
+    buildDeploymentConfigForAppMock.mockResolvedValue({ status: 'orphaned_job' });
+
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'auto_update' });
+
+    expect(result).toEqual({ status: 'skipped', reason: 'config_unavailable' });
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('saves an ignore policy without building a deployment config', async () => {
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'ignore' });
+
+    expect(result).toEqual({ status: 'saved' });
+    expect(buildDeploymentConfigForAppMock).not.toHaveBeenCalled();
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy_type: 'ignore',
+        deployment_config: null,
+        original_upload_history_id: null,
+      }),
+      { onConflict: 'user_id,tenant_id,winget_id' }
+    );
+  });
+
+  it('returns error instead of throwing when the upsert fails', async () => {
+    upsertMock.mockResolvedValue({ error: { message: 'boom' } });
+
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'ignore' });
+
+    expect(result).toEqual({ status: 'error', error: { message: 'boom' } });
+  });
+
+  it('returns error instead of throwing on unexpected failures', async () => {
+    buildDeploymentConfigForAppMock.mockRejectedValue(new Error('network down'));
+
+    const result = await ensureUpdatePolicy({ ...ARGS, policyType: 'auto_update' });
+
+    expect(result.status).toBe('error');
+  });
+});

--- a/lib/update-policies/ensure-policy.ts
+++ b/lib/update-policies/ensure-policy.ts
@@ -1,0 +1,110 @@
+/**
+ * Deploy-time update policy creation.
+ *
+ * When a user picks an update policy in the cart (PackageConfig /
+ * CartItemConfig), the choice travels on the cart item into
+ * packaging_jobs.package_config and is materialized here once the deployment
+ * completes, i.e. the moment an upload_history row exists. That row is what
+ * makes an auto_update policy usable by the cron trigger (the
+ * requirePriorDeployment gate needs original_upload_history_id).
+ *
+ * "Notify" is the implicit default and never writes a row, so redeploying
+ * without an explicit choice preserves any policy set earlier on the Updates
+ * page.
+ */
+
+import { createServerClient, isSupabaseServerConfigured } from '@/lib/supabase';
+import { buildDeploymentConfigForApp } from '@/lib/update-policies/build-deployment-config';
+import type { Json } from '@/types/database';
+
+export type CartUpdatePolicyChoice = 'auto_update' | 'ignore';
+
+export function parseCartUpdatePolicy(packageConfig: unknown): CartUpdatePolicyChoice | null {
+  if (typeof packageConfig !== 'object' || packageConfig === null || Array.isArray(packageConfig)) {
+    return null;
+  }
+  const value = (packageConfig as Record<string, unknown>).updatePolicy;
+  return value === 'auto_update' || value === 'ignore' ? value : null;
+}
+
+export type EnsureUpdatePolicyResult =
+  | { status: 'saved' }
+  | { status: 'skipped'; reason: 'not_configured' | 'config_unavailable' }
+  | { status: 'error'; error: unknown };
+
+/**
+ * Upsert an app_update_policies row for a just-deployed app. Never throws;
+ * callers run this as a post-deployment side effect that must not affect the
+ * callback response.
+ */
+export async function ensureUpdatePolicy(args: {
+  userId: string;
+  tenantId: string;
+  wingetId: string;
+  policyType: CartUpdatePolicyChoice;
+  deployedVersion: string;
+}): Promise<EnsureUpdatePolicyResult> {
+  if (!isSupabaseServerConfigured()) {
+    return { status: 'skipped', reason: 'not_configured' };
+  }
+
+  try {
+    const { userId, tenantId, wingetId, policyType, deployedVersion } = args;
+    const supabase = createServerClient();
+
+    let deploymentConfig: Json | null = null;
+    let originalUploadHistoryId: string | null = null;
+
+    if (policyType === 'auto_update') {
+      const { data: userSettingsRow } = await (supabase as any)
+        .from('user_settings')
+        .select('settings')
+        .eq('user_id', userId)
+        .maybeSingle();
+      const userSettings = (userSettingsRow?.settings as Record<string, unknown> | null) || null;
+      const globalCarryOver = Boolean(userSettings?.carryOverAssignments);
+
+      const built = await buildDeploymentConfigForApp(supabase, {
+        userId,
+        tenantId,
+        wingetId,
+        latestVersion: deployedVersion,
+        globalCarryOver,
+      });
+
+      // A null-config auto_update policy is worse than no policy: nothing
+      // backfills it and it blocks the trigger route's rebuild branch.
+      if (built.status !== 'ok') {
+        return { status: 'skipped', reason: 'config_unavailable' };
+      }
+
+      deploymentConfig = built.deploymentConfig as unknown as Json;
+      originalUploadHistoryId = built.originalUploadHistoryId;
+    }
+
+    const { error } = await supabase
+      .from('app_update_policies')
+      .upsert(
+        {
+          user_id: userId,
+          tenant_id: tenantId,
+          winget_id: wingetId,
+          policy_type: policyType,
+          pinned_version: null,
+          deployment_config: deploymentConfig,
+          original_upload_history_id: originalUploadHistoryId,
+          is_enabled: true,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,tenant_id,winget_id' }
+      );
+
+    if (error) {
+      return { status: 'error', error };
+    }
+
+    return { status: 'saved' };
+  } catch (error) {
+    return { status: 'error', error };
+  }
+}

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -162,6 +162,11 @@ interface CartItemBase {
   // Explicit acknowledgement of a failed QA result for this exact version.
   qaOverride?: boolean;
 
+  // Update policy chosen during deployment configuration. Absent = "Notify"
+  // (default): no policy row is written on deploy, preserving any policy set
+  // earlier on the Updates page. Win32 only; the UI never sets it for Store apps.
+  updatePolicy?: 'auto_update' | 'ignore';
+
   // Cart metadata
   addedAt: string;
 }


### PR DESCRIPTION
## Summary
- Adds an App Updates section (Auto update / Notify / Ignore) to both deployment configuration modals (PackageConfig and CartItemConfig) for Win32 apps, so auto update is discoverable during initial setup instead of only on the Updates page
- Carries the choice on the cart item into packaging_jobs.package_config, then materializes an app_update_policies row on deployment completion (hosted callback and self-hosted packager paths), when upload_history exists to anchor original_upload_history_id for the cron trigger
- Notify remains the implicit default and writes nothing, so redeploys never overwrite a policy set earlier on the Updates page; auto_update rows are never written with a null deployment_config

## Testing
- 8 new unit tests for ensureUpdatePolicy and parseCartUpdatePolicy
- Full suite green on top of main: 1497/1497
- tsc --noEmit: no non-test errors

Prompted by user feedback: auto update could not be found during the setup process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)