### PR TITLE
chore(qa): activate IrfanView uninstall repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'e029c0e9f7884eb07ba8f277413298ec354fb597',
+  packagerCommit: 'b09111db20f3aa13aced140d1bddbc83c437d459',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -394,6 +394,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // the accompanying Visual C++ registrations outside the removal boundary.
   // Preserve every unrelated pass from the Poly Lens identity release.
   '085de20195dacc66c0d465945f93c6a780cc14c4',
+  // IrfanView now appends the vendor-documented, case-sensitive /silent switch
+  // to its exact captured iv_uninstall.exe command. Preserve every unrelated
+  // pass from the Jamovi registered-identity release.
+  'e029c0e9f7884eb07ba8f277413298ec354fb597',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -116,6 +116,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'IrfanSkiljan.IrfanView',
       'Jamovi.Desktop.Current',
       'Poly.PolyLens',
       'Ghisler.TotalCommander',
@@ -180,6 +181,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'IrfanSkiljan.IrfanView',
         'Jamovi.Desktop.Current',
         'Poly.PolyLens',
         'Ghisler.TotalCommander',
@@ -360,6 +362,17 @@ describe('QA toolchain targeted retries', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '085de20195dacc66c0d465945f93c6a780cc14c4',
       { wingetId: 'Jamovi.Desktop.Current', status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries IrfanView only after activating its documented silent uninstall', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' irfanskILJan.irfanview ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'e029c0e9f7884eb07ba8f277413298ec354fb597',
+      { wingetId: 'IrfanSkiljan.IrfanView', status: 'failed' }
     )).toBe(false);
   });
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -277,7 +277,17 @@ const JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...POLY_LENS_RENAMED_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 4.75 lifecycle with IrfanView's documented case-sensitive
+  // /silent switch appended to the exact captured iv_uninstall.exe command.
+  'IrfanSkiljan.IrfanView',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b09111db20f3aa13aced140d1bddbc83c437d459':
+    IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   'e029c0e9f7884eb07ba8f277413298ec354fb597':
     JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS,
   '085de20195dacc66c0d465945f93c6a780cc14c4':


### PR DESCRIPTION
Activates source packager commit b09111db20f3aa13aced140d1bddbc83c437d459 and targets the failed IrfanView lifecycle for a fresh QA profile. Prior compatible passes remain valid.\n\nValidation:\n- 206 package-profile and backfill tests passed\n- scoped ESLint passed\n- git diff --check