### PR TITLE
fix: run SeqLens in user context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -272,6 +272,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' webcatalogltd.switchbar ', undefined)
     ).toBe('user');
+    expect(resolveApplicationInstallScope('SeqLens.SeqLens', 'machine')).toBe(
+      'user'
+    );
+    expect(resolveApplicationInstallScope(' seqlens.seqlens ', undefined)).toBe(
+      'user'
+    );
     expect(resolveApplicationInstallScope('AvaCC.AvaDesktop', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -202,6 +202,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // SeqLens' NSIS installer registers below the invoking account's
+    // LocalAppData even though WinGet omits Scope. Running it as LocalSystem
+    // records an uninstaller below systemprofile that is unavailable for the
+    // managed removal cycle. Keep QA and customer Intune packages in the
+    // intended signed-in user context instead.
+    // https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/32977854917
+    wingetId: 'SeqLens.SeqLens',
+    requiredInstallScope: 'user',
+  },
+  {
     // Zalo's NSIS bootstrapper is per-user even though its WinGet manifest
     // currently omits Scope. Under LocalSystem it registers a disposable
     // systemprofile path and leaves no usable vendor uninstaller.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -723,6 +723,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps SeqLens out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'SeqLens.SeqLens',
+      displayName: 'SeqLens',
+      publisher: 'SeqLens',
+      version: '26.13.1',
+      architecture: 'x64',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{30843803-C83D-591B-931A-DD9E4FBAA77C}:SeqLens',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\SeqLens_SeqLens',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
## Summary
- run SeqLens' per-user NSIS lifecycle in the signed-in user context
- prevent LocalSystem from registering a disposable systemprofile uninstaller
- verify the shared QA/customer PSADT profile uses user scope and HKCU detection

## Evidence
QA run 32977854917 installed and detected successfully, but its captured uninstaller resolved below LocalSystem's systemprofile and was unavailable during managed removal. WinGet omits Scope for this NSIS package.

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts lib/qa/dispatch.test.ts (174 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- npm run build:ci