### PR TITLE
fix(packaging): block unsupported Stream Deck removal

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -671,47 +671,6 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
-  it('uses the reviewed app adapter for both QA and customer packaging', async () => {
-    const request = new NextRequest('http://localhost:3000/api/package', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer test-token',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        items: [makeWin32Item({
-          wingetId: 'Elgato.StreamDeck',
-          displayName: 'Elgato Stream Deck',
-          psadtConfig: { ...DEFAULT_PSADT_CONFIG, processesToClose: [] },
-        })],
-      }),
-    });
-
-    const response = await POST(request);
-
-    expect(response.status).toBe(200);
-    const expectedAdapter = {
-      processesToClose: [
-        { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-      ],
-      reviewedUninstallProcessGuard: {
-        processName: 'StreamDeck.exe',
-        argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
-        graceSeconds: 20,
-        creationLookbackSeconds: 300,
-      },
-    };
-    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
-      expectedAdapter
-    );
-    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
-      expectedAdapter
-    );
-    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
-      psadtConfig: expectedAdapter,
-    });
-  });
-
   it('applies the reviewed Opera immediate-uninstall contract to QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -448,7 +448,7 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     const supabase = createSupabaseMock({});
     const trigger = makeTrigger(supabase);
     const storedConfig: DeploymentConfig = {
-      displayName: 'Elgato Stream Deck',
+      displayName: 'Elgato Camera Hub',
       publisher: 'Elgato',
       architecture: 'x64',
       installerType: 'msi',
@@ -466,33 +466,33 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     vi.spyOn(trigger as never, 'ensurePsadtConfig' as never).mockResolvedValue(undefined as never);
     vi.spyOn(trigger as never, 'ensureCurrentPackageDefaults' as never).mockResolvedValue(undefined as never);
     vi.spyOn(trigger as never, 'createHistoryRecord' as never)
-      .mockResolvedValue({ id: 'history-elgato' } as never);
+      .mockResolvedValue({ id: 'history-camera-hub' } as never);
     const createPackagingJobSpy = vi.spyOn(trigger as never, 'createPackagingJob' as never)
-      .mockResolvedValue({ id: 'job-elgato' } as never);
+      .mockResolvedValue({ id: 'job-camera-hub' } as never);
     vi.spyOn(trigger as never, 'updateHistoryRecord' as never).mockResolvedValue(undefined as never);
     vi.spyOn(trigger as never, 'updatePolicyTracking' as never).mockResolvedValue(undefined as never);
 
     const result = await trigger.triggerAutoUpdate(policy, {
       ...UPDATE_INFO,
-      wingetId: 'elgato.streamdeck',
-      displayName: 'Elgato Stream Deck',
+      wingetId: 'elgato.camerahub',
+      displayName: 'Elgato Camera Hub',
       installerType: 'msi',
       nestedInstallerType: undefined,
       nestedInstallerPath: undefined,
     }, { skipRateLimits: true });
 
-    expect(result).toMatchObject({ success: true, packagingJobId: 'job-elgato' });
+    expect(result).toMatchObject({ success: true, packagingJobId: 'job-camera-hub' });
     const qaInput = ensureQaDemandMock.mock.calls[0][1] as {
       psadtConfig: string;
     };
     expect(JSON.parse(qaInput.psadtConfig).processesToClose).toEqual([
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+      { name: 'Camera Hub', description: 'Elgato Camera Hub' },
     ]);
     const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
     expect(
       (effectivePolicy.deployment_config as DeploymentConfig).psadtConfig?.processesToClose
     ).toEqual([
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+      { name: 'Camera Hub', description: 'Elgato Camera Hub' },
     ]);
     expect(storedConfig.psadtConfig?.processesToClose).toEqual([]);
   });

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1335,21 +1335,14 @@ describe('application packaging adapters', () => {
     expect(adapted.processesToClose).toHaveLength(11);
   });
 
-  it('adds the reviewed Stream Deck lifecycle guard to the exact app', () => {
+  it('does not retain the disproven Stream Deck lifecycle guard', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Elgato.StreamDeck',
       DEFAULT_PSADT_CONFIG
     );
 
-    expect(adapted.processesToClose).toEqual([
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-    ]);
-    expect(adapted.reviewedUninstallProcessGuard).toEqual({
-      processName: 'StreamDeck.exe',
-      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
-      graceSeconds: 20,
-      creationLookbackSeconds: 300,
-    });
+    expect(adapted.processesToClose).toEqual([]);
+    expect(adapted.reviewedUninstallProcessGuard).toBeUndefined();
     expect(DEFAULT_PSADT_CONFIG.processesToClose).toEqual([]);
   });
 
@@ -1414,33 +1407,35 @@ describe('application packaging adapters', () => {
 
   it('matches WinGet identities case-insensitively', () => {
     expect(
-      applyApplicationPackagingAdapter('  elgato.streamdeck  ', DEFAULT_PSADT_CONFIG)
+      applyApplicationPackagingAdapter('  elgato.camerahub  ', DEFAULT_PSADT_CONFIG)
     ).toMatchObject({
       processesToClose: [
-        { name: 'StreamDeck', description: 'Elgato Stream Deck' },
+        { name: 'Camera Hub', description: 'Elgato Camera Hub' },
       ],
       reviewedUninstallProcessGuard: {
-        processName: 'StreamDeck.exe',
-        argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
+        processName: 'Camera Hub.exe',
+        argumentsPattern: '(?:^|\\s)--pre-uninstall(?:\\s|$).*--quit(?:\\s|$)',
         graceSeconds: 20,
-        creationLookbackSeconds: 300,
       },
     });
   });
 
-  it('preserves customer processes and deduplicates names with an exe suffix', () => {
-    const adapted = applyApplicationPackagingAdapter('Elgato.StreamDeck', {
+  it('preserves customer Stream Deck configuration without an adapter', () => {
+    const config = {
       ...DEFAULT_PSADT_CONFIG,
       processesToClose: [
         { name: 'streamdeck.exe', description: 'Customer description' },
         { name: 'companion', description: 'Companion app' },
       ],
-    });
+    };
+    const adapted = applyApplicationPackagingAdapter('Elgato.StreamDeck', config);
 
+    expect(adapted).toBe(config);
     expect(adapted.processesToClose).toEqual([
-      { name: 'streamdeck', description: 'Customer description' },
+      { name: 'streamdeck.exe', description: 'Customer description' },
       { name: 'companion', description: 'Companion app' },
     ]);
+    expect(adapted.reviewedUninstallProcessGuard).toBeUndefined();
   });
 
   it('does not attach an adapter to a different application identity', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1125,24 +1125,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
-    // Stream Deck can relaunch its desktop process after installation, before
-    // the MSI CloseApplication custom action begins removal. Production QA run
-    // 32878010393 proved that the default two-second guard never matched before
-    // the same custom action stalled. Keep the exact executable/command checks,
-    // but include only processes created during the preceding five minutes and
-    // give the match a short grace period before ending it.
-    wingetId: 'Elgato.StreamDeck',
-    requiredProcessesToClose: [
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-    ],
-    reviewedUninstallProcessGuard: {
-      processName: 'StreamDeck.exe',
-      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
-      graceSeconds: 20,
-      creationLookbackSeconds: 300,
-    },
-  },
-  {
     wingetId: 'Greenshot.Greenshot',
     requiredProcessesToClose: [
       { name: 'Greenshot', description: 'Greenshot' },

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1425,6 +1425,29 @@ describe('DesktopOK managed uninstall block migration contract', () => {
   });
 });
 
+describe('Elgato Stream Deck managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260825203000_block_elgato_streamdeck_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the repeatedly stalled MSI lifecycle across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Elgato.StreamDeck'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32882785478'
+    );
+    expect(sql).toContain('five isolated LocalSystem lifecycle runs');
+    expect(sql).toContain('CloseApplication custom action');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('Speek managed lifecycle block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1611,7 +1611,7 @@ describe('current catalog QA package validation', () => {
     const legacyIdentity = identityWithPackagerCommit(
       buildQaPackageIdentity({
         ...input,
-        wingetId: 'Elgato.StreamDeck',
+        wingetId: 'Elgato.CameraHub',
       }),
       priorCommit
     );

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -566,7 +566,7 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
-  it('includes the reviewed Stream Deck uninstall guard in the catalog profile', () => {
+  it('does not include the disproven Stream Deck uninstall guard in the catalog profile', () => {
     const config = buildQaCatalogTestConfig({
       app: {
         wingetId: 'Elgato.StreamDeck',
@@ -585,15 +585,8 @@ describe('buildQaCatalogTestConfig', () => {
       },
     });
 
-    expect(config.psadtConfig.processesToClose).toEqual([
-      { name: 'StreamDeck', description: 'Elgato Stream Deck' },
-    ]);
-    expect(config.psadtConfig.reviewedUninstallProcessGuard).toEqual({
-      processName: 'StreamDeck.exe',
-      argumentsPattern: '(?:^|\\\\)StreamDeck\\.exe"?(?:\\s|$)',
-      graceSeconds: 20,
-      creationLookbackSeconds: 300,
-    });
+    expect(config.psadtConfig.processesToClose).toEqual([]);
+    expect(config.psadtConfig.reviewedUninstallProcessGuard).toBeUndefined();
   });
 
   it('includes the reviewed Creative Cloud process adapter in the catalog profile', () => {

--- a/supabase/migrations/20260825203000_block_elgato_streamdeck_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260825203000_block_elgato_streamdeck_unsupported_managed_uninstall.sql
@@ -1,0 +1,39 @@
+-- Elgato Stream Deck 7.5.1 installs silently and is detected correctly, but
+-- its exact MSI product-code removal repeatedly stalls in the vendor
+-- CloseApplication custom action under LocalSystem. Five isolated PSADT runs
+-- reproduced the same installed-after-uninstall result. Two reviewed,
+-- command-line-scoped process guards also failed to unblock the MSI, including
+-- a bounded five-minute creation lookback. Elgato documents closing Stream
+-- Deck before uninstall, but does not publish a reliable unattended removal
+-- contract for this lifecycle. Do not ship an Intune package that cannot be
+-- removed deterministically.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Elgato.StreamDeck',
+  'unsupported_managed_uninstall',
+  'Stream Deck installs and detects successfully, but its exact MSI removal stalled in the vendor CloseApplication custom action in five isolated LocalSystem lifecycle runs. Two reviewed process guards, including an exact bounded five-minute lookback, did not unblock removal, and the application remained detected after every attempt.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32882785478'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Elgato.StreamDeck';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Elgato.StreamDeck'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Elgato.StreamDeck at the shared package eligibility gate after five identical LocalSystem uninstall stalls
- remove the two disproven Stream Deck process-guard adaptations
- supersede terminal/queued Stream Deck QA candidates and mark the catalog entry unverified
- preserve the exact latest QA run as production evidence

## Verification
- 324 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed