### PR TITLE
chore(qa): activate Stream Deck uninstall guard

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
+  packagerCommit: 'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -369,6 +369,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Egnyte now carries the vendor-required update-on-boot property whenever
   // the managed package suppresses reboots. Preserve unrelated prior passes.
   'b798917a85465cb2fe7b55582322d1e30b20e088',
+  // Stream Deck now guards only the fresh CloseApplication helper launched by
+  // its MSI uninstall. Preserve every unrelated pass from the Egnyte release.
+  'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -302,6 +302,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Stream Deck only after activating its MSI close-helper guard', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' elgato.streamdeck ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
+      { wingetId: 'Elgato.StreamDeck', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries ElegantClipboard only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -237,7 +237,17 @@ const EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS = [
   ...AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const STREAM_DECK_CLOSE_HELPER_RELEASE_RETRY_TARGETS = [
+  // Re-run Stream Deck with the command-line-scoped guard for the fresh
+  // executable launched by its stalled MSI CloseApplication custom action.
+  'Elgato.StreamDeck',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'eee661ae3eab578d011dd5052df5e901ffa3a4bf':
+    STREAM_DECK_CLOSE_HELPER_RELEASE_RETRY_TARGETS,
   'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9':
     EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
   'b798917a85465cb2fe7b55582322d1e30b20e088':


### PR DESCRIPTION
## Summary
- pin the QA/customer PSADT toolchain to exact packager commit eee661ae3eab578d011dd5052df5e901ffa3a4bf
- retain compatible passes from the previous Egnyte release
- add a bounded one-time retry for Elgato.StreamDeck while carrying forward unconsumed targeted retries

## Verification
- 196 package-profile and targeted-retry tests passed
- focused ESLint passed
- git diff --check passed

The production pipeline remains paused until deployment, workflow pinning, and the protected Elgato proof are complete.