### PR TITLE
Activate Logitech LGS package repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b09111db20f3aa13aced140d1bddbc83c437d459',
+  packagerCommit: 'd019be69468b73ca47974c25e47932c589976624',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -398,6 +398,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // to its exact captured iv_uninstall.exe command. Preserve every unrelated
   // pass from the Jamovi registered-identity release.
   'e029c0e9f7884eb07ba8f277413298ec354fb597',
+  // Logitech LGS keeps selecting its trusted user-scoped WinGet bytes while
+  // executing the managed lifecycle as LocalSystem. Preserve every unrelated
+  // pass from the IrfanView silent-uninstall release.
+  'b09111db20f3aa13aced140d1bddbc83c437d459',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,17 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('softwareok.desktopok');
   });
 
+  it('retries Logitech LGS only after activating its LocalSystem execution contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' logitech.lgs ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b09111db20f3aa13aced140d1bddbc83c437d459',
+      { wingetId: 'Logitech.LGS', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries RedisInsight only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -116,6 +127,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Logitech.LGS',
       'IrfanSkiljan.IrfanView',
       'Jamovi.Desktop.Current',
       'Poly.PolyLens',
@@ -181,6 +193,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'Logitech.LGS',
         'IrfanSkiljan.IrfanView',
         'Jamovi.Desktop.Current',
         'Poly.PolyLens',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -285,7 +285,17 @@ const IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...JAMOVI_REGISTERED_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 9.04.49 lifecycle while selecting the same trusted
+  // user-scoped catalog bytes and executing their /S contract as LocalSystem.
+  'Logitech.LGS',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd019be69468b73ca47974c25e47932c589976624':
+    LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS,
   'b09111db20f3aa13aced140d1bddbc83c437d459':
     IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   'e029c0e9f7884eb07ba8f277413298ec354fb597':


### PR DESCRIPTION
## Summary
- pin QA and customer package generation to the exact Logitech LGS repair commit
- preserve compatible historical passes from the previous release
- target the failed Logitech LGS lifecycle for a fresh protected retry

## Verification
- npx vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (208 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check