### PR TITLE
Block unsupported ROBOTC managed uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -605,18 +605,6 @@ describe('application packaging adapters', () => {
     });
     expect(
       applyApplicationPackagingAdapter(
-        'Robomatter.ROBOTC.LEGOMindstorms',
-        DEFAULT_PSADT_CONFIG
-      )
-    ).toMatchObject({
-      reviewedExactUninstall: {
-        executablePath: '%PackageInstaller%',
-        arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
-        completionTimeoutMinutes: 10,
-      },
-    });
-    expect(
-      applyApplicationPackagingAdapter(
         'Dell.DisplayAndPeripheralManager',
         DEFAULT_PSADT_CONFIG
       )

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -865,20 +865,6 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
-    // ROBOTC 4.56's MSI uninstall enters the vendor HelpDocs custom action,
-    // attempts nested Windows Installer work, and then stalls under
-    // non-interactive LocalSystem (QA run 33118297421). Re-enter the same
-    // manifest-hashed InstallShield launcher with its removal verb so the outer
-    // bootstrapper can coordinate that vendor lifecycle. The captured exact
-    // MSI registration remains the authoritative completion signal.
-    wingetId: 'Robomatter.ROBOTC.LEGOMindstorms',
-    reviewedExactUninstall: {
-      executablePath: '%PackageInstaller%',
-      arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
-      completionTimeoutMinutes: 10,
-    },
-  },
-  {
     // DDPM registers its private setup helper with interactive removal
     // arguments. Replaying that ARP command from Intune leaves the exact
     // product registration, services, and drivers installed. Stop the reviewed

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1606,3 +1606,28 @@ describe('MD Editor managed install block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('ROBOTC managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260828003000_block_robotc_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks both disproven ROBOTC removal strategies across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Robomatter.ROBOTC.LEGOMindstorms'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33121783325'
+    );
+    expect(sql).toContain('two isolated LocalSystem lifecycle runs');
+    expect(sql).toContain('281-second no-activity timeout');
+    expect(sql).toContain('direct exact MSI removal');
+    expect(sql).toContain('manifest-hashed InstallShield wrapper');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -2024,32 +2024,6 @@ describe('current catalog QA package validation', () => {
     ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
   });
 
-  it('invalidates only ROBOTC coverage from before its wrapper uninstall release', () => {
-    const priorCommit = '22f30aa42fc522cf00d0fa3f1561563d0d4372d5';
-    const legacyRobotcIdentity = identityWithPackagerCommit(
-      buildQaPackageIdentity({
-        ...input,
-        wingetId: 'Robomatter.ROBOTC.LEGOMindstorms',
-      }),
-      priorCommit
-    );
-    const legacyUnrelatedIdentity = identityWithPackagerCommit(
-      buildQaPackageIdentity(input),
-      priorCommit
-    );
-
-    expect(
-      validateCompatiblePassedCatalogQaProfile(
-        candidateFromIdentity(legacyRobotcIdentity)
-      )
-    ).toEqual({ valid: false, reason: 'compatible-application-adapter-changed' });
-    expect(
-      validateCompatiblePassedCatalogQaProfile(
-        candidateFromIdentity(legacyUnrelatedIdentity)
-      )
-    ).toMatchObject({ valid: true });
-  });
-
   it('reuses an adapted pass when a later release leaves its behavior unchanged', () => {
     const legacyIdentity = identityWithPackagerCommit(
       buildQaPackageIdentity({

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -1168,43 +1168,6 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'replays the hash-verified ROBOTC InstallShield wrapper for silent removal',
-    () => {
-      const generated = generateRegistryUninstallPackage(
-        'exe',
-        'ROBOTC for LEGO Mindstorms',
-        [],
-        {
-          reviewedExactUninstall: {
-            executablePath: '%PackageInstaller%',
-            arguments: ['/S', '/x', '/V/quiet', '/V/norestart'],
-            completionTimeoutMinutes: 10,
-          },
-        },
-        [],
-        'Robomatter.ROBOTC.LEGOMindstorms'
-      );
-      const uninstallFunction = generated.slice(
-        generated.indexOf('function Uninstall-ADTDeployment'),
-        generated.indexOf('function Repair-ADTDeployment')
-      );
-
-      expect(uninstallFunction).toContain(
-        "$registeredUninstallFile = Join-Path $adtSession.DirFiles 'setup.exe'"
-      );
-      expect(uninstallFunction).toContain(
-        "$registeredUninstallArguments = @('/S', '/x', '/V/quiet', '/V/norestart')"
-      );
-      expect(uninstallFunction).toContain(
-        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 10 }'
-      );
-      expect(uninstallFunction).toContain(
-        'Waiting for vendor uninstall registration [$registeredUninstallRegistryKey] to be removed.'
-      );
-    }
-  );
-
-  it.runIf(canRunWindowsPowerShellPackager)(
     'verifies and removes a reviewed self-extracted managed directory without ARP capture',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/supabase/migrations/20260828003000_block_robotc_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260828003000_block_robotc_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- ROBOTC for LEGO Mindstorms 4.56 installs and detects successfully under
+-- LocalSystem, but its vendor HelpDocs uninstall action attempts nested
+-- Windows Installer work and cannot complete unattended. Two isolated runs
+-- exercised distinct removal paths: direct exact MSI removal and the original
+-- manifest-hashed InstallShield wrapper with /S /x /V/quiet /V/norestart.
+-- Both reached the same 281-second no-activity timeout and left the exact
+-- {9701AFD7-E853-4CCB-88DA-306B2F37546D} product registration installed.
+-- Do not publish a PSADT package whose managed removal cannot be verified.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Robomatter.ROBOTC.LEGOMindstorms',
+  'unsupported_managed_uninstall',
+  'ROBOTC for LEGO Mindstorms 4.56 installs unattended, but two isolated LocalSystem lifecycle runs could not remove it. Direct exact MSI removal and the manifest-hashed InstallShield wrapper both reached the same 281-second no-activity timeout and left the exact product registration installed.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33121783325'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Robomatter.ROBOTC.LEGOMindstorms';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Robomatter.ROBOTC.LEGOMindstorms'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Robomatter.ROBOTC.LEGOMindstorms at the shared eligibility gate
- remove the disproven exact-wrapper uninstall adapter
- unverify the catalog entry and supersede terminal or queued QA records

## Evidence
- direct exact MSI removal stalled and left the product registered in run 33118297421
- the manifest-hashed InstallShield wrapper reached the same 281-second no-activity timeout and left the exact registration installed in run 33121783325

## Validation
- 307 focused adapter, PSADT contract, and migration tests passed
- lint passed
- git diff --check passed