### PR TITLE
Fix MD Editor MSI execution scope

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -419,6 +419,21 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('runs MD Editor\'s machine-scoped Tauri MSI as LocalSystem', () => {
+    expect(
+      resolveApplicationInstallScope('rushabhpasad.MDEditor', 'user')
+    ).toBe('machine');
+    expect(
+      resolveApplicationInstallerSelectionScope(
+        'rushabhpasad.MDEditor',
+        'machine'
+      )
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' rushabhpasad.mdeditor ', 'user')
+    ).toBe('machine');
+  });
+
   it('models Tor Browser as the vendor-documented extracted user folder', () => {
     expect(
       applyApplicationPackagingAdapter('TorProject.TorBrowser', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -507,6 +507,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /ALLUSERS',
   },
   {
+    // MD Editor's WinGet manifest labels the published MSI as per-user, but
+    // the tagged Tauri configuration builds every target and Tauri's WiX MSI
+    // template hard-codes InstallScope="perMachine" under Program Files. A
+    // standard-user launch therefore returns MSI 1603 before registration.
+    // Keep selecting and attesting the catalog's user-labelled MSI bytes while
+    // executing that machine-wide vendor package as LocalSystem for Intune.
+    // https://github.com/rushabhpasad/md-editor/blob/v1.1.0/src-tauri/tauri.conf.json
+    // https://github.com/tauri-apps/tauri/blob/tauri-v2.10.1/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
+    wingetId: 'rushabhpasad.MDEditor',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+  },
+  {
     // WPS Office is cataloged as a per-user EXE, but the signed installer
     // elevates even with its exact -S switch. A standard-user launch therefore
     // ends at the unattended UAC boundary without creating the registered


### PR DESCRIPTION
## Summary
- correct `rushabhpasad.MDEditor` execution to machine scope while preserving selection of the exact user-labelled WinGet MSI
- document the mismatch between the WinGet manifest and Tauri's WiX `InstallScope="perMachine"` template
- cover execution-scope and installer-selection-scope behavior with a regression test

## Failure evidence
QA run `33078731063` launched the MSI as a standard user and returned `1603` before any product registration. The exact v1.1.0 source builds all Tauri targets, and the matching Tauri v2.10.1 WiX template installs the MSI per-machine under Program Files.

## Validation
- `npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts` (173 passed)
- `npm test -- lib/db/__tests__/sqlite.test.ts lib/catalog/snapshot-source.test.ts scripts/maybe-translate.test.ts` (54 passed after rebuilding the lockfile-pinned native SQLite dependency)
- `npm run lint`
- `git diff --check`

`npx tsc --noEmit` remains red on the unchanged repository baseline because test files are included without Vitest globals and existing test fixtures have unrelated type drift.