### PR TITLE
Activate Brity Meeting user-scope repair in QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8712fc3a1a0239d34083952cda0f0a6676d0bb18',
+  packagerCommit: '105adee4044b86a29f824581c8383cbd06101eae',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -434,6 +434,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // user context. Preserve every unrelated pass from the Q-Dir eligibility
   // release.
   '12fed0efb16de79951e9d3761c737aa382560e12',
+  // Brity Meeting now runs in the desktop client's intended signed-in user
+  // context. Preserve every unrelated pass from the SeaMeet user-scope release.
+  '8712fc3a1a0239d34083952cda0f0a6676d0bb18',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Brity Meeting only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' samsungsds.britymeeting ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '8712fc3a1a0239d34083952cda0f0a6676d0bb18',
+      { wingetId: 'SamsungSDS.BrityMeeting', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries SeaMeet Snap Recorder only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -344,7 +344,17 @@ const SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...QDIR_UNSUPPORTED_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 2.7.26.07281 lifecycle with the same vendor -s command in
+  // the desktop client's intended signed-in user context.
+  'SamsungSDS.BrityMeeting',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '105adee4044b86a29f824581c8383cbd06101eae':
+    BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '8712fc3a1a0239d34083952cda0f0a6676d0bb18':
     SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '12fed0efb16de79951e9d3761c737aa382560e12':


### PR DESCRIPTION
## Summary
- advance the QA packager pin to the merged Brity Meeting user-scope repair
- preserve compatible passes from the SeaMeet release
- schedule a bounded Brity Meeting retry only on the new pin

## Verification
- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts (223 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check