### PR TITLE
fix(packager): resolve UTF-8 script output path

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -4306,8 +4306,11 @@ $scriptContent = $lines -join "`r`n"
 # script without a BOM as the active ANSI code page. Preserve non-ASCII catalog
 # identities so registry capture, detection, and uninstall compare the exact
 # vendor display name that was embedded at package creation time.
+$deploymentScriptPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+    (Join-Path $packageDir 'Invoke-AppDeployToolkit.ps1')
+)
 [System.IO.File]::WriteAllText(
-    (Join-Path $packageDir 'Invoke-AppDeployToolkit.ps1'),
+    $deploymentScriptPath,
     $scriptContent,
     [System.Text.UTF8Encoding]::new($true)
 )

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -65,7 +65,8 @@ function generateRegistryUninstallPackage(
   installScope: 'machine' | 'user' = 'machine',
   nestedInstallerType = '',
   nestedInstallerPath = '',
-  verifyPackage?: (packageDirectory: string) => void
+  verifyPackage?: (packageDirectory: string) => void,
+  divergeProcessDirectory = false
 ): string {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'intuneget-psadt-packager-'));
 
@@ -100,8 +101,15 @@ function generateRegistryUninstallPackage(
       }
     }
 
-    const result = spawnSync('pwsh', ['-NoProfile', '-File', packagerPath], {
-      cwd: fixtureRoot,
+    const packagerArguments = divergeProcessDirectory
+      ? [
+          '-NoProfile',
+          '-Command',
+          '[Environment]::CurrentDirectory = $env:PACKAGER_PROCESS_DIRECTORY; Set-Location -LiteralPath $env:GITHUB_WORKSPACE; & $env:PACKAGER_SCRIPT_PATH',
+        ]
+      : ['-NoProfile', '-File', packagerPath];
+    const result = spawnSync('pwsh', packagerArguments, {
+      cwd: divergeProcessDirectory ? process.cwd() : fixtureRoot,
       encoding: 'utf8',
       env: {
         ...process.env,
@@ -122,6 +130,12 @@ function generateRegistryUninstallPackage(
         INPUT_UNINSTALL_COMMAND: uninstallCommand,
         INSTALLER_PATH: installerPath,
         INSTALLER_FILENAME: installerFileName,
+        ...(divergeProcessDirectory
+          ? {
+              PACKAGER_PROCESS_DIRECTORY: process.cwd(),
+              PACKAGER_SCRIPT_PATH: packagerPath,
+            }
+          : {}),
         ...(packageDependencies.length > 0
           ? { DEPENDENCIES_PATH: dependencyPath }
           : {}),
@@ -2738,7 +2752,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'writes generated deployment scripts as UTF-8 with BOM for Windows PowerShell',
+    'writes UTF-8 BOM scripts when process and PowerShell locations differ',
     () => {
       const displayName = '班级优化大师';
       const generated = generateRegistryUninstallPackage(
@@ -2764,7 +2778,8 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
             0xbb,
             0xbf,
           ]);
-        }
+        },
+        true
       );
 
       expect(generated).toContain(


### PR DESCRIPTION
## What changed

- resolve the generated deployment script through the active PowerShell provider location before using the .NET UTF-8 BOM writer
- retain the explicit BOM needed for non-ASCII app identities
- extend the Seewo regression to deliberately separate the process directory from PowerShell current location

## Live failure addressed

QA run 33176358722 failed before VM execution because .NET resolved package/Invoke-AppDeployToolkit.ps1 against the runner process directory rather than the packager PowerShell location. The new regression reproduces that exact runner condition.

## Verification

- 136/136 PSADT packager contract tests passed
- changed-file ESLint passed
- npm run build:ci passed, including TypeScript and 145 static pages