### PR TITLE
Fix authenticated installer manifest preflight

### DIFF
--- a/lib/__tests__/manifest-api.test.ts
+++ b/lib/__tests__/manifest-api.test.ts
@@ -1032,6 +1032,25 @@ describe('getLiveInstallers trust semantics', () => {
     mockFetch.mockReset();
   });
 
+  it('uses the authenticated GitHub Contents API raw media endpoint', async () => {
+    mockFetch.mockResolvedValue(
+      yamlResponse('PackageIdentifier: Foo.Bar\nPackageVersion: 1.0+build\nInstallers: []\n')
+    );
+
+    await expect(getLiveInstallers('Foo.Bar', '1.0+build')).resolves.toEqual([]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/Bar/1.0%2Bbuild/Foo.Bar.installer.yaml?ref=master',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: expect.objectContaining({
+          Accept: 'application/vnd.github.raw+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        }),
+      })
+    );
+  });
+
   it('returns an empty list for an authoritative missing manifest', async () => {
     mockFetch.mockResolvedValue(notFound());
 
@@ -1178,7 +1197,7 @@ describe('getFullManifest description order', () => {
   it('prefers ShortDescription over Description, matching the catalog syncs', async () => {
     mockFetch.mockImplementation(async (input: unknown) => {
       const url = String(input);
-      if (url.endsWith('Foo.App.installer.yaml')) {
+      if (url.includes('Foo.App.installer.yaml')) {
         return yamlResponse(
           [
             'PackageIdentifier: Foo.App',
@@ -1208,9 +1227,10 @@ describe('getFullManifest description order', () => {
 
     // Common case stays at 3 parallel GitHub fetches (installer + en-US
     // locale + version manifest) with no extra DefaultLocale request
-    const githubCalls = mockFetch.mock.calls.filter((call) =>
-      String(call[0]).includes('raw.githubusercontent.com')
-    );
+    const githubCalls = mockFetch.mock.calls.filter((call) => {
+      const url = String(call[0]);
+      return url.includes('api.github.com') || url.includes('raw.githubusercontent.com');
+    });
     expect(githubCalls).toHaveLength(3);
   });
 });

--- a/lib/manifest-api.ts
+++ b/lib/manifest-api.ts
@@ -177,10 +177,17 @@ async function fetchInstallerManifestFromGitHub(
   version: string
 ): Promise<Record<string, unknown> | null> {
   const { basePath } = getManifestPaths(wingetId);
-  const url = `${GITHUB_RAW_BASE}/${basePath}/${version}/${wingetId}.installer.yaml`;
+  const manifestPath = `${basePath}/${version}/${wingetId}.installer.yaml`
+    .split('/')
+    .map(encodeURIComponent)
+    .join('/');
+  const url = `${GITHUB_API_BASE}/${manifestPath}?ref=master`;
 
   const response = await fetch(url, {
-    headers: githubReadHeaders('text/plain'),
+    headers: {
+      ...githubReadHeaders('application/vnd.github.raw+json'),
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
     cache: 'no-store',
   });
 


### PR DESCRIPTION
## Summary
- fetch strict installer manifests through GitHub's authenticated Contents API raw-media endpoint
- URL-encode manifest path segments and pin the REST API version
- preserve authoritative 404 and transient failure semantics

## Verification
- npm test -- lib/__tests__/manifest-api.test.ts (83 passed)
- npm test -- app/api/cron/qa-dispatch/route.test.ts lib/catalog-installer-reconciliation.test.ts (32 passed)
- npx eslint lib/manifest-api.ts lib/__tests__/manifest-api.test.ts
- npm run build:ci