### PR TITLE
fix: keep SEGGER installer observable

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -421,6 +421,17 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('keeps the SEGGER Embedded Studio installer observable within a bounded wait', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Segger.EmbeddedStudioARM',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('does not extend the blocked Acronis managed-uninstall lifecycle', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -300,6 +300,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallCompletionTimeoutMinutes: 15,
   },
   {
+    // SEGGER Embedded Studio's official unattended command created the full
+    // application tree and ARP registration during QA, but the vendor process
+    // remained quiet longer than the generic inactivity window. Preserve the
+    // official --silent --accept-license contract and make the shared PSADT
+    // wait observable and bounded for both QA and customer Intune packages.
+    wingetId: 'Segger.EmbeddedStudioARM',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // ZeeDrive's official MSI is a command wrapper that deliberately does not
     // register in Add/Remove Programs. Thinkscape documents COMMAND=Install,
     // versioned Program Files detection, and direct directory removal for its

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -971,6 +971,33 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
   });
 
+  it('binds the bounded SEGGER installer wait to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Segger.EmbeddedStudioARM',
+      displayName: 'SEGGER Embedded Studio for ARM',
+      publisher: 'SEGGER',
+      version: '8.28',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--silent --accept-license',
+      uninstallCommand: 'REGISTRY_UNINSTALL:SEGGER Embedded Studio for ARM',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { silentArgs: string; uninstallCommand: string };
+      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+    };
+
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.installer.silentArgs).toBe('--silent --accept-license');
+    expect(profile.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:SEGGER Embedded Studio for ARM'
+    );
+  });
+
   it('binds the bounded Webroot MSI wait to the QA execution profile', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Webroot.SecureAnywhere',


### PR DESCRIPTION
## Summary
- add a reviewed 15-minute completion window for Segger.EmbeddedStudioARM
- preserve the official vendor silent arguments and normal ARP lifecycle
- verify the adapter reaches the shared QA/customer PSADT package profile

## Evidence
The QA install created the full application tree and ARP registration, but remained quiet beyond the generic inactivity watchdog. The shared packager emits progress while enforcing this bounded deadline, so the fix applies to both QA and customer Intune packages.

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/dispatch.test.ts (173 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- npm run build:ci