### PR TITLE
chore(qa): activate Olive non-ARP lifecycle

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47',
+  packagerCommit: '3f417a26c57c689b57c9f50914f254c3898c3356',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -485,6 +485,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // reviewed machine-labelled manifest bytes. Preserve every unrelated
   // compatible pass from the BarryCarlyon user-scope release.
   'f47779dbec9572a0ad72e59413b81dee8e0d13f7',
+  // Olive now uses its source-defined Program Files payload and exact NSIS
+  // uninstaller without requiring an ARP registration. Preserve every
+  // unrelated compatible pass from the FightPlanner user-scope release.
+  '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -81,6 +81,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Olive only after activating its reviewed non-ARP lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' oliveteam.olivevideoeditor ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47',
+      { wingetId: 'OliveTeam.OliveVideoEditor', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -400,7 +400,17 @@ const FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...BARRYCARLYON_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const OLIVE_NON_ARP_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 0.1.0 lifecycle against Olive's source-defined Program
+  // Files payload and exact NSIS uninstaller instead of unrelated ARP noise.
+  'OliveTeam.OliveVideoEditor',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '3f417a26c57c689b57c9f50914f254c3898c3356':
+    OLIVE_NON_ARP_RELEASE_RETRY_TARGETS,
   '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47':
     FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'f47779dbec9572a0ad72e59413b81dee8e0d13f7':


### PR DESCRIPTION
## Summary
- Advance the QA packager pin to the merged Olive non-ARP lifecycle commit.
- Preserve compatible historical passes from the prior FightPlanner release.
- Add a bounded terminal retry for Olive while carrying forward unconsumed targets.

## Verification
- 291 focused Vitest tests passed.
- Targeted ESLint passed.
- git diff --check passed.