### PR TITLE
Fix Somiibo per-user packaging lifecycle

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -272,6 +272,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' webcatalogltd.switchbar ', undefined)
     ).toBe('user');
+    expect(
+      resolveApplicationInstallScope('ITWCreativeWorks.Somiibo', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' itwcreativeworks.somiibo ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('SeqLens.SeqLens', 'machine')).toBe(
       'user'
     );

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -217,6 +217,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Somiibo's NSIS installer registers its application below the invoking
+    // account's LocalAppData even though WinGet omits Scope. Isolated QA run
+    // 33164837340 captured an uninstaller below LocalSystem's systemprofile
+    // that was already unavailable by the managed removal cycle. Keep QA and
+    // customer Intune packages in the signed-in user's persistent profile.
+    wingetId: 'ITWCreativeWorks.Somiibo',
+    requiredInstallScope: 'user',
+  },
+  {
     // SeqLens' NSIS installer registers below the invoking account's
     // LocalAppData even though WinGet omits Scope. Running it as LocalSystem
     // records an uninstaller below systemprofile that is unavailable for the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -751,6 +751,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Somiibo out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'ITWCreativeWorks.Somiibo',
+      displayName: 'Somiibo',
+      publisher: 'ITWCreativeWorks',
+      version: '1.2.32',
+      architecture: 'x64',
+      installerSha256: '3'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Somiibo',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\ITWCreativeWorks_Somiibo',
+      }),
+    ]);
+  });
+
   it('keeps SeqLens out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SeqLens.SeqLens',


### PR DESCRIPTION
## What changed
- force ITWCreativeWorks.Somiibo packages to the signed-in user context
- keep QA, portal, catalog, and update packaging on the shared adapter path
- generate the user-scoped HKCU IntuneGet marker

## Evidence
QA run 33164837340 installed and detected successfully, then failed uninstall with 60001 because the captured NSIS uninstaller resolved below LocalSystem systemprofile and was unavailable. WinGet 1.2.32 omits Scope.

## Verification
- 449 focused Vitest tests passed
- ESLint passed
- diff validation passed
- Next.js production build passed