### PR TITLE
Fix ROBOTC silent uninstall in QA packages

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -605,6 +605,18 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
+        'Robomatter.ROBOTC.LEGOMindstorms',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedExactUninstall: {
+        executablePath: '%PackageInstaller%',
+        arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
+        completionTimeoutMinutes: 10,
+      },
+    });
+    expect(
+      applyApplicationPackagingAdapter(
         'Dell.DisplayAndPeripheralManager',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -865,6 +865,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // ROBOTC 4.56's MSI uninstall enters the vendor HelpDocs custom action,
+    // attempts nested Windows Installer work, and then stalls under
+    // non-interactive LocalSystem (QA run 33118297421). Re-enter the same
+    // manifest-hashed InstallShield launcher with its removal verb so the outer
+    // bootstrapper can coordinate that vendor lifecycle. The captured exact
+    // MSI registration remains the authoritative completion signal.
+    wingetId: 'Robomatter.ROBOTC.LEGOMindstorms',
+    reviewedExactUninstall: {
+      executablePath: '%PackageInstaller%',
+      arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
+      completionTimeoutMinutes: 10,
+    },
+  },
+  {
     // DDPM registers its private setup helper with interactive removal
     // arguments. Replaying that ARP command from Intune leaves the exact
     // product registration, services, and drivers installed. Stop the reviewed

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1168,6 +1168,43 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'replays the hash-verified ROBOTC InstallShield wrapper for silent removal',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'ROBOTC for LEGO Mindstorms',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath: '%PackageInstaller%',
+            arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
+            completionTimeoutMinutes: 10,
+          },
+        },
+        [],
+        'Robomatter.ROBOTC.LEGOMindstorms'
+      );
+      const uninstallFunction = generated.slice(
+        generated.indexOf('function Uninstall-ADTDeployment'),
+        generated.indexOf('function Repair-ADTDeployment')
+      );
+
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallFile = Join-Path $adtSession.DirFiles 'setup.exe'"
+      );
+      expect(uninstallFunction).toContain(
+        "$registeredUninstallArguments = @('/S', '/x', '/V/quiet', '/V/norestart')"
+      );
+      expect(uninstallFunction).toContain(
+        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 10 }'
+      );
+      expect(uninstallFunction).toContain(
+        'Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed.'
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'verifies and removes a reviewed self-extracted managed directory without ARP capture',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Summary
- add an app-scoped reviewed exact uninstall for Robomatter.ROBOTC.LEGOMindstorms
- reuse the manifest-hashed InstallShield wrapper with its silent removal switches
- keep the captured exact MSI registration as the authoritative completion signal

## Failure evidence
QA run 33118297421 installed and detected successfully, but direct MSI removal stalled after the vendor HelpDocs custom action attempted nested Windows Installer work. Detection after uninstall still found the app.

## Validation
- 209 focused adapter/PSADT contract tests passed
- 355 broader packaging/QA contract tests passed
- lint passed
- full suite: 1507 passed; 33 local-environment failures were caused by the shared Windows node_modules junction lacking the better-sqlite3 native binding for Node 26, plus one translation-provider timeout