### PR TITLE
Fix FightPlanner user-scope packaging

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -307,6 +307,14 @@ describe('application packaging adapters', () => {
       ' barrycarlyon.barrycarlyonextensiontools ',
       undefined
     )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      'ShatteredChaos.FightPlanner',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope(
+      ' shatteredchaos.fightplanner ',
+      undefined
+    )).toBe('user');
     expect(resolveApplicationInstallScope(' vngcorp.zalo ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Youdao.YoudaoTranslate', 'machine')).toBe('user');
     expect(resolveApplicationInstallScope(' youdao.youdaotranslate ', undefined)).toBe('user');
@@ -373,6 +381,17 @@ describe('application packaging adapters', () => {
     )).toBe('user');
     expect(resolveApplicationInstallerSelectionScope(
       'BarryCarlyon.BarryCarlyonExtensionTools',
+      'user'
+    )).toBe('machine');
+  });
+
+  it('keeps FightPlanner on its machine-labelled bytes while executing per-user', () => {
+    expect(resolveApplicationInstallScope(
+      'ShatteredChaos.FightPlanner',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallerSelectionScope(
+      'ShatteredChaos.FightPlanner',
       'user'
     )).toBe('machine');
   });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -280,6 +280,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'machine',
   },
   {
+    // FightPlanner is cataloged as a machine-scoped Nullsoft installer, but
+    // isolated LocalSystem QA run 33148960390 captured its application and
+    // uninstall registration below systemprofile LocalAppData. The registered
+    // uninstaller was already unavailable by managed removal. Keep selecting
+    // the exact machine-labelled bytes while executing the shared QA/customer
+    // package in the signed-in user's persistent profile.
+    wingetId: 'ShatteredChaos.FightPlanner',
+    requiredInstallScope: 'user',
+    reviewedInstallerSelectionScope: 'machine',
+  },
+  {
     // UHK Agent is built with Electron Builder's assisted NSIS profile
     // (oneClick: false) without perMachine. Electron Builder defaults that
     // profile to per-user installation. WinGet currently omits Scope, so the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -864,6 +864,33 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps FightPlanner out of LocalSystem while retaining its machine-labelled installer', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'ShatteredChaos.FightPlanner',
+      displayName: 'FightPlanner',
+      publisher: 'ShatteredChaos',
+      version: '3.3.33',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:FightPlanner',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\ShatteredChaos_FightPlanner',
+      }),
+    ]);
+  });
+
   it('keeps Brity Meeting out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SamsungSDS.BrityMeeting',


### PR DESCRIPTION
## Summary
- execute FightPlanner's machine-labelled NSIS installer in the signed-in user context
- retain exact reviewed WinGet installer selection for QA and customer PSADT packaging
- generate HKCU detection for the effective per-user lifecycle

## Evidence
- isolated LocalSystem QA run 33148960390 captured FightPlanner 3.3.33 below systemprofile LocalAppData
- registered uninstaller was missing at managed removal, causing uninstall 60001 and post-uninstall detection 0

## Verification
- npm test -- lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts (178 passed)
- npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts lib/qa/package-profile.test.ts
- git diff --check