### PR TITLE
Fix reboot-required uninstall verification

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -3642,7 +3642,9 @@ if ($useManagedDirectoryLifecycle) {
             '        if ($remainingApplications.Count -eq 0) { break }'
             '        if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }'
             '    }'
-            '    if ($remainingApplications.Count -gt 0) {'
+            '    if ($remainingApplications.Count -gt 0 -and $uninstallProcessExitCode -in @(1641, 3010)) {'
+            '        Write-ADTLogEntry -Message "The Burn uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '    } elseif ($remainingApplications.Count -gt 0) {'
             '        throw "The captured Burn/MSI uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."'
             '    }'
         )
@@ -3868,7 +3870,9 @@ if ($useManagedDirectoryLifecycle) {
             '        if ($remainingApplications.Count -eq 0) { break }'
             '        if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }'
             '    }'
-            '    if ($remainingApplications.Count -gt 0) {'
+            '    if ($remainingApplications.Count -gt 0 -and $uninstallProcessExitCode -in @(1641, 3010)) {'
+            '        Write-ADTLogEntry -Message "The vendor uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '    } elseif ($remainingApplications.Count -gt 0) {'
             '        throw "The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."'
             '    }'
         )

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3397,6 +3397,11 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(packager).toContain(
       'continuing to wait for exact registration [$registeredUninstallRegistryKey] because a child process may still be working'
     );
+    for (const source of [packager, hostedPackager]) {
+      expect(source).toContain(
+        'The vendor uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot.'
+      );
+    }
     expect(packager).not.toContain('TotalSeconds -ge 15');
   });
 
@@ -3427,6 +3432,11 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(packager).toContain(
       'The Burn uninstaller requested a reboot with exit code [$uninstallProcessExitCode].'
     );
+    for (const source of [packager, hostedPackager]) {
+      expect(source).toContain(
+        'The Burn uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot.'
+      );
+    }
   });
 
   it('reuses only independently safe manifest switches for uninstall', () => {

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1864,7 +1864,9 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
         if ($remainingApplications.Count -eq 0) { break }
         if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
     }
-    if ($remainingApplications.Count -gt 0) {
+    if ($remainingApplications.Count -gt 0 -and $uninstallProcessExitCode -in @(1641, 3010)) {
+        Write-ADTLogEntry -Message "The Burn uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+    } elseif ($remainingApplications.Count -gt 0) {
         throw "The Burn uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."
     }
     }`;
@@ -2008,7 +2010,9 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
         if ($remainingApplications.Count -eq 0) { break }
         if ($verificationAttempt -lt 5) { Start-Sleep -Seconds 2 }
     }
-    if ($remainingApplications.Count -gt 0) {
+    if ($remainingApplications.Count -gt 0 -and $uninstallProcessExitCode -in @(1641, 3010)) {
+        Write-ADTLogEntry -Message "The vendor uninstaller returned reboot-required exit code [$uninstallProcessExitCode]; the exact registration remains pending reboot." -Severity 'Warning' -Source 'Uninstall-ADTDeployment'
+    } elseif ($remainingApplications.Count -gt 0) {
         throw "The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."
     }`;
     }


### PR DESCRIPTION
## Summary
- accept a residual exact uninstall registration only when the vendor uninstaller explicitly returns reboot-required 1641 or 3010
- preserve fail-closed registration verification for all other exit codes
- apply the same lifecycle behavior to the repository QA packager and hosted customer packager
- add shared contract coverage for both Burn and generic registry uninstall paths

## Production QA evidence
Datto.WindowsAgent 3.0.18.24 installed and detected successfully. Its exact registered Burn uninstaller returned 3010, but the ARP registration correctly remained pending reboot, causing the prior packager to return 60001. This change preserves the 3010 reboot signal so Intune can complete the lifecycle normally.

## Validation
- npm test -- lib/qa/psadt-packager-contract.test.ts (131 passed)
- npx eslint packager/src/job-processor.ts lib/qa/psadt-packager-contract.test.ts
- git diff --check