### PR TITLE
chore(qa): activate Poly Lens packaging repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '5636cda74d31de95d9ee5689050ba04e432ede61',
+  packagerCommit: '085de20195dacc66c0d465945f93c6a780cc14c4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -386,6 +386,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // its exact captured uninstaller. Preserve every unrelated pass from the
   // Windows App Runtime identity release.
   '384d36477200c3410f47645e376fe2dfd3682a9e',
+  // Poly Lens 5.1 now captures the exact renamed Poly Studio ARP identity,
+  // while bounded zero-match diagnostics execute only on the fail-closed path.
+  // Preserve every unrelated pass from the Total Commander adapter release.
+  '5636cda74d31de95d9ee5689050ba04e432ede61',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -116,6 +116,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Poly.PolyLens',
       'Ghisler.TotalCommander',
       'Tricentis.NeoLoad',
       'Piriform.Recuva',
@@ -178,6 +179,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Poly.PolyLens',
         'Ghisler.TotalCommander',
         'Tricentis.NeoLoad',
         'Piriform.Recuva',
@@ -334,6 +336,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '384d36477200c3410f47645e376fe2dfd3682a9e',
       { wingetId: 'Ghisler.TotalCommander', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Poly Lens only after activating its renamed Poly Studio identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' poly.polylens ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '5636cda74d31de95d9ee5689050ba04e432ede61',
+      { wingetId: 'Poly.PolyLens', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -261,7 +261,17 @@ const TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...WINDOWS_APP_RUNTIME_13_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 5.1 transitional MSI using HP's renamed Poly Studio ARP
+  // identity while retaining exact observed-key capture and removal.
+  'Poly.PolyLens',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '085de20195dacc66c0d465945f93c6a780cc14c4':
+    POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS,
   '5636cda74d31de95d9ee5689050ba04e432ede61':
     TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   '384d36477200c3410f47645e376fe2dfd3682a9e':


### PR DESCRIPTION
## Summary
- pin QA package profiles to the reviewed Poly Lens/Poly Studio packaging repair
- target Poly.PolyLens for a terminal QA retry on this exact packager release
- preserve all prior targeted retries and the immutable release history

## Verification
- npm exec vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (202 passed)
- npm exec eslint lib/qa/package-profile.ts lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check