### PR TITLE
feat(updates): make the stat cards clickable

### DIFF
--- a/app/(app)/dashboard/updates/page.tsx
+++ b/app/(app)/dashboard/updates/page.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { PageHeader, AnimatedStatCard, StatCardGrid, AnimatedEmptyState } from '@/components/dashboard';
 import { UpdateCard, UpdateCardSkeleton, AutoUpdateHistory } from '@/components/updates';
+import { AutoUpdateAppsModal } from '@/components/updates/AutoUpdateAppsModal';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   useAvailableUpdates,
@@ -76,6 +77,7 @@ export default function UpdatesPage() {
   const [activeTab, setActiveTab] = useState<'available' | 'history'>('available');
   const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set());
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
+  const [autoUpdateModalOpen, setAutoUpdateModalOpen] = useState(false);
   const [newAppDialogOpen, setNewAppDialogOpen] = useState(false);
   const [pendingNewAppUpdate, setPendingNewAppUpdate] = useState<AvailableUpdate | null>(null);
   const [bulkProgress, setBulkProgress] = useState<{
@@ -175,11 +177,13 @@ export default function UpdatesPage() {
   // Stats
   const availableCount = updates.length;
   const criticalCount = updates.filter((u) => u.is_critical).length;
-  // Count every app with auto-update enabled for this tenant, not just the
-  // ones that currently have an update pending.
-  const autoUpdateCount = ((policiesData?.policies || []) as AppUpdatePolicy[]).filter(
+  // Every app with auto-update enabled for this tenant, not just the ones
+  // that currently have an update pending. Backs both the stat card count
+  // and the card's click-through list.
+  const autoUpdatePolicies = ((policiesData?.policies || []) as AppUpdatePolicy[]).filter(
     (p) => p.policy_type === 'auto_update' && p.is_enabled
-  ).length;
+  );
+  const autoUpdateCount = autoUpdatePolicies.length;
   const recentAutoUpdates = history.filter(
     (h) => h.status === 'completed' && isWithinDays(h.completed_at, 7)
   ).length;
@@ -738,6 +742,10 @@ export default function UpdatesPage() {
           color="cyan"
           delay={0}
           loading={isLoadingUpdates}
+          onClick={() => {
+            setActiveTab('available');
+            setShowCriticalOnly(false);
+          }}
         />
         <AnimatedStatCard
           title={<T>Critical Updates</T>}
@@ -747,6 +755,11 @@ export default function UpdatesPage() {
           delay={0.1}
           loading={isLoadingUpdates}
           description={oldestCriticalAge || undefined}
+          onClick={() => {
+            setActiveTab('available');
+            setShowCriticalOnly(true);
+          }}
+          isActive={activeTab === 'available' && showCriticalOnly}
         />
         <AnimatedStatCard
           title={<T>Auto-Update Enabled</T>}
@@ -755,6 +768,7 @@ export default function UpdatesPage() {
           color="success"
           delay={0.2}
           loading={isLoadingPolicies}
+          onClick={() => setAutoUpdateModalOpen(true)}
         />
         <AnimatedStatCard
           title={<T>Updated (7 days)</T>}
@@ -764,6 +778,7 @@ export default function UpdatesPage() {
           delay={0.3}
           loading={isLoadingHistory}
           description={failedUpdates > 0 ? `${failedUpdates} failed` : undefined}
+          onClick={() => setActiveTab('history')}
         />
       </StatCardGrid>
 
@@ -1032,6 +1047,20 @@ export default function UpdatesPage() {
           )}
         </TabsContent>
       </Tabs>
+
+      {/* Auto-update apps list, opened from the stat card */}
+      <AutoUpdateAppsModal
+        open={autoUpdateModalOpen}
+        onOpenChange={setAutoUpdateModalOpen}
+        policies={autoUpdatePolicies}
+        onPolicyChange={async (policy, policyType) => {
+          await updatePolicy({
+            winget_id: policy.winget_id,
+            tenant_id: policy.tenant_id,
+            policy_type: policyType,
+          });
+        }}
+      />
     </div>
   );
 }

--- a/components/updates/AutoUpdateAppsModal.tsx
+++ b/components/updates/AutoUpdateAppsModal.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { T } from 'gt-next';
+import { RefreshCw } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { UpdatePolicySelector } from '@/components/updates/UpdatePolicySelector';
+import type { AppUpdatePolicy, UpdatePolicyType } from '@/types/update-policies';
+
+interface AutoUpdateAppsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  policies: AppUpdatePolicy[];
+  onPolicyChange: (policy: AppUpdatePolicy, policyType: UpdatePolicyType) => Promise<void>;
+}
+
+// Lists every app with auto-update enabled for the selected tenant. These
+// apps are not necessarily in the Available list (an up-to-date app has no
+// pending update), so the stat card opens this dedicated view.
+export function AutoUpdateAppsModal({ open, onOpenChange, policies, onPolicyChange }: AutoUpdateAppsModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-bg-surface border-overlay/10 max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <RefreshCw className="w-5 h-5 text-status-success" />
+            <T>Auto-Update Enabled</T>
+          </DialogTitle>
+          <DialogDescription>
+            <T>These apps are updated automatically when a new version is available.</T>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto -mx-1 px-1">
+          {policies.length === 0 ? (
+            <p className="text-sm text-text-muted text-center py-8">
+              <T>No apps have auto-update enabled for this tenant yet. Choose Auto-update for an app during deployment or from its update card.</T>
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {policies.map((policy) => (
+                <li
+                  key={policy.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-overlay/10 bg-bg-elevated/50 px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-text-primary truncate">
+                      {policy.deployment_config?.displayName || policy.winget_id}
+                    </p>
+                    <p className="text-xs font-mono text-text-muted truncate">{policy.winget_id}</p>
+                  </div>
+                  <UpdatePolicySelector
+                    currentPolicy={policy.policy_type}
+                    onPolicyChange={(type) => onPolicyChange(policy, type)}
+                    size="sm"
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Available Updates and Critical Updates cards switch to the Available tab; the critical card also arms the critical-only filter and shows an active ring while it is on
- Updated (7 days) opens the History tab
- Auto-Update Enabled opens a new modal listing every app with auto update enabled for the tenant (up-to-date apps are absent from the Available list, so this is their only aggregate view), with the existing UpdatePolicySelector embedded per row for in-place changes

## Testing
- Full suite green on main: 1502/1502
- tsc --noEmit: no non-test errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)