### PR TITLE
fix(packaging): uninstall IrfanView silently

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -79,6 +79,15 @@ describe('application packaging adapters', () => {
     ).toBe('jamovi');
   });
 
+  it('uses IrfanView\'s documented case-sensitive silent uninstall switch', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'irfanskILJan.irfanview',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['/silent']);
+  });
+
   it('uses the reviewed Chrome EXE registry identity without widening matching', () => {
     expect(resolveApplicationUninstallCommand(
       'Google.Chrome.EXE',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -407,6 +407,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedRegistryUninstallDisplayName: 'jamovi',
   },
   {
+    // IrfanView registers iv_uninstall.exe without the vendor's case-sensitive
+    // unattended switch. Under LocalSystem the interactive command exits while
+    // IrfanView64 remains registered (QA run 32918339448). IrfanView's official
+    // FAQ documents `iv_uninstall.exe /silent` for unattended removal, so append
+    // that exact switch to the captured ARP command for QA and customer packages.
+    wingetId: 'IrfanSkiljan.IrfanView',
+    reviewedUninstallArguments: ['/silent'],
+  },
+  {
     // TreeSize's dual-mode Inno installer defaults to the invoking account even
     // when the catalog declares machine scope. Under LocalSystem that places the
     // app and its uninstaller below the 32-bit system profile, where silent

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -252,6 +252,28 @@ describe('PSADT QA package identity', () => {
       .toBe('jamovi');
   });
 
+  it('binds IrfanView customer and QA packages to the documented silent uninstall', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'IrfanSkiljan.IrfanView',
+      displayName: 'IrfanView',
+      publisher: 'Irfan Skiljan',
+      version: '4.75',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/silent /desktop=1 /group=1 /allusers=1',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:IrfanView64:IrfanView',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/silent']);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/silent']);
+  });
+
   it('binds Postgres Pro 17 customer packages to the exact vendor lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'PostgresPro.Standard.17',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2631,6 +2631,26 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'appends IrfanView\'s documented silent switch to its captured ARP command',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'IrfanView',
+        [],
+        { reviewedUninstallArguments: ['/silent'] },
+        [],
+        'IrfanSkiljan.IrfanView'
+      );
+
+      expect(generated).toContain("$reviewedUninstallArguments = @('/silent')");
+      expect(generated).toContain(
+        '$registeredUninstallArguments += $reviewedArgument'
+      );
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'emits the reviewed visible-primary selector only when enabled',
     () => {
       const enabled = generateRegistryUninstallPackage(


### PR DESCRIPTION
QA run 32918339448 proved install and detection succeeded, but the registered interactive iv_uninstall.exe command left IrfanView64 installed until the five-minute deadline (0/0/60001/0).\n\nIrfanView's official FAQ documents the case-sensitive unattended command iv_uninstall.exe /silent. This app-scoped adapter appends that exact switch to the captured ARP command for both customer PSADT packages and QA.\n\nValidation:\n- 291 focused packaging/profile/contract tests passed\n- scoped ESLint passed\n- git diff --check