### PR TITLE
Run SeaMeet Snap Recorder packages in user context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -304,6 +304,14 @@ describe('application packaging adapters', () => {
       ' ultimategadgetlaboratories.uhkagent ',
       undefined
     )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      'SeasaltAI.SeaMeetSnapRecorder',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      ' seasaltai.seameetsnaprecorder ',
+      undefined
+    )).toBe('user');
     expect(
       resolveApplicationInstallScope('RedisInsight.RedisInsight', 'machine')
     ).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -257,6 +257,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // SeaMeet Snap Recorder's Nullsoft installer writes its application and
+    // exact uninstall registration below the invoking account's LocalAppData,
+    // while its WinGet manifest omits Scope. Under LocalSystem, QA run
+    // 33046444278 captured a systemprofile uninstaller that was already absent
+    // by the managed removal cycle. Keep the shared customer package and QA
+    // lifecycle in the intended signed-in user context instead.
+    wingetId: 'SeasaltAI.SeaMeetSnapRecorder',
+    requiredInstallScope: 'user',
+  },
+  {
     // RedisInsight 3.4.2's tagged Electron Builder configuration explicitly
     // sets NSIS perMachine=false. WinGet omits Scope, so the generic machine
     // default installs below LocalSystem's disposable systemprofile and records

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -751,6 +751,35 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps SeaMeet Snap Recorder out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'SeasaltAI.SeaMeetSnapRecorder',
+      displayName: 'SeaMeet Snap Recorder',
+      publisher: 'SeasaltAI',
+      version: '3.6.2',
+      architecture: 'x64',
+      installerSha256: 'e'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:5fd06921-7b39-5610-a9f4-36171cefce37:SeaMeet Snap Recorder',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\SeasaltAI_SeaMeetSnapRecorder',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
## Summary
- run SeasaltAI.SeaMeetSnapRecorder in the signed-in user context
- keep exact QA and customer PSADT packaging behavior aligned
- add adapter and normalized package-profile regression coverage

## Root cause
The WinGet Nullsoft manifest omits Scope, so the generic machine default executed under LocalSystem. QA run 33046444278 captured the exact registration under systemprofile, but its registered uninstaller path was already absent at removal time. The app installed and detected, then failed uninstall with 60001 and remained detected.

## Verification
- 170 focused adapter/package-profile tests passed
- 29 QA test-configuration tests passed
- touched-file ESLint passed
- git diff --check passed