### PR TITLE
Activate Somiibo user-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'c96b0c7605388a652d05e226bb566d6e62f3c268',
+  packagerCommit: '493b141d093be4d3fa25b550c41d47f7b9a91a67',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -493,6 +493,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // its retained trusted archive. Preserve every unrelated compatible pass
   // from the Olive non-ARP release.
   '3f417a26c57c689b57c9f50914f254c3898c3356',
+  // Somiibo now runs in the signed-in user's persistent profile instead of
+  // LocalSystem's disposable systemprofile. Preserve every unrelated
+  // compatible pass from the Teradata archive-uninstall release.
+  'c96b0c7605388a652d05e226bb566d6e62f3c268',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -111,6 +111,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Somiibo only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' itwcreativeworks.somiibo ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'c96b0c7605388a652d05e226bb566d6e62f3c268',
+      { wingetId: 'ITWCreativeWorks.Somiibo', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -416,7 +416,17 @@ const TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...OLIVE_NON_ARP_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry the failed 1.2.32 lifecycle in the signed-in user's profile where
+  // its LocalAppData NSIS uninstaller remains available for managed removal.
+  'ITWCreativeWorks.Somiibo',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '493b141d093be4d3fa25b550c41d47f7b9a91a67':
+    SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'c96b0c7605388a652d05e226bb566d6e62f3c268':
     TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS,
   '3f417a26c57c689b57c9f50914f254c3898c3356':


### PR DESCRIPTION
## What changed
- activate production packager commit 493b141d093be4d3fa25b550c41d47f7b9a91a67
- retain unrelated compatible passes from the previous Teradata release
- target failed ITWCreativeWorks.Somiibo candidates for one corrected user-scope replay

## Verification
- 324 focused Vitest tests passed
- ESLint passed
- diff validation passed