### PR TITLE
Fix BarryCarlyon Extension Tools user-scope packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -299,6 +299,14 @@ describe('application packaging adapters', () => {
     ).toBe('user');
     expect(resolveApplicationInstallScope('Zoho.Mail', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' zoho.mail ', undefined)).toBe('user');
+    expect(resolveApplicationInstallScope(
+      'BarryCarlyon.BarryCarlyonExtensionTools',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      ' barrycarlyon.barrycarlyonextensiontools ',
+      undefined
+    )).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');
@@ -354,6 +362,17 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope('Zoho.Mail', 'machine')).toBe('user');
     expect(resolveApplicationInstallerSelectionScope(
       'Zoho.Mail',
+      'user'
+    )).toBe('machine');
+  });
+
+  it('keeps BarryCarlyon Extension Tools on its machine-labelled bytes while executing per-user', () => {
+    expect(resolveApplicationInstallScope(
+      'BarryCarlyon.BarryCarlyonExtensionTools',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallerSelectionScope(
+      'BarryCarlyon.BarryCarlyonExtensionTools',
       'user'
     )).toBe('machine');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -269,6 +269,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'machine',
   },
   {
+    // BarryCarlyon Extension Tools is cataloged as a machine-scoped Nullsoft
+    // installer, but isolated LocalSystem QA run 33145440547 captured its
+    // application and uninstall registration below systemprofile LocalAppData.
+    // The registered uninstaller was already unavailable by managed removal.
+    // Keep selecting the exact machine-labelled bytes while executing the
+    // shared QA/customer package in the signed-in user's persistent profile.
+    wingetId: 'BarryCarlyon.BarryCarlyonExtensionTools',
+    requiredInstallScope: 'user',
+    reviewedInstallerSelectionScope: 'machine',
+  },
+  {
     // UHK Agent is built with Electron Builder's assisted NSIS profile
     // (oneClick: false) without perMachine. Electron Builder defaults that
     // profile to per-user installation. WinGet currently omits Scope, so the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -836,6 +836,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps BarryCarlyon Extension Tools out of LocalSystem while retaining its machine-labelled installer', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'BarryCarlyon.BarryCarlyonExtensionTools',
+      displayName: 'BarryCarlyon Extension Tools',
+      publisher: 'BarryCarlyon',
+      version: '1.4.0',
+      architecture: 'x64',
+      installerSha256: 'a'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:BarryCarlyon Extension Tools',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\BarryCarlyon_BarryCarlyonExtensionTools',
+      }),
+    ]);
+  });
+
   it('keeps Brity Meeting out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SamsungSDS.BrityMeeting',


### PR DESCRIPTION
## Summary
- keep selecting the exact machine-labelled WinGet installer bytes
- execute BarryCarlyon Extension Tools in the signed-in user context
- generate HKCU detection for the per-profile lifecycle
- add adapter and QA package-profile regressions

## Evidence
- isolated QA run 33145440547 installed under LocalSystem but registered an unavailable systemprofile LocalAppData uninstaller
- install/detect passed; uninstall returned 60001 and removal verification remained detected

## Validation
- 176 focused Vitest tests passed
- targeted ESLint passed