### PR TITLE
fix(packaging): block unsupported Ximalaya Live install

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1516,3 +1516,26 @@ describe('WinSCP Beta installer source block migration contract', () => {
     expect(sql).not.toContain("'WinSCP.WinSCP',");
   });
 });
+
+describe('Ximalaya Live managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260826124500_block_ximalaya_live_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the disproven unattended install across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'Ximalaya.XimalayaLive'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32956188340'
+    );
+    expect(sql).toContain('default Nullsoft /S argument');
+    expect(sql).toContain('added no uninstall registration');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260826124500_block_ximalaya_live_unsupported_managed_install.sql
+++ b/supabase/migrations/20260826124500_block_ximalaya_live_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- Ximalaya Live 4.67.987 declares a user-scoped Nullsoft installer but does
+-- not publish an explicit unattended install contract. In the isolated
+-- standard-user PSADT lifecycle, the exact signed WinGet payload exited 1 in
+-- under two seconds with the default Nullsoft /S argument, added no uninstall
+-- registration, and remained undetected. The deployment host emitted only
+-- "Press any key to exit..." for both attempted lifecycle commands. Do not
+-- offer customers a package that cannot install silently and deterministically.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Ximalaya.XimalayaLive',
+  'unsupported_managed_install',
+  'Ximalaya Live 4.67.987 exited 1 in under two seconds during the isolated standard-user PSADT install with the default Nullsoft /S argument. It added no uninstall registration, failed detection, and exposed no verified unattended install contract.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32956188340'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Ximalaya.XimalayaLive';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Ximalaya.XimalayaLive'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Ximalaya.XimalayaLive at the shared package eligibility gate after its exact user-scope PSADT lifecycle exited 1 immediately
- prevent both web-portal and catalog packaging for an installer with no verified unattended contract
- mark the catalog entry unverified and supersede its terminal QA candidate
- preserve the exact failed QA run as production evidence

## Verification
- 95 focused migration-contract tests passed
- focused ESLint passed
- `git diff --check` passed