### PR TITLE
Keep packaging-ineligible QA candidates dormant

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -378,16 +378,23 @@ afterEach(() => {
 });
 
 describe('GET /api/cron/qa-enqueue', () => {
-  it('keeps an exact quarantined installer tuple dormant until its identity changes', () => {
+  it('keeps quarantined and packaging-ineligible superseded tuples dormant', () => {
     expect(shouldReactivateSupersededCandidate(
       'superseded',
       'Installer source quarantined before QA: HASH_MISMATCH. Publisher bytes changed.',
+      true,
     )).toBe(false);
     expect(shouldReactivateSupersededCandidate(
       'superseded',
       'Superseded before dispatch: wrong-toolchain.',
+      true,
     )).toBe(true);
-    expect(shouldReactivateSupersededCandidate('queued', null)).toBe(false);
+    expect(shouldReactivateSupersededCandidate(
+      'superseded',
+      'Packaging preflight: explicit silent installer switches are required.',
+      false,
+    )).toBe(false);
+    expect(shouldReactivateSupersededCandidate('queued', null, true)).toBe(false);
   });
 
   it('does not poll or mutate the queue while maintenance is paused', async () => {

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -1127,6 +1127,7 @@ export async function GET(request: Request) {
               if (existing && shouldReactivateSupersededCandidate(
                 existing.status,
                 existing.failure_summary,
+                packagingContract.valid,
               )) {
                 const { error: reactivateError } = await supabase!
                   .from('qa_candidates')

--- a/lib/qa/candidate-reactivation.ts
+++ b/lib/qa/candidate-reactivation.ts
@@ -3,7 +3,12 @@ const INSTALLER_SOURCE_QUARANTINE_PREFIX = 'Installer source quarantined before 
 export function shouldReactivateSupersededCandidate(
   status: string | null | undefined,
   failureSummary: string | null | undefined,
+  packagingContractValid: boolean,
 ): boolean {
-  return status === 'superseded' &&
+  // Reconciliation may rediscover the same immutable tuple after its first
+  // preflight. Never turn a deliberate packaging-contract rejection back into
+  // executable work merely because the insert collided with that old row.
+  return packagingContractValid &&
+    status === 'superseded' &&
     !failureSummary?.startsWith(INSTALLER_SOURCE_QUARANTINE_PREFIX);
 }

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -297,7 +297,7 @@ export async function ensureQaDemand(
 
   if (
     existing.status === 'superseded' &&
-    !shouldReactivateSupersededCandidate(existing.status, existing.failure_summary)
+    !shouldReactivateSupersededCandidate(existing.status, existing.failure_summary, true)
   ) {
     return {
       identity,


### PR DESCRIPTION
## Summary
- require a valid current packaging contract before reactivating an exact superseded QA tuple
- preserve quarantined and packaging-ineligible rows as dormant during later catalog reconciliation
- cover the regression exposed by the nested plain-EXE Wiimm archive

## Verification
- npm test -- lib/packaging-contract.test.ts app/api/cron/qa-enqueue/route.test.ts lib/qa/demand.test.ts (60 passed)
- npm run lint -- app/api/cron/qa-enqueue/route.ts app/api/cron/qa-enqueue/route.test.ts lib/qa/candidate-reactivation.ts lib/qa/demand.ts
- npm run build:ci
- full suite: 1534 passed; one unrelated translation-provider timeout passed on isolated rerun (2 passed)