### PR TITLE
fix(qa): model Olive non-ARP lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -475,6 +475,28 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('models Olive as the vendor-defined machine-wide non-ARP lifecycle', () => {
+    expect(
+      resolveApplicationInstallScope('OliveTeam.OliveVideoEditor', 'user')
+    ).toBe('machine');
+    expect(
+      applyApplicationPackagingAdapter(
+        'OliveTeam.OliveVideoEditor',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedManagedInstallDirectory: '%ProgramW6432%\\Olive',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramW6432%\\Olive\\olive-editor.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 5,
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramW6432%\\Olive\\uninstall.exe',
+        arguments: ['/S'],
+        completionTimeoutMinutes: 5,
+      },
+    });
+  });
+
   it('keeps the darktable NSIS extraction observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter('darktable.darktable', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -351,6 +351,24 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedManagedInstallDirectory: '%USERPROFILE%\\Desktop\\Tor Browser',
   },
   {
+    // Olive 0.1.x's official NSIS source installs the x64 payload directly to
+    // $PROGRAMFILES64\Olive and writes $INSTDIR\uninstall.exe, but deliberately
+    // creates no Add/Remove Programs registration. Verify the exact application
+    // binary and invoke that exact vendor uninstaller instead of attempting to
+    // select unrelated ARP changes made while the installer is running.
+    wingetId: 'OliveTeam.OliveVideoEditor',
+    requiredInstallScope: 'machine',
+    reviewedManagedInstallDirectory: '%ProgramW6432%\\Olive',
+    reviewedManagedInstallEvidenceFile:
+      '%ProgramW6432%\\Olive\\olive-editor.exe',
+    reviewedManagedInstallCompletionTimeoutMinutes: 5,
+    reviewedManagedUninstall: {
+      executablePath: '%ProgramW6432%\\Olive\\uninstall.exe',
+      arguments: ['/S'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // darktable's official CPack/NSIS installer writes its ARP registration
     // only after the complete application tree has been extracted. The signed
     // 5.6.0 package can therefore remain quiet longer than the generic QA

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1654,6 +1654,48 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds Olive to its exact machine-wide non-ARP lifecycle for customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'OliveTeam.OliveVideoEditor',
+      displayName: 'Olive Video Editor',
+      publisher: 'Olive Team',
+      version: '0.1.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Olive Video Editor',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = {
+      reviewedManagedInstallDirectory: '%ProgramW6432%\\Olive',
+      reviewedManagedInstallEvidenceFile:
+        '%ProgramW6432%\\Olive\\olive-editor.exe',
+      reviewedManagedInstallCompletionTimeoutMinutes: 5,
+      reviewedManagedUninstall: {
+        executablePath: '%ProgramW6432%\\Olive\\uninstall.exe',
+        arguments: ['/S'],
+        completionTimeoutMinutes: 5,
+      },
+    };
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\OliveTeam_OliveVideoEditor',
+      }),
+    ]);
+  });
+
   it('binds the Visual Studio 2022 Build Tools x86 instance root to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.VisualStudio.2022.BuildTools',


### PR DESCRIPTION
## Why
Olive 0.1.x intentionally does not create an Add/Remove Programs entry. The generic lifecycle therefore rejects unrelated ARP changes and cannot select a vendor uninstall entry.

## Fix
- Bind Olive to its official x64 Program Files directory.
- Verify olive-editor.exe as exact install evidence.
- Run the exact installed NSIS uninstaller with /S.
- Keep the lifecycle machine-scoped so customer PSADT packaging and QA use the same adapter.

Official source: https://github.com/olive-editor/olive/blob/7e0e94abf6610026aebb9ddce8564c39522fac6e/app/packaging/windows/nsis/olive.nsi

## Verification
- 313 focused Vitest tests passed.
- Targeted ESLint passed.
- git diff --check passed.
- Repository-wide tsc --noEmit remains red on unrelated pre-existing test-global/type errors.