### PR TITLE
fix(packaging): reject empty close-process names before dispatch

### DIFF
--- a/components/CartItemConfig.tsx
+++ b/components/CartItemConfig.tsx
@@ -43,6 +43,7 @@ import type { CartItem, StoreCartItem, IntuneAppCategorySelection, PackageAssign
 import type { EspProfileSelection } from '@/types/esp';
 import { isStoreCartItem, isWin32CartItem } from '@/types/upload';
 import type { AppRelationship, MsiDetectionRule } from '@/types/intune';
+import { sanitizeProcessesToClose } from '@/types/psadt';
 import type {
   PSADTConfig,
   ProcessToClose,
@@ -124,6 +125,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   // UI state
   const [expandedSection, setExpandedSection] = useState<ConfigSection | null>(isStore ? 'assignment' : 'behavior');
   const [isSaving, setIsSaving] = useState(false);
+  const [processesError, setProcessesError] = useState<string | null>(null);
 
   const modalRef = useFocusTrap<HTMLDivElement>();
 
@@ -173,6 +175,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   };
 
   const removeProcess = (index: number) => {
+    setProcessesError(null);
     setConfig((prev) => ({
       ...prev,
       processesToClose: prev.processesToClose.filter((_, i) => i !== index),
@@ -180,6 +183,7 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   };
 
   const updateProcess = (index: number, updates: Partial<ProcessToClose>) => {
+    setProcessesError(null);
     setConfig((prev) => ({
       ...prev,
       processesToClose: prev.processesToClose.map((p, i) =>
@@ -193,6 +197,20 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
   };
 
   const handleSave = async () => {
+    // The packaging pipeline rejects close-process entries without an
+    // executable name, so block the save instead of storing a config that
+    // fails minutes later during packaging.
+    const sanitizedProcesses = isWin32
+      ? sanitizeProcessesToClose(config.processesToClose)
+      : null;
+    if (sanitizedProcesses && sanitizedProcesses.invalid.length > 0) {
+      setProcessesError(
+        'Each process to close needs an executable name, for example chrome. Fill in the process name or remove the row.'
+      );
+      setExpandedSection('behavior');
+      return;
+    }
+
     setIsSaving(true);
     try {
       if (isStore) {
@@ -220,7 +238,9 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
 
         updateItem(item.id, {
           installScope: selectedScope,
-          psadtConfig: config,
+          psadtConfig: sanitizedProcesses
+            ? { ...config, processesToClose: sanitizedProcesses.processes }
+            : config,
           assignments: assignments.length > 0 ? assignments : undefined,
           categories: categories.length > 0 ? categories : undefined,
           espProfiles: espProfiles.length > 0 ? espProfiles : undefined,
@@ -451,7 +471,12 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
                               value={process.name}
                               onChange={(e) => updateProcess(index, { name: e.target.value })}
                               placeholder="Process name (e.g., chrome)"
-                              className="flex-1 px-3 py-2 bg-bg-elevated border border-overlay/15 rounded-lg text-text-primary text-sm"
+                              className={cn(
+                                'flex-1 px-3 py-2 bg-bg-elevated border rounded-lg text-text-primary text-sm',
+                                processesError && !process.name.trim() && process.description.trim()
+                                  ? 'border-red-500/60'
+                                  : 'border-overlay/15'
+                              )}
                             />
                             <input
                               type="text"
@@ -468,6 +493,9 @@ export function CartItemConfig({ item, onClose }: CartItemConfigProps) {
                             </button>
                           </div>
                         ))
+                      )}
+                      {processesError && (
+                        <p className="text-red-400 text-sm">{processesError}</p>
                       )}
                     </div>
                   </div>

--- a/components/PackageConfig.tsx
+++ b/components/PackageConfig.tsx
@@ -62,7 +62,7 @@ import type {
 import type { CartItem, IntuneAppCategorySelection, PackageAssignment } from '@/types/upload';
 import type { AppRelationship } from '@/types/intune';
 import type { EspProfileSelection } from '@/types/esp';
-import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose } from '@/types/psadt';
+import { DEFAULT_PSADT_CONFIG, getDefaultProcessesToClose, sanitizeProcessesToClose } from '@/types/psadt';
 import { useCartStore, createStoreCartItem } from '@/stores/cart-store';
 import { useUserSettings } from '@/components/providers/UserSettingsProvider';
 import { useUpdateAppSettings } from '@/hooks/use-update-app-settings';
@@ -220,6 +220,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   // UI state
   const [expandedSection, setExpandedSection] = useState<ConfigSection | null>(isStoreApp ? 'assignment' : 'detection');
   const [isAddingToCart, setIsAddingToCart] = useState(false);
+  const [processesError, setProcessesError] = useState<string | null>(null);
   const [addedToCartSuccess, setAddedToCartSuccess] = useState(false);
   const [configMode, setConfigMode] = useState<'quick' | 'advanced'>('quick');
 
@@ -409,6 +410,20 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
     if (!isStoreApp && isFetchingVersionInstallers) return;
     if (!isStoreApp && inCart) return;
 
+    // The packaging pipeline rejects close-process entries without an
+    // executable name, so block adding to cart instead of storing a config
+    // that fails minutes later during packaging.
+    const sanitizedProcesses = isStoreApp
+      ? null
+      : sanitizeProcessesToClose(config.processesToClose);
+    if (sanitizedProcesses && sanitizedProcesses.invalid.length > 0) {
+      setProcessesError(
+        'Each process to close needs an executable name, for example chrome. Fill in the process name or remove the row.'
+      );
+      setExpandedSection('behavior');
+      return;
+    }
+
     setIsAddingToCart(true);
     try {
       if (isStoreApp) {
@@ -463,7 +478,9 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
           installCommand: config.installCommand || generateInstallCommand(selectedInstaller!, selectedScope),
           uninstallCommand: config.uninstallCommand || generateUninstallCommand(selectedInstaller!, pkg.name),
           detectionRules: config.detectionRules,
-          psadtConfig: config,
+          psadtConfig: sanitizedProcesses
+            ? { ...config, processesToClose: sanitizedProcesses.processes }
+            : config,
           assignments: assignments.length > 0 ? assignments : undefined,
           requirementRules: buildCartItemRequirementRules(
             displayName,
@@ -527,6 +544,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   };
 
   const removeProcess = (index: number) => {
+    setProcessesError(null);
     setConfig((prev) => ({
       ...prev,
       processesToClose: prev.processesToClose.filter((_, i) => i !== index),
@@ -534,6 +552,7 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
   };
 
   const updateProcess = (index: number, updates: Partial<ProcessToClose>) => {
+    setProcessesError(null);
     setConfig((prev) => ({
       ...prev,
       processesToClose: prev.processesToClose.map((p, i) =>
@@ -1022,7 +1041,12 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
                               value={process.name}
                               onChange={(e) => updateProcess(index, { name: e.target.value })}
                               placeholder="Process name (e.g., chrome)"
-                              className="flex-1 px-3 py-2 bg-bg-elevated border border-overlay/15 rounded-lg text-text-primary text-sm"
+                              className={cn(
+                                'flex-1 px-3 py-2 bg-bg-elevated border rounded-lg text-text-primary text-sm',
+                                processesError && !process.name.trim() && process.description.trim()
+                                  ? 'border-red-500/60'
+                                  : 'border-overlay/15'
+                              )}
                             />
                             <input
                               type="text"
@@ -1039,6 +1063,9 @@ export function PackageConfig({ package: pkg, installers, versions = [], onClose
                             </button>
                           </div>
                         ))
+                      )}
+                      {processesError && (
+                        <p className="text-red-400 text-sm">{processesError}</p>
                       )}
                     </div>
                   </div>

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1684,4 +1684,59 @@ describe('application packaging adapters', () => {
     const config = { ...DEFAULT_PSADT_CONFIG, processesToClose: [] };
     expect(applyApplicationPackagingAdapter('Example.StreamDeck', config)).toBe(config);
   });
+
+  it('rejects a close-process entry without an executable name for apps without an adapter', () => {
+    const config = {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: '', description: 'Git' },
+        { name: '', description: 'Git Bash' },
+      ],
+    };
+
+    expect(() => applyApplicationPackagingAdapter('Git.Git', config)).toThrow(
+      'A process to close for Git.Git is missing its executable name (Git, Git Bash)'
+    );
+  });
+
+  it('rejects a name that is only a .exe suffix', () => {
+    const config = {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [{ name: '.exe', description: 'Broken entry' }],
+    };
+
+    expect(() => applyApplicationPackagingAdapter('Git.Git', config)).toThrow(
+      'missing its executable name'
+    );
+  });
+
+  it('drops fully empty close-process rows for apps without an adapter', () => {
+    const config = {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [
+        { name: 'git', description: 'Git' },
+        { name: '', description: '' },
+        { name: '   ', description: '' },
+      ],
+    };
+
+    const adapted = applyApplicationPackagingAdapter('Git.Git', config);
+
+    expect(adapted.processesToClose).toEqual([{ name: 'git', description: 'Git' }]);
+  });
+
+  it('keeps valid close-process rows byte-identical for apps without an adapter', () => {
+    const config = {
+      ...DEFAULT_PSADT_CONFIG,
+      processesToClose: [{ name: 'notepad++.exe', description: 'Notepad++' }],
+    };
+
+    const adapted = applyApplicationPackagingAdapter('Notepad++.Notepad++', config);
+
+    expect(adapted).toBe(config);
+    expect(adapted.processesToClose[0]).toEqual({
+      name: 'notepad++.exe',
+      description: 'Notepad++',
+    });
+  });
 });

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1,3 +1,4 @@
+import { sanitizeProcessesToClose } from '@/types/psadt';
 import type { ProcessToClose, PSADTConfig } from '@/types/psadt';
 import type { WingetInstallerType, WingetScope } from '@/types/winget';
 
@@ -1740,6 +1741,23 @@ export function applyApplicationPackagingAdapter(
   config: PSADTConfig
 ): PSADTConfig {
   const adapter = applicationPackagingAdapter(wingetId);
+  // The packaging pipeline rejects close-process entries without an executable
+  // name. Validate for every app here, not just adapter apps, so a bad config
+  // fails at dispatch with a clear per-app error instead of minutes later
+  // inside the packaging workflow.
+  const { processes: keptProcesses, invalid: invalidProcesses } =
+    sanitizeProcessesToClose(config.processesToClose);
+  if (invalidProcesses.length > 0) {
+    const labels = invalidProcesses
+      .map((process) => process.description?.trim() || 'unnamed entry')
+      .join(', ');
+    throw new Error(
+      `A process to close for ${wingetId} is missing its executable name (${labels}). Edit the app configuration and set the process name or remove the entry.`
+    );
+  }
+  if (keptProcesses.length !== (config.processesToClose || []).length) {
+    config = { ...config, processesToClose: keptProcesses };
+  }
   if (!adapter) {
     // These internal lifecycle fields are never accepted from customer config.
     if (
@@ -1790,13 +1808,10 @@ export function applyApplicationPackagingAdapter(
     };
   }
 
-  const processesToClose = (config.processesToClose || []).map((process) => {
-    const name = normalizeProcessName(process.name);
-    if (!name) {
-      throw new Error(`Invalid empty PSADT process name for ${adapter.wingetId}`);
-    }
-    return { ...process, name };
-  });
+  const processesToClose = keptProcesses.map((process) => ({
+    ...process,
+    name: normalizeProcessName(process.name),
+  }));
   const configuredNames = new Set(
     processesToClose.map(({ name }) => name.toLowerCase())
   );

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -519,3 +519,30 @@ export function getDefaultProcessesToClose(
 
   return processes;
 }
+
+/**
+ * The packaging pipeline rejects close-process entries without an executable
+ * name, so validate before save or dispatch: drop rows with no content at
+ * all, and report rows that still lack a usable name (for example a filled
+ * description with an empty name) so callers can block instead of shipping a
+ * config the packager will fail on. Kept rows are returned unchanged; the
+ * packager itself trims and strips a trailing .exe, and rewriting names here
+ * would needlessly change QA execution-profile hashes.
+ */
+export function sanitizeProcessesToClose(
+  processes: ProcessToClose[] | undefined
+): { processes: ProcessToClose[]; invalid: ProcessToClose[] } {
+  const kept: ProcessToClose[] = [];
+  const invalid: ProcessToClose[] = [];
+  for (const process of processes || []) {
+    const name = (process.name || '').trim().replace(/\.exe$/i, '');
+    const description = (process.description || '').trim();
+    if (!name && !description) continue;
+    if (!name) {
+      invalid.push(process);
+      continue;
+    }
+    kept.push(process);
+  }
+  return { processes: kept, invalid };
+}


### PR DESCRIPTION
## Why

Packaging workflow runs 33165035531 and 33165148657 (Git.Git 2.55.0.3, Aug 28) failed in the Create PSADT package step with `Invalid PSADT process name []`. The dispatched config carried `processesToClose` entries with a filled description ("Git", "Git Bash") but an empty executable name. The job record shows the config was already stored that way at creation, so the client sent it and nothing server-side caught it: `applyApplicationPackagingAdapter` validates `processesToClose` only for apps with a packaging adapter, and Git.Git has none. The bad config sailed through and burned a full Actions run (runner spin-up plus installer download) before failing.

## What

- `types/psadt.ts`: new `sanitizeProcessesToClose` helper. Drops rows with no content, reports rows whose name is empty or reduces to empty after trimming and stripping a `.exe` suffix. Kept rows are returned unchanged so QA execution-profile hashes do not churn (the packager itself trims and strips `.exe`).
- `lib/packaging-adapters.ts`: the validation now runs for every app before the adapter early-return. A described row without a name fails the dispatch with a per-app message naming the offending entries, which the package route surfaces as a per-item error. Object identity is preserved when nothing changes.
- `components/CartItemConfig.tsx` and `components/PackageConfig.tsx`: save and add to cart are blocked on the same rule with a visible message and red highlight on the offending name fields; fully empty rows are silently dropped.

## Testing

- 4 new tests in `lib/packaging-adapters.test.ts`: the exact Git.Git failure shape throws with both descriptions named, a `.exe`-only name throws, fully empty rows are dropped, and valid rows (including a `.exe` suffix) pass through byte-identical with object identity.
- Full suite: 1589/1589 pass. ESLint clean on all changed files. `tsc --noEmit` reports no errors in changed files (pre-existing errors in unrelated test files remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)