### PR TITLE
Activate reboot-required uninstall repair in QA

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '105adee4044b86a29f824581c8383cbd06101eae',
+  packagerCommit: '80675c437cc4fe894c8b65a08b8e98ed80a25138',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -437,6 +437,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Brity Meeting now runs in the desktop client's intended signed-in user
   // context. Preserve every unrelated pass from the SeaMeet user-scope release.
   '8712fc3a1a0239d34083952cda0f0a6676d0bb18',
+  // Explicit reboot-required uninstall results can leave an exact registration
+  // pending restart. Preserve every pass from the Brity Meeting release.
+  '105adee4044b86a29f824581c8383cbd06101eae',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Datto only after activating reboot-required uninstall handling', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' datto.windowsagent ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '105adee4044b86a29f824581c8383cbd06101eae',
+      { wingetId: 'Datto.WindowsAgent', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Brity Meeting only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -352,7 +352,17 @@ const BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...SEAMEET_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 3.0.18.24 lifecycle while preserving the vendor Burn
+  // uninstaller's explicit 3010 pending-reboot completion signal.
+  'Datto.WindowsAgent',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '80675c437cc4fe894c8b65a08b8e98ed80a25138':
+    REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '105adee4044b86a29f824581c8383cbd06101eae':
     BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '8712fc3a1a0239d34083952cda0f0a6676d0bb18':


### PR DESCRIPTION
## Summary
- advance the shared QA/customer packager pin to the merged reboot-required uninstall repair
- preserve compatible passes from the Brity Meeting release
- schedule a bounded Datto.WindowsAgent retry only on the new pin

## Verification
- npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts (224 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check