### PR TITLE
fix(qa): run Zoho Mail in user context

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -297,6 +297,8 @@ describe('application packaging adapters', () => {
         'machine'
       )
     ).toBe('user');
+    expect(resolveApplicationInstallScope('Zoho.Mail', 'machine')).toBe('user');
+    expect(resolveApplicationInstallScope(' zoho.mail ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');
@@ -344,6 +346,14 @@ describe('application packaging adapters', () => {
     )).toBe('user');
     expect(resolveApplicationInstallerSelectionScope(
       'AppiumDevelopers.AppiumInspector',
+      'user'
+    )).toBe('machine');
+  });
+
+  it('keeps Zoho Mail on its machine-labelled manifest bytes while executing per-user', () => {
+    expect(resolveApplicationInstallScope('Zoho.Mail', 'machine')).toBe('user');
+    expect(resolveApplicationInstallerSelectionScope(
+      'Zoho.Mail',
       'user'
     )).toBe('machine');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -257,6 +257,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'machine',
   },
   {
+    // Zoho Mail's WinGet manifest labels its Nullsoft installer as machine
+    // scope, but isolated QA run 33130665727 proved that it registers the app
+    // below the invoking account's LocalAppData. Under LocalSystem, the exact
+    // captured uninstaller resolves below systemprofile and is already absent
+    // by the managed removal cycle. Keep selecting the same machine-labelled
+    // bytes while executing the shared QA/customer package as the signed-in
+    // user, where the vendor's per-profile lifecycle can persist.
+    wingetId: 'Zoho.Mail',
+    requiredInstallScope: 'user',
+    reviewedInstallerSelectionScope: 'machine',
+  },
+  {
     // UHK Agent is built with Electron Builder's assisted NSIS profile
     // (oneClick: false) without perMachine. Electron Builder defaults that
     // profile to per-user installation. WinGet currently omits Scope, so the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -808,6 +808,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Zoho Mail out of LocalSystem while retaining its machine-labelled installer', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Zoho.Mail',
+      displayName: 'Zoho Mail - Desktop',
+      publisher: 'Zoho',
+      version: '1.10.3',
+      architecture: 'x64',
+      installerSha256: 'f'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{435BDA16-99FD-51D0-938D-C156968A2AA4}:Zoho Mail - Desktop',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\Zoho_Mail',
+      }),
+    ]);
+  });
+
   it('keeps Brity Meeting out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SamsungSDS.BrityMeeting',


### PR DESCRIPTION
## Summary
- keep selecting Zoho Mail's exact machine-labelled WinGet installer bytes
- execute the vendor's per-profile Nullsoft lifecycle in signed-in user context for QA and customer PSADT packages
- regenerate the package profile with HKCU detection and add scope/selection regression tests

## QA evidence
Run 33130665727 installed and detected successfully under LocalSystem, but captured an exact uninstaller below systemprofile that no longer existed during removal. The packager safely returned 60001 instead of guessing, leaving detection present. This adapter follows the same reviewed pattern used for other per-profile NSIS applications.

## Verification
- npx vitest run lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (174 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check