### PR TITLE
Activate Switchbar user-scope QA repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0dfe1593dbf19ef43beceb2574c440287eaf1dc8',
+  packagerCommit: '8dde5049437903912ac003cea71e2fef0e85e86c',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -414,6 +414,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // context. Preserve every unrelated pass from the Android Apps Manager
   // user-scope release.
   '54f0c26d3dbda39f78367178345c7d33eb214ec3',
+  // Switchbar now runs in the NSIS installer's intended signed-in user
+  // context. Preserve every unrelated pass from the WowUp Beta user-scope
+  // release.
+  '0dfe1593dbf19ef43beceb2574c440287eaf1dc8',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -17,6 +17,17 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('softwareok.desktopok');
   });
 
+  it('retries Switchbar only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' webcatalogltd.switchbar ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '0dfe1593dbf19ef43beceb2574c440287eaf1dc8',
+      { wingetId: 'WebCatalogLtd.Switchbar', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries WowUp Beta only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -309,7 +309,17 @@ const WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...ANDROID_APPS_MANAGER_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 32.6.0 lifecycle in the NSIS installer's intended
+  // signed-in user context instead of LocalSystem's systemprofile.
+  'WebCatalogLtd.Switchbar',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '8dde5049437903912ac003cea71e2fef0e85e86c':
+    SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '0dfe1593dbf19ef43beceb2574c440287eaf1dc8':
     WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '54f0c26d3dbda39f78367178345c7d33eb214ec3':


### PR DESCRIPTION
## Summary
- activate exact packager source 8dde5049437903912ac003cea71e2fef0e85e86c
- preserve the prior WowUp Beta release as compatible history
- target both WebCatalogLtd.Switchbar and WowUp.Wowup.Beta for clean-VM retries

## Verification
- 250 focused activation/profile/enqueue tests passed
- scoped ESLint passed
- git diff --check passed