### PR TITLE
Activate ROBOTC wrapper uninstall QA retry

### DIFF
--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -2024,6 +2024,32 @@ describe('current catalog QA package validation', () => {
     ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
   });
 
+  it('invalidates only ROBOTC coverage from before its wrapper uninstall release', () => {
+    const priorCommit = '22f30aa42fc522cf00d0fa3f1561563d0d4372d5';
+    const legacyRobotcIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity({
+        ...input,
+        wingetId: 'Robomatter.ROBOTC.LEGOMindstorms',
+      }),
+      priorCommit
+    );
+    const legacyUnrelatedIdentity = identityWithPackagerCommit(
+      buildQaPackageIdentity(input),
+      priorCommit
+    );
+
+    expect(
+      validateCompatiblePassedCatalogQaProfile(
+        candidateFromIdentity(legacyRobotcIdentity)
+      )
+    ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
+    expect(
+      validateCompatiblePassedCatalogQaProfile(
+        candidateFromIdentity(legacyUnrelatedIdentity)
+      )
+    ).toMatchObject({ valid: true });
+  });
+
   it('reuses an adapted pass when a later release leaves its behavior unchanged', () => {
     const legacyIdentity = identityWithPackagerCommit(
       buildQaPackageIdentity({

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '22f30aa42fc522cf00d0fa3f1561563d0d4372d5',
+  packagerCommit: '3a1a14e69d4d290515e8617339dab5717cc83629',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -461,6 +461,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // strategies failed before MSI product registration. Removing its disproven
   // adapter cannot invalidate a passing profile for any other application.
   '83c81768f8c1800a5296251e473b758c62ec9358',
+  // ROBOTC now re-enters its manifest-hashed InstallShield wrapper for silent
+  // removal after the nested MSI HelpDocs action stalled. Preserve every
+  // unrelated compatible pass from the MD Editor eligibility release.
+  '22f30aa42fc522cf00d0fa3f1561563d0d4372d5',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries only the failed ROBOTC lifecycle on its wrapper uninstall release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' robomatter.robotc.legomindstorms ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '22f30aa42fc522cf00d0fa3f1561563d0d4372d5',
+      { wingetId: 'Robomatter.ROBOTC.LEGOMindstorms', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -368,7 +368,17 @@ const POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...REBOOT_REQUIRED_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ROBOTC_WRAPPER_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 4.56 lifecycle through the same manifest-hashed
+  // InstallShield wrapper after direct MSI removal stalled in HelpDocs.
+  'Robomatter.ROBOTC.LEGOMindstorms',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3a1a14e69d4d290515e8617339dab5717cc83629':
+    ROBOTC_WRAPPER_UNINSTALL_RELEASE_RETRY_TARGETS,
   '22f30aa42fc522cf00d0fa3f1561563d0d4372d5':
     POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '83c81768f8c1800a5296251e473b758c62ec9358':


### PR DESCRIPTION
## Summary
- advance the immutable QA packager pin to the merged ROBOTC adapter commit
- preserve unrelated compatible passing profiles
- invalidate and retry only the failed ROBOTC lifecycle while carrying existing unconsumed bounded retries

## Validation
- 258 focused package-profile, retry, workflow, and test-config tests passed
- lint passed