### PR TITLE
Prevent QA candidate loss during GitHub Actions outages

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createServerClientMock, dispatchQaCandidateMock } = vi.hoisted(() => ({
+const { createServerClientMock, dispatchQaCandidateMock, getGitHubActionsHealthMock } = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
   dispatchQaCandidateMock: vi.fn(),
+  getGitHubActionsHealthMock: vi.fn(),
 }));
 
 vi.mock('@/lib/supabase', () => ({ createServerClient: createServerClientMock }));
 vi.mock('@/lib/qa/dispatch', () => ({ dispatchQaCandidate: dispatchQaCandidateMock }));
+vi.mock('@/lib/qa/github-actions-health', () => ({
+  getGitHubActionsHealth: getGitHubActionsHealthMock,
+}));
 
 import { GET, maxDuration } from './route';
 import { InstallerPreflightError } from '@/lib/installer-preflight';
@@ -219,6 +223,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   process.env.CRON_SECRET = 'test-cron-secret';
   dispatchQaCandidateMock.mockResolvedValue(undefined);
+  getGitHubActionsHealthMock.mockResolvedValue({ operational: true, status: 'operational' });
 });
 
 it('allows large installer preflight the same bounded window as customer packaging', () => {
@@ -263,6 +268,29 @@ describe('GET /api/cron/qa-dispatch', () => {
       success: true,
       dispatched: false,
       reason: 'packager_release_pending',
+    });
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile or dispatch while GitHub Actions is unavailable', async () => {
+    const row = candidate('catalog-default');
+    const { client, claimedIds } = createSupabaseStub([row]);
+    createServerClientMock.mockReturnValue(client);
+    getGitHubActionsHealthMock.mockResolvedValue({
+      operational: false,
+      status: 'major_outage',
+    });
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      dispatched: false,
+      reason: 'github_actions_unavailable',
+      githubActionsStatus: 'major_outage',
     });
     expect(claimedIds).toEqual([]);
     expect(dispatchQaCandidateMock).not.toHaveBeenCalled();

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -6,6 +6,7 @@ import { getQaPipelineControl, isQaPackagerReleaseReady } from '@/lib/qa/pipelin
 import { qaTimeoutRecoveryUpdate } from '@/lib/qa/recovery';
 import { InstallerPreflightError } from '@/lib/installer-preflight';
 import { isQaRunnerArchitectureSupported } from '@/lib/qa/candidate';
+import { getGitHubActionsHealth } from '@/lib/qa/github-actions-health';
 
 const DISPATCH_TIMEOUT_MS = 15 * 60 * 1000;
 const RUN_TIMEOUT_MS = 5 * 60 * 60 * 1000;
@@ -61,6 +62,15 @@ export async function GET(request: Request) {
       success: true,
       dispatched: false,
       reason: 'packager_release_pending',
+    });
+  }
+  const githubActions = await getGitHubActionsHealth();
+  if (!githubActions.operational) {
+    return NextResponse.json({
+      success: true,
+      dispatched: false,
+      reason: 'github_actions_unavailable',
+      githubActionsStatus: githubActions.status,
     });
   }
   const now = new Date();

--- a/lib/qa/github-actions-health.test.ts
+++ b/lib/qa/github-actions-health.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getGitHubActionsHealth } from './github-actions-health';
+
+describe('getGitHubActionsHealth', () => {
+  it('allows dispatch only when the Actions component is operational', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      components: [
+        { name: 'Git Operations', status: 'operational' },
+        { name: 'Actions', status: 'operational' },
+      ],
+    }), { status: 200 }));
+
+    await expect(getGitHubActionsHealth(fetchMock)).resolves.toEqual({
+      operational: true,
+      status: 'operational',
+    });
+  });
+
+  it('blocks dispatch during a reported Actions outage', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      components: [{ name: 'Actions', status: 'major_outage' }],
+    }), { status: 200 }));
+
+    await expect(getGitHubActionsHealth(fetchMock)).resolves.toEqual({
+      operational: false,
+      status: 'major_outage',
+    });
+  });
+
+  it('fails closed when the status response cannot be trusted', async () => {
+    const fetchMock = vi.fn(async () => new Response('unavailable', { status: 503 }));
+
+    await expect(getGitHubActionsHealth(fetchMock)).resolves.toEqual({
+      operational: false,
+      status: 'unknown',
+    });
+  });
+});

--- a/lib/qa/github-actions-health.ts
+++ b/lib/qa/github-actions-health.ts
@@ -1,0 +1,50 @@
+const GITHUB_STATUS_COMPONENTS_URL =
+  'https://www.githubstatus.com/api/v2/components.json';
+const GITHUB_STATUS_TIMEOUT_MS = 5_000;
+
+export interface GitHubActionsHealth {
+  operational: boolean;
+  status: string;
+}
+
+interface StatusPageComponent {
+  name?: unknown;
+  status?: unknown;
+}
+
+export async function getGitHubActionsHealth(
+  fetchImpl: typeof fetch = fetch
+): Promise<GitHubActionsHealth> {
+  try {
+    const response = await fetchImpl(GITHUB_STATUS_COMPONENTS_URL, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(GITHUB_STATUS_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return { operational: false, status: 'unknown' };
+    }
+
+    const payload = await response.json() as { components?: unknown };
+    if (!Array.isArray(payload.components)) {
+      return { operational: false, status: 'unknown' };
+    }
+
+    const actions = (payload.components as StatusPageComponent[]).find(
+      (component) => component.name === 'Actions'
+    );
+    if (typeof actions?.status !== 'string') {
+      return { operational: false, status: 'unknown' };
+    }
+
+    return {
+      operational: actions.status === 'operational',
+      status: actions.status,
+    };
+  } catch {
+    // QA can safely wait for the next cron tick. Failing closed prevents an
+    // unavailable status endpoint from consuming app attempts as false
+    // workflow-dispatch timeouts.
+    return { operational: false, status: 'unknown' };
+  }
+}


### PR DESCRIPTION
## Summary
- gate QA reconciliation and dispatch on the official GitHub Actions component status
- preserve active candidates while Actions is degraded or unavailable
- fail closed when the status response cannot be trusted

## Why
During the 2026-08-26 GitHub Actions outage, GitHub accepted a workflow dispatch but did not create a runnable job before the 15-minute lease expired. The scheduler consumed retry attempts and falsely terminalized a package as a safety timeout. This guard keeps infrastructure outages separate from installer results.

## Verification
- 23 focused Vitest tests passed
- ESLint passed for all changed files