### PR TITLE
Activate BarryCarlyon user-scope packaging

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3d10fde499ebe5f2987a44db5df35c3801a519ea',
+  packagerCommit: 'f47779dbec9572a0ad72e59413b81dee8e0d13f7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -477,6 +477,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // the reviewed machine-labelled manifest bytes. Preserve every unrelated
   // compatible pass from the League eligibility release.
   '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf',
+  // BarryCarlyon Extension Tools now runs in the signed-in user's profile
+  // while retaining the reviewed machine-labelled manifest bytes. Preserve
+  // every unrelated compatible pass from the Zoho Mail user-scope release.
+  '3d10fde499ebe5f2987a44db5df35c3801a519ea',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -51,6 +51,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries BarryCarlyon Extension Tools only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' barrycarlyon.barrycarlyonextensiontools ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '3d10fde499ebe5f2987a44db5df35c3801a519ea',
+      { wingetId: 'BarryCarlyon.BarryCarlyonExtensionTools', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -384,7 +384,17 @@ const ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...POWERSHELL_REGISTERED_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 1.4.0 lifecycle in the signed-in user's profile where
+  // the Nullsoft uninstaller is registered and retained for managed removal.
+  'BarryCarlyon.BarryCarlyonExtensionTools',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f47779dbec9572a0ad72e59413b81dee8e0d13f7':
+    BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '3d10fde499ebe5f2987a44db5df35c3801a519ea':
     ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '89c8a2c5ef6b2358e50984fc8357e3f56ffcc5cf':


### PR DESCRIPTION
## Summary
- pin QA and customer PSADT packaging to the merged BarryCarlyon user-scope adapter
- preserve unrelated compatible QA passes across the narrow app-specific change
- target the failed BarryCarlyon lifecycle for retry while carrying prior unconsumed retries

## Verification
- npm test -- lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (233 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check