### PR TITLE
Fix MD Editor MSI feature selection

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -439,7 +439,7 @@ describe('application packaging adapters', () => {
       )
     ).toMatchObject({
       reviewedInstallArgumentsOverride:
-        '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
+        '/qn /norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External',
     });
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -514,16 +514,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // Its shortcut feature nevertheless combines per-user HKCU components with
     // a DesktopFolder component inside the per-machine package. Windows
     // Installer aborts in CostFinalize under LocalSystem before registration,
-    // even when DesktopFolder is redirected to the public desktop. Exclude only
-    // that broken feature; the Environment feature still installs the main
-    // binary while IntuneGet supplies deterministic detection and uninstall.
+    // even when DesktopFolder is redirected to the public desktop. Explicitly
+    // select the required parent, binary, and external features so MSI does not
+    // select the broken nested ShortcutsFeature. REMOVE=ShortcutsFeature is not
+    // valid here: this MSI rewrites it to REMOVE=ALL during InstallValidate.
     // https://github.com/rushabhpasad/md-editor/blob/v1.1.0/src-tauri/tauri.conf.json
     // https://github.com/tauri-apps/tauri/blob/tauri-v2.10.1/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
     wingetId: 'rushabhpasad.MDEditor',
     requiredInstallScope: 'machine',
     reviewedInstallerSelectionScope: 'user',
     reviewedInstallArgumentsOverride:
-      '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
+      '/qn /norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External',
   },
   {
     // WPS Office is cataloged as a per-user EXE, but the signed installer

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1319,11 +1319,11 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.installScope).toBe('machine');
     expect(profile.installer.silentArgs).toBe('/qn /norestart ALLUSERS=1');
     expect(profile.psadtConfig.reviewedInstallArgumentsOverride).toBe(
-      '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature'
+      '/qn /norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External'
     );
     expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
       reviewedInstallArgumentsOverride:
-        '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
+        '/qn /norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External',
     });
   });
 

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1757,7 +1757,7 @@ describe('PSADT vendor argument contract', () => {
         [],
         {
           reviewedInstallArgumentsOverride:
-            '/qn /norestart ALLUSERS=1 REMOVE=ShortcutsFeature',
+            '/qn /norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External',
         },
         [],
         'rushabhpasad.MDEditor',
@@ -1769,7 +1769,7 @@ describe('PSADT vendor argument contract', () => {
       );
 
       expect(generated).toContain(
-        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=1 REMOVE=ShortcutsFeature'"
+        "Start-ADTMsiProcess -Action 'Install' -FilePath 'setup.exe' -AdditionalArgumentList '/norestart ALLUSERS=1 ADDLOCAL=MainProgram,Environment,External'"
       );
       expect(generated).not.toContain('DesktopFolder=');
     }


### PR DESCRIPTION
## Summary`n- replace REMOVE=ShortcutsFeature, which this MSI rewrites to REMOVE=ALL`n- explicitly select MainProgram, Environment, and External while omitting the broken nested shortcut feature`n- update adapter, canonical package profile, and generated PSADT contract coverage`n`n## Verification`n- 308 targeted tests passed`n- targeted ESLint passed`n- git diff --check passed