### PR TITLE
Activate Total Commander uninstall adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '384d36477200c3410f47645e376fe2dfd3682a9e',
+  packagerCommit: '5636cda74d31de95d9ee5689050ba04e432ede61',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -382,6 +382,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // instead of a nonexistent ARP entry. Preserve every unrelated pass from
   // the Stream Deck eligibility-block release.
   'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
+  // Total Commander now appends Ghisler's documented unattended /7 mode to
+  // its exact captured uninstaller. Preserve every unrelated pass from the
+  // Windows App Runtime identity release.
+  '384d36477200c3410f47645e376fe2dfd3682a9e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -116,6 +116,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Ghisler.TotalCommander',
       'Tricentis.NeoLoad',
       'Piriform.Recuva',
       'Trimble.SketchUp.2022',
@@ -177,6 +178,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Ghisler.TotalCommander',
         'Tricentis.NeoLoad',
         'Piriform.Recuva',
         'Trimble.SketchUp.2022',
@@ -321,6 +323,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       'd30bedbc4374346b7900b4ffef2d7c77f222d3d2',
       { wingetId: 'Microsoft.WindowsAppRuntime.1.3', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Total Commander only after activating its unattended uninstall contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' ghisler.totalcommander ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '384d36477200c3410f47645e376fe2dfd3682a9e',
+      { wingetId: 'Ghisler.TotalCommander', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -253,7 +253,17 @@ const WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS = [
   ...EGNYTE_UPDATE_ON_BOOT_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the exact failed 11.58 lifecycle with Ghisler's documented /7
+  // unattended mode appended to the captured Total Commander uninstaller.
+  'Ghisler.TotalCommander',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '5636cda74d31de95d9ee5689050ba04e432ede61':
+    TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   '384d36477200c3410f47645e376fe2dfd3682a9e':
     WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS,
   // Stream Deck is eligibility-blocked after five identical MSI removal


### PR DESCRIPTION
## Summary
- activate shared packager commit 5636cda74d31de95d9ee5689050ba04e432ede61`n- retain compatible passes from the prior protected release
- target the failed Ghisler.TotalCommander lifecycle for one corrected retry

## Verification
- 200 focused package-profile and toolchain-backfill tests passed
- scoped ESLint passed
- source adapter PR #922 passed all protected checks and merged