### PR TITLE
chore(qa): activate Ximalaya Live eligibility block

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8dde5049437903912ac003cea71e2fef0e85e86c',
+  packagerCommit: '3887e769d1e6bfdea2027b73c1e287203aa8f3f7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -418,6 +418,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // context. Preserve every unrelated pass from the WowUp Beta user-scope
   // release.
   '0dfe1593dbf19ef43beceb2574c440287eaf1dc8',
+  // Ximalaya Live is blocked at the shared eligibility gate after its exact
+  // unattended install failed. Preserve every compatible passing result from
+  // the Switchbar user-scope release.
+  '8dde5049437903912ac003cea71e2fef0e85e86c',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('does not replay eligibility-blocked Ximalaya Live', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' ximalaya.ximalayalive ', status: 'failed' }
+    )).toBe(false);
+    expect(
+      terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
+        .map((wingetId) => wingetId.toLowerCase())
+    ).not.toContain('ximalaya.ximalayalive');
+  });
+
   it('does not replay DesktopOK after activating its managed-uninstall block', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -318,6 +318,10 @@ const SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  // Ximalaya Live is eligibility-blocked after its exact user-scope /S
+  // lifecycle failed, so carry prior bounded targets without replaying it.
+  '3887e769d1e6bfdea2027b73c1e287203aa8f3f7':
+    SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '8dde5049437903912ac003cea71e2fef0e85e86c':
     SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '0dfe1593dbf19ef43beceb2574c440287eaf1dc8':


### PR DESCRIPTION
## Summary
- activate exact source commit 3887e769d1e6bfdea2027b73c1e287203aa8f3f7
- preserve compatible passing coverage from the Switchbar user-scope release
- carry all still-valid targeted retries without replaying blocked Ximalaya.XimalayaLive

## Verification
- 215 focused QA profile/backfill tests passed
- focused ESLint passed
- `git diff --check` passed