### PR TITLE
Fix Egnyte reboot-suppressed PSADT installs

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -899,6 +899,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('stages Egnyte updates on boot when managed packaging suppresses reboot', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Egnyte.EgnyteDesktopApp',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArguments).toEqual(['ED_UPDATE_ON_BOOT=1']);
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('uses PDFsam\'s documented managed MSI command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'PDFsam.PDFsam',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -288,6 +288,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArguments: ['MY_SPECIAL_MODE=2'],
   },
   {
+    // Egnyte Desktop App 4.2.1 and newer requires this documented property
+    // whenever an MDM package suppresses the installer-requested reboot.
+    // PSADT adds REBOOT=ReallySuppress for managed installs, so keep the
+    // vendor's update-on-boot contract in both QA and customer packages.
+    wingetId: 'Egnyte.EgnyteDesktopApp',
+    reviewedInstallArguments: ['ED_UPDATE_ON_BOOT=1'],
+  },
+  {
     // BlueJ 6.0.0 is a dual-purpose WiX MSI. Windows Installer 5 requires
     // ALLUSERS=2 with MSIINSTALLPERUSER=1 to select its per-user registration
     // context; the older ALLUSERS=0 example leaves this package failing under a

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -773,6 +773,33 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(30);
   });
 
+  it('binds Egnyte\'s reboot-suppressed update contract to QA and customer packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Egnyte.EgnyteDesktopApp',
+      displayName: 'Egnyte Desktop App',
+      publisher: 'Egnyte',
+      version: '4.5.1.201',
+      architecture: 'x64',
+      installerSha256: 'e'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/quiet ALLUSERS=1',
+      uninstallCommand: 'msiexec /x "{D205BFAE-B251-4EDF-B4DF-5ABF19F96B59}" /qn /norestart',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedInstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedInstallArguments).toEqual([
+      'ED_UPDATE_ON_BOOT=1',
+    ]);
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      reviewedInstallArguments: ['ED_UPDATE_ON_BOOT=1'],
+    });
+  });
+
   it('binds reviewed Wiris and Azure Monitor removal contracts to QA profiles', () => {
     const mathType = normalizeQaWorkflowPackageInput({
       wingetId: 'Wiris.MathType.7',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2904,6 +2904,28 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'combines Egnyte update-on-boot with the managed MSI reboot suppression',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'Egnyte Desktop App',
+        [],
+        { reviewedInstallArguments: ['ED_UPDATE_ON_BOOT=1'] },
+        [],
+        'Egnyte.EgnyteDesktopApp',
+        'Egnyte Desktop App',
+        '4.5.1.201',
+        'msiexec /x "{D205BFAE-B251-4EDF-B4DF-5ABF19F96B59}" /qn /norestart',
+        '/quiet ALLUSERS=1'
+      );
+
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList 'ALLUSERS=1 ED_UPDATE_ON_BOOT=1'"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'keeps a reviewed nested FlashPrint bootstrapper observable',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- add the documented `ED_UPDATE_ON_BOOT=1` property for Egnyte Desktop App
- keep PSADT's managed reboot suppression while allowing Egnyte 4.2.1+ to stage completion on boot
- bind the adapter to both catalog QA profiles and customer-generated packages

## QA evidence
- protected run 32864567970 failed install with MSI 1603 using `REBOOT=ReallySuppress /QN ALLUSERS=1`
- Egnyte documents that reboot-suppressed MDM installs require `ED_UPDATE_ON_BOOT=1`
- focused suite: 276 tests passed
- focused ESLint and `git diff --check` passed

Official contract: https://helpdesk.egnyte.com/hc/en-us/articles/44359575703949-Desktop-App-for-Windows-4-2-1-and-Higher-Migration-to-64-Bit-Client