### PR TITLE
Activate Teradata archive uninstall QA toolchain

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '3f417a26c57c689b57c9f50914f254c3898c3356',
+  packagerCommit: 'c96b0c7605388a652d05e226bb566d6e62f3c268',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -489,6 +489,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // uninstaller without requiring an ARP registration. Preserve every
   // unrelated compatible pass from the FightPlanner user-scope release.
   '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47',
+  // Teradata ODBC now uses the vendor-documented silent uninstall batch from
+  // its retained trusted archive. Preserve every unrelated compatible pass
+  // from the Olive non-ARP release.
+  '3f417a26c57c689b57c9f50914f254c3898c3356',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -96,6 +96,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Teradata ODBC only after activating its reviewed archive uninstall', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' teradata.ttuodbc ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '3f417a26c57c689b57c9f50914f254c3898c3356',
+      { wingetId: 'Teradata.TTUOdbc', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -408,7 +408,17 @@ const OLIVE_NON_ARP_RELEASE_RETRY_TARGETS = [
   ...FIGHTPLANNER_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 20.00.38.00 lifecycle through Teradata's documented
+  // suite-specific silent_uninstall.bat instead of the asynchronous ARP entry.
+  'Teradata.TTUOdbc',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...OLIVE_NON_ARP_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'c96b0c7605388a652d05e226bb566d6e62f3c268':
+    TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS,
   '3f417a26c57c689b57c9f50914f254c3898c3356':
     OLIVE_NON_ARP_RELEASE_RETRY_TARGETS,
   '7bf6273c67d66a0d2a27e52d4fd4976b056d2f47':


### PR DESCRIPTION
## Summary
- pin QA package identity to reviewed packager commit c96b0c7605388a652d05e226bb566d6e62f3c268
- preserve unrelated compatible passes from the previous Olive release
- target the failed Teradata.TTUOdbc lifecycle for retry under the new packager

## Verification
- 293 focused QA/toolchain tests passed
- ESLint passed