### PR TITLE
Block incomplete Wiimm managed uninstall

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -808,6 +808,25 @@ describe('Canon printer driver managed install block migration contract', () => 
   });
 });
 
+describe('Wiimms ISO Tools managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260826140000_block_wiimm_iso_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the incomplete publisher lifecycle across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Wiimm.ISO'");
+    expect(sql).toContain('windows-uninstall.sh');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('darktable managed install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260826140000_block_wiimm_iso_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260826140000_block_wiimm_iso_unsupported_managed_uninstall.sql
@@ -1,0 +1,36 @@
+-- Wiimms ISO Tools is distributed as a ZIP containing an argumentless plain
+-- EXE installer. The publisher's Windows instructions only say to start that
+-- executable, and the official uninstall implementation removes App Paths and
+-- PATH entries but does not remove the installed Program Files payload. An
+-- Intune package therefore cannot provide a complete, deterministic managed
+-- uninstall without inventing unsupported cleanup behavior.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Wiimm.ISO',
+  'unsupported_managed_uninstall',
+  'Wiimms ISO Tools 3.05a provides an argumentless nested EXE and its official Windows uninstall implementation removes PATH and App Paths entries without removing the installed Program Files payload. A complete unattended managed lifecycle is not available.',
+  'https://github.com/Wiimm/wiimms-iso-tools/blob/fc1c0b840cb3ac41ca6e4f1d5e16da12b47eab58/project/setup/windows-uninstall.sh'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Wiimm.ISO';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Wiimm.ISO'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Wiimm.ISO from automated managed packaging because its official Windows uninstall implementation does not remove the installed Program Files payload
- clear catalog verification and supersede terminal/queued QA rows
- use the shared package eligibility gate consumed by both portal uploads and the app catalog

## Evidence
- publisher uninstall source: https://github.com/Wiimm/wiimms-iso-tools/blob/fc1c0b840cb3ac41ca6e4f1d5e16da12b47eab58/project/setup/windows-uninstall.sh
- failed pre-VM QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32963233869

## Verification
- npm test -- lib/qa/migration-contract.test.ts (96 passed)
- npm run lint -- lib/qa/migration-contract.test.ts