### PR TITLE
Activate Windows App Runtime 1.3 QA adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
+  packagerCommit: '384d36477200c3410f47645e376fe2dfd3682a9e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -378,6 +378,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Removing Stream Deck's disproven adapter affects only an app now blocked
   // at the shared eligibility gate. Preserve every unrelated compatible pass.
   '63219f1fe5c953c8fd799c79030176444ba637b4',
+  // Windows App Runtime 1.3 now uses its exact shared Appx framework identity
+  // instead of a nonexistent ARP entry. Preserve every unrelated pass from
+  // the Stream Deck eligibility-block release.
+  'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -313,6 +313,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
   });
 
+  it('retries Windows App Runtime 1.3 only after activating exact shared Appx evidence', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' microsoft.windowsappruntime.1.3 ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
+      { wingetId: 'Microsoft.WindowsAppRuntime.1.3', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries ElegantClipboard only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -245,7 +245,17 @@ const STREAM_DECK_EXISTING_HELPER_RELEASE_RETRY_TARGETS = [
   ...EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS = [
+  // Retry the exact failed 1.3.3 installer with Microsoft's observed shared
+  // Appx framework identity instead of requiring a nonexistent ARP entry.
+  'Microsoft.WindowsAppRuntime.1.3',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '384d36477200c3410f47645e376fe2dfd3682a9e':
+    WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS,
   // Stream Deck is eligibility-blocked after five identical MSI removal
   // stalls, so carry every prior bounded target without replaying it.
   'd30bedbc4374346b7900b4ffef2d7c77f222d3d2':


### PR DESCRIPTION
## Summary
- pin QA package generation to exact shared source commit 384d36477200c3410f47645e376fe2dfd3682a9e
- preserve compatible passes from d30bedbc4374346b7900b4ffef2d7c77f222d3d2
- retry only Microsoft.WindowsAppRuntime.1.3 plus still-unconsumed bounded targets
- prove the preceding d30 release does not replay this app

## Validation
- focused QA profile/backfill tests: 198 passed
- full Vitest: 1507 passed
- ESLint: passed