### PR TITLE
Activate SeaMeet user-scope repair in QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '12fed0efb16de79951e9d3761c737aa382560e12',
+  packagerCommit: '8712fc3a1a0239d34083952cda0f0a6676d0bb18',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -430,6 +430,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // registered command failed twice. Removing its unproven adapter does not
   // invalidate any unrelated passing package profile.
   'ce809649aed63f1127aa256cbafb8d085e193951',
+  // SeaMeet Snap Recorder now runs in the NSIS installer's intended signed-in
+  // user context. Preserve every unrelated pass from the Q-Dir eligibility
+  // release.
+  '12fed0efb16de79951e9d3761c737aa382560e12',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries SeaMeet Snap Recorder only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' seasaltai.seameetsnaprecorder ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '12fed0efb16de79951e9d3761c737aa382560e12',
+      { wingetId: 'SeasaltAI.SeaMeetSnapRecorder', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries the catalog-scoped August 26 packaging fixes only after activation', () => {
     for (const wingetId of [
       ' Trimble.SketchUpViewer ',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -336,7 +336,17 @@ const QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...SKETCHUPVIEWER_SILENT_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 3.6.2 lifecycle in the NSIS installer's intended signed-in
+  // user context instead of LocalSystem's disposable systemprofile.
+  'SeasaltAI.SeaMeetSnapRecorder',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '8712fc3a1a0239d34083952cda0f0a6676d0bb18':
+    SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '12fed0efb16de79951e9d3761c737aa382560e12':
     QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS,
   'ce809649aed63f1127aa256cbafb8d085e193951':


### PR DESCRIPTION
## Summary
- advance the QA packager pin to the merged SeaMeet user-scope repair
- preserve compatible passes from the prior Q-Dir eligibility release
- schedule a bounded retry for the failed SeaMeet lifecycle only on the new pin

## Verification
- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts (221 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check