### PR TITLE
Fix Switchbar per-user packaging lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -266,6 +266,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' wowup.wowup.beta ', undefined)
     ).toBe('user');
+    expect(
+      resolveApplicationInstallScope('WebCatalogLtd.Switchbar', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' webcatalogltd.switchbar ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -192,6 +192,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Switchbar's NSIS installer also registers below the invoking account's
+    // LocalAppData while WinGet omits Scope. LocalSystem therefore captures an
+    // uninstaller below systemprofile that is unavailable by the managed
+    // removal cycle. Keep QA and customer packages in the signed-in user's
+    // context instead.
+    // https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32951625105
+    wingetId: 'WebCatalogLtd.Switchbar',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -694,6 +694,35 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Switchbar out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'WebCatalogLtd.Switchbar',
+      displayName: 'Switchbar',
+      publisher: 'WebCatalog Ltd',
+      version: '32.6.0',
+      architecture: 'x86',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{B130AB35-9C9C-5FEC-A754-546F900521F2}:Switchbar',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\WebCatalogLtd_Switchbar',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
## Summary
- force WebCatalogLtd.Switchbar into its vendor-supported user install context
- keep QA and customer PSADT package generation on the same exact adapter
- add regression coverage for scope resolution and HKCU package profiles

## QA evidence
Run 32951625105 installed as LocalSystem but registered C:\Windows\system32\config\systemprofile\AppData\Local\Programs\Switchbar\Uninstall Switchbar.exe, which was unavailable during removal and returned 60001.

## Verification
- 255 focused tests passed
- scoped ESLint passed
- git diff --check passed