### PR TITLE
fix(packager): preserve non-ASCII deployment identities

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -4302,5 +4302,13 @@ $lines += @(
 )
 
 $scriptContent = $lines -join "`r`n"
-Set-Content -Path "$packageDir\Invoke-AppDeployToolkit.ps1" -Value $scriptContent -Encoding UTF8
+# Invoke-AppDeployToolkit.exe can host Windows PowerShell, which treats a UTF-8
+# script without a BOM as the active ANSI code page. Preserve non-ASCII catalog
+# identities so registry capture, detection, and uninstall compare the exact
+# vendor display name that was embedded at package creation time.
+[System.IO.File]::WriteAllText(
+    (Join-Path $packageDir 'Invoke-AppDeployToolkit.ps1'),
+    $scriptContent,
+    [System.Text.UTF8Encoding]::new($true)
+)
 Write-Host "Generated PSADT v4 deployment script"

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2738,6 +2738,44 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'writes generated deployment scripts as UTF-8 with BOM for Windows PowerShell',
+    () => {
+      const displayName = '班级优化大师';
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        displayName,
+        [],
+        {},
+        [],
+        'Seewo.EasiCare',
+        displayName,
+        '2.1.0.1428',
+        `REGISTRY_UNINSTALL:${displayName}`,
+        '/S',
+        'machine',
+        '',
+        '',
+        (packageDirectory) => {
+          const scriptBytes = readFileSync(
+            join(packageDirectory, 'Invoke-AppDeployToolkit.ps1')
+          );
+          expect(Array.from(scriptBytes.subarray(0, 3))).toEqual([
+            0xef,
+            0xbb,
+            0xbf,
+          ]);
+        }
+      );
+
+      expect(generated).toContain(
+        `$configuredUninstallDisplayName = '${displayName}'`
+      );
+      expect(generated).toContain(`$appName = '${displayName}'`);
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'appends IrfanView\'s documented silent switch to its captured ARP command',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## What changed

- write generated Invoke-AppDeployToolkit.ps1 with an explicit UTF-8 BOM
- preserve non-ASCII catalog display names when PSADT is hosted by Windows PowerShell
- add a Seewo Chinese-name regression contract that verifies both the BOM and embedded identity

## Why

Seewo.EasiCare installed successfully and registered the correct Chinese ARP identity, but Windows PowerShell decoded the BOM-less generated script through the legacy ANSI code page. The package then could not capture or uninstall the app it had installed.

## Verification

- 136/136 PSADT packager contract tests passed
- changed-file ESLint passed
- npm run build:ci passed, including TypeScript and 145 static pages