### PR TITLE
fix(packager): skip broken MD Editor shortcuts

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -439,7 +439,7 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedInstallArgumentsOverride:
-        '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
+        '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
     });
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -511,19 +511,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // the tagged Tauri configuration builds every target and Tauri's WiX MSI
     // template hard-codes InstallScope="perMachine" under Program Files. A
     // standard-user launch therefore returns MSI 1603 before registration.
-    // Its desktop-shortcut component is nevertheless rooted at DesktopFolder;
-    // under LocalSystem the clean VM resolves that to a literal
-    // %USERPROFILE%\Desktop and CostFinalize returns 1603. Pin the directory to
-    // the Windows public desktop so the vendor's machine-wide shortcut remains
-    // visible to users and the same deterministic MSI contract is used by QA
-    // and customer packages.
+    // Its shortcut feature nevertheless combines per-user HKCU components with
+    // a DesktopFolder component inside the per-machine package. Windows
+    // Installer aborts in CostFinalize under LocalSystem before registration,
+    // even when DesktopFolder is redirected to the public desktop. Exclude only
+    // that broken feature; the Environment feature still installs the main
+    // binary while IntuneGet supplies deterministic detection and uninstall.
     // https://github.com/rushabhpasad/md-editor/blob/v1.1.0/src-tauri/tauri.conf.json
     // https://github.com/tauri-apps/tauri/blob/tauri-v2.10.1/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
     wingetId: 'rushabhpasad.MDEditor',
     requiredInstallScope: 'machine',
     reviewedInstallerSelectionScope: 'user',
     reviewedInstallArgumentsOverride:
-      '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
+      '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
   },
   {
     // WPS Office is cataloged as a per-user EXE, but the signed installer

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1295,7 +1295,7 @@ describe('PSADT QA package identity', () => {
     );
   });
 
-  it('binds MD Editor to the reviewed machine-wide public desktop contract', () => {
+  it('binds MD Editor to the reviewed machine-wide no-shortcuts contract', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'rushabhpasad.MDEditor',
       displayName: 'MD Editor',
@@ -1319,11 +1319,11 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.installScope).toBe('machine');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"'
+      '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature'
     );
     expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
       reviewedInstallArgumentsOverride:
-        '/qn /norestart ALLUSERS=1 DesktopFolder="C:\\Users\\Public\\Desktop"',
+        '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
     });
   });
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1749,6 +1749,33 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'excludes the broken MD Editor shortcut feature from the machine MSI',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi',
+        'MD Editor',
+        [],
+        {
+          reviewedInstallArgumentsOverride:
+            '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
+        },
+        [],
+        'rushabhpasad.MDEditor',
+        'MD Editor',
+        '1.1.0',
+        'msiexec /x "{F55BC603-EAB6-45CB-B5D9-571FAF94490D}" /qn /norestart',
+        '/qn /norestart ALLUSERS=1',
+        'machine'
+      );
+
+      expect(generated).toContain(
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=1 REMOVE=ShortcutsFeature'"
+      );
+      expect(generated).not.toContain('DesktopFolder=');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'strips the complete MSI quiet token without leaking a trailing fragment',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- replace the ineffective DesktopFolder redirect with the vendor MSI's feature-level exclusion
- keep MD Editor machine-wide while excluding only its broken per-user shortcut feature
- verify the exact generated PSADT MSI command used by QA and customer packages

## Evidence
- corrected QA run 33091613715 applied the public-desktop override but still failed in Windows Installer CostFinalize before registration
- the vendor Tauri WiX template places HKCU shortcut components under a per-machine package
- targeted tests: 308 passed
- targeted ESLint and git diff checks passed