### PR TITLE
fix(qa): release claims before installer preflight timeout

### DIFF
--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -508,6 +508,46 @@ describe('GET /api/cron/qa-dispatch', () => {
     }));
   });
 
+  it('returns after a preflight wall-clock deadline so Vercel can release the claim', async () => {
+    const unavailable = candidate('catalog-default');
+    unavailable.id = testUuid(54);
+    const waiting = candidate('catalog-default');
+    waiting.id = testUuid(55);
+    const { client, claimedIds, rollbackIds, rollbackPayloads } = createSupabaseStub([
+      unavailable,
+      waiting,
+    ]);
+    createServerClientMock.mockReturnValue(client);
+    dispatchQaCandidateMock.mockRejectedValueOnce(new InstallerPreflightError(
+      'PREFLIGHT_DEADLINE_EXCEEDED',
+      'Installer verification exceeded the wall-clock deadline',
+      true,
+    ));
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      dispatched: false,
+      reason: 'installer_unavailable',
+      installerUnavailable: {
+        candidateId: unavailable.id,
+        code: 'PREFLIGHT_DEADLINE_EXCEEDED',
+        attempts: 1,
+        exhausted: false,
+      },
+    });
+    expect(claimedIds).toEqual([unavailable.id]);
+    expect(rollbackIds).toEqual([unavailable.id]);
+    expect(rollbackPayloads).toContainEqual(expect.objectContaining({
+      status: 'queued',
+      attempts: 1,
+      dispatched_at: null,
+    }));
+    expect(dispatchQaCandidateMock).toHaveBeenCalledTimes(1);
+  });
+
   it('terminates an exhausted installer preflight retry and continues dispatching', async () => {
     const unavailable = candidate('catalog-default');
     unavailable.id = testUuid(52);

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -334,6 +334,17 @@ export async function GET(request: Request) {
             exhausted,
           };
           console.warn('QA installer preflight deferred', lastInstallerUnavailable);
+          if (error.code === 'PREFLIGHT_DEADLINE_EXCEEDED') {
+            return NextResponse.json({
+              success: true,
+              dispatched: false,
+              reason: 'installer_unavailable',
+              reconciled,
+              scanned,
+              superseded,
+              installerUnavailable: lastInstallerUnavailable,
+            });
+          }
           // A transient publisher/CDN response must not block unrelated apps.
           // Move the candidate behind the current queue (or terminate after the
           // bounded retry limit) and continue within this dispatch tick.

--- a/lib/__tests__/installer-download.test.ts
+++ b/lib/__tests__/installer-download.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildByteRanges,
   hashesEqual,
@@ -8,9 +8,30 @@ import {
   parsePublisherChecksum,
   publisherChecksumUrlForInstaller,
   shouldUseRangedInstallerHash,
+  withInstallerDownloadDeadline,
 } from '@/lib/installer-download';
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('installer download safety helpers', () => {
+  it('enforces a wall-clock deadline even while an operation remains active', async () => {
+    vi.useFakeTimers();
+    const result = withInstallerDownloadDeadline(25, (signal) =>
+      new Promise<never>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      })
+    );
+
+    const assertion = expect(result).rejects.toMatchObject({
+      name: 'InstallerDownloadDeadlineError',
+      message: 'Installer verification exceeded the 25ms wall-clock deadline',
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    await assertion;
+  });
+
   it('rejects private and reserved network addresses', () => {
     expect(isPublicIpAddress('127.0.0.1')).toBe(false);
     expect(isPublicIpAddress('10.0.0.10')).toBe(false);

--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -23,6 +23,7 @@ import {
   InstallerPreflightError,
   resetInstallerPreflightStateForTests,
 } from '@/lib/installer-preflight';
+import { InstallerDownloadDeadlineError } from '@/lib/installer-download';
 
 const expectedSha256 = 'a'.repeat(64).toUpperCase();
 const actualSha256 = 'b'.repeat(64).toUpperCase();
@@ -261,6 +262,16 @@ describe('installer dispatch preflight', () => {
     });
 
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps the hard download deadline to a retryable preflight result', async () => {
+    hashRemoteInstallerMock.mockRejectedValueOnce(new InstallerDownloadDeadlineError(240_000));
+
+    await expect(enforceInstallerPreflight(request)).rejects.toMatchObject({
+      code: 'PREFLIGHT_DEADLINE_EXCEEDED',
+      retryable: true,
+      message: 'Installer verification exceeded the 240000ms wall-clock deadline',
+    });
   });
 
   it('caches manifest drift as a deterministic tuple error', async () => {

--- a/lib/installer-download.ts
+++ b/lib/installer-download.ts
@@ -6,6 +6,7 @@ import * as https from 'node:https';
 
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 180_000;
+const DEFAULT_TOTAL_TIMEOUT_MS = 240_000;
 const MAX_REDIRECTS = 5;
 const DEFAULT_RANGE_CHUNK_BYTES = 1024 * 1024;
 const RANGE_DOWNLOAD_CONCURRENCY = 4;
@@ -21,6 +22,36 @@ export interface InstallerHashResult {
   bytes: number;
   finalUrl: string;
   verificationMethod?: 'content-hash' | 'publisher-checksum';
+}
+
+export class InstallerDownloadDeadlineError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Installer verification exceeded the ${timeoutMs}ms wall-clock deadline`);
+    this.name = 'InstallerDownloadDeadlineError';
+  }
+}
+
+export async function withInstallerDownloadDeadline<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError('Installer verification deadline must be a positive number');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  try {
+    return await operation(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new InstallerDownloadDeadlineError(timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 interface ByteRange {
@@ -195,6 +226,7 @@ async function readRangeMetadata(
   redirectsRemaining: number,
   maxBytes: number,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<RangeMetadata> {
   const resolved = await resolvePublicAddress(url.hostname);
   const headers = {
@@ -228,6 +260,7 @@ async function readRangeMetadata(
           redirectsRemaining - 1,
           maxBytes,
           timeoutMs,
+          signal,
         ).then(resolve, reject);
         return;
       }
@@ -271,6 +304,7 @@ async function readRangeMetadata(
       path: `${url.pathname}${url.search}`,
       method: 'HEAD',
       headers,
+      signal,
     };
     const request = url.protocol === 'https:'
       ? https.request({ ...commonOptions, servername: url.hostname }, onResponse)
@@ -290,6 +324,7 @@ async function downloadInstallerRange(
   totalBytes: number,
   validator: string,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<Buffer> {
   const resolved = await resolvePublicAddress(url.hostname);
   const expectedBytes = range.end - range.start + 1;
@@ -353,6 +388,7 @@ async function downloadInstallerRange(
       path: `${url.pathname}${url.search}`,
       method: 'GET',
       headers,
+      signal,
     };
     const request = url.protocol === 'https:'
       ? https.request({ ...commonOptions, servername: url.hostname }, onResponse)
@@ -372,11 +408,12 @@ async function downloadInstallerRangeWithRetry(
   totalBytes: number,
   validator: string,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<Buffer> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= RANGE_DOWNLOAD_ATTEMPTS; attempt += 1) {
     try {
-      return await downloadInstallerRange(url, range, totalBytes, validator, timeoutMs);
+      return await downloadInstallerRange(url, range, totalBytes, validator, timeoutMs, signal);
     } catch (error) {
       lastError = error;
     }
@@ -388,6 +425,7 @@ async function readPublisherChecksum(
   url: URL,
   redirectsRemaining: number,
   trustedHostname: string,
+  signal: AbortSignal,
 ): Promise<string> {
   const resolved = await resolvePublicAddress(url.hostname);
   const headers = {
@@ -427,6 +465,7 @@ async function readPublisherChecksum(
           redirectUrl,
           redirectsRemaining - 1,
           trustedHostname,
+          signal,
         ).then(resolve, reject);
         return;
       }
@@ -467,6 +506,7 @@ async function readPublisherChecksum(
       method: 'GET',
       headers,
       servername: url.hostname,
+      signal,
     }, onResponse);
     request.setTimeout(PUBLISHER_CHECKSUM_TIMEOUT_MS, () => {
       request.destroy(new Error(
@@ -483,6 +523,7 @@ async function attestInstallerWithPublisherChecksum(
   checksumUrl: URL,
   maxBytes: number,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<InstallerHashResult> {
   const trustedHostname = installerUrl.hostname.toLowerCase();
   const metadata = await readRangeMetadata(
@@ -490,6 +531,7 @@ async function attestInstallerWithPublisherChecksum(
     MAX_REDIRECTS,
     maxBytes,
     timeoutMs,
+    signal,
   );
   if (
     metadata.finalUrl.hostname.toLowerCase() !== trustedHostname ||
@@ -508,6 +550,7 @@ async function attestInstallerWithPublisherChecksum(
     checksumUrl,
     MAX_REDIRECTS,
     trustedHostname,
+    signal,
   );
   const filename = installerUrl.pathname.split('/').at(-1) || '';
   const sha256 = parsePublisherChecksum(checksumContent, filename);
@@ -523,6 +566,7 @@ async function attestInstallerWithPublisherChecksum(
       totalBytes,
       metadata.validator,
       timeoutMs,
+      signal,
     ),
     downloadInstallerRangeWithRetry(
       metadata.finalUrl,
@@ -533,6 +577,7 @@ async function attestInstallerWithPublisherChecksum(
       totalBytes,
       metadata.validator,
       timeoutMs,
+      signal,
     ),
   ]);
 
@@ -549,15 +594,22 @@ async function hashUrlInRanges(
   redirectsRemaining: number,
   maxBytes: number,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<InstallerHashResult> {
-  const metadata = await readRangeMetadata(url, redirectsRemaining, maxBytes, timeoutMs);
+  const metadata = await readRangeMetadata(
+    url,
+    redirectsRemaining,
+    maxBytes,
+    timeoutMs,
+    signal,
+  );
   if (
     !metadata.acceptsRanges ||
     metadata.totalBytes === null ||
     !metadata.validator ||
     metadata.totalBytes <= DEFAULT_RANGE_CHUNK_BYTES
   ) {
-    return hashUrl(metadata.finalUrl, redirectsRemaining, maxBytes, timeoutMs);
+    return hashUrl(metadata.finalUrl, redirectsRemaining, maxBytes, timeoutMs, signal);
   }
 
   const totalBytes = metadata.totalBytes;
@@ -574,6 +626,7 @@ async function hashUrlInRanges(
           totalBytes,
           validator,
           timeoutMs,
+          signal,
         )
       ),
     );
@@ -596,6 +649,7 @@ async function hashUrl(
   redirectsRemaining: number,
   maxBytes: number,
   timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<InstallerHashResult> {
   const resolved = await resolvePublicAddress(url.hostname);
   const headers = {
@@ -624,7 +678,13 @@ async function hashUrl(
           return;
         }
 
-        hashUrl(redirectUrl, redirectsRemaining - 1, maxBytes, timeoutMs).then(resolve, reject);
+        hashUrl(
+          redirectUrl,
+          redirectsRemaining - 1,
+          maxBytes,
+          timeoutMs,
+          signal,
+        ).then(resolve, reject);
         return;
       }
 
@@ -670,6 +730,7 @@ async function hashUrl(
       path: `${url.pathname}${url.search}`,
       method: 'GET',
       headers,
+      signal,
     };
 
     const request = url.protocol === 'https:'
@@ -686,23 +747,27 @@ async function hashUrl(
 
 export async function hashRemoteInstaller(
   installerUrl: string,
-  options?: { maxBytes?: number; timeoutMs?: number },
+  options?: { maxBytes?: number; timeoutMs?: number; totalTimeoutMs?: number },
 ): Promise<InstallerHashResult> {
   const url = validateUrl(installerUrl);
   const maxBytes = options?.maxBytes ?? parseMaximumBytes();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const totalTimeoutMs = options?.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
   const publisherChecksumUrl = publisherChecksumUrlForInstaller(installerUrl);
-  if (publisherChecksumUrl) {
-    return attestInstallerWithPublisherChecksum(
-      url,
-      validateUrl(publisherChecksumUrl),
-      maxBytes,
-      timeoutMs,
-    );
-  }
-  return shouldUseRangedInstallerHash(installerUrl)
-    ? hashUrlInRanges(url, MAX_REDIRECTS, maxBytes, timeoutMs)
-    : hashUrl(url, MAX_REDIRECTS, maxBytes, timeoutMs);
+  return withInstallerDownloadDeadline(totalTimeoutMs, (signal) => {
+    if (publisherChecksumUrl) {
+      return attestInstallerWithPublisherChecksum(
+        url,
+        validateUrl(publisherChecksumUrl),
+        maxBytes,
+        timeoutMs,
+        signal,
+      );
+    }
+    return shouldUseRangedInstallerHash(installerUrl)
+      ? hashUrlInRanges(url, MAX_REDIRECTS, maxBytes, timeoutMs, signal)
+      : hashUrl(url, MAX_REDIRECTS, maxBytes, timeoutMs, signal);
+  });
 }
 
 export function hashesEqual(left: string, right: string): boolean {

--- a/lib/installer-preflight.ts
+++ b/lib/installer-preflight.ts
@@ -4,6 +4,7 @@ import { getLiveInstallers } from '@/lib/manifest-api';
 import {
   hashRemoteInstaller,
   hashesEqual,
+  InstallerDownloadDeadlineError,
   isLikelyMutableInstallerUrl,
 } from '@/lib/installer-download';
 import { normalizeQaInstallerType } from '@/lib/qa/candidate';
@@ -372,7 +373,13 @@ async function performLivePreflight(
 
     const normalized = error instanceof InstallerPreflightError
       ? error
-      : new InstallerPreflightError(
+      : error instanceof InstallerDownloadDeadlineError
+        ? new InstallerPreflightError(
+            'PREFLIGHT_DEADLINE_EXCEEDED',
+            error.message,
+            true,
+          )
+        : new InstallerPreflightError(
           'PREFLIGHT_UNAVAILABLE',
           error instanceof Error ? error.message : 'Installer verification failed',
           true,


### PR DESCRIPTION
## Summary
- enforce a cancellable 240-second wall-clock deadline around shared installer verification
- map deadline expiry to a retryable preflight result used by both customer packaging and QA
- requeue the claimed QA candidate and return immediately instead of running into Vercel's 300-second invocation limit

## Production incident
OCLC.CONTENTdmProjectClient 7.0.77.0 kept transferring bytes long enough for /api/cron/qa-dispatch to hit FUNCTION_INVOCATION_TIMEOUT after the row had been claimed. No GitHub run was created. This change leaves 60 seconds for shared-state cleanup and the HTTP response.

## Verification
- focused Vitest: 42 passed
- ESLint on all changed files: passed
- 
pm run build:ci: passed