### PR TITLE
chore(qa): activate Jamovi packaging repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '085de20195dacc66c0d465945f93c6a780cc14c4',
+  packagerCommit: 'e029c0e9f7884eb07ba8f277413298ec354fb597',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -390,6 +390,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // while bounded zero-match diagnostics execute only on the fail-closed path.
   // Preserve every unrelated pass from the Total Commander adapter release.
   '5636cda74d31de95d9ee5689050ba04e432ede61',
+  // Jamovi 2.7 captures the exact lowercase jamovi ARP identity while keeping
+  // the accompanying Visual C++ registrations outside the removal boundary.
+  // Preserve every unrelated pass from the Poly Lens identity release.
+  '085de20195dacc66c0d465945f93c6a780cc14c4',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -116,6 +116,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Jamovi.Desktop.Current',
       'Poly.PolyLens',
       'Ghisler.TotalCommander',
       'Tricentis.NeoLoad',
@@ -179,6 +180,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Jamovi.Desktop.Current',
         'Poly.PolyLens',
         'Ghisler.TotalCommander',
         'Tricentis.NeoLoad',
@@ -347,6 +349,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '5636cda74d31de95d9ee5689050ba04e432ede61',
       { wingetId: 'Poly.PolyLens', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Jamovi only after activating its observed registered identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' jamovi.desktop.current ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '085de20195dacc66c0d465945f93c6a780cc14c4',
+      { wingetId: 'Jamovi.Desktop.Current', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -269,7 +269,17 @@ const POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...TOTAL_COMMANDER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 2.7.18 lifecycle against the exact lowercase jamovi ARP
+  // identity while leaving the installer's Visual C++ registrations untouched.
+  'Jamovi.Desktop.Current',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'e029c0e9f7884eb07ba8f277413298ec354fb597':
+    JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS,
   '085de20195dacc66c0d465945f93c6a780cc14c4':
     POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS,
   '5636cda74d31de95d9ee5689050ba04e432ede61':


### PR DESCRIPTION
## Summary
- pin QA profiles to Jamovi repair source commit e029c0e9f7884eb07ba8f277413298ec354fb597
- target Jamovi.Desktop.Current for a terminal retry on this exact release
- preserve all prior targeted retries and compatible pass history

## Verification
- npm exec vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (204 passed)
- npm exec eslint lib/qa/package-profile.ts lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check