### PR TITLE
fix(packaging): run Android Apps Manager per user

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -254,6 +254,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' y-aslant.elegantclipboard ', undefined)
     ).toBe('user');
+    expect(
+      resolveApplicationInstallScope('SIMSDEV.AndroidAppsManager', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' simsdev.androidappsmanager ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -171,6 +171,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Android Apps Manager is built with Tauri v2 and does not override the
+    // NSIS install mode, so Tauri's current-user default applies. Its WinGet
+    // manifest omits Scope; running those bytes as LocalSystem installs below
+    // systemprofile and registers an uninstall.exe path that is unavailable by
+    // the managed removal cycle. Keep QA and customer packages in the intended
+    // signed-in user context instead.
+    // https://github.com/SimStm/android-apps-manager/blob/main/app/src-tauri/tauri.conf.json
+    wingetId: 'SIMSDEV.AndroidAppsManager',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -638,6 +638,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Android Apps Manager out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'SIMSDEV.AndroidAppsManager',
+      displayName: 'Android Apps Manager',
+      publisher: 'SIMSDEV',
+      version: '0.1.0',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Android Apps Manager',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\SIMSDEV_AndroidAppsManager',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
QA run 32939695948 proved the Tauri NSIS installer defaults to current-user installation while WinGet omits Scope. Under LocalSystem it registered a systemprofile uninstaller that was already unavailable during removal. This reviewed adapter forces user execution context for both QA and customer PSADT packaging, with normalized HKCU detection coverage. Verified: 253 focused tests, scoped ESLint, and git diff check.