### PR TITLE
Fix Logitech LGS managed install context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -317,6 +317,18 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallerSelectionType('Example.App')).toBeUndefined();
   });
 
+  it('runs Logitech LGS elevated without weakening catalog scope matching', () => {
+    expect(resolveApplicationInstallScope('Logitech.LGS', 'user')).toBe('machine');
+    expect(resolveApplicationInstallerSelectionScope(
+      'Logitech.LGS',
+      'machine'
+    )).toBe('user');
+    expect(
+      applyApplicationPackagingAdapter('Logitech.LGS', DEFAULT_PSADT_CONFIG)
+        .reviewedInstallArgumentsOverride
+    ).toBeUndefined();
+  });
+
   it('runs Logitech Presentation elevated without weakening catalog scope matching', () => {
     expect(resolveApplicationInstallScope('Logitech.Presentation', 'user')).toBe('machine');
     expect(resolveApplicationInstallerSelectionScope(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -628,6 +628,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     ],
   },
   {
+    // WinGet publishes the legacy Logitech Gaming Software bootstrapper as a
+    // user-scope NSIS package. In an isolated standard-user lifecycle, its
+    // documented /S invocation returned success without creating the exact
+    // Logitech Gaming Software registration or installing the product. Keep
+    // selecting and attesting those user-scoped catalog bytes, but execute the
+    // managed package in Intune's LocalSystem context so the silent installer
+    // can complete and leave a serviceable lifecycle for later removal.
+    wingetId: 'Logitech.LGS',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+  },
+  {
     // Logitech publishes Presentation as a user-scope NSIS package, but the
     // signed bootstrapper requests elevation even when /S is supplied. A
     // standard Intune user therefore receives an unserviceable UAC credential

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -700,6 +700,37 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds Logitech LGS to LocalSystem while retaining its catalog installer contract', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Logitech.LGS',
+      displayName: 'Logitech Gaming Software',
+      publisher: 'Logitech',
+      version: '9.04.49',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:Logitech Gaming Software:Logitech Gaming Software',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe('/S');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBeUndefined();
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Logitech_LGS',
+      }),
+    ]);
+  });
+
   it('binds the reviewed Logitech G HUB lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Logitech.GHUB',


### PR DESCRIPTION
## Summary
- keep selecting the trusted user-scoped WinGet installer for Logitech LGS
- execute the generated Intune/QA package as LocalSystem so the legacy silent bootstrapper can complete
- add adapter and normalized package-profile regressions, including the unchanged /S contract and machine marker

## Verification
- npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (293 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check

Repository-wide tsc remains red on existing unrelated test typing issues.