### PR TITLE
Activate MD Editor MSI scope fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '68a58563b15a5b09d32afa6a4d805e61a9e5635f',
+  packagerCommit: '43fbb6c586da8919c35c7409a38377b8188914c2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -443,6 +443,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Registered PowerShell -File uninstall commands are now resolved through a
   // bounded inbox-host contract. Preserve every pass from the reboot release.
   '80675c437cc4fe894c8b65a08b8e98ed80a25138',
+  // MD Editor's reviewed scope adapter changes only its previously failing
+  // user-launched machine MSI. Preserve every unrelated compatible pass from
+  // the registered PowerShell uninstall release.
+  '68a58563b15a5b09d32afa6a4d805e61a9e5635f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,17 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries MD Editor only after activating its machine-scope MSI adapter', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' rushabhpasad.mdeditor ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '68a58563b15a5b09d32afa6a4d805e61a9e5635f',
+      { wingetId: 'rushabhpasad.MDEditor', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries NammaAgent only after activating registered PowerShell uninstall resolution', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -368,7 +368,17 @@ const POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const MDEDITOR_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 1.1.0 lifecycle as LocalSystem because the exact Tauri
+  // WiX MSI is machine-scoped despite its user-labelled WinGet manifest.
+  'rushabhpasad.MDEditor',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '43fbb6c586da8919c35c7409a38377b8188914c2':
+    MDEDITOR_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   '68a58563b15a5b09d32afa6a4d805e61a9e5635f':
     POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '80675c437cc4fe894c8b65a08b8e98ed80a25138':


### PR DESCRIPTION
## Summary
- activate immutable packager commit `43fbb6c586da8919c35c7409a38377b8188914c2`
- retain `68a58563b15a5b09d32afa6a4d805e61a9e5635f` in compatible pass history because the change is confined to MD Editor
- enqueue failed `rushabhpasad.MDEditor` as the first terminal retry while carrying prior unconsumed targets

## Validation
- `npm test -- lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts lib/packaging-adapters.test.ts` (303 passed)
- targeted ESLint on all changed files
- `git diff --check`