### PR TITLE
Fix Total Commander unattended uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1008,6 +1008,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
   });
 
+  it('uses Total Commander\'s documented complete unattended uninstall mode', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'ghisler.totalcommander',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedUninstallArguments).toEqual(['/7']);
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+  });
+
   it('pins RobotStudio to its complete silent install and exact 2025.2 MSI identity', () => {
     const adapted = applyApplicationPackagingAdapter(
       'abb.robotstudio',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -326,6 +326,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallArgumentsOverride: '/vADDLOCAL="ALL" /qn /norestart',
   },
   {
+    // Total Commander registers its exact tcunin64.exe/tcuninst.exe product
+    // uninstaller without arguments, which opens the interactive removal UI
+    // behind a non-interactive Intune session. Ghisler documents /0 through /7
+    // as the unattended uninstall modes; /7 removes the program, shortcuts,
+    // and settings. Append it only to the exact captured Total Commander ARP
+    // command so QA and customer packages share the supported lifecycle.
+    wingetId: 'Ghisler.TotalCommander',
+    reviewedUninstallArguments: ['/7'],
+  },
+  {
     // Apryse documents -q as the unattended Windows uninstall switch for the
     // install4j-based Xodo/PDF Studio family. The registered Xodo PDF Reader
     // command omits it, which leaves the confirmation flow waiting in a

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -183,6 +183,29 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/headless']);
   });
 
+  it('binds Total Commander customer and QA packages to unattended removal', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Ghisler.TotalCommander',
+      displayName: 'Total Commander',
+      publisher: 'Ghisler',
+      version: '11.58',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/AHN*',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:Totalcmd64:Total Commander 64-bit (Remove or Repair)',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/7']);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/7']);
+  });
+
   it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'PostgresPro.Standard.17',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -443,6 +443,37 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'appends Total Commander unattended removal to the exact captured product command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Total Commander',
+        [],
+        { reviewedUninstallArguments: ['/7'] },
+        [],
+        'Ghisler.TotalCommander',
+        'Total Commander 64-bit (Remove or Repair)',
+        '11.58',
+        'REGISTRY_UNINSTALL_KEY:Totalcmd64:Total Commander 64-bit (Remove or Repair)',
+        '/AHN*'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain("$configuredProductCode = 'Totalcmd64'");
+      expect(uninstallFunction).toContain("$reviewedUninstallArguments = @('/7')");
+      expect(uninstallFunction).toContain(
+        '$registeredUninstallArguments += $reviewedArgument'
+      );
+      expect(uninstallFunction).toContain(
+        'Get-ADTApplication -FilterScript { $_.PSChildName -eq $registeredUninstallRegistryKey }'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'appends FSLogix restart suppression to the exact captured Burn command',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- append Ghisler's documented /7 unattended uninstall mode to the exact captured Total Commander ARP command
- carry the adapter into both catalog QA and customer PSADT package profiles
- add adapter, profile, generated-package, and PowerShell-parse regression coverage

## Failure evidence
- QA run 32902845756 installed and detected Total Commander 11.58 successfully
- the exact registered 	cunin64.exe was launched without arguments and left Totalcmd64 registered for the full 5-minute lifecycle deadline
- uninstall exited 60001 and independent removal detection remained positive

## Vendor contract
- Total Commander author documentation: https://www.ghisler.ch/board/viewtopic.php?t=37973
- /7 selects unattended uninstall and removes the program, shortcuts, and settings

## Verification
- 282 focused Vitest contracts passed
- generated PSADT PowerShell parsed successfully
- scoped ESLint passed
- repository-wide 	sc --noEmit remains blocked by pre-existing test-global/type-fixture errors outside these files