### PR TITLE
Fix MD Editor LocalSystem desktop resolution

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -432,6 +432,15 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' rushabhpasad.mdeditor ', 'user')
     ).toBe('machine');
+    expect(
+      applyApplicationPackagingAdapter(
+        'rushabhpasad.MDEditor',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallArgumentsOverride:
+        '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
+    });
   });
 
   it('models Tor Browser as the vendor-documented extracted user folder', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -511,13 +511,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // the tagged Tauri configuration builds every target and Tauri's WiX MSI
     // template hard-codes InstallScope="perMachine" under Program Files. A
     // standard-user launch therefore returns MSI 1603 before registration.
-    // Keep selecting and attesting the catalog's user-labelled MSI bytes while
-    // executing that machine-wide vendor package as LocalSystem for Intune.
+    // Its desktop-shortcut component is nevertheless rooted at DesktopFolder;
+    // under LocalSystem the clean VM resolves that to a literal
+    // %USERPROFILE%\Desktop and CostFinalize returns 1603. Pin the directory to
+    // the Windows public desktop so the vendor's machine-wide shortcut remains
+    // visible to users and the same deterministic MSI contract is used by QA
+    // and customer packages.
     // https://github.com/rushabhpasad/md-editor/blob/v1.1.0/src-tauri/tauri.conf.json
     // https://github.com/tauri-apps/tauri/blob/tauri-v2.10.1/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
     wingetId: 'rushabhpasad.MDEditor',
     requiredInstallScope: 'machine',
     reviewedInstallerSelectionScope: 'user',
+    reviewedInstallArgumentsOverride:
+      '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
   },
   {
     // WPS Office is cataloged as a per-user EXE, but the signed installer

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1295,6 +1295,38 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds MD Editor to the reviewed machine-wide public desktop contract', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'rushabhpasad.MDEditor',
+      displayName: 'MD Editor',
+      publisher: 'rpasad',
+      version: '1.1.0',
+      architecture: 'x64',
+      installerSha256: 'c'.repeat(64),
+      installerType: 'msi',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand:
+        'msiexec /x "{F55BC603-EAB6-45CB-B5D9-571FAF94490D}" /qn /norestart',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallArgumentsOverride?: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
+    expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
+      '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"'
+    );
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      reviewedInstallArgumentsOverride:
+        '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
+    });
+  });
+
   it('binds WPS Office to the elevated managed deployment context', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Kingsoft.WPSOffice',


### PR DESCRIPTION
## Summary
- keep the exact WinGet-attested MDEditor MSI in machine scope
- supply the public desktop directory required by its Tauri WiX shortcut component under LocalSystem
- bind the reviewed override into the shared QA and customer PSADT profile

## Failure evidence
The preserved clean-VM MSI log from QA run 33087535190 reaches CostFinalize with DesktopFolder resolved as the literal %USERPROFILE%\\Desktop, then immediately returns 1603 before product registration. The tagged Tauri WiX template defines a per-machine MSI but roots its desktop shortcut at the per-user DesktopFolder.

## Validation
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (174 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check