### PR TITLE
chore(qa): activate Zoho Mail user scope

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf',
+  packagerCommit: '3d10fde499ebe5f2987a44db5df35c3801a519ea',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -473,6 +473,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // bootstrapper could not complete a bounded unattended lifecycle. Preserve
   // every unrelated compatible pass from the ROBOTC eligibility release.
   '2b38ecc29469abcc4045cc7a1ff27229c196115b',
+  // Zoho Mail now runs in the effective per-profile user context while keeping
+  // the reviewed machine-labelled manifest bytes. Preserve every unrelated
+  // compatible pass from the League eligibility release.
+  '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -36,6 +36,21 @@ describe('QA toolchain targeted retries', () => {
     ).not.toContain('riotgames.leagueoflegends.la1');
   });
 
+  it('retries Zoho Mail only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' zoho.mail ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf',
+      { wingetId: 'Zoho.Mail', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -376,7 +376,17 @@ const ROBOTC_WRAPPER_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 1.10.3 lifecycle in the per-profile context where the
+  // Nullsoft installer actually registers and retains its uninstaller.
+  'Zoho.Mail',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3d10fde499ebe5f2987a44db5df35c3801a519ea':
+    ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf':
     POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '2b38ecc29469abcc4045cc7a1ff27229c196115b':


### PR DESCRIPTION
## Summary
- activate packager commit `3d10fde499ebe5f2987a44db5df35c3801a519ea`
- retain unrelated successful QA results from the prior production packager
- target the failed `Zoho.Mail` lifecycle for a fresh QA retry under the reviewed user-context adapter

## Verification
- `npx vitest run lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.test.ts` (231 passed)
- `npx eslint lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts lib/qa/package-profile.ts`
- `git diff --check`