### PR TITLE
fix: silence SketchUp Viewer uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -502,6 +502,12 @@ describe('application packaging adapters', () => {
       ).reviewedUninstallArguments
     ).toEqual(['-silent']);
     expect(
+      applyApplicationPackagingAdapter(
+        'Trimble.SketchUpViewer',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['-silent']);
+    expect(
       applyApplicationPackagingAdapter('Tricentis.NeoLoad', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['-q']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1309,6 +1309,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-silent'],
   },
   {
+    // SketchUp Viewer 2022 registers the same cached InstallShield removal
+    // contract as SketchUp Pro: -remove -runfromtemp without its unattended
+    // mode. QA run 32997644078 observed that command remained interactive under
+    // LocalSystem until the exact registration deadline. Reuse the proven
+    // SketchUp 2022 -silent removal argument for this specific catalog ID.
+    wingetId: 'Trimble.SketchUpViewer',
+    reviewedUninstallArguments: ['-silent'],
+  },
+  {
     // NeoLoad registers its install4j uninstaller without an unattended
     // argument. install4j documents -q for both installers and uninstallers;
     // append it to the exact captured registration instead of guessing a


### PR DESCRIPTION
## Summary
- extend the proven SketchUp 2022 InstallShield `-silent` uninstall adapter to `Trimble.SketchUpViewer`
- ensure the reviewed switch reaches both QA packages and customer web/catalog PSADT packages
- add regression coverage for the Viewer catalog ID

## Evidence
QA run 32997644078 installed and detected SketchUp Viewer 22.0.316 successfully, then timed out because the registered `-remove -runfromtemp` command remained interactive under LocalSystem. SketchUp Pro 2022 previously showed the same registration shape and passed end-to-end after adding `-silent`.

## Verification
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`
- `npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts` (169 passed)
- `npx vitest run lib/github-actions.test.ts lib/qa/psadt-packager-contract.test.ts packager/tests/psadt-nested-portable.test.ts` (210 passed)