### PR TITLE
fix(packaging): cover resident Stream Deck helper

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -441,6 +441,7 @@ $reviewedUninstallProcessGuardConfigured = $false
 $reviewedUninstallProcessGuardName = ''
 $reviewedUninstallProcessGuardPattern = ''
 $reviewedUninstallProcessGuardGraceSeconds = 0
+$reviewedUninstallProcessGuardCreationLookbackSeconds = 2
 if ($psadtConfig.Contains('reviewedUninstallProcessGuard') -and
     $null -ne $psadtConfig['reviewedUninstallProcessGuard']) {
     $rawProcessGuard = $psadtConfig['reviewedUninstallProcessGuard']
@@ -451,6 +452,11 @@ if ($psadtConfig.Contains('reviewedUninstallProcessGuard') -and
     $reviewedUninstallProcessGuardName = ([string]$rawProcessGuard['processName']).Trim()
     $reviewedUninstallProcessGuardPattern = ([string]$rawProcessGuard['argumentsPattern']).Trim()
     $rawProcessGuardGraceSeconds = $rawProcessGuard['graceSeconds']
+    $rawProcessGuardCreationLookbackSeconds = if ($rawProcessGuard.Contains('creationLookbackSeconds')) {
+        $rawProcessGuard['creationLookbackSeconds']
+    } else {
+        2
+    }
     if ($reviewedUninstallProcessGuardName -notmatch '^[A-Za-z0-9 _().-]+\.exe$' -or
         $reviewedUninstallProcessGuardName.Length -gt 128) {
         throw 'PSADT reviewedUninstallProcessGuard.processName must be a bounded executable leaf name.'
@@ -475,6 +481,15 @@ if ($psadtConfig.Contains('reviewedUninstallProcessGuard') -and
         throw 'PSADT reviewedUninstallProcessGuard.graceSeconds must be an integer from 5 to 120.'
     }
     $reviewedUninstallProcessGuardGraceSeconds = [int]$rawProcessGuardGraceSeconds
+    if (($rawProcessGuardCreationLookbackSeconds -isnot [byte] -and
+         $rawProcessGuardCreationLookbackSeconds -isnot [int16] -and
+         $rawProcessGuardCreationLookbackSeconds -isnot [int32] -and
+         $rawProcessGuardCreationLookbackSeconds -isnot [int64]) -or
+        [int]$rawProcessGuardCreationLookbackSeconds -lt 2 -or
+        [int]$rawProcessGuardCreationLookbackSeconds -gt 600) {
+        throw 'PSADT reviewedUninstallProcessGuard.creationLookbackSeconds must be an integer from 2 to 600.'
+    }
+    $reviewedUninstallProcessGuardCreationLookbackSeconds = [int]$rawProcessGuardCreationLookbackSeconds
     $reviewedUninstallProcessGuardConfigured = $true
 }
 
@@ -488,7 +503,8 @@ if ($reviewedUninstallProcessGuardConfigured) {
         "        `$reviewedGuardProcessName = '$reviewedUninstallProcessGuardNameLiteral'"
         "        `$reviewedGuardArgumentsPattern = '$reviewedUninstallProcessGuardPatternLiteral'"
         "        `$reviewedGuardGraceSeconds = $reviewedUninstallProcessGuardGraceSeconds"
-        '        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-2)'
+        "        `$reviewedGuardCreationLookbackSeconds = $reviewedUninstallProcessGuardCreationLookbackSeconds"
+        '        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-$reviewedGuardCreationLookbackSeconds)'
         '        $reviewedGuardJob = Start-Job -ScriptBlock {'
         '            param($ProcessName, $ArgumentsPattern, $StartedAt, $GraceSeconds)'
         '            $deadline = [DateTime]::UtcNow.AddMinutes(3)'

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -698,6 +698,7 @@ describe('POST /api/package (workflow dispatch)', () => {
         processName: 'StreamDeck.exe',
         argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
         graceSeconds: 20,
+        creationLookbackSeconds: 300,
       },
     };
     expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1348,6 +1348,7 @@ describe('application packaging adapters', () => {
       processName: 'StreamDeck.exe',
       argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
       graceSeconds: 20,
+      creationLookbackSeconds: 300,
     });
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
@@ -1422,6 +1423,7 @@ describe('application packaging adapters', () => {
         processName: 'StreamDeck.exe',
         argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
         graceSeconds: 20,
+        creationLookbackSeconds: 300,
       },
     });
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -28,6 +28,7 @@ interface ApplicationPackagingAdapter {
     processName: string;
     argumentsPattern: string;
     graceSeconds: number;
+    creationLookbackSeconds?: number;
   }>;
   reviewedUninstallServiceNames?: readonly string[];
   uninstallCompletionTimeoutMinutes?: number;
@@ -1124,11 +1125,12 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // Stream Deck's MSI launches a fresh StreamDeck.exe from its
-    // CloseApplication custom action during removal. Under LocalSystem that
-    // helper can remain idle indefinitely even after PSADT closes the original
-    // desktop process. Give only the newly spawned executable a short grace
-    // period before ending it so the exact MSI uninstall can continue.
+    // Stream Deck can relaunch its desktop process after installation, before
+    // the MSI CloseApplication custom action begins removal. Production QA run
+    // 32878010393 proved that the default two-second guard never matched before
+    // the same custom action stalled. Keep the exact executable/command checks,
+    // but include only processes created during the preceding five minutes and
+    // give the match a short grace period before ending it.
     wingetId: 'Elgato.StreamDeck',
     requiredProcessesToClose: [
       { name: 'StreamDeck', description: 'Elgato Stream Deck' },
@@ -1137,6 +1139,7 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       processName: 'StreamDeck.exe',
       argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
       graceSeconds: 20,
+      creationLookbackSeconds: 300,
     },
   },
   {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3223,6 +3223,10 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       expect(source).toContain('reviewedUninstallProcessGuard');
       expect(source).toContain('Get-CimInstance -ClassName Win32_Process');
       expect(source).toContain('CreationDate.ToUniversalTime()');
+      expect(source).toContain('reviewedGuardCreationLookbackSeconds');
+      expect(source).toContain(
+        '[DateTime]::UtcNow.AddSeconds(-$reviewedGuardCreationLookbackSeconds)'
+      );
       expect(source).toContain('Stop-Process -Id $current.ProcessId -Force');
       expect(source).toContain('Ended the reviewed vendor uninstall helper after its grace period.');
     }

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -592,6 +592,7 @@ describe('buildQaCatalogTestConfig', () => {
       processName: 'StreamDeck.exe',
       argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
       graceSeconds: 20,
+      creationLookbackSeconds: 300,
     });
   });
 

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -943,13 +943,15 @@ catch
   /**
    * Validate the adapter-only guard for an MSI custom-action helper that can
    * otherwise wait indefinitely. Both the executable leaf name and command
-   * line must match before a newly spawned process is ended after its grace
-   * period. This is intentionally not a general customer command surface.
+   * line must match before a recently created process is ended after its grace
+   * period. The optional bounded lookback covers vendor processes relaunched
+   * shortly before MSI removal. This is not a general customer command surface.
    */
   private getReviewedUninstallProcessGuard(job: PackagingJob): {
     processName: string;
     argumentsPattern: string;
     graceSeconds: number;
+    creationLookbackSeconds: number;
   } | null {
     const raw = this.getPsadtConfig(job)?.reviewedUninstallProcessGuard;
     if (raw === undefined || raw === null) return null;
@@ -965,6 +967,9 @@ catch
       ? record.argumentsPattern.trim()
       : '';
     const graceSeconds = record.graceSeconds;
+    const creationLookbackSeconds = record.creationLookbackSeconds === undefined
+      ? 2
+      : record.creationLookbackSeconds;
     if (
       !/^[A-Za-z0-9 _().-]+\.exe$/.test(processName) ||
       processName.length > 128
@@ -998,11 +1003,21 @@ catch
         'PSADT reviewedUninstallProcessGuard.graceSeconds must be an integer from 5 to 120'
       );
     }
+    if (
+      !Number.isInteger(creationLookbackSeconds) ||
+      (creationLookbackSeconds as number) < 2 ||
+      (creationLookbackSeconds as number) > 600
+    ) {
+      throw new Error(
+        'PSADT reviewedUninstallProcessGuard.creationLookbackSeconds must be an integer from 2 to 600'
+      );
+    }
 
     return {
       processName,
       argumentsPattern,
       graceSeconds: graceSeconds as number,
+      creationLookbackSeconds: creationLookbackSeconds as number,
     };
   }
 
@@ -1660,7 +1675,8 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
         ? `$reviewedGuardProcessName = '${reviewedUninstallProcessGuard.processName.replace(/'/g, "''")}'
         $reviewedGuardArgumentsPattern = '${reviewedUninstallProcessGuard.argumentsPattern.replace(/'/g, "''")}'
         $reviewedGuardGraceSeconds = ${reviewedUninstallProcessGuard.graceSeconds}
-        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-2)
+        $reviewedGuardCreationLookbackSeconds = ${reviewedUninstallProcessGuard.creationLookbackSeconds}
+        $reviewedGuardStartedAt = [DateTime]::UtcNow.AddSeconds(-$reviewedGuardCreationLookbackSeconds)
         $reviewedGuardJob = Start-Job -ScriptBlock {
             param($ProcessName, $ArgumentsPattern, $StartedAt, $GraceSeconds)
             $deadline = [DateTime]::UtcNow.AddMinutes(3)

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -911,7 +911,7 @@ describe('EXE product identity PSADT generation', () => {
     )).toThrow('single-line');
   });
 
-  it('guards only the reviewed newly spawned MSI uninstall helper', () => {
+  it('guards only the reviewed recently created MSI uninstall helper', () => {
     const uninstall = generator.getUninstallCommand.call(
       generator,
       packagingJob({
@@ -924,6 +924,7 @@ describe('EXE product identity PSADT generation', () => {
               processName: 'Camera Hub.exe',
               argumentsPattern: '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)',
               graceSeconds: 20,
+              creationLookbackSeconds: 300,
             },
           },
         },
@@ -936,6 +937,10 @@ describe('EXE product identity PSADT generation', () => {
       "$reviewedGuardArgumentsPattern = '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)'"
     );
     expect(uninstall).toContain('$reviewedGuardGraceSeconds = 20');
+    expect(uninstall).toContain('$reviewedGuardCreationLookbackSeconds = 300');
+    expect(uninstall).toContain(
+      '[DateTime]::UtcNow.AddSeconds(-$reviewedGuardCreationLookbackSeconds)'
+    );
     expect(uninstall).toContain('$_.CreationDate.ToUniversalTime() -ge $StartedAt');
     expect(uninstall).toContain('$current.Name -ieq $ProcessName');
     expect(uninstall).toContain('Stop-Process -Id $current.ProcessId -Force');
@@ -962,6 +967,25 @@ describe('EXE product identity PSADT generation', () => {
       }),
       'example.msi'
     )).toThrow('executable leaf name');
+
+    expect(() => generator.getUninstallCommand.call(
+      generator,
+      packagingJob({
+        installer_type: 'msi',
+        uninstall_command: 'REGISTRY_UNINSTALL:Example',
+        package_config: {
+          psadtConfig: {
+            reviewedUninstallProcessGuard: {
+              processName: 'helper.exe',
+              argumentsPattern: '--quit',
+              graceSeconds: 20,
+              creationLookbackSeconds: 601,
+            },
+          },
+        },
+      }),
+      'example.msi'
+    )).toThrow('creationLookbackSeconds');
   });
 
   it('extends registry-aware completion only for a reviewed vendor profile', () => {

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -245,11 +245,13 @@ export interface PSADTConfig {
   // Internal guard for a reviewed vendor MSI custom-action helper that can
   // remain alive indefinitely during removal. The packager only accepts this
   // value from an application adapter and matches both the executable name and
-  // command line before ending the newly spawned helper after a grace period.
+  // command line before ending a recently created helper after a grace period.
+  // The optional lookback remains bounded and is supplied only by an adapter.
   reviewedUninstallProcessGuard?: {
     processName: string;
     argumentsPattern: string;
     graceSeconds: number;
+    creationLookbackSeconds?: number;
   };
 
   // Internal list of exact Windows service names that a reviewed vendor


### PR DESCRIPTION
Production-equivalent QA run 32878010393 confirmed that the first Stream Deck guard still stalled in the MSI CloseApplication custom action: install 0, detection 0, uninstall -1 after 261 seconds, removal verification 0. The exact process/command guard remained unmatched with its default two-second creation window. This adds an adapter-only, validated creationLookbackSeconds contract (2-600 seconds) to both repository and hosted customer PSADT packagers, and sets only Elgato.StreamDeck to 300 seconds while retaining the exact StreamDeck.exe name, command-line regex, and 20-second grace. The same adapted config is asserted through QA demand and the customer packaging workflow. Verification: 313 focused Vitest tests passed, focused ESLint passed, hosted packager TypeScript build passed, and git diff --check passed. The protected pipeline remains paused pending production activation and a clean VM proof.