### PR TITLE
fix(catalog): quote values in PostgREST or() filters

### DIFF
--- a/app/api/sccm/match/route.ts
+++ b/app/api/sccm/match/route.ts
@@ -8,6 +8,7 @@ import { createServerClient } from '@/lib/supabase';
 import { getAuthFromRequest } from '@/lib/auth/parse-token';
 import { logMigrationHistoryAsync, createSuccessEntry, createAppEntry } from '@/lib/sccm/history-logger';
 import { matchSccmApp, type SccmMatchResult } from '@/lib/matching/sccm-matcher';
+import { quotePostgrestLikePattern } from '@/lib/catalog/postgrest-filter';
 import type {
   SccmApplication,
   SccmMatchRequest,
@@ -375,7 +376,13 @@ export async function GET(request: NextRequest) {
     }
 
     if (search) {
-      query = query.or(`display_name.ilike.%${search}%,manufacturer.ilike.%${search}%`);
+      const searchPattern = quotePostgrestLikePattern(search);
+      query = query.or(
+        [
+          `display_name.ilike.${searchPattern}`,
+          `manufacturer.ilike.${searchPattern}`,
+        ].join(',')
+      );
     }
 
     query = query

--- a/lib/catalog/postgrest-filter.test.ts
+++ b/lib/catalog/postgrest-filter.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  quotePostgrestValue,
+  quotePostgrestLikePattern,
+} from './postgrest-filter';
+
+describe('quotePostgrestValue', () => {
+  it('wraps a plain value in double quotes', () => {
+    expect(quotePostgrestValue('Zoom')).toBe('"Zoom"');
+  });
+
+  it('protects the logic tree from a value containing a comma', () => {
+    expect(quotePostgrestValue('Arhus, Randers & Hobro')).toBe(
+      '"Arhus, Randers & Hobro"'
+    );
+  });
+
+  it('escapes embedded double quotes instead of dropping them', () => {
+    expect(quotePostgrestValue('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it('escapes backslashes before quotes so the escape cannot be broken out of', () => {
+    // String.fromCharCode(92) keeps these cases readable: a literal
+    // backslash in a JS string or template is easy to miscount.
+    const bs = String.fromCharCode(92);
+    expect(quotePostgrestValue('back' + bs + 'slash')).toBe(
+      '"back' + bs + bs + 'slash"'
+    );
+    expect(quotePostgrestValue('trailing' + bs)).toBe(
+      '"trailing' + bs + bs + '"'
+    );
+    // A lone trailing backslash must not let the value escape its quotes.
+    expect(quotePostgrestValue('evil' + bs + '"')).toBe(
+      '"evil' + bs + bs + bs + '""'
+    );
+  });
+
+  it('keeps parentheses inside the quoted value', () => {
+    expect(quotePostgrestValue('Zoom Workplace (64-bit)')).toBe(
+      '"Zoom Workplace (64-bit)"'
+    );
+  });
+});
+
+describe('quotePostgrestLikePattern', () => {
+  it('wraps the term in contains-wildcards inside the quotes', () => {
+    expect(quotePostgrestLikePattern('zoom')).toBe('"%zoom%"');
+  });
+
+  it('produces a parseable or() operand for a comma-bearing app name', () => {
+    const pattern = quotePostgrestLikePattern(
+      'docubizz -tck arhus, randers & hobro'
+    );
+    const filter = [
+      `name.ilike.${pattern}`,
+      `publisher.ilike.${pattern}`,
+    ].join(',');
+
+    // The only unquoted comma must be the operand separator, otherwise
+    // PostgREST splits the value and the logic tree fails to parse.
+    expect(splitTopLevel(filter)).toEqual([
+      'name.ilike."%docubizz -tck arhus, randers & hobro%"',
+      'publisher.ilike."%docubizz -tck arhus, randers & hobro%"',
+    ]);
+  });
+  it('neutralises an injection payload combining comma, parens, quote and backslash', () => {
+    const bs = String.fromCharCode(92);
+    // A value crafted to close the quote and append a second operand that
+    // would match Zoom rows. Verified against the production PostgREST
+    // endpoint: unquoted, `%zzzznomatch%,name.ilike.%zoom%` really does
+    // inject and return Zoom rows; the escaped form below returns HTTP 200
+    // with no rows.
+    const hostile = 'zzzznomatch%"),name.ilike.%zoom%' + bs;
+    const filter = `name.ilike.${quotePostgrestLikePattern(hostile)}`;
+
+    expect(filter).toBe(
+      'name.ilike."%zzzznomatch%\\"),name.ilike.%zoom%' + bs + bs + '%"'
+    );
+    // Exactly one operand: nothing the value contained became filter syntax.
+    expect(splitTopLevel(filter)).toHaveLength(1);
+  });
+});
+/** Split on commas that are not inside a quoted section, mirroring PostgREST. */
+function splitTopLevel(filter: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < filter.length; i++) {
+    const char = filter[i];
+    if (char === String.fromCharCode(92) && inQuotes) {
+      current += char + filter[++i];
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+      continue;
+    }
+    if (char === ',' && !inQuotes) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts;
+}

--- a/lib/catalog/postgrest-filter.ts
+++ b/lib/catalog/postgrest-filter.ts
@@ -1,0 +1,33 @@
+/**
+ * Helpers for building PostgREST filter strings by hand (the argument to
+ * `.or()`, which supabase-js passes through verbatim).
+ *
+ * PostgREST parses that argument as a logic tree: commas separate the
+ * operands and parentheses group them. Any value interpolated into it must
+ * therefore be double-quoted, or a name as ordinary as
+ * "Docubizz -TCK Arhus, Randers & Hobro" splits the tree and the whole query
+ * fails with "failed to parse logic tree". Inside double quotes, backslash
+ * and double quote are the only characters that still need escaping, and
+ * backslashes must be escaped first so an input ending in one cannot break
+ * out of the quotes.
+ */
+
+/** Quote and escape a single value for use inside a PostgREST filter. */
+export function quotePostgrestValue(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+/**
+ * Build a quoted `%term%` pattern for an ilike filter.
+ *
+ * Quoting protects PostgREST's parser without disabling LIKE semantics, so
+ * the surrounding `%` still match as wildcards. Any `%` or `_` inside the
+ * term keeps its existing wildcard meaning; that only widens the match and
+ * is unchanged from the previous unquoted behaviour.
+ */
+export function quotePostgrestLikePattern(term: string): string {
+  return quotePostgrestValue(`%${term}%`);
+}

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -15,6 +15,10 @@
 import { createClient } from '@supabase/supabase-js';
 import { createServerClient } from '@/lib/supabase';
 import { getLocaleDisplay } from '@/lib/locale-utils';
+import {
+  quotePostgrestLikePattern,
+  quotePostgrestValue,
+} from '@/lib/catalog/postgrest-filter';
 import type { LocaleVariant } from '@/types/winget';
 import type { CuratedAppMatch } from '@/lib/app-mappings';
 import type { InstallationSnapshot } from '@/lib/winget-api';
@@ -635,6 +639,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     }
 
     const normalizedSearch = term.toLowerCase().trim();
+    const searchPattern = quotePostgrestLikePattern(normalizedSearch);
     const supabase = createServerClient();
 
     try {
@@ -643,7 +648,11 @@ export class SupabaseCatalogSource implements CatalogSource {
         .select('winget_id, name, publisher, latest_version')
         .not('latest_version', 'is', null)
         .or(
-          `name.ilike.%${normalizedSearch}%,publisher.ilike.%${normalizedSearch}%,winget_id.ilike.%${normalizedSearch}%`
+          [
+            `name.ilike.${searchPattern}`,
+            `publisher.ilike.${searchPattern}`,
+            `winget_id.ilike.${searchPattern}`,
+          ].join(',')
         )
         .order('popularity_rank', { ascending: true, nullsFirst: false })
         .limit(10);
@@ -699,10 +708,12 @@ export class SupabaseCatalogSource implements CatalogSource {
     };
 
     // Build the OR conditions defensively: quote values so names containing
-    // spaces or parentheses (e.g. "Zoom Workplace (64-bit)") don't break the
+    // commas or parentheses (e.g. "Zoom Workplace (64-bit)") don't break the
     // PostgREST or() parser, and only filter on product code when one exists
-    // (eq.null would not match NULL rows anyway).
-    const quote = (v: string) => `"${v.replace(/"/g, '')}"`;
+    // (eq.null would not match NULL rows anyway). The shared helper escapes
+    // embedded quotes rather than stripping them, so a name carrying one is
+    // still matched exactly instead of silently missing its row.
+    const quote = quotePostgrestValue;
     const orConditions = [
       `sccm_display_name_normalized.eq.${quote(displayNameNormalized)}`,
       `sccm_ci_id.eq.${quote(ciId)}`,
@@ -798,12 +809,18 @@ export class SupabaseCatalogSource implements CatalogSource {
     term: string,
     limit: number
   ): Promise<{ winget_id: string; name: string }[]> {
+    const termPattern = quotePostgrestLikePattern(term);
     const supabase = createServerClient();
 
     const { data } = await supabase
       .from('curated_apps')
       .select('winget_id, name')
-      .or(`winget_id.ilike.%${term}%,name.ilike.%${term}%`)
+      .or(
+        [
+          `winget_id.ilike.${termPattern}`,
+          `name.ilike.${termPattern}`,
+        ].join(',')
+      )
       .eq('is_verified', true)
       .limit(limit);
 


### PR DESCRIPTION
## Why

Production has been logging this repeatedly on `/api/updates/refresh`:

```
Error searching curated apps: "failed to parse logic tree
((name.ilike.%docubizz -tck århus, randers & hobro%,publisher.ilike.%...%))" (line 1, column 45)
```

`supabase-js` `.or()` takes a **raw PostgREST filter string**, and PostgREST parses it as a logic tree where commas separate operands. Search terms were interpolated unescaped, so an Intune app whose display name merely contains a comma ("Docubizz -TCK Århus, Randers & Hobro") splits the tree and the query 400s. `searchCuratedAppsForMatching` swallows the error and returns `[]`, so those apps **silently never match the catalog and never get update detection**.

This is also a filter-injection hole, not just breakage. Against the live endpoint, the value `%zzzznomatch%,name.ilike.%zoom%` really does append a second operand and return Zoom rows. `app/api/sccm/match` takes its `search` term straight from a user-supplied query parameter.

## Verified against production PostgREST (not assumed)

| case | result |
|---|---|
| unquoted value with comma | HTTP 400 `PGRST100`, reproduces the exact production error incl. `column 45` |
| same value quoted | HTTP 200 |
| `"%zoom%"` quoted | still returns Zoom rows, so LIKE semantics are unchanged |
| injection payload unquoted | injected operand fires, returns Zoom rows |
| same payload escaped by the shipped helper | HTTP 200, no rows |

## What

- New `lib/catalog/postgrest-filter.ts`: `quotePostgrestValue` / `quotePostgrestLikePattern`. Backslashes are escaped **before** quotes, so a value ending in a backslash cannot break out of its quotes.
- Applied to the four call sites carrying user- or tenant-controlled text: catalog matching search, similar-app search, the SCCM mapping lookup, and the SCCM match route's `search` param.
- The local SCCM helper it replaces *stripped* embedded quotes rather than escaping them, which silently mismatched any name containing one; that is now an exact match.
- Remaining raw `.or()` sites interpolate only resolved UUID tenant ids, numeric priorities and DB timestamps (none can contain a comma) and are deliberately left alone.

## Review

Reviewed by Codex `gpt-5.6-sol`. It found no blocking issue, could construct no breakout payload, and independently reached the same call-site audit. Its one finding — no single test combined comma + parens + quote + backslash in one value — is addressed by the injection test added here, whose expected string was additionally confirmed to return HTTP 200 against the live endpoint.

Not addressed (pre-existing, out of scope): `searchCuratedAppsForMatching` still swallows query errors and returns `[]`, so an unrelated backend failure can still look like "no matches". That is observability debt worth a separate change.

## Testing

8 new unit tests; 34 catalog tests pass; ESLint clean; no new `tsc` errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
