### PR TITLE
Activate WowUp Beta user-scope QA repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '54f0c26d3dbda39f78367178345c7d33eb214ec3',
+  packagerCommit: '0dfe1593dbf19ef43beceb2574c440287eaf1dc8',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -410,6 +410,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // instead of LocalSystem's systemprofile. Preserve every unrelated pass
   // from the Logitech LGS silent-uninstall release.
   '8127bf1923e4a4863758acdebbe7f28f6a999790',
+  // WowUp Beta now runs in the NSIS installer's intended signed-in user
+  // context. Preserve every unrelated pass from the Android Apps Manager
+  // user-scope release.
+  '54f0c26d3dbda39f78367178345c7d33eb214ec3',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,17 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('softwareok.desktopok');
   });
 
+  it('retries WowUp Beta only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' wowup.wowup.beta ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '54f0c26d3dbda39f78367178345c7d33eb214ec3',
+      { wingetId: 'WowUp.Wowup.Beta', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Android Apps Manager only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -301,7 +301,17 @@ const ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...LOGITECH_LGS_SYSTEM_EXECUTION_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 2.21.0-beta.6 lifecycle in the NSIS installer's intended
+  // signed-in user context instead of LocalSystem's systemprofile.
+  'WowUp.Wowup.Beta',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '0dfe1593dbf19ef43beceb2574c440287eaf1dc8':
+    WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '54f0c26d3dbda39f78367178345c7d33eb214ec3':
     ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '8127bf1923e4a4863758acdebbe7f28f6a999790':


### PR DESCRIPTION
## Summary
- activate exact packager source 0dfe1593dbf19ef43beceb2574c440287eaf1dc8
- preserve the prior Android Apps Manager release as compatible history
- target WowUp.Wowup.Beta for an immediate clean-VM retry

## Verification
- 248 focused activation/profile/enqueue tests passed
- scoped ESLint passed
- git diff --check passed