### PR TITLE
chore(qa): activate Android Apps Manager user scope

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8127bf1923e4a4863758acdebbe7f28f6a999790',
+  packagerCommit: '54f0c26d3dbda39f78367178345c7d33eb214ec3',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -406,6 +406,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // helper contract. Preserve every unrelated pass from the machine-scope
   // execution release.
   'd019be69468b73ca47974c25e47932c589976624',
+  // Android Apps Manager now runs in the publisher's current-user context
+  // instead of LocalSystem's systemprofile. Preserve every unrelated pass
+  // from the Logitech LGS silent-uninstall release.
+  '8127bf1923e4a4863758acdebbe7f28f6a999790',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,17 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('softwareok.desktopok');
   });
 
+  it('retries Android Apps Manager only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' simsdev.androidappsmanager ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '8127bf1923e4a4863758acdebbe7f28f6a999790',
+      { wingetId: 'SIMSDEV.AndroidAppsManager', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('carries the Logitech LGS retry into its exact silent uninstall release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -293,7 +293,17 @@ const LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS = [
   ...IRFANVIEW_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 0.1.0 lifecycle in the Tauri NSIS installer's intended
+  // signed-in user context instead of LocalSystem's systemprofile.
+  'SIMSDEV.AndroidAppsManager',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '54f0c26d3dbda39f78367178345c7d33eb214ec3':
+    ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '8127bf1923e4a4863758acdebbe7f28f6a999790':
     LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS,
   'd019be69468b73ca47974c25e47932c589976624':


### PR DESCRIPTION
Pins QA to source repair 54f0c26d3dbda39f78367178345c7d33eb214ec3, preserves unrelated prior pass compatibility, and carries only the affected Android Apps Manager terminal retry into the new release. Verified: 246 focused tests, scoped ESLint, and git diff check.