### PR TITLE
Fix Luniq per-user packaging scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -284,6 +284,12 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' avacc.avadesktop ', undefined)).toBe(
       'user'
     );
+    expect(resolveApplicationInstallScope('saraansx.Luniq', 'machine')).toBe(
+      'user'
+    );
+    expect(resolveApplicationInstallScope(' saraansx.luniq ', undefined)).toBe(
+      'user'
+    );
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
       resolveApplicationInstallScope(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -161,6 +161,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Luniq's published Electron Builder configuration sets NSIS perMachine to
+    // false and allowElevation to false. WinGet currently omits Scope, so the
+    // generic machine default installs below LocalSystem's systemprofile and
+    // captures an uninstaller path that is unavailable by the removal cycle.
+    // Keep QA and customer Intune packages in the vendor-supported user context.
+    // https://github.com/saraansx/Luniq-Music/blob/main/electron-builder.json
+    wingetId: 'saraansx.Luniq',
+    requiredInstallScope: 'user',
+  },
+  {
     // ElegantClipboard's tagged Tauri v2 configuration explicitly builds its
     // NSIS installer with installMode=currentUser, while the WinGet manifest
     // omits Scope. The generic machine default installs below LocalSystem's

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -638,6 +638,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Luniq out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'saraansx.Luniq',
+      displayName: 'Luniq',
+      publisher: 'saraansx',
+      version: '2.0.1',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{75473D6D-5D57-5DE9-A4C2-E43CA90D272C}:Luniq',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\saraansx_Luniq',
+      }),
+    ]);
+  });
+
   it('keeps Android Apps Manager out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SIMSDEV.AndroidAppsManager',


### PR DESCRIPTION
## Summary
- run Luniq's NSIS package in its vendor-supported per-user context
- prevent LocalSystem systemprofile installations with disposable uninstall paths
- cover both adapter resolution and the QA package identity/detection marker

## Evidence
- QA run 33058970682 installed successfully but captured a missing systemprofile uninstaller and returned 60001
- the upstream Electron Builder configuration sets perMachine=false and allowElevation=false

## Validation
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (172 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check