### PR TITLE
chore(qa): activate Stream Deck helper lookback

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
+  packagerCommit: '63219f1fe5c953c8fd799c79030176444ba637b4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -372,6 +372,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Stream Deck now guards only the fresh CloseApplication helper launched by
   // its MSI uninstall. Preserve every unrelated pass from the Egnyte release.
   'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
+  // Stream Deck's first exact helper guard did not see the already-running
+  // process. Preserve unrelated passes while the bounded lookback rolls out.
+  'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -167,6 +167,7 @@ describe('QA toolchain targeted retries', () => {
       'IObit.Uninstaller',
       'Autodesk.DesktopConnector',
       'Egnyte.EgnyteDesktopApp',
+      'Elgato.StreamDeck',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -226,6 +227,7 @@ describe('QA toolchain targeted retries', () => {
         'IObit.Uninstaller',
         'Autodesk.DesktopConnector',
         'Egnyte.EgnyteDesktopApp',
+        'Elgato.StreamDeck',
       ])
     );
     expect(
@@ -302,13 +304,13 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Stream Deck only after activating its MSI close-helper guard', () => {
+  it('retries Stream Deck only after activating the existing-helper lookback', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' elgato.streamdeck ', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9',
+      'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
       { wingetId: 'Elgato.StreamDeck', status: 'failed' }
     )).toBe(false);
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -237,17 +237,19 @@ const EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS = [
   ...AUTODESK_DESKTOP_CONNECTOR_ODIS_RELEASE_RETRY_TARGETS,
 ] as const;
 
-const STREAM_DECK_CLOSE_HELPER_RELEASE_RETRY_TARGETS = [
-  // Re-run Stream Deck with the command-line-scoped guard for the fresh
-  // executable launched by its stalled MSI CloseApplication custom action.
+const STREAM_DECK_EXISTING_HELPER_RELEASE_RETRY_TARGETS = [
+  // Re-run Stream Deck after extending only its exact helper guard to include
+  // a bounded pre-uninstall creation window.
   'Elgato.StreamDeck',
   // Carry every still-unconsumed targeted retry across the atomic pin.
   ...EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '63219f1fe5c953c8fd799c79030176444ba637b4':
+    STREAM_DECK_EXISTING_HELPER_RELEASE_RETRY_TARGETS,
   'eee661ae3eab578d011dd5052df5e901ffa3a4bf':
-    STREAM_DECK_CLOSE_HELPER_RELEASE_RETRY_TARGETS,
+    EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
   'ab0fbf7d35ad601611d4d4ca1029df826dbdfde9':
     EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
   'b798917a85465cb2fe7b55582322d1e30b20e088':


### PR DESCRIPTION
## Summary
- activate exact shared packager commit 63219f1fe5c953c8fd799c79030176444ba637b4
- preserve compatible passes from the prior Stream Deck guard release
- retry Stream Deck only on the bounded existing-helper lookback release

## Verification
- 249 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed