### PR TITLE
chore(qa): activate Q-Dir eligibility release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ce809649aed63f1127aa256cbafb8d085e193951',
+  packagerCommit: '12fed0efb16de79951e9d3761c737aa382560e12',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -426,6 +426,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Viewer's silent removal are all catalog-ID-scoped adapters. Preserve every
   // unrelated compatible pass from the Ximalaya eligibility release.
   '3887e769d1e6bfdea2027b73c1e287203aa8f3f7',
+  // Q-Dir is now rejected by the shared eligibility gate after its exact
+  // registered command failed twice. Removing its unproven adapter does not
+  // invalidate any unrelated passing package profile.
+  'ce809649aed63f1127aa256cbafb8d085e193951',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -34,6 +34,17 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('ximalaya.ximalayalive');
   });
 
+  it('does not replay Q-Dir after activating its managed-uninstall block', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' softwareok.q-dir ', status: 'failed' }
+    )).toBe(false);
+    expect(
+      terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)
+        .map((wingetId) => wingetId.toLowerCase())
+    ).not.toContain('softwareok.q-dir');
+  });
+
   it('does not replay DesktopOK after activating its managed-uninstall block', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -329,7 +329,16 @@ const SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...SWITCHBAR_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Q-Dir is eligibility-blocked after two isolated runs disproved its exact
+  // registered removal command. Carry the remaining bounded retries without
+  // replaying the unsupported lifecycle.
+  ...SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '12fed0efb16de79951e9d3761c737aa382560e12':
+    QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS,
   'ce809649aed63f1127aa256cbafb8d085e193951':
     SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
   // Ximalaya Live is eligibility-blocked after its exact user-scope /S


### PR DESCRIPTION
## Summary
- pin the QA package profile to the protected Q-Dir eligibility release
- preserve compatible passing results from the prior packager
- carry outstanding targeted retries without replaying blocked Q-Dir

## Verification
- 284 package-profile, backfill, gate, enqueue, and dispatch tests passed
- touched-file ESLint passed