### PR TITLE
chore(qa): activate SketchUp Viewer uninstall repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3887e769d1e6bfdea2027b73c1e287203aa8f3f7',
+  packagerCommit: 'ce809649aed63f1127aa256cbafb8d085e193951',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -422,6 +422,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // unattended install failed. Preserve every compatible passing result from
   // the Switchbar user-scope release.
   '8dde5049437903912ac003cea71e2fef0e85e86c',
+  // SEGGER's observable install wait, SeqLens' user context, and SketchUp
+  // Viewer's silent removal are all catalog-ID-scoped adapters. Preserve every
+  // unrelated compatible pass from the Ximalaya eligibility release.
+  '3887e769d1e6bfdea2027b73c1e287203aa8f3f7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,23 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries the catalog-scoped August 26 packaging fixes only after activation', () => {
+    for (const wingetId of [
+      ' Trimble.SketchUpViewer ',
+      ' SeqLens.SeqLens ',
+      ' Segger.EmbeddedStudioARM ',
+    ]) {
+      expect(shouldRetryTerminalToolchainCandidate(
+        QA_PSADT_TOOLCHAIN.packagerCommit,
+        { wingetId, status: 'failed' }
+      )).toBe(true);
+      expect(shouldRetryTerminalToolchainCandidate(
+        '3887e769d1e6bfdea2027b73c1e287203aa8f3f7',
+        { wingetId, status: 'failed' }
+      )).toBe(false);
+    }
+  });
+
   it('does not replay eligibility-blocked Ximalaya Live', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -317,7 +317,21 @@ const SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...WOWUP_BETA_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the failed Viewer 2022 lifecycle with the same reviewed -silent
+  // InstallShield removal mode already proven by SketchUp Pro 2022.
+  'Trimble.SketchUpViewer',
+  // Activate the two earlier catalog-scoped fixes that were intentionally held
+  // behind the prior immutable packager pin.
+  'SeqLens.SeqLens',
+  'Segger.EmbeddedStudioARM',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ce809649aed63f1127aa256cbafb8d085e193951':
+    SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   // Ximalaya Live is eligibility-blocked after its exact user-scope /S
   // lifecycle failed, so carry prior bounded targets without replaying it.
   '3887e769d1e6bfdea2027b73c1e287203aa8f3f7':


### PR DESCRIPTION
## Summary
- atomically advance the protected QA/customer packager pin to `ce809649aed63f1127aa256cbafb8d085e193951`
- preserve unrelated compatible passes from the prior packager release
- schedule bounded terminal retries for SketchUp Viewer, SeqLens, and SEGGER, whose catalog-scoped fixes are included in this immutable release

## Verification
- `npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts`
- release/profile/backfill suite: 293 passed
- scheduler/dispatch/gate suite: 65 passed