### PR TITLE
Fix Windows App Runtime 1.3 shared framework packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1113,6 +1113,22 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('uses exact Microsoft Appx evidence for Windows App Runtime 1.3', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'microsoft.windowsappruntime.1.3',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedAppxInstallEvidence: {
+        packageName: 'Microsoft.WindowsAppRuntime.1.3',
+        publisherId: '8wekyb3d8bbwe',
+        minimumVersion: '3000.934.1904.0',
+      },
+    });
+  });
+
   it('uses reviewed multi-product evidence for the shared Visual C++ runtime bundle', () => {
     expect(
       applyApplicationPackagingAdapter('ABBODI1406.VCREDIST', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1013,6 +1013,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSuccessCodes: [1223],
   },
   {
+    // Windows App Runtime 1.3 is a shared MSIX framework. The 1.3.3 x64
+    // installer deploys Microsoft.WindowsAppRuntime.1.3 version
+    // 3000.934.1904.0 under Microsoft's publisher and does not create one
+    // authoritative ARP entry. Verify the exact framework identity and retain
+    // it when Intune relinquishes ownership so dependent apps are not broken.
+    wingetId: 'Microsoft.WindowsAppRuntime.1.3',
+    preserveVendorInstallationOnUninstall: true,
+    reviewedAppxInstallEvidence: {
+      packageName: 'Microsoft.WindowsAppRuntime.1.3',
+      publisherId: '8wekyb3d8bbwe',
+      minimumVersion: '3000.934.1904.0',
+    },
+  },
+  {
     // Windows App Runtime is a shared MSIX framework. Microsoft's package
     // identity is Microsoft.WindowsAppRuntime.1.8, and the 1.8.9 installer
     // deploys framework version 8000.879.2017.0 under Microsoft's publisher.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1376,6 +1376,42 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds reviewed Windows App Runtime 1.3 Appx evidence to the QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.WindowsAppRuntime.1.3',
+      displayName: 'Windows App Runtime',
+      publisher: 'Microsoft',
+      version: '1.3.3',
+      architecture: 'x64',
+      installerSha256: 'e'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Windows App Runtime',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedEvidence = {
+      packageName: 'Microsoft.WindowsAppRuntime.1.3',
+      publisherId: '8wekyb3d8bbwe',
+      minimumVersion: '3000.934.1904.0',
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        preserveVendorInstallationOnUninstall?: boolean;
+        reviewedAppxInstallEvidence?: typeof expectedEvidence;
+      };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      preserveVendorInstallationOnUninstall: true,
+      reviewedAppxInstallEvidence: expectedEvidence,
+    });
+    expect(profile.psadtConfig.reviewedAppxInstallEvidence).toEqual(
+      expectedEvidence
+    );
+  });
+
   it('preserves PSADT detection rules when the top-level workflow list is unusable', () => {
     const fileRule = {
       type: 'file' as const,

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -805,6 +805,55 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'verifies Windows App Runtime 1.3 with its exact shared Appx framework evidence',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Windows App Runtime',
+        [],
+        {
+          verifyInstall: true,
+          preserveVendorInstallationOnUninstall: true,
+          reviewedAppxInstallEvidence: {
+            packageName: 'Microsoft.WindowsAppRuntime.1.3',
+            publisherId: '8wekyb3d8bbwe',
+            minimumVersion: '3000.934.1904.0',
+          },
+        },
+        [],
+        'Microsoft.WindowsAppRuntime.1.3'
+      );
+      const installFunction = generated.slice(
+        generated.indexOf('function Install-ADTDeployment'),
+        generated.indexOf('function Uninstall-ADTDeployment')
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(installFunction).toContain(
+        "Get-AppxPackage -AllUsers -Name 'Microsoft.WindowsAppRuntime.1.3'"
+      );
+      expect(installFunction).toContain(
+        "[string]$_.PublisherId -eq '8wekyb3d8bbwe'"
+      );
+      expect(installFunction).toContain('[bool]$_.IsFramework');
+      expect(installFunction).toContain(
+        "[version]'3000.934.1904.0'"
+      );
+      expect(installFunction).not.toContain('$preInstallApplications');
+      expect(installFunction).not.toContain(
+        'Could not select one vendor uninstall entry'
+      );
+      expect(uninstallFunction).toContain(
+        'Retaining the shared vendor installation and removing only the IntuneGet management marker.'
+      );
+      expect(uninstallFunction).not.toContain('Start-ADTProcess @uninstallProcessParameters');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'rejects wildcard and unretained reviewed Appx evidence',
     () => {
       expect(() =>


### PR DESCRIPTION
## Summary
- add a reviewed shared-runtime adapter for Microsoft.WindowsAppRuntime.1.3
- verify the exact Microsoft.WindowsAppRuntime.1.3 Appx framework at version 3000.934.1904.0 or newer
- retain the shared framework during Intune uninstall and remove only IntuneGet ownership
- bind the adapter into both QA and customer package profiles

## Production QA evidence
- failing run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32891416249
- installer SHA256: A722EE97261E01E8DD6165A8EFAE67CEFDB21B3EE5D9122C662324A0B11DAF38
- observed exact framework: Microsoft.WindowsAppRuntime.1.3_3000.934.1904.0_x64__8wekyb3d8bbwe
- repeat of run 32001669312: no ARP entry, install/uninstall exit 60001

## Validation
- focused Vitest: 279 passed
- ESLint: passed
- full Vitest: 1505 passed; one unrelated translation-process timeout passed on isolated rerun (2/2)
- Next.js production build and TypeScript: passed