### PR TITLE
chore: activate PowerShell uninstaller packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '80675c437cc4fe894c8b65a08b8e98ed80a25138',
+  packagerCommit: '68a58563b15a5b09d32afa6a4d805e61a9e5635f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -440,6 +440,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Explicit reboot-required uninstall results can leave an exact registration
   // pending restart. Preserve every pass from the Brity Meeting release.
   '105adee4044b86a29f824581c8383cbd06101eae',
+  // Registered PowerShell -File uninstall commands are now resolved through a
+  // bounded inbox-host contract. Preserve every pass from the reboot release.
+  '80675c437cc4fe894c8b65a08b8e98ed80a25138',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries NammaAgent only after activating registered PowerShell uninstall resolution', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' santhoshreddy352.nammaagent ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '80675c437cc4fe894c8b65a08b8e98ed80a25138',
+      { wingetId: 'SanthoshReddy352.NammaAgent', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Datto only after activating reboot-required uninstall handling', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -360,7 +360,17 @@ const REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...BRITYMEETING_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry NammaAgent now that its exact registered powershell -File
+  // uninstaller can be resolved below the captured install location.
+  'SanthoshReddy352.NammaAgent',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '68a58563b15a5b09d32afa6a4d805e61a9e5635f':
+    POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '80675c437cc4fe894c8b65a08b8e98ed80a25138':
     REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '105adee4044b86a29f824581c8383cbd06101eae':


### PR DESCRIPTION
## Summary
- activate packager commit 68a58563b15a5b09d32afa6a4d805e61a9e5635f
- preserve compatible passes from the previous release
- target NammaAgent for a repaired lifecycle replay

## Validation
- 226 targeted Vitest tests passed
- touched-file ESLint passed
- git diff --check passed