### PR TITLE
fix: block unsupported League LA1 bootstrapper

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1631,3 +1631,27 @@ describe('ROBOTC managed uninstall block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('League of Legends LA1 managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260828014000_block_league_la1_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the unbounded online bootstrapper across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'RiotGames.LeagueOfLegends.LA1'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33126223846'
+    );
+    expect(sql).toContain('272-second no-activity guard');
+    expect(sql).toContain('managed detection marker');
+    expect(sql).toContain('one unambiguous vendor uninstall registration');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260828014000_block_league_la1_unsupported_managed_install.sql
+++ b/supabase/migrations/20260828014000_block_league_la1_unsupported_managed_install.sql
@@ -1,0 +1,38 @@
+-- League of Legends LA1 is delivered as an online Riot bootstrapper rather
+-- than a bounded, versioned enterprise installer. In isolated Windows 11
+-- user-context lifecycle QA, the vendor's published silent arguments kept the
+-- bootstrapper active until the 272-second no-activity guard. The run created
+-- thousands of filesystem changes but never produced the managed detection
+-- marker or one unambiguous vendor uninstall registration. The remaining
+-- child process also resisted bounded cleanup. Do not publish a PSADT package
+-- whose installation and removal lifecycle cannot be verified.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'RiotGames.LeagueOfLegends.LA1',
+  'unsupported_managed_install',
+  'League of Legends LA1 uses an online Riot bootstrapper that did not complete a bounded unattended install. Isolated Windows 11 QA reached the 272-second no-activity guard without producing the managed detection marker or one unambiguous vendor uninstall registration.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33126223846'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'RiotGames.LeagueOfLegends.LA1';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'RiotGames.LeagueOfLegends.LA1'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Evidence
- QA run 33126223846 used the production PSADT packager commit 2b38ecc29469abcc4045cc7a1ff27229c196115b.
- The Riot online bootstrapper hit the 272-second stalled-no-activity guard.
- Detection after install returned 1 and no unambiguous vendor uninstall registration existed.
- The run left thousands of residual filesystem changes; bounded child-process cleanup also failed.

## Change
- Add a fail-closed unsupported_managed_install eligibility block for RiotGames.LeagueOfLegends.LA1.
- Mark any catalog row unverified and supersede queued or terminal candidates.
- Add a migration contract test tied to the evidence run.

## Verification
- Focused migration contract: 100 passed.
- ESLint: passed.
- Full local suite: 1509 passed, 20 skipped; unrelated native better-sqlite3 binding failures and one translation-provider timeout remain local-environment issues.