### PR TITLE
fix(packaging): capture Jamovi registered identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -70,6 +70,15 @@ describe('application packaging adapters', () => {
     ).toBeUndefined();
   });
 
+  it('binds Jamovi Desktop to its actual lowercase jamovi ARP identity', () => {
+    expect(
+      applyApplicationPackagingAdapter('Jamovi.Desktop.Current', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRegistryUninstallDisplayName: 'customer override',
+      }).reviewedRegistryUninstallDisplayName
+    ).toBe('jamovi');
+  });
+
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
     expect(resolveApplicationUninstallCommand(
       'Google.Chrome.EXE',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -399,6 +399,14 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedRegistryUninstallDisplayName: 'Poly Studio',
   },
   {
+    // The 2.7.18 NSIS installer registers its primary product as `jamovi`,
+    // despite the WinGet manifest declaring `Jamovi Desktop`. QA run
+    // 32913050396 observed that exact ARP identity alongside Visual C++ runtime
+    // changes, so capture only `jamovi` and keep every broader match fail-closed.
+    wingetId: 'Jamovi.Desktop.Current',
+    reviewedRegistryUninstallDisplayName: 'jamovi',
+  },
+  {
     // TreeSize's dual-mode Inno installer defaults to the invoking account even
     // when the catalog declares machine scope. Under LocalSystem that places the
     // app and its uninstaller below the 32-bit system profile, where silent

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -230,6 +230,28 @@ describe('PSADT QA package identity', () => {
       .toBe('Poly Studio');
   });
 
+  it('binds Jamovi customer and QA packages to the observed jamovi ARP identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Jamovi.Desktop.Current',
+      displayName: 'Jamovi Desktop',
+      publisher: 'Jamovi',
+      version: '2.7.18.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Jamovi Desktop',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedRegistryUninstallDisplayName?: string };
+    };
+
+    expect(profile.psadtConfig.reviewedRegistryUninstallDisplayName).toBe('jamovi');
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedRegistryUninstallDisplayName)
+      .toBe('jamovi');
+  });
+
   it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'PostgresPro.Standard.17',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2613,6 +2613,24 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses Jamovi current installer registered identity instead of its stale catalog name',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'Jamovi Desktop',
+        [],
+        { reviewedRegistryUninstallDisplayName: 'jamovi' },
+        [],
+        'Jamovi.Desktop.Current'
+      );
+
+      expect(generated).toContain("$configuredUninstallDisplayName = 'jamovi'");
+      expect(generated).toContain("$appName = 'jamovi'");
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'emits the reviewed visible-primary selector only when enabled',
     () => {
       const enabled = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- bind Jamovi.Desktop.Current to the exact observed ARP display identity jamovi
- retain fail-closed selection when the installer also changes Visual C++ registrations
- apply the same reviewed adapter to QA and customer PSADT packages

## Evidence
- QA run 32913050396 installed jamovi 2.7.18.0, while WinGet declares Jamovi Desktop
- the installer changed four ARP entries; the generic packager correctly refused a broad guess

## Verification
- npm exec vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (288 passed)
- npm exec eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts
- git diff --check