### PR TITLE
fix(packaging): guard Stream Deck MSI close helper

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -690,17 +690,24 @@ describe('POST /api/package (workflow dispatch)', () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
-    const expectedProcesses = [
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-    ];
-    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject({
-      processesToClose: expectedProcesses,
-    });
-    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject({
-      processesToClose: expectedProcesses,
-    });
+    const expectedAdapter = {
+      processesToClose: [
+        { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+      ],
+      reviewedUninstallProcessGuard: {
+        processName: 'StreamDeck.exe',
+        argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+        graceSeconds: 20,
+      },
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
     expect(createMock.mock.calls[0][0].package_config).toMatchObject({
-      psadtConfig: { processesToClose: expectedProcesses },
+      psadtConfig: expectedAdapter,
     });
   });
 

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1335,7 +1335,7 @@ describe('application packaging adapters', () => {
     expect(adapted.processesToClose).toHaveLength(11);
   });
 
-  it('adds the reviewed Stream Deck lifecycle process to the exact app', () => {
+  it('adds the reviewed Stream Deck lifecycle guard to the exact app', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Elgato.StreamDeck',
       DEFAULT_PSADT_CONFIG
@@ -1344,6 +1344,11 @@ describe('application packaging adapters', () => {
     expect(adapted.processesToClose).toEqual([
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ]);
+    expect(adapted.reviewedUninstallProcessGuard).toEqual({
+      processName: 'StreamDeck.exe',
+      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+      graceSeconds: 20,
+    });
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
@@ -1409,10 +1414,16 @@ describe('application packaging adapters', () => {
   it('matches WinGet identities case-insensitively', () => {
     expect(
       applyApplicationPackagingAdapter('  elgato.streamdeck  ', DEFAULT_PSADT_CONFIG)
-        .processesToClose
-    ).toEqual([
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-    ]);
+    ).toMatchObject({
+      processesToClose: [
+        { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+      ],
+      reviewedUninstallProcessGuard: {
+        processName: 'StreamDeck.exe',
+        argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+        graceSeconds: 20,
+      },
+    });
   });
 
   it('preserves customer processes and deduplicates names with an exe suffix', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1124,10 +1124,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // Stream Deck's MSI launches a fresh StreamDeck.exe from its
+    // CloseApplication custom action during removal. Under LocalSystem that
+    // helper can remain idle indefinitely even after PSADT closes the original
+    // desktop process. Give only the newly spawned executable a short grace
+    // period before ending it so the exact MSI uninstall can continue.
     wingetId: 'Elgato.StreamDeck',
     requiredProcessesToClose: [
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ],
+    reviewedUninstallProcessGuard: {
+      processName: 'StreamDeck.exe',
+      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+      graceSeconds: 20,
+    },
   },
   {
     wingetId: 'Greenshot.Greenshot',

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -566,7 +566,7 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
-  it('includes the reviewed Stream Deck process adapter in the catalog profile', () => {
+  it('includes the reviewed Stream Deck uninstall guard in the catalog profile', () => {
     const config = buildQaCatalogTestConfig({
       app: {
         wingetId: 'Elgato.StreamDeck',
@@ -588,6 +588,11 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.psadtConfig.processesToClose).toEqual([
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
     ]);
+    expect(config.psadtConfig.reviewedUninstallProcessGuard).toEqual({
+      processName: 'StreamDeck.exe',
+      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+      graceSeconds: 20,
+    });
   });
 
   it('includes the reviewed Creative Cloud process adapter in the catalog profile', () => {


### PR DESCRIPTION
## Summary
- guard only a newly spawned StreamDeck.exe during the exact MSI uninstall
- preserve the existing PSADT close-process behavior and allow the vendor helper a 20-second grace period
- verify the adapter reaches both protected QA profiles and customer package jobs

## Failure evidence
- protected run 32873820288 installed and detected successfully, then stalled at the vendor MSI CloseApplication custom action
- the same 7.5.1 package previously failed twice at the same action, including after the existing StreamDeck process-close adapter was active
- the pipeline remains paused pending a protected proof run

## Verification
- 396 relevant Vitest tests passed
- focused ESLint passed
- git diff --check passed