### PR TITLE
Fix Logitech LGS silent uninstall lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -323,10 +323,27 @@ describe('application packaging adapters', () => {
       'Logitech.LGS',
       'machine'
     )).toBe('user');
-    expect(
-      applyApplicationPackagingAdapter('Logitech.LGS', DEFAULT_PSADT_CONFIG)
-        .reviewedInstallArgumentsOverride
-    ).toBeUndefined();
+    const adapted = applyApplicationPackagingAdapter(
+      'Logitech.LGS',
+      DEFAULT_PSADT_CONFIG
+    );
+    expect(adapted.reviewedInstallArgumentsOverride).toBeUndefined();
+    expect(adapted.reviewedExactUninstall).toEqual({
+      executablePath:
+        '%ProgramFiles%\\Logitech Gaming Software\\uninstallhlpr.exe',
+      arguments: [
+        '/bitness=x64',
+        '/silentmode=on',
+        '/langid=ENU',
+        '/downgrade=no',
+        '/firstRun=yes',
+        '/S',
+      ],
+      completionTimeoutMinutes: 5,
+    });
+    expect(adapted.reviewedExactUninstall?.arguments).not.toContain(
+      '/silentmode=off'
+    );
   });
 
   it('runs Logitech Presentation elevated without weakening catalog scope matching', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -630,14 +630,31 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   {
     // WinGet publishes the legacy Logitech Gaming Software bootstrapper as a
     // user-scope NSIS package. In an isolated standard-user lifecycle, its
-    // documented /S invocation returned success without creating the exact
+    // catalog /S invocation returned success without creating the exact
     // Logitech Gaming Software registration or installing the product. Keep
     // selecting and attesting those user-scoped catalog bytes, but execute the
     // managed package in Intune's LocalSystem context so the silent installer
-    // can complete and leave a serviceable lifecycle for later removal.
+    // can complete. The resulting ARP command explicitly registers
+    // /silentmode=off; use the same captured helper contract with only that
+    // vendor mode inverted and NSIS /S retained. This prevents the interactive
+    // helper from remaining behind an invisible Intune session while keeping
+    // the exact ARP registration authoritative for completion.
     wingetId: 'Logitech.LGS',
     requiredInstallScope: 'machine',
     reviewedInstallerSelectionScope: 'user',
+    reviewedExactUninstall: {
+      executablePath:
+        '%ProgramFiles%\\Logitech Gaming Software\\uninstallhlpr.exe',
+      arguments: [
+        '/bitness=x64',
+        '/silentmode=on',
+        '/langid=ENU',
+        '/downgrade=no',
+        '/firstRun=yes',
+        '/S',
+      ],
+      completionTimeoutMinutes: 5,
+    },
   },
   {
     // Logitech publishes Presentation as a user-scope NSIS package, but the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -718,12 +718,32 @@ describe('PSADT QA package identity', () => {
     });
     const profile = normalized.identity.profile as {
       installer: { installScope: string; silentArgs: string };
-      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+      psadtConfig: {
+        reviewedInstallArgumentsOverride?: string;
+        reviewedExactUninstall?: {
+          executablePath: string;
+          arguments: string[];
+          completionTimeoutMinutes: number;
+        };
+      };
     };
 
     expect(profile.installer.installScope).toBe('machine');
     expect(profile.installer.silentArgs).toBe('/S');
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBeUndefined();
+    expect(profile.psadtConfig.reviewedExactUninstall).toEqual({
+      executablePath:
+        '%ProgramFiles%\\Logitech Gaming Software\\uninstallhlpr.exe',
+      arguments: [
+        '/bitness=x64',
+        '/silentmode=on',
+        '/langid=ENU',
+        '/downgrade=no',
+        '/firstRun=yes',
+        '/S',
+      ],
+      completionTimeoutMinutes: 5,
+    });
     expect(normalized.detectionRules).toEqual([
       expect.objectContaining({
         keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Logitech_LGS',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3162,6 +3162,49 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'replaces Logitech LGS interactive mode with its reviewed silent helper contract',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        'Logitech Gaming Software',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath:
+              '%ProgramFiles%\\Logitech Gaming Software\\uninstallhlpr.exe',
+            arguments: [
+              '/bitness=x64',
+              '/silentmode=on',
+              '/langid=ENU',
+              '/downgrade=no',
+              '/firstRun=yes',
+              '/S',
+            ],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Logitech.LGS',
+        'Logitech Gaming Software',
+        '9.04.49',
+        'REGISTRY_UNINSTALL_KEY:Logitech Gaming Software:Logitech Gaming Software',
+        '/S'
+      );
+
+      expect(generated).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles%\\Logitech Gaming Software\\uninstallhlpr.exe')"
+      );
+      expect(generated).toContain(
+        "$registeredUninstallArguments = @('/bitness=x64', '/silentmode=on', '/langid=ENU', '/downgrade=no', '/firstRun=yes', '/S')"
+      );
+      expect(generated).not.toContain('/silentmode=off');
+      expect(generated).toContain(
+        'Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed.'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'stops the reviewed Azure Monitor Agent service before MSI removal',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## What changed
- bind Logitech.LGS to its exact installed uninstall helper
- preserve the captured vendor arguments but replace the interactive /silentmode=off value with /silentmode=on
- retain Nullsoft /S and exact ARP removal as the completion signal
- cover the adapter, normalized customer/QA profile, and generated PSADT command

## Production QA evidence
Run 32930976133 proved the machine-scope repair: install and detection both returned 0 under LocalSystem. Its exact ARP command was uninstallhlpr.exe /bitness=x64 /silentmode=off /langid=ENU /downgrade=no /firstRun=yes; appending /S left the exact registration present for the full bounded wait.

## Verification
- npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/psadt-packager-contract.test.ts (294 passed)
- scoped ESLint
- git diff --check