### PR TITLE
feat(updates): per-app assignment carry-over and true auto-update count

### DIFF
--- a/app/(app)/dashboard/updates/page.tsx
+++ b/app/(app)/dashboard/updates/page.tsx
@@ -48,13 +48,14 @@ import {
   useRefreshAvailableUpdates,
   useTriggerUpdate,
   useUpdatePolicy,
+  useUpdatePolicies,
 } from '@/hooks/use-updates';
 import { useMspOptional } from '@/hooks/useMspOptional';
 import { useUserSettings } from '@/components/providers/UserSettingsProvider';
 import { fadeIn } from '@/lib/animations/variants';
 import { cn } from '@/lib/utils';
 import { classifyUpdateType } from '@/types/update-policies';
-import type { AvailableUpdate, TriggerUpdateResponse, UpdatePolicyType, UpdateType } from '@/types/update-policies';
+import type { AppUpdatePolicy, AvailableUpdate, TriggerUpdateResponse, UpdatePolicyType, UpdateType } from '@/types/update-policies';
 
 type SortOption = 'name' | 'severity' | 'type' | 'detected';
 
@@ -116,6 +117,7 @@ export default function UpdatesPage() {
   const { refreshUpdates, isRefreshing } = useRefreshAvailableUpdates({ tenantId });
   const { triggerUpdate } = useTriggerUpdate();
   const { updatePolicy } = useUpdatePolicy();
+  const { data: policiesData, isLoading: isLoadingPolicies } = useUpdatePolicies(tenantId);
 
   const updates = updatesData?.updates || [];
   const history = historyData?.history || [];
@@ -173,8 +175,10 @@ export default function UpdatesPage() {
   // Stats
   const availableCount = updates.length;
   const criticalCount = updates.filter((u) => u.is_critical).length;
-  const autoUpdateCount = updates.filter(
-    (u) => u.policy?.policy_type === 'auto_update' && u.policy?.is_enabled
+  // Count every app with auto-update enabled for this tenant, not just the
+  // ones that currently have an update pending.
+  const autoUpdateCount = ((policiesData?.policies || []) as AppUpdatePolicy[]).filter(
+    (p) => p.policy_type === 'auto_update' && p.is_enabled
   ).length;
   const recentAutoUpdates = history.filter(
     (h) => h.status === 'completed' && isWithinDays(h.completed_at, 7)
@@ -750,8 +754,7 @@ export default function UpdatesPage() {
           icon={RefreshCw}
           color="success"
           delay={0.2}
-          loading={isLoadingUpdates}
-          description={availableCount > 0 ? `${autoUpdateCount} of ${availableCount}` : undefined}
+          loading={isLoadingPolicies}
         />
         <AnimatedStatCard
           title={<T>Updated (7 days)</T>}

--- a/app/api/update-policies/route.ts
+++ b/app/api/update-policies/route.ts
@@ -171,21 +171,11 @@ export async function POST(request: NextRequest) {
         latestVersion = catalogApp?.latest_version || '';
       }
 
-      // Read the user's global carry-over setting (same source as the trigger route)
-      const { data: userSettingsRow } = await (supabase as any)
-        .from('user_settings')
-        .select('settings')
-        .eq('user_id', user.userId)
-        .maybeSingle();
-      const userSettings = (userSettingsRow?.settings as Record<string, unknown> | null) || null;
-      const globalCarryOver = Boolean(userSettings?.carryOverAssignments);
-
       const built = await buildDeploymentConfigForApp(supabase, {
         userId: user.userId,
         tenantId: body.tenant_id,
         wingetId: body.winget_id,
         latestVersion,
-        globalCarryOver,
       });
 
       if (built.status !== 'ok') {

--- a/app/api/updates/trigger/route.ts
+++ b/app/api/updates/trigger/route.ts
@@ -190,7 +190,6 @@ export async function POST(request: NextRequest) {
             tenantId: req.tenant_id,
             wingetId: req.winget_id,
             latestVersion: updateResult.latest_version,
-            globalCarryOver,
           });
 
           if (built.status === 'orphaned_job') {

--- a/components/CartItemConfig.tsx
+++ b/components/CartItemConfig.tsx
@@ -56,6 +56,7 @@ import type {
 } from '@/types/psadt';
 import type { WingetScope } from '@/types/winget';
 import { useCartStore } from '@/stores/cart-store';
+import { useUserSettings } from '@/components/providers/UserSettingsProvider';
 import { buildCartItemRequirementRules } from '@/lib/requirement-rules';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 
@@ -113,6 +114,12 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   const [updatePolicy, setUpdatePolicy] = useState<CartUpdatePolicyValue>(
     isWin32 ? item.updatePolicy : undefined
   );
+  const { settings: userSettings } = useUserSettings();
+  const [carryOverAssignments, setCarryOverAssignments] = useState<boolean>(
+    isWin32
+      ? item.assignmentMigration?.carryOverAssignments ?? Boolean(userSettings.carryOverAssignments)
+      : false
+  );
 
   // UI state
   const [expandedSection, setExpandedSection] = useState<ConfigSection | null>(isStore ? 'assignment' : 'behavior');
@@ -126,6 +133,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
     storeInstallExperience, selectedScope, config, assignments, categories,
     espProfiles, relationships, installCommand, uninstallCommand,
     updatePolicy: updatePolicy ?? null,
+    carryOverAssignments,
   });
   const baselineSnapshotRef = useRef(configSnapshot);
   const requestClose = () => {
@@ -221,6 +229,13 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
           installCommand,
           uninstallCommand,
           updatePolicy,
+          assignmentMigration:
+            updatePolicy === 'auto_update'
+              ? {
+                  carryOverAssignments,
+                  removeAssignmentsFromPreviousApp: carryOverAssignments,
+                }
+              : undefined,
         });
       }
       onClose();
@@ -1154,7 +1169,12 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
                   <p className="text-sm text-text-secondary">
                     Choose how IntuneGet handles future versions of this app.
                   </p>
-                  <CartUpdatePolicyPicker value={updatePolicy} onChange={setUpdatePolicy} />
+                  <CartUpdatePolicyPicker
+                    value={updatePolicy}
+                    onChange={setUpdatePolicy}
+                    carryOverAssignments={carryOverAssignments}
+                    onCarryOverAssignmentsChange={setCarryOverAssignments}
+                  />
                 </div>
               </ConfigSection>}
 

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -64,6 +64,7 @@ import type { AppRelationship } from '@/types/intune';
 import type { EspProfileSelection } from '@/types/esp';
 import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt';
 import { useCartStore, createStoreCartItem } from '@/stores/cart-store';
+import { useUserSettings } from '@/components/providers/UserSettingsProvider';
 import { useUpdateAppSettings } from '@/hooks/use-update-app-settings';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { generateDetectionRules, generateInstallCommand, generateUninstallCommand } from '@/lib/detection-rules';
@@ -209,6 +210,11 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   );
   const [updatePolicy, setUpdatePolicy] = useState<CartUpdatePolicyValue>(
     deployedConfig?.updatePolicy
+  );
+  const { settings: userSettings } = useUserSettings();
+  const [carryOverAssignments, setCarryOverAssignments] = useState<boolean>(
+    deployedConfig?.assignmentMigration?.carryOverAssignments ??
+      Boolean(userSettings.carryOverAssignments)
   );
 
   // UI state
@@ -471,6 +477,13 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
           localeCode: selectedLocale || undefined,
           iconPath: pkg.iconPath,
           updatePolicy,
+          assignmentMigration:
+            updatePolicy === 'auto_update'
+              ? {
+                  carryOverAssignments,
+                  removeAssignmentsFromPreviousApp: carryOverAssignments,
+                }
+              : undefined,
           ...(isDeployed ? { forceCreate: true } : {}),
         });
       }
@@ -1785,7 +1798,12 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
                   <p className="text-sm text-text-secondary">
                     Choose how IntuneGet handles future versions of this app.
                   </p>
-                  <CartUpdatePolicyPicker value={updatePolicy} onChange={setUpdatePolicy} />
+                  <CartUpdatePolicyPicker
+                    value={updatePolicy}
+                    onChange={setUpdatePolicy}
+                    carryOverAssignments={carryOverAssignments}
+                    onCarryOverAssignmentsChange={setCarryOverAssignments}
+                  />
                 </div>
               </ConfigSection>}
 

--- a/components/updates/CartUpdatePolicyPicker.tsx
+++ b/components/updates/CartUpdatePolicyPicker.tsx
@@ -34,9 +34,16 @@ const POLICY_OPTIONS: PolicyOption[] = [
 interface CartUpdatePolicyPickerProps {
   value: CartUpdatePolicyValue;
   onChange: (value: CartUpdatePolicyValue) => void;
+  carryOverAssignments: boolean;
+  onCarryOverAssignmentsChange: (value: boolean) => void;
 }
 
-export function CartUpdatePolicyPicker({ value, onChange }: CartUpdatePolicyPickerProps) {
+export function CartUpdatePolicyPicker({
+  value,
+  onChange,
+  carryOverAssignments,
+  onCarryOverAssignmentsChange,
+}: CartUpdatePolicyPickerProps) {
   const selected = POLICY_OPTIONS.find((option) => option.value === value) ?? POLICY_OPTIONS[0];
 
   return (
@@ -59,6 +66,24 @@ export function CartUpdatePolicyPicker({ value, onChange }: CartUpdatePolicyPick
         ))}
       </div>
       <p className="text-xs text-text-muted">{selected.description}</p>
+      {value === 'auto_update' && (
+        <label className="flex items-start gap-2.5 rounded-lg border border-overlay/15 bg-bg-elevated px-3 py-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={carryOverAssignments}
+            onChange={(e) => onCarryOverAssignmentsChange(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-overlay/30 accent-blue-600"
+          />
+          <span>
+            <span className="block text-sm font-medium text-text-primary">
+              Carry over assignments
+            </span>
+            <span className="block text-xs text-text-muted mt-0.5">
+              Move this app&apos;s group assignments to each new version and remove them from the previous one.
+            </span>
+          </span>
+        </label>
+      )}
       <p className="text-xs text-text-muted">
         Applies after this deployment completes. You can change it anytime on the Updates page.
       </p>

--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -632,12 +632,13 @@ export class AutoUpdateTrigger {
     const assignments = normalizeAssignments(config);
     const categories = normalizeCategories(config);
 
-    // Always re-read the user's current global settings instead of trusting
-    // the stored policy values, which may be stale if the user toggled the
-    // settings after the policy was created.
+    // Re-read the user's current global settings so policies without an
+    // explicit per-app choice follow the settings toggle live. An explicit
+    // assignmentMigration on the policy config (set via the deployment
+    // flow's App Updates checkbox) wins over the global value.
     const { carryOverAssignments: globalCarryOver, supersedePreviousApp } =
       await this.getUserUpdateSettings(policy.user_id);
-    const assignmentMigration = {
+    const assignmentMigration = config.assignmentMigration ?? {
       carryOverAssignments: globalCarryOver,
       removeAssignmentsFromPreviousApp: globalCarryOver,
     };

--- a/lib/update-policies/__tests__/ensure-policy.test.ts
+++ b/lib/update-policies/__tests__/ensure-policy.test.ts
@@ -105,7 +105,6 @@ describe('ensureUpdatePolicy', () => {
       tenantId: 'tenant-1',
       wingetId: 'Publisher.App',
       latestVersion: '1.2.3',
-      globalCarryOver: true,
     });
     expect(upsertMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/lib/update-policies/build-deployment-config.ts
+++ b/lib/update-policies/build-deployment-config.ts
@@ -364,10 +364,9 @@ export async function buildDeploymentConfigForApp(
     tenantId: string;
     wingetId: string;
     latestVersion: string;
-    globalCarryOver: boolean;
   }
 ): Promise<BuildDeploymentConfigResult> {
-  const { userId, tenantId, wingetId, latestVersion, globalCarryOver } = args;
+  const { userId, tenantId, wingetId, latestVersion } = args;
 
   // Get the original deployment config from upload_history
   const { data: uploadHistory } = await supabase
@@ -398,16 +397,11 @@ export async function buildDeploymentConfigForApp(
     const parsedCategories = parsePackageCategories(packageConfig);
     const parsedRequirementRules = parseRequirementRules(packageConfig);
     const parsedRelationships = parseAppRelationships(packageConfig);
-    let assignmentMigration = parseAssignmentMigration(packageConfig);
-
-    // If no explicit migration config was stored on the packaging job,
-    // fall back to the user's global carryOverAssignments setting.
-    if (!assignmentMigration) {
-      assignmentMigration = {
-        carryOverAssignments: globalCarryOver,
-        removeAssignmentsFromPreviousApp: globalCarryOver,
-      };
-    }
+    // Explicit per-app choice only. When the packaging job stored no
+    // migration config, leave it undefined so the auto-update trigger falls
+    // back to the user's current global carryOverAssignments setting at
+    // update time (baking the global value in here would freeze it).
+    const assignmentMigration = parseAssignmentMigration(packageConfig);
 
     const deploymentConfig: DeploymentConfig = {
       displayName: packagingJob.display_name,

--- a/lib/update-policies/ensure-policy.ts
+++ b/lib/update-policies/ensure-policy.ts
@@ -56,20 +56,11 @@ export async function ensureUpdatePolicy(args: {
     let originalUploadHistoryId: string | null = null;
 
     if (policyType === 'auto_update') {
-      const { data: userSettingsRow } = await (supabase as any)
-        .from('user_settings')
-        .select('settings')
-        .eq('user_id', userId)
-        .maybeSingle();
-      const userSettings = (userSettingsRow?.settings as Record<string, unknown> | null) || null;
-      const globalCarryOver = Boolean(userSettings?.carryOverAssignments);
-
       const built = await buildDeploymentConfigForApp(supabase, {
         userId,
         tenantId,
         wingetId,
         latestVersion: deployedVersion,
-        globalCarryOver,
       });
 
       // A null-config auto_update policy is worse than no policy: nothing

--- a/types/upload.ts
+++ b/types/upload.ts
@@ -167,6 +167,14 @@ interface CartItemBase {
   // earlier on the Updates page. Win32 only; the UI never sets it for Store apps.
   updatePolicy?: 'auto_update' | 'ignore';
 
+  // Explicit per-app assignment carry-over for auto updates, set alongside
+  // updatePolicy === 'auto_update'. Absent = follow the user's global
+  // carryOverAssignments setting at update time.
+  assignmentMigration?: {
+    carryOverAssignments: boolean;
+    removeAssignmentsFromPreviousApp: boolean;
+  };
+
   // Cart metadata
   addedAt: string;
 }


### PR DESCRIPTION
## Summary
- The Auto-Update Enabled stat card now counts every enabled auto_update policy for the tenant instead of only apps with a pending update, and the "X of Y" subtitle is removed
- The App Updates section gains a per-app "Carry over assignments" checkbox when Auto update is selected, defaulting to the user global setting
- The explicit per-app choice is stored as assignmentMigration on the cart item and wins in the auto-update trigger; policies without an explicit choice keep following the global settings toggle live (buildDeploymentConfigForApp no longer bakes the global value into deployment_config)

## Testing
- Full suite green on main: 1498/1498
- tsc --noEmit: no non-test errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)