### PR TITLE
release(qa): activate Egnyte reboot contract

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b798917a85465cb2fe7b55582322d1e30b20e088',
+  packagerCommit: 'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -366,6 +366,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Desktop Connector now waits for its detached ODIS registration. Preserve
   // every package that already passed on the prior IObit detain release.
   '3400509334e29c78e960ba3b05ba3e4bec408b87',
+  // Egnyte now carries the vendor-required update-on-boot property whenever
+  // the managed package suppresses reboots. Preserve unrelated prior passes.
+  'b798917a85465cb2fe7b55582322d1e30b20e088',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -166,6 +166,7 @@ describe('QA toolchain targeted retries', () => {
       'Tonec.InternetDownloadManager',
       'IObit.Uninstaller',
       'Autodesk.DesktopConnector',
+      'Egnyte.EgnyteDesktopApp',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -224,6 +225,7 @@ describe('QA toolchain targeted retries', () => {
         'Tonec.InternetDownloadManager',
         'IObit.Uninstaller',
         'Autodesk.DesktopConnector',
+        'Egnyte.EgnyteDesktopApp',
       ])
     );
     expect(
@@ -286,6 +288,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '3400509334e29c78e960ba3b05ba3e4bec408b87',
       { wingetId: 'Autodesk.DesktopConnector', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Egnyte only after activating its update-on-boot contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' egnyte.egnytedesktopapp ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b798917a85465cb2fe7b55582322d1e30b20e088',
+      { wingetId: 'Egnyte.EgnyteDesktopApp', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -230,7 +230,16 @@ const AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS = [
   ...IOBIT_DETAIN_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS = [
+  // Re-run Egnyte with the vendor-required update-on-boot property when the
+  // managed package suppresses reboot, then carry every unconsumed retry.
+  'Egnyte.EgnyteDesktopApp',
+  ...AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9':
+    EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
   'b798917a85465cb2fe7b55582322d1e30b20e088':
     AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS,
   '3400509334e29c78e960ba3b05ba3e4bec408b87':


### PR DESCRIPTION
## Summary
- activate the exact shared PSADT packager release containing Egnyte's required ED_UPDATE_ON_BOOT=1 property
- preserve successful packages produced by the prior compatible release
- retry Egnyte once while carrying the remaining bounded retry targets

## Verification
- npx vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts app/api/cron/qa-enqueue/route.test.ts app/api/cron/qa-dispatch/route.test.ts app/api/cron/qa-resume/route.test.ts (254 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check