### PR TITLE
Run Brity Meeting packages in user context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -312,6 +312,11 @@ describe('application packaging adapters', () => {
       ' seasaltai.seameetsnaprecorder ',
       undefined
     )).toBe('user');
+    expect(resolveApplicationInstallScope('SamsungSDS.BrityMeeting', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(
+      ' samsungsds.britymeeting ',
+      undefined
+    )).toBe('user');
     expect(
       resolveApplicationInstallScope('RedisInsight.RedisInsight', 'machine')
     ).toBe('user');

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -267,6 +267,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Brity Meeting is an interactive desktop client whose WinGet manifest
+    // supplies -s but omits Scope. Under LocalSystem, QA run 33050008107 saw
+    // the installer exit 1 without creating its declared uninstall entry or
+    // any detectable application. Run the identical reviewed vendor command
+    // in the intended signed-in user context instead of systemprofile.
+    wingetId: 'SamsungSDS.BrityMeeting',
+    requiredInstallScope: 'user',
+  },
+  {
     // RedisInsight 3.4.2's tagged Electron Builder configuration explicitly
     // sets NSIS perMachine=false. WinGet omits Scope, so the generic machine
     // default installs below LocalSystem's disposable systemprofile and records

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -780,6 +780,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Brity Meeting out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'SamsungSDS.BrityMeeting',
+      displayName: 'Brity Meeting',
+      publisher: 'SamsungSDS',
+      version: '2.7.26.07281',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '-s',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:SamsungBrityMeeting:Brity Meeting',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\SamsungSDS_BrityMeeting',
+      }),
+    ]);
+  });
+
   it('binds MiKTeX to its documented unattended integrated setup lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'MiKTeX.MiKTeX',


### PR DESCRIPTION
## Summary
- keep Samsung Brity Meeting out of LocalSystem when WinGet omits installer scope
- preserve the manifest-declared vendor silent switch while running the desktop client for the signed-in user
- generate HKCU detection for the same shared customer and QA PSADT profile

## Failure evidence
- QA run 33050008107: install 1, detection 1, no declared ARP entry, uninstall 60001

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (171 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check