### PR TITLE
chore(qa): activate Stream Deck eligibility block

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '63219f1fe5c953c8fd799c79030176444ba637b4',
+  packagerCommit: 'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -375,6 +375,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Stream Deck's first exact helper guard did not see the already-running
   // process. Preserve unrelated passes while the bounded lookback rolls out.
   'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
+  // Removing Stream Deck's disproven adapter affects only an app now blocked
+  // at the shared eligibility gate. Preserve every unrelated compatible pass.
+  '63219f1fe5c953c8fd799c79030176444ba637b4',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -167,7 +167,6 @@ describe('QA toolchain targeted retries', () => {
       'IObit.Uninstaller',
       'Autodesk.DesktopConnector',
       'Egnyte.EgnyteDesktopApp',
-      'Elgato.StreamDeck',
     ]));
     expect(targets).not.toContain('Acronis.CyberProtectHomeOffice');
     expect(targets).not.toContain('Tencent.QQ.NT');
@@ -227,7 +226,6 @@ describe('QA toolchain targeted retries', () => {
         'IObit.Uninstaller',
         'Autodesk.DesktopConnector',
         'Egnyte.EgnyteDesktopApp',
-        'Elgato.StreamDeck',
       ])
     );
     expect(
@@ -304,15 +302,15 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries Stream Deck only after activating the existing-helper lookback', () => {
+  it('does not retry blocked Stream Deck after removing the disproven guard', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' elgato.streamdeck ', status: 'failed' }
-    )).toBe(true);
-    expect(shouldRetryTerminalToolchainCandidate(
-      'eee661ae3eab578d011dd5052df5e901ffa3a4bf',
-      { wingetId: 'Elgato.StreamDeck', status: 'failed' }
     )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '63219f1fe5c953c8fd799c79030176444ba637b4',
+      { wingetId: 'Elgato.StreamDeck', status: 'failed' }
+    )).toBe(true);
   });
 
   it('retries ElegantClipboard only after activating its reviewed user scope', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -246,6 +246,10 @@ const STREAM_DECK_EXISTING_HELPER_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  // Stream Deck is eligibility-blocked after five identical MSI removal
+  // stalls, so carry every prior bounded target without replaying it.
+  'd30bedbc4374346b7900b4ffef2d7c77f222d3d2':
+    EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
   '63219f1fe5c953c8fd799c79030176444ba637b4':
     STREAM_DECK_EXISTING_HELPER_RELEASE_RETRY_TARGETS,
   'eee661ae3eab578d011dd5052df5e901ffa3a4bf':


### PR DESCRIPTION
## Summary
- activate exact packager commit d30bedbc4374346b7900b4ffef2d7c77f222d3d2
- preserve compatible passing coverage from the prior release
- carry all still-valid targeted retries without replaying blocked Elgato.StreamDeck

## Verification
- 249 focused Vitest tests passed
- focused ESLint passed
- git diff --check passed