### PR TITLE
fix(packaging): block unsupported Q-Dir uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -478,7 +478,7 @@ describe('application packaging adapters', () => {
     expect(
       applyApplicationPackagingAdapter('SoftwareOK.Q-Dir', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
-    ).toEqual(['/silent', 'forall']);
+    ).toEqual([]);
     expect(
       applyApplicationPackagingAdapter('Google.GoogleDrive', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -824,10 +824,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
-    wingetId: 'SoftwareOK.Q-Dir',
-    reviewedUninstallArguments: ['/silent', 'forall'],
-  },
-  {
     // Dell Optimizer's registered InstallShield helper exits without removing
     // the product even with Dell's documented switches. Invoke the original,
     // hash-verified Dell Update Package instead; Dell documents the

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1558,3 +1558,26 @@ describe('Ximalaya Live managed install block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Q-Dir managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260826230401_block_qdir_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the repeatedly disproven vendor removal lifecycle', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'SoftwareOK.Q-Dir'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33008768166'
+    );
+    expect(sql).toContain('two isolated LocalSystem lifecycle runs');
+    expect(sql).toContain('Press any key to exit');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260826230401_block_qdir_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260826230401_block_qdir_unsupported_managed_uninstall.sql
@@ -1,0 +1,39 @@
+-- Q-Dir documents unattended installation with `-install /silent`, but its
+-- official support material does not document an unattended uninstall command:
+-- https://www.softwareok.com/?faq=23&seite=faq-Q-DIR
+-- https://www.softwareok.com/?faq=105&seite=faq-Q-DIR
+-- In two isolated LocalSystem lifecycle runs, the exact registered Q-Dir
+-- command already included `-uninstall /silent forall`. The process returned
+-- exit code 1, printed `Press any key to exit...`, and left the exact Q-Dir
+-- registration installed for the full bounded completion wait. The former
+-- reviewed-argument adapter did not establish a working managed lifecycle.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'SoftwareOK.Q-Dir',
+  'unsupported_managed_uninstall',
+  'Q-Dir installs unattended, but its exact registered removal command failed in two isolated LocalSystem lifecycle runs. The vendor process returned exit code 1, printed Press any key to exit, and left the exact Q-Dir registration installed; the vendor does not document a supported unattended uninstall contract.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33008768166'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'SoftwareOK.Q-Dir';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'SoftwareOK.Q-Dir'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- remove the unproven Q-Dir reviewed uninstall-argument adapter
- block Q-Dir through the shared customer/QA package eligibility gate
- supersede open Q-Dir QA candidates and clear catalog verification

## Evidence
- runs 31558446443 and 33008768166 both installed and detected successfully, then left exact registration Q-Dir after the bounded LocalSystem uninstall wait
- the registered command already contained -uninstall /silent forall; the vendor process returned 1 and printed Press any key to exit
- official vendor material documents unattended installation but not an unattended uninstall contract

## Verification
- 172 focused adapter and migration tests passed
- package-profile tests passed in the combined run
- touched-file ESLint passed
- generated-PSADT suite reached 122/131 passing; the nine failures are existing PowerShell 7.6 error-format assertion mismatches, not generated-package failures