### PR TITLE
Activate FightPlanner user-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f47779dbec9572a0ad72e59413b81dee8e0d13f7',
+  packagerCommit: '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -481,6 +481,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // while retaining the reviewed machine-labelled manifest bytes. Preserve
   // every unrelated compatible pass from the Zoho Mail user-scope release.
   '3d10fde499ebe5f2987a44db5df35c3801a519ea',
+  // FightPlanner now runs in the signed-in user's profile while retaining the
+  // reviewed machine-labelled manifest bytes. Preserve every unrelated
+  // compatible pass from the BarryCarlyon user-scope release.
+  'f47779dbec9572a0ad72e59413b81dee8e0d13f7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -66,6 +66,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries FightPlanner only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' shatteredchaos.fightplanner ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f47779dbec9572a0ad72e59413b81dee8e0d13f7',
+      { wingetId: 'ShatteredChaos.FightPlanner', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -392,7 +392,17 @@ const BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...ZOHO_MAIL_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 3.3.33 lifecycle in the signed-in user's profile where
+  // the Nullsoft uninstaller is registered and retained for managed removal.
+  'ShatteredChaos.FightPlanner',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47':
+    FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'f47779dbec9572a0ad72e59413b81dee8e0d13f7':
     BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '3d10fde499ebe5f2987a44db5df35c3801a519ea':


### PR DESCRIPTION
## Summary
- make packager commit 7bf6273c67d66a0d2a27e52d4fd4976b056d2f47 the QA production toolchain
- preserve compatible passes from the previous BarryCarlyon release
- schedule the failed ShatteredChaos.FightPlanner lifecycle for one bounded retry

## Verification
- npx vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (235 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts
- git diff --check