### PR TITLE
Fix WowUp Beta per-user packaging lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -260,6 +260,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' simsdev.androidappsmanager ', undefined)
     ).toBe('user');
+    expect(resolveApplicationInstallScope('WowUp.Wowup.Beta', 'machine')).toBe(
+      'user'
+    );
+    expect(
+      resolveApplicationInstallScope(' wowup.wowup.beta ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -182,6 +182,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // WowUp Beta's NSIS installer registers its application below the invoking
+    // account's LocalAppData even though WinGet omits Scope. Running it as
+    // LocalSystem records an uninstaller below systemprofile that is already
+    // unavailable by the managed removal cycle. Keep QA and customer packages
+    // in the intended signed-in user context instead.
+    // https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32948950629
+    wingetId: 'WowUp.Wowup.Beta',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -666,6 +666,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps WowUp Beta out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'WowUp.Wowup.Beta',
+      displayName: 'WowUp',
+      publisher: 'WowUp',
+      version: '2.21.0-beta.6',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{B31CA559-50E4-54D8-A458-330E72A28314}:WowUp',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\WowUp_Wowup_Beta',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
## Summary
- force WowUp.Wowup.Beta into its vendor-supported user install context
- keep QA and customer PSADT package generation on the same adapter
- add regression coverage for scope resolution and HKCU package profiles

## QA evidence
Run 32948950629 installed as LocalSystem but registered C:\Windows\system32\config\systemprofile\AppData\Local\Programs\wowup\Uninstall WowUp.exe, which was unavailable during removal and returned 60001.

## Verification
- 254 focused tests passed
- scoped ESLint passed
- git diff --check passed