### PR TITLE
Fix Teradata silent suite uninstall in PSADT packages

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -974,6 +974,68 @@ if ($psadtConfig.Contains('reviewedExactUninstall') -and
     $reviewedExactUninstallConfigured = $true
 }
 
+$reviewedArchiveUninstallConfigured = $false
+$reviewedArchiveUninstallRelativePath = ''
+$reviewedArchiveUninstallArguments = @()
+$reviewedArchiveUninstallTimeoutMinutes = 0
+if ($psadtConfig.Contains('reviewedArchiveUninstall') -and
+    $null -ne $psadtConfig['reviewedArchiveUninstall']) {
+    $rawArchiveUninstall = $psadtConfig['reviewedArchiveUninstall']
+    if ($rawArchiveUninstall -isnot [System.Collections.IDictionary]) {
+        throw 'PSADT reviewedArchiveUninstall must be an object.'
+    }
+    $reviewedArchiveUninstallRelativePath = ([string]$rawArchiveUninstall['relativePath']).Trim() -replace '/', '\'
+    $archiveUninstallPathSegments = @($reviewedArchiveUninstallRelativePath -split '\\')
+    if ([string]::IsNullOrWhiteSpace($reviewedArchiveUninstallRelativePath) -or
+        $reviewedArchiveUninstallRelativePath.Length -gt 260 -or
+        [System.IO.Path]::IsPathRooted($reviewedArchiveUninstallRelativePath) -or
+        $reviewedArchiveUninstallRelativePath.StartsWith('\') -or
+        $archiveUninstallPathSegments -contains '..' -or
+        $reviewedArchiveUninstallRelativePath.Contains(':') -or
+        $reviewedArchiveUninstallRelativePath -notmatch '(?i)\.bat$' -or
+        $reviewedArchiveUninstallRelativePath -match '[*?"<>|\x00-\x1f]') {
+        throw 'PSADT reviewedArchiveUninstall.relativePath must be a safe relative batch-file path.'
+    }
+    $rawArchiveUninstallArguments = $rawArchiveUninstall['arguments']
+    if ($rawArchiveUninstallArguments -is [string] -or
+        $rawArchiveUninstallArguments -isnot [System.Collections.IEnumerable]) {
+        throw 'PSADT reviewedArchiveUninstall.arguments must be an array.'
+    }
+    foreach ($rawArchiveUninstallArgument in @($rawArchiveUninstallArguments)) {
+        if ($rawArchiveUninstallArgument -isnot [string]) {
+            throw 'Every PSADT reviewed archive uninstall argument must be a string.'
+        }
+        $archiveUninstallArgument = $rawArchiveUninstallArgument.Trim()
+        if ([string]::IsNullOrWhiteSpace($archiveUninstallArgument) -or
+            $archiveUninstallArgument.Length -gt 128 -or
+            $archiveUninstallArgument -notmatch '^[A-Za-z0-9._:=,+{}-]+$') {
+            throw 'Every PSADT reviewed archive uninstall argument must be a bounded safe token.'
+        }
+        $reviewedArchiveUninstallArguments += $archiveUninstallArgument
+    }
+    if ($reviewedArchiveUninstallArguments.Count -gt 20) {
+        throw 'PSADT reviewedArchiveUninstall.arguments must contain at most 20 entries.'
+    }
+    $rawArchiveUninstallTimeoutMinutes = $rawArchiveUninstall['completionTimeoutMinutes']
+    if (($rawArchiveUninstallTimeoutMinutes -isnot [byte] -and
+         $rawArchiveUninstallTimeoutMinutes -isnot [int16] -and
+         $rawArchiveUninstallTimeoutMinutes -isnot [int32] -and
+         $rawArchiveUninstallTimeoutMinutes -isnot [int64]) -or
+        [int]$rawArchiveUninstallTimeoutMinutes -lt 1 -or
+        [int]$rawArchiveUninstallTimeoutMinutes -gt 60) {
+        throw 'PSADT reviewedArchiveUninstall.completionTimeoutMinutes must be an integer from 1 to 60.'
+    }
+    $reviewedArchiveUninstallTimeoutMinutes = [int]$rawArchiveUninstallTimeoutMinutes
+    $reviewedArchiveUninstallConfigured = $true
+}
+if ($reviewedExactUninstallConfigured -and $reviewedArchiveUninstallConfigured) {
+    throw 'PSADT reviewed exact and archive uninstall contracts are mutually exclusive.'
+}
+if ($reviewedArchiveUninstallConfigured) {
+    # Both trusted override types share the generated registry-removal wait.
+    $reviewedExactUninstallTimeoutMinutes = $reviewedArchiveUninstallTimeoutMinutes
+}
+
 function ConvertTo-PSADTConfigValue {
     param(
         [AllowNull()][string]$Value,
@@ -1584,6 +1646,35 @@ if ($reviewedUninstallWindowAutomationConfigured) {
     }
     Copy-Item -LiteralPath $windowAutomationHelperSource -Destination (Join-Path $supportFilesDir 'Invoke-IntuneGetReviewedUninstallWindowAutomation.ps1') -Force
     Write-Host "Embedded reviewed uninstall window automation for: $windowAutomationProcessName"
+}
+
+if ($reviewedArchiveUninstallConfigured) {
+    if ($IsUserScope -or
+        $installerTypeLower -ne 'zip' -or
+        $fileExtension -ne '.zip' -or
+        -not $useRegistryUninstall -or
+        $registeredInstallerTypeLower -in @('msi', 'wix', 'burn') -or
+        -not [string]::IsNullOrWhiteSpace($customUninstallCommand) -or
+        $preserveVendorInstallationOnUninstall) {
+        throw 'PSADT reviewedArchiveUninstall requires a machine-scope registry EXE lifecycle sourced from a ZIP archive.'
+    }
+
+    $supportFilesDir = Join-Path $packageDir 'SupportFiles'
+    $null = New-Item -ItemType Directory -Path $supportFilesDir -Force
+    $archiveUninstallConfigPath = Join-Path $supportFilesDir 'ReviewedArchiveUninstall.json'
+    [ordered]@{
+        relativePath = $reviewedArchiveUninstallRelativePath
+        arguments = @($reviewedArchiveUninstallArguments)
+    } |
+        ConvertTo-Json -Depth 3 |
+        Set-Content -LiteralPath $archiveUninstallConfigPath -Encoding UTF8
+
+    $archiveUninstallHelperSource = Join-Path $PSScriptRoot 'Invoke-IntuneGetReviewedArchiveUninstall.ps1'
+    if (-not (Test-Path -LiteralPath $archiveUninstallHelperSource -PathType Leaf)) {
+        throw 'The reviewed archive uninstall helper source is missing.'
+    }
+    Copy-Item -LiteralPath $archiveUninstallHelperSource -Destination (Join-Path $supportFilesDir 'Invoke-IntuneGetReviewedArchiveUninstall.ps1') -Force
+    Write-Host "Embedded reviewed archive uninstall contract for: $reviewedArchiveUninstallRelativePath"
 }
 
 if ($useRegistryUninstall) {
@@ -3363,6 +3454,24 @@ if ($reviewedExactUninstallConfigured) {
         '    $isAdobeCreativeCloudUninstall = $false'
         '    Write-ADTLogEntry -Message "Using the reviewed exact vendor uninstall command [$registeredUninstallFile]." -Source ''Uninstall-ADTDeployment'''
     )
+} elseif ($reviewedArchiveUninstallConfigured) {
+    $reviewedExactUninstallOverrideLines += @(
+        '    $useReviewedExactUninstall = $true'
+        '    $reviewedArchiveUninstallScript = Join-Path $adtSession.DirSupportFiles ''Invoke-IntuneGetReviewedArchiveUninstall.ps1'''
+        "    `$reviewedArchivePath = Join-Path `$adtSession.DirFiles '$installerFileNameSingleQuoteEscaped'"
+        '    if (-not (Test-Path -LiteralPath $reviewedArchiveUninstallScript -PathType Leaf)) {'
+        '        throw "The reviewed archive uninstall helper was not found: $reviewedArchiveUninstallScript"'
+        '    }'
+        '    if (-not (Test-Path -LiteralPath $reviewedArchivePath -PathType Leaf)) {'
+        '        throw "The retained vendor archive was not found: $reviewedArchivePath"'
+        '    }'
+        '    $registeredUninstallFile = Join-Path $env:SystemRoot ''System32\WindowsPowerShell\v1.0\powershell.exe'''
+        '    [string[]]$registeredUninstallArguments = @(''-NoLogo'', ''-NoProfile'', ''-NonInteractive'', ''-ExecutionPolicy'', ''Bypass'', ''-File'', $reviewedArchiveUninstallScript, ''-ArchivePath'', $reviewedArchivePath)'
+        '    $hasQuietUninstall = $true'
+        '    $isVivaldiUninstall = $false'
+        '    $isAdobeCreativeCloudUninstall = $false'
+        '    Write-ADTLogEntry -Message "Using the reviewed packaged archive uninstall command [$reviewedArchiveUninstallScript]." -Source ''Uninstall-ADTDeployment'''
+    )
 }
 $reviewedUninstallWindowAutomationLines = @(
     '        $uninstallHandle = Start-ADTProcess @uninstallProcessParameters'
@@ -3801,7 +3910,7 @@ if ($useManagedDirectoryLifecycle) {
             '            }'
             '            $registeredUninstallFile = Join-Path $env:SystemRoot ''System32\msiexec.exe'''
             '            $registeredUninstallArguments = @(''/x'', $registeredMsiProductCode, ''/qn'', ''/norestart'')'
-            '        } elseif ($isRegisteredPowerShellHost) {'
+            '        } elseif ($isRegisteredPowerShellHost -and -not $useReviewedExactUninstall) {'
             '            # Some vendors register an inbox PowerShell launcher instead of a literal EXE path.'
             '            # Resolve only a single -File command whose script is an existing .ps1 below the'
             '            # exact captured InstallLocation. Host-side switches are allowlisted so an ARP entry'

--- a/.github/scripts/Invoke-IntuneGetReviewedArchiveUninstall.ps1
+++ b/.github/scripts/Invoke-IntuneGetReviewedArchiveUninstall.ps1
@@ -1,0 +1,110 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArchivePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$configPath = Join-Path $PSScriptRoot 'ReviewedArchiveUninstall.json'
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw 'The reviewed archive uninstall configuration is missing.'
+}
+
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json -ErrorAction Stop
+$relativePath = ([string]$config.relativePath).Trim().Replace('/', '\')
+$relativeSegments = @($relativePath -split '\\')
+if ([string]::IsNullOrWhiteSpace($relativePath) -or
+    $relativePath.Length -gt 260 -or
+    [IO.Path]::IsPathRooted($relativePath) -or
+    $relativePath.StartsWith('\') -or
+    $relativeSegments -contains '..' -or
+    $relativePath.Contains(':') -or
+    $relativePath -notmatch '(?i)\.bat$' -or
+    $relativePath -match '[*?"<>|\x00-\x1f]') {
+    throw 'The reviewed archive uninstall relative path is unsafe.'
+}
+
+$commandArguments = @($config.arguments)
+if ($commandArguments.Count -gt 20) {
+    throw 'The reviewed archive uninstall contains too many arguments.'
+}
+foreach ($commandArgument in $commandArguments) {
+    if ($commandArgument -isnot [string] -or
+        [string]::IsNullOrWhiteSpace($commandArgument) -or
+        $commandArgument.Length -gt 128 -or
+        $commandArgument -notmatch '^[A-Za-z0-9._:=,+{}-]+$') {
+        throw 'A reviewed archive uninstall argument is unsafe.'
+    }
+}
+
+$resolvedArchivePath = [IO.Path]::GetFullPath(
+    [Environment]::ExpandEnvironmentVariables($ArchivePath)
+)
+if ([IO.Path]::GetExtension($resolvedArchivePath) -ine '.zip' -or
+    -not (Test-Path -LiteralPath $resolvedArchivePath -PathType Leaf)) {
+    throw 'The reviewed archive uninstall source is missing or is not a ZIP archive.'
+}
+
+$extractRoot = [IO.Path]::Combine(
+    $env:TEMP,
+    'IntuneGet_ReviewedUninstall_' + [Guid]::NewGuid().ToString('N').Substring(0, 8)
+)
+
+try {
+    $null = New-Item -Path $extractRoot -ItemType Directory -Force
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $stageRoot = [IO.Path]::GetFullPath($extractRoot)
+    $stageRootPrefix = $stageRoot.TrimEnd([char[]]@('\', '/')) + [IO.Path]::DirectorySeparatorChar
+    $archive = [IO.Compression.ZipFile]::OpenRead($resolvedArchivePath)
+    try {
+        foreach ($entry in $archive.Entries) {
+            $entryRelativePath = $entry.FullName.Replace('/', [IO.Path]::DirectorySeparatorChar)
+            if ([string]::IsNullOrWhiteSpace($entryRelativePath)) { continue }
+            if ($entryRelativePath.Contains(':')) {
+                throw "Archive entry contains an unsupported path: $($entry.FullName)"
+            }
+            $targetPath = [IO.Path]::GetFullPath(
+                [IO.Path]::Combine($stageRoot, $entryRelativePath)
+            )
+            if ($targetPath -ne $stageRoot -and
+                -not $targetPath.StartsWith($stageRootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Archive entry escapes the reviewed uninstall directory: $($entry.FullName)"
+            }
+            if ([string]::IsNullOrEmpty($entry.Name)) {
+                $null = New-Item -Path $targetPath -ItemType Directory -Force
+                continue
+            }
+            $targetDirectory = [IO.Path]::GetDirectoryName($targetPath)
+            if ($targetDirectory) {
+                $null = New-Item -Path $targetDirectory -ItemType Directory -Force
+            }
+            [IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $targetPath, $true)
+        }
+    }
+    finally {
+        if ($archive) { $archive.Dispose() }
+    }
+
+    $batchPath = [IO.Path]::GetFullPath((Join-Path $stageRoot $relativePath))
+    if (-not $batchPath.StartsWith($stageRootPrefix, [StringComparison]::OrdinalIgnoreCase) -or
+        -not (Test-Path -LiteralPath $batchPath -PathType Leaf)) {
+        throw "The reviewed uninstall batch file was not found in the package archive: $relativePath"
+    }
+
+    Write-Output "Executing reviewed archive uninstall batch [$relativePath]."
+    & $batchPath @commandArguments
+    $batchExitCode = $LASTEXITCODE
+    if ($batchExitCode -notin @(0, 1641, 3010)) {
+        throw "The reviewed archive uninstall batch exited with code [$batchExitCode]."
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $extractRoot) {
+        Remove-Item -LiteralPath $extractRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+exit $batchExitCode

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -709,6 +709,50 @@ describe('POST /api/package (workflow dispatch)', () => {
     });
   });
 
+  it('applies the reviewed Teradata archive uninstall to QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Teradata.TTUOdbc',
+          displayName: 'Teradata ODBC Driver',
+          installerType: 'zip',
+          installerUrl: 'https://example.com/TeradataODBC.zip',
+          installCommand: 'TeradataODBC\\TTUSuiteSilent.exe /silent',
+          uninstallCommand:
+            'REGISTRY_UNINSTALL_PRODUCT:{F075B63A-C629-41F8-BA56-33D9940F2000}:Teradata ODBC Driver',
+          nestedInstallerType: 'exe',
+          nestedInstallerPath: 'TeradataODBC\\TTUSuiteSilent.exe',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedContract = {
+      reviewedArchiveUninstall: {
+        relativePath: 'TeradataODBC\\silent_uninstall.bat',
+        arguments: ['ALL'],
+        completionTimeoutMinutes: 15,
+      },
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedContract
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedContract
+    );
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedContract,
+    });
+  });
+
   it('adds a usable Build Tools workload to QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -240,6 +240,39 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
       .toMatchObject({ reviewedUninstallArguments: ['/S'] });
   });
 
+  it('dispatches Teradata silent archive removal through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Teradata.TTUOdbc',
+      displayName: 'Teradata ODBC Driver',
+      publisher: 'Teradata Corporation',
+      version: '20.00.38.00',
+      architecture: 'x64',
+      installerUrl: 'https://example.com/TeradataODBC.zip',
+      installerSha256: 'D'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerPath: 'TeradataODBC\\TTUSuiteSilent.exe',
+      silentSwitches: '/silent',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{F075B63A-C629-41F8-BA56-33D9940F2000}:Teradata ODBC Driver',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
+      reviewedArchiveUninstall: {
+        relativePath: 'TeradataODBC\\silent_uninstall.bat',
+        arguments: ['ALL'],
+        completionTimeoutMinutes: 15,
+      },
+    });
+  });
+
   it('dispatches the observable Webroot MSI lifecycle through the customer packager', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -497,6 +497,18 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('uses Teradata\'s suite-specific silent archive removal contract', () => {
+    expect(
+      applyApplicationPackagingAdapter('Teradata.TTUOdbc', DEFAULT_PSADT_CONFIG)
+    ).toMatchObject({
+      reviewedArchiveUninstall: {
+        relativePath: 'TeradataODBC\\silent_uninstall.bat',
+        arguments: ['ALL'],
+        completionTimeoutMinutes: 15,
+      },
+    });
+  });
+
   it('keeps the darktable NSIS extraction observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter('darktable.darktable', DEFAULT_PSADT_CONFIG)
@@ -1395,6 +1407,11 @@ describe('application packaging adapters', () => {
         arguments: ['/quiet'],
         completionTimeoutMinutes: 5,
       },
+      reviewedArchiveUninstall: {
+        relativePath: 'Example\\silent_uninstall.bat',
+        arguments: ['ALL'],
+        completionTimeoutMinutes: 5,
+      },
     });
 
     expect(adapted.preserveVendorInstallationOnUninstall).toBeUndefined();
@@ -1410,6 +1427,7 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedManagedInstallCompletionTimeoutMinutes).toBeUndefined();
     expect(adapted.reviewedManagedUninstall).toBeUndefined();
     expect(adapted.reviewedExactUninstall).toBeUndefined();
+    expect(adapted.reviewedArchiveUninstall).toBeUndefined();
   });
 
   it('preserves and deduplicates reviewed install arguments case-insensitively', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -49,6 +49,11 @@ interface ApplicationPackagingAdapter {
     arguments: readonly string[];
     completionTimeoutMinutes: number;
   }>;
+  reviewedArchiveUninstall?: Readonly<{
+    relativePath: string;
+    arguments: readonly string[];
+    completionTimeoutMinutes: number;
+  }>;
   reviewedMultiProductInstallDisplayNamePrefixes?: readonly string[];
   reviewedMultiProductInstallMinimumCount?: number;
   reviewedRegistryInstallEvidence?: Readonly<{
@@ -366,6 +371,20 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
       executablePath: '%ProgramW6432%\\Olive\\uninstall.exe',
       arguments: ['/S'],
       completionTimeoutMinutes: 5,
+    },
+  },
+  {
+    // Teradata documents silent suite removal through the suite-specific
+    // silent_uninstall.bat file shipped in the same Windows archive. The
+    // generic InstallShield ARP command is asynchronous and leaves the exact
+    // suite registration installed under LocalSystem. Retain the trusted
+    // archive in every PSADT package and execute the documented batch contract
+    // so QA and customer Intune deployments share the same lifecycle.
+    wingetId: 'Teradata.TTUOdbc',
+    reviewedArchiveUninstall: {
+      relativePath: 'TeradataODBC\\silent_uninstall.bat',
+      arguments: ['ALL'],
+      completionTimeoutMinutes: 15,
     },
   },
   {
@@ -1733,7 +1752,8 @@ export function applyApplicationPackagingAdapter(
       !config.reviewedManagedInstallCompletionProcess &&
       !config.reviewedManagedInstallCompletionTimeoutMinutes &&
       !config.reviewedManagedUninstall &&
-      !config.reviewedExactUninstall
+      !config.reviewedExactUninstall &&
+      !config.reviewedArchiveUninstall
     ) return config;
     return {
       ...config,
@@ -1757,6 +1777,7 @@ export function applyApplicationPackagingAdapter(
       reviewedManagedInstallCompletionTimeoutMinutes: undefined,
       reviewedManagedUninstall: undefined,
       reviewedExactUninstall: undefined,
+      reviewedArchiveUninstall: undefined,
     };
   }
 
@@ -1892,6 +1913,14 @@ export function applyApplicationPackagingAdapter(
           arguments: [...adapter.reviewedExactUninstall.arguments],
           completionTimeoutMinutes:
             adapter.reviewedExactUninstall.completionTimeoutMinutes,
+        }
+      : undefined,
+    reviewedArchiveUninstall: adapter.reviewedArchiveUninstall
+      ? {
+          relativePath: adapter.reviewedArchiveUninstall.relativePath,
+          arguments: [...adapter.reviewedArchiveUninstall.arguments],
+          completionTimeoutMinutes:
+            adapter.reviewedArchiveUninstall.completionTimeoutMinutes,
         }
       : undefined,
     reviewedMultiProductInstallDisplayNamePrefixes,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1167,6 +1167,40 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
   });
 
+  it('binds Teradata silent archive removal to customer and QA package identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Teradata.TTUOdbc',
+      displayName: 'Teradata ODBC Driver',
+      publisher: 'Teradata Corporation',
+      version: '20.00.38.00',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'zip',
+      nestedInstallerType: 'exe',
+      nestedInstallerPath: 'TeradataODBC\\TTUSuiteSilent.exe',
+      silentSwitches:
+        '/silent ALLARGS="{F075B63A-C629-41F8-BA56-33D9940F2000} 20.00 "ALL" ODBC"',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{F075B63A-C629-41F8-BA56-33D9940F2000}:Teradata ODBC Driver',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedContract = {
+      relativePath: 'TeradataODBC\\silent_uninstall.bat',
+      arguments: ['ALL'],
+      completionTimeoutMinutes: 15,
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedArchiveUninstall?: typeof expectedContract };
+    };
+
+    expect(profile.psadtConfig.reviewedArchiveUninstall).toEqual(expectedContract);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedArchiveUninstall).toEqual(
+      expectedContract
+    );
+  });
+
   it('binds the bounded SEGGER installer wait to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Segger.EmbeddedStudioARM',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -30,6 +30,14 @@ const reviewedWindowAutomationHelper = readFileSync(
   'utf8'
 );
 
+const reviewedArchiveUninstallHelper = readFileSync(
+  resolve(
+    process.cwd(),
+    '.github/scripts/Invoke-IntuneGetReviewedArchiveUninstall.ps1'
+  ),
+  'utf8'
+);
+
 const packagerPath = resolve(
   process.cwd(),
   '.github/scripts/Create-PSADTPackage.ps1'
@@ -257,6 +265,66 @@ describe('PSADT Inno packaging contract', () => {
 });
 
 describe('PSADT vendor argument contract', () => {
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'executes a reviewed archive batch from a confined temporary extraction',
+    () => {
+      const fixtureRoot = mkdtempSync(
+        join(tmpdir(), 'intuneget-archive-uninstall-helper-')
+      );
+      try {
+        const archiveContent = join(fixtureRoot, 'archive', 'TeradataODBC');
+        mkdirSync(archiveContent, { recursive: true });
+        writeFileSync(
+          join(archiveContent, 'silent_uninstall.bat'),
+          '@echo off\r\necho reviewed-archive-uninstall-ok\r\nexit /b 0\r\n'
+        );
+        const archivePath = join(fixtureRoot, 'setup.zip');
+        const compression = spawnSync(
+          'pwsh',
+          [
+            '-NoProfile',
+            '-Command',
+            "Compress-Archive -Path (Join-Path $env:ARCHIVE_SOURCE '*') -DestinationPath $env:ARCHIVE_DESTINATION -Force",
+          ],
+          {
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              ARCHIVE_SOURCE: join(fixtureRoot, 'archive'),
+              ARCHIVE_DESTINATION: archivePath,
+            },
+          }
+        );
+        expect(compression.status).toBe(0);
+
+        const helperPath = join(
+          fixtureRoot,
+          'Invoke-IntuneGetReviewedArchiveUninstall.ps1'
+        );
+        writeFileSync(helperPath, reviewedArchiveUninstallHelper);
+        writeFileSync(
+          join(fixtureRoot, 'ReviewedArchiveUninstall.json'),
+          JSON.stringify({
+            relativePath: 'TeradataODBC\\silent_uninstall.bat',
+            arguments: ['ALL'],
+          })
+        );
+        const result = spawnSync(
+          'pwsh',
+          ['-NoProfile', '-File', helperPath, '-ArchivePath', archivePath],
+          { encoding: 'utf8' }
+        );
+
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`).toContain(
+          'reviewed-archive-uninstall-ok'
+        );
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    }
+  );
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'loads the reviewed window-control native helper and fails closed without a matching button',
     () => {
@@ -3136,6 +3204,70 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       );
       expect(generated).not.toContain(
         "Start-ADTProcess -FilePath $nestedInstallerPath -ArgumentList '/exenoui /qb! REBOOT=ReallySuppress' -WindowStyle Hidden -WaitForMsiExec -Timeout"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'packages Teradata vendor-documented silent archive removal for QA and customers',
+    () => {
+      const reviewedArchiveUninstall = {
+        relativePath: 'TeradataODBC\\silent_uninstall.bat',
+        arguments: ['ALL'],
+        completionTimeoutMinutes: 15,
+      };
+      const generated = generateRegistryUninstallPackage(
+        'zip',
+        'Teradata ODBC Driver',
+        [],
+        { reviewedArchiveUninstall },
+        [],
+        'Teradata.TTUOdbc',
+        'Teradata ODBC Driver',
+        '20.00.38.00',
+        'REGISTRY_UNINSTALL_PRODUCT:{F075B63A-C629-41F8-BA56-33D9940F2000}:Teradata ODBC Driver',
+        '/silent ALLARGS="{F075B63A-C629-41F8-BA56-33D9940F2000} 20.00 "ALL" ODBC"',
+        'machine',
+        'exe',
+        'TeradataODBC\\TTUSuiteSilent.exe',
+        (packageDirectory) => {
+          const helperPath = join(
+            packageDirectory,
+            'SupportFiles',
+            'Invoke-IntuneGetReviewedArchiveUninstall.ps1'
+          );
+          const configPath = join(
+            packageDirectory,
+            'SupportFiles',
+            'ReviewedArchiveUninstall.json'
+          );
+          expect(existsSync(helperPath)).toBe(true);
+          expect(readFileSync(helperPath, 'utf8')).toBe(reviewedArchiveUninstallHelper);
+          expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({
+            relativePath: reviewedArchiveUninstall.relativePath,
+            arguments: reviewedArchiveUninstall.arguments,
+          });
+          expect(existsSync(join(packageDirectory, 'Files', 'setup.zip'))).toBe(true);
+        }
+      );
+
+      expect(generated).toContain(
+        "$reviewedArchiveUninstallScript = Join-Path $adtSession.DirSupportFiles 'Invoke-IntuneGetReviewedArchiveUninstall.ps1'"
+      );
+      expect(generated).toContain(
+        "$reviewedArchivePath = Join-Path $adtSession.DirFiles 'setup.zip'"
+      );
+      expect(generated).toContain(
+        "$registeredUninstallFile = Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe'"
+      );
+      expect(generated).toContain(
+        "'-File', $reviewedArchiveUninstallScript, '-ArchivePath', $reviewedArchivePath"
+      );
+      expect(generated).toContain(
+        '$effectiveUninstallCompletionTimeoutMinutes = if ($useReviewedExactUninstall) { 15 }'
+      );
+      expect(generated).toContain(
+        '} elseif ($isRegisteredPowerShellHost -and -not $useReviewedExactUninstall) {'
       );
     }
   );

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -309,6 +309,17 @@ export interface PSADTConfig {
     completionTimeoutMinutes: number;
   };
 
+  // Internal exact-command contract for a reviewed ZIP package whose vendor
+  // ships a suite-specific silent uninstall batch file in the signed archive.
+  // The shared packager extracts the retained archive to a bounded temporary
+  // directory and invokes only this validated relative path. Application
+  // adapters are the only trusted source for this value.
+  reviewedArchiveUninstall?: {
+    relativePath: string;
+    arguments: string[];
+    completionTimeoutMinutes: number;
+  };
+
   // Internal install-evidence contract for reviewed bundles that intentionally
   // install several independently registered products. The generated package
   // requires multiple matching ARP entries instead of weakening the ordinary


### PR DESCRIPTION
## Summary
- add an internal reviewed ZIP uninstall contract for vendor-supplied silent batch files
- apply Teradata.TTUOdbc's documented TeradataODBC\\silent_uninstall.bat ALL lifecycle
- retain the trusted archive in QA and customer PSADT packages and wait for exact ARP removal
- fail closed on unsafe paths, arguments, ZIP traversal, incompatible scopes, or missing helpers

## Verification
- 406 focused Vitest tests passed
- synthetic nested batch execution passed
- ESLint passed for changed TypeScript files
- PowerShell source and generated PSADT script parse checks passed
- production Next.js build passed