### PR TITLE
Fix Poly Lens renamed ARP lifecycle

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -749,6 +749,20 @@ $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
 $reviewedPreferVisiblePrimaryUninstallRegistration = Get-StrictPSADTBoolean `
     -Config $psadtConfig `
     -Name 'reviewedPreferVisiblePrimaryUninstallRegistration'
+$reviewedRegistryUninstallDisplayName = ''
+if ($psadtConfig.Contains('reviewedRegistryUninstallDisplayName') -and
+    $null -ne $psadtConfig['reviewedRegistryUninstallDisplayName']) {
+    if ($psadtConfig['reviewedRegistryUninstallDisplayName'] -isnot [string]) {
+        throw 'PSADT reviewedRegistryUninstallDisplayName must be a string.'
+    }
+    $reviewedRegistryUninstallDisplayName = [string]$psadtConfig['reviewedRegistryUninstallDisplayName']
+    if ([string]::IsNullOrWhiteSpace($reviewedRegistryUninstallDisplayName) -or
+        $reviewedRegistryUninstallDisplayName.Length -gt 128 -or
+        $reviewedRegistryUninstallDisplayName -match '[\x00-\x1f\x7f]') {
+        throw 'PSADT reviewedRegistryUninstallDisplayName must be a non-empty display name of at most 128 characters.'
+    }
+    $reviewedRegistryUninstallDisplayName = $reviewedRegistryUninstallDisplayName.Trim()
+}
 if ($reviewedRegistryInstallEvidenceConfigured -and
     -not $preserveVendorInstallationOnUninstall) {
     throw 'PSADT reviewedRegistryInstallEvidence requires preserveVendorInstallationOnUninstall.'
@@ -1497,6 +1511,16 @@ if ($fileExtension -eq '.msi') {
     } else {
         throw 'The MSI database did not expose a valid ProductCode; refusing ambiguous detection or removal.'
     }
+}
+
+# A reviewed rename adapter may deliberately replace a stale transitional MSI
+# ProductCode with the exact ARP display identity created by the vendor's
+# chained install. Ordinary MSI packages keep the database ProductCode above.
+if (-not [string]::IsNullOrWhiteSpace($reviewedRegistryUninstallDisplayName)) {
+    $useRegistryUninstall = $true
+    $registryUninstallProductCode = ''
+    $registryUninstallDisplayName = $reviewedRegistryUninstallDisplayName
+    Write-Host "Using reviewed registry display identity: $registryUninstallDisplayName"
 }
 
 $useManagedDirectoryLifecycle = -not [string]::IsNullOrWhiteSpace($reviewedManagedInstallDirectory)
@@ -3124,12 +3148,20 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         '    } elseif ($multiProductInstallationVerified) {'
         '        Write-ADTLogEntry -Message "Verified reviewed multi-product installation from $($reviewedMultiProductMatches.Count) matching vendor registrations." -Source ''Install-ADTDeployment'''
         '    } else {'
-        '        foreach ($ambiguousApplication in @($selectedApplications)) {'
+        '        $diagnosticApplications = if ($selectedApplications.Count -gt 0) {'
+        '            @($selectedApplications | Select-Object -First 20)'
+        '        } else {'
+        '            @($changedApplications | Select-Object -First 20)'
+        '        }'
+        '        foreach ($ambiguousApplication in $diagnosticApplications) {'
         '            $ambiguousSystemComponent = if ($ambiguousApplication.PSObject.Properties[''SystemComponent'']) { [bool]$ambiguousApplication.SystemComponent } else { $false }'
         '            $ambiguousUninstallLeaf = if (-not [string]::IsNullOrWhiteSpace([string]$ambiguousApplication.QuietUninstallStringFilePath)) {'
         '                Split-Path -Leaf ([string]$ambiguousApplication.QuietUninstallStringFilePath)'
         '            } else { Split-Path -Leaf ([string]$ambiguousApplication.UninstallStringFilePath) }'
         '            Write-ADTLogEntry -Message "Ambiguous vendor uninstall candidate: name=[$($ambiguousApplication.DisplayName)]; publisher=[$($ambiguousApplication.Publisher)]; version=[$($ambiguousApplication.DisplayVersion)]; key=[$($ambiguousApplication.PSChildName)]; windowsInstaller=[$([bool]$ambiguousApplication.WindowsInstaller)]; systemComponent=[$ambiguousSystemComponent]; uninstallLeaf=[$ambiguousUninstallLeaf]." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+        '        }'
+        '        if ($changedApplications.Count -gt $diagnosticApplications.Count) {'
+        '            Write-ADTLogEntry -Message "ARP delta diagnostics truncated after $($diagnosticApplications.Count) of $($changedApplications.Count) changed entries." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
         '        }'
         '        throw "Could not select one vendor uninstall entry. The installer changed $($changedApplications.Count) entries and $($selectedApplications.Count) matched the configured identity."'
         '    }'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -55,6 +55,21 @@ describe('application packaging adapters', () => {
     ).toBeUndefined();
   });
 
+  it('binds the legacy Poly Lens catalog ID to the renamed Poly Studio ARP identity', () => {
+    expect(
+      applyApplicationPackagingAdapter('Poly.PolyLens', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRegistryUninstallDisplayName: 'customer override',
+      }).reviewedRegistryUninstallDisplayName
+    ).toBe('Poly Studio');
+    expect(
+      applyApplicationPackagingAdapter('Example.App', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRegistryUninstallDisplayName: 'customer override',
+      }).reviewedRegistryUninstallDisplayName
+    ).toBeUndefined();
+  });
+
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
     expect(resolveApplicationUninstallCommand(
       'Google.Chrome.EXE',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -34,6 +34,7 @@ interface ApplicationPackagingAdapter {
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
+  reviewedRegistryUninstallDisplayName?: string;
   reviewedManagedInstallDirectory?: string;
   reviewedManagedInstallEvidenceFile?: string;
   reviewedManagedInstallCompletionProcess?: string;
@@ -386,6 +387,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // zero or multiple visible matches remain an ambiguity failure.
     wingetId: 'Surfshark.Surfshark',
     reviewedPreferVisiblePrimaryUninstallRegistration: true,
+  },
+  {
+    // HP replaced Poly Lens Desktop with Poly Studio Desktop in 5.1 while the
+    // old Poly.PolyLens WinGet entry remained mapped to the exact same MSI as
+    // Poly.PolyStudio. The transitional MSI does not retain its own published
+    // ProductCode or the old `Poly Lens` ARP name after its chained install.
+    // Capture the single observed `Poly Studio` registration instead; the
+    // generated package persists its exact key and command for safe removal.
+    wingetId: 'Poly.PolyLens',
+    reviewedRegistryUninstallDisplayName: 'Poly Studio',
   },
   {
     // TreeSize's dual-mode Inno installer defaults to the invoking account even
@@ -1524,6 +1535,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedPreferVisiblePrimaryUninstallRegistration &&
+      !config.reviewedRegistryUninstallDisplayName &&
       !config.reviewedInstallArgumentsOverride &&
       !config.reviewedArgumentlessInstall &&
       !config.reviewedInstallCompletionTimeoutMinutes &&
@@ -1545,6 +1557,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
+      reviewedRegistryUninstallDisplayName: undefined,
       reviewedInstallArgumentsOverride: undefined,
       reviewedArgumentlessInstall: undefined,
       reviewedInstallCompletionTimeoutMinutes: undefined,
@@ -1629,6 +1642,14 @@ export function applyApplicationPackagingAdapter(
       normalizeReviewedDisplayNamePrefix(prefix, adapter.wingetId)
     );
 
+  const reviewedRegistryUninstallDisplayName =
+    adapter.reviewedRegistryUninstallDisplayName
+      ? normalizeReviewedDisplayNamePrefix(
+          adapter.reviewedRegistryUninstallDisplayName,
+          adapter.wingetId
+        )
+      : undefined;
+
   return {
     ...config,
     processesToClose,
@@ -1666,6 +1687,7 @@ export function applyApplicationPackagingAdapter(
       adapter.preserveVendorInstallationOnUninstall || undefined,
     reviewedPreferVisiblePrimaryUninstallRegistration:
       adapter.reviewedPreferVisiblePrimaryUninstallRegistration || undefined,
+    reviewedRegistryUninstallDisplayName,
     reviewedManagedInstallDirectory:
       adapter.reviewedManagedInstallDirectory || undefined,
     reviewedManagedInstallEvidenceFile:

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -206,6 +206,30 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/7']);
   });
 
+  it('binds legacy Poly Lens packages to the renamed Poly Studio ARP identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Poly.PolyLens',
+      displayName: 'Poly Lens',
+      publisher: 'Poly',
+      version: '5.1.0.1111',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'wix',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand:
+        'msiexec /x "{50E3D49D-AAA9-45B6-B16E-ED99645C8B71}" /qn /norestart',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedRegistryUninstallDisplayName?: string };
+    };
+
+    expect(profile.psadtConfig.reviewedRegistryUninstallDisplayName)
+      .toBe('Poly Studio');
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedRegistryUninstallDisplayName)
+      .toBe('Poly Studio');
+  });
+
   it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'PostgresPro.Standard.17',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2594,6 +2594,25 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   });
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses a reviewed renamed ARP identity instead of a stale transitional MSI ProductCode',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'Poly Lens',
+        [],
+        { reviewedRegistryUninstallDisplayName: 'Poly Studio' },
+        [],
+        'Poly.PolyLens'
+      );
+
+      expect(generated).toContain("$configuredUninstallProductCode = ''");
+      expect(generated).toContain("$configuredUninstallDisplayName = 'Poly Studio'");
+      expect(generated).toContain("$appName = 'Poly Studio'");
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'emits the reviewed visible-primary selector only when enabled',
     () => {
       const enabled = generateRegistryUninstallPackage(
@@ -2619,8 +2638,10 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
 
   it('logs bounded ARP identity metadata before rejecting an ambiguous install delta', () => {
     expect(packager).toContain(
-      'foreach ($ambiguousApplication in @($selectedApplications))'
+      '@($changedApplications | Select-Object -First 20)'
     );
+    expect(packager).toContain('foreach ($ambiguousApplication in $diagnosticApplications)');
+    expect(packager).toContain('ARP delta diagnostics truncated after');
     expect(packager).toContain(
       'Ambiguous vendor uninstall candidate: name=[$($ambiguousApplication.DisplayName)]; publisher=[$($ambiguousApplication.Publisher)]; version=[$($ambiguousApplication.DisplayVersion)]; key=[$($ambiguousApplication.PSChildName)]; windowsInstaller=[$([bool]$ambiguousApplication.WindowsInstaller)]; systemComponent=[$ambiguousSystemComponent]; uninstallLeaf=[$ambiguousUninstallLeaf].'
     );

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -276,6 +276,13 @@ export interface PSADTConfig {
   // adapters are the only trusted source for this value.
   reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
 
+  // Internal exact ARP display identity for a reviewed package whose current
+  // vendor installer no longer registers the MSI ProductCode or catalog name
+  // published by WinGet. The shared packager still captures exactly one
+  // observed install delta and persists its exact registry key for removal.
+  // Application adapters are the only trusted source for this value.
+  reviewedRegistryUninstallDisplayName?: string;
+
   // Internal lifecycle contract for reviewed self-extracting packages that do
   // not register an application in Add/Remove Programs. The generated package
   // verifies this exact directory after install and removes it on uninstall.
@@ -416,6 +423,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   reviewedUninstallProcessGuard: undefined,
   reviewedUninstallServiceNames: undefined,
   reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
+  reviewedRegistryUninstallDisplayName: undefined,
 };
 
 /**


### PR DESCRIPTION
Binds the legacy Poly.PolyLens catalog ID to the exact Poly Studio ARP identity created by the 5.1 transitional MSI, preserves fail-closed exact-key removal for customer packages, and adds bounded changed-ARP diagnostics. Verified by 285 focused Vitest contracts, scoped ESLint, and generated PowerShell parsing.