### PR TITLE
fix(packaging): name the real failure when a tenant has no usable Intune

### DIFF
--- a/.github/scripts/Check-DuplicateApp.ps1
+++ b/.github/scripts/Check-DuplicateApp.ps1
@@ -108,6 +108,11 @@ try {
         catch {
             $filterStatus = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
             if ($filterStatus -ne 400) { throw }
+            # "Request not applicable to target tenant" means Intune itself is
+            # not usable in this tenant (no Intune license or MDM authority not
+            # set). Every deviceAppManagement request fails the same way, so
+            # trying simpler query shapes is pointless.
+            if ([string]$_.ErrorDetails.Message -match 'not applicable to target tenant') { throw }
             if ($candidateFilter -eq $candidateFilters[-1]) { throw }
             Write-Host "::warning::Graph rejected duplicate-check filter [$candidateFilter]; trying a simpler query shape"
         }
@@ -209,17 +214,26 @@ try {
 }
 catch {
     $errorMessage = $_.Exception.Message
+    $errorBody = [string]$_.ErrorDetails.Message
+    # Intune's signature error for a tenant where Intune is not usable at all
+    # (no Intune license or MDM authority never set). Retrying cannot succeed,
+    # so tell the customer what to fix instead of blaming Graph availability.
+    $tenantNotProvisioned = $errorBody -match 'not applicable to target tenant'
     Write-Host "::error::Duplicate check failed: $errorMessage"
     Send-Callback -Body @{
         jobId = $env:JOB_ID
         status = "failed"
-        message = "Could not verify whether this app already exists in Intune. Retry when Microsoft Graph is available."
+        message = if ($tenantNotProvisioned) {
+            "Microsoft Intune does not appear to be set up in this tenant. Confirm the tenant has an Intune license and the MDM authority is set to Intune, then deploy again."
+        } else {
+            "Could not verify whether this app already exists in Intune. Retry when Microsoft Graph is available."
+        }
         progress = 0
         errorStage = "upload"
-        errorCategory = "intune_api"
-        errorCode = "DUPLICATE_CHECK_FAILED"
+        errorCategory = if ($tenantNotProvisioned) { "tenant_config" } else { "intune_api" }
+        errorCode = if ($tenantNotProvisioned) { "TENANT_NOT_INTUNE_PROVISIONED" } else { "DUPLICATE_CHECK_FAILED" }
         errorDetails = @{ operation = "duplicate_check"; error = $errorMessage }
-        retryable = $true
+        retryable = -not $tenantNotProvisioned
         runId = "$env:GITHUB_RUN_ID"
         runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
     } -CallbackUrl $env:CALLBACK_URL -CallbackSecret $env:CALLBACK_SECRET -MaxRetries 5 | Out-Null

--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -69,6 +69,9 @@ const categoryHints: Record<string, { message: string; showReVerify?: boolean }>
   intune_api: {
     message: 'The Intune API returned an error. This could be a temporary issue with Microsoft services.',
   },
+  tenant_config: {
+    message: 'Microsoft Intune does not appear to be set up in this tenant. Confirm the tenant has an Intune license and the MDM authority is set to Intune, then deploy again.',
+  },
   system: {
     message: 'An unexpected system error occurred. Please try again or contact support if the issue persists.',
   },
@@ -106,6 +109,7 @@ const errorCodeMessages: Record<string, string> = {
   INTUNE_COMMIT_FAILED: 'Failed to commit the uploaded file to Intune',
   WORKFLOW_DISPATCH_FAILED: 'The packaging workflow could not be started. No upload was performed.',
   DUPLICATE_CHECK_FAILED: 'Intune could not confirm whether this app already exists. Retry when Microsoft Graph is available.',
+  TENANT_NOT_INTUNE_PROVISIONED: 'This tenant rejected Intune API requests as not applicable. Intune is likely unlicensed here or the MDM authority is not set.',
   UNEXPECTED_ERROR: 'An unexpected error occurred during the pipeline',
 };
 


### PR DESCRIPTION
## Why

Correction to the diagnosis behind #992. The Graph 400s that failed the Aug 28 four-app batch carried a response body that was in the workflow logs all along: `"Request not applicable to target tenant"`. That is Intune's signature error for a tenant where Intune is not usable at all (no Intune license, or MDM authority never set). Every `deviceAppManagement` request from that tenant fails identically, so the filter-shape fallbacks from #992 (kept; still correct hardening for genuine isof rejections) cannot help this customer, and the current retryable "Retry when Microsoft Graph is available" callback is wrong guidance since retrying cannot succeed.

## What

- `Check-DuplicateApp.ps1`: when a 400 body matches "not applicable to target tenant", skip the pointless simpler-filter fallbacks and fail immediately; the outer catch sends a **non-retryable** `TENANT_NOT_INTUNE_PROVISIONED` callback with `errorCategory: tenant_config` and a message telling the customer to confirm their Intune license and MDM authority. All other failures keep the existing retryable `DUPLICATE_CHECK_FAILED` behavior.
- `components/ErrorDisplay.tsx`: adds the matching `tenant_config` category hint and `TENANT_NOT_INTUNE_PROVISIONED` code message so the dashboard shows the actionable explanation. Unknown categories already degraded gracefully; this makes the hint explicit.

`error_category` is a free-text column (migration 015), so no schema change is needed.

## Testing

PowerShell parser check passes and the hashtable conditional pattern was verified in pwsh directly. The `.github/scripts` PowerShell has no test harness; the first real exercise will be the affected tenant's next attempt. Note: after this merges, the scripts pin in IntuneGet-Workflows must be bumped for the packaging workflow to pick it up (same as #992).

🤖 Generated with [Claude Code](https://claude.com/claude-code)