### PR TITLE
fix(packaging): survive tenants that reject the isof duplicate-check filter

### DIFF
--- a/.github/scripts/Check-DuplicateApp.ps1
+++ b/.github/scripts/Check-DuplicateApp.ps1
@@ -87,20 +87,30 @@ try {
         return , $apps
     }
 
+    # Intune's $filter support on this collection is uneven, and some tenants
+    # reject the isof() cast filter outright with 400 (observed Aug 2026 across
+    # a whole tenant batch). Try progressively simpler query shapes before
+    # failing a deployment over a query-shape limitation. The name-only shape
+    # can return non-Win32 apps; the detail fetch below verifies the type
+    # before an app can count as a duplicate.
+    $candidateFilters = @(
+        "$typeFilter and $nameFilter",
+        $nameFilter,
+        $typeFilter
+    )
     $allApps = $null
-    try {
-        $allApps = Get-CandidateApps -Filter "$typeFilter and $nameFilter"
-        Write-Host "Found $($allApps.Count) Win32 app(s) matching '$displayName'"
-    }
-    catch {
-        # Intune's $filter support on this collection is uneven. If the combined
-        # filter is rejected, fall back to the type-only enumeration rather than
-        # failing a deployment over a query-shape limitation.
-        $filterStatus = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
-        if ($filterStatus -ne 400) { throw }
-        Write-Host "::warning::Graph rejected the combined duplicate-check filter; falling back to a full Win32 enumeration"
-        $allApps = Get-CandidateApps -Filter $typeFilter
-        Write-Host "Found $($allApps.Count) Win32 app(s) in tenant"
+    foreach ($candidateFilter in $candidateFilters) {
+        try {
+            $allApps = Get-CandidateApps -Filter $candidateFilter
+            Write-Host "Found $($allApps.Count) candidate app(s) using filter [$candidateFilter]"
+            break
+        }
+        catch {
+            $filterStatus = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+            if ($filterStatus -ne 400) { throw }
+            if ($candidateFilter -eq $candidateFilters[-1]) { throw }
+            Write-Host "::warning::Graph rejected duplicate-check filter [$candidateFilter]; trying a simpler query shape"
+        }
     }
 
     $nameMatches = @($allApps | Where-Object { $_.displayName -ieq $displayName })
@@ -135,6 +145,13 @@ try {
         # Win32-only properties such as displayVersion and committedContentVersion.
         $detailUrl = "$baseUrl/$($app.id)"
         $appDetails = Invoke-GraphRequest -Uri $detailUrl -MaxRetries 3
+
+        # The name-only filter shape can surface Store or LOB apps that share a
+        # display name. Only a Win32 app can be a duplicate of this deployment.
+        if ($appDetails.'@odata.type' -ne '#microsoft.graph.win32LobApp') {
+            Write-Host "Ignoring non-Win32 app $($app.id) with matching name (type: $($appDetails.'@odata.type'))"
+            continue
+        }
 
         # Only committed, published apps are deployable duplicates. Failed or
         # partially-created apps from an earlier upload must not block a safe retry.


### PR DESCRIPTION
## Why

Four packaging runs at 13:53 (one tenant's batch: Google.Chrome, Microsoft.Teams, Adobe.Acrobat.Reader.64-bit, Microsoft.Office) all failed in the Check for duplicate app step. Microsoft Graph rejected `$filter=isof('microsoft.graph.win32LobApp')` with 400 in **both** existing query shapes (combined with displayName, and type-only), so the existing single fallback did not help and the check failed the runs closed. Runs for other tenants 15 minutes earlier succeeded, and neither of today's merged PRs touched this code: this is a tenant-specific Graph rejection of the isof cast filter.

## What

`Check-DuplicateApp.ps1` now tries progressively simpler query shapes:

1. `isof(...) and displayName eq '...'` (current primary)
2. `displayName eq '...'` (new; supported on every tenant, returns a tiny result set)
3. `isof(...)` (current fallback, kept as last resort)

Because the name-only shape can return Store or LOB apps sharing a display name, the per-app detail fetch now verifies `@odata.type` is `#microsoft.graph.win32LobApp` before an app can count as a duplicate. Without that guard, a Store app deployed by IntuneGet under the same name could wrongly skip a Win32 deployment as "duplicate".

Fail-closed behavior is unchanged: if every shape gets 400, the run still fails with the retryable `DUPLICATE_CHECK_FAILED` callback rather than risking a second app, and non-400 errors still propagate immediately.

## Testing

There is no test harness for the .github/scripts PowerShell (only the icon TS scripts have tests), so this was validated by PowerShell parser check and review. Honest caveat: the first real exercise will be the affected tenant's retry. The four failed jobs are already marked retryable, so the customer can retry once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)