### PR TITLE
chore(qa): activate UTF-8 PSADT scripts

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '493b141d093be4d3fa25b550c41d47f7b9a91a67',
+  packagerCommit: 'c2cd8a1db09d584e6f59e7e46cfe6bb6e39f82fd',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -497,6 +497,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // LocalSystem's disposable systemprofile. Preserve every unrelated
   // compatible pass from the Teradata archive-uninstall release.
   'c96b0c7605388a652d05e226bb566d6e62f3c268',
+  // Generated deployment scripts now retain non-ASCII catalog identities when
+  // hosted by Windows PowerShell. Preserve every unrelated compatible pass
+  // from the Somiibo user-scope release.
+  '493b141d093be4d3fa25b550c41d47f7b9a91a67',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -126,6 +126,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries Seewo only after activating UTF-8 BOM deployment scripts', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' seewo.easicare ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '493b141d093be4d3fa25b550c41d47f7b9a91a67',
+      { wingetId: 'Seewo.EasiCare', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -424,7 +424,17 @@ const SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...TERADATA_ARCHIVE_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS = [
+  // Retry the failed Seewo lifecycle with its Chinese ARP identity preserved
+  // exactly when Invoke-AppDeployToolkit.exe hosts Windows PowerShell.
+  'Seewo.EasiCare',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'c2cd8a1db09d584e6f59e7e46cfe6bb6e39f82fd':
+    PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS,
   '493b141d093be4d3fa25b550c41d47f7b9a91a67':
     SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'c96b0c7605388a652d05e226bb566d6e62f3c268':


### PR DESCRIPTION
## What changed

- pin QA package profiles to packager commit c2cd8a1db09d584e6f59e7e46cfe6bb6e39f82fd
- retain unrelated compatible passes from the previous release
- target the failed Seewo.EasiCare profile for a production-toolchain retry

## Production parity

The pin is consumed by the web QA scheduler and the same repository commit is used by customer PSADT packaging. The workflow repository and database control pins will be updated atomically after this protected change is deployed.

## Verification

- 242/242 focused profile and backfill tests passed
- changed-file ESLint passed
- npm run build:ci passed, including TypeScript and 145 static pages