### PR TITLE
fix(packager): recover replaced IObit uninstall identity

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -749,6 +749,9 @@ $preserveVendorInstallationOnUninstall = Get-StrictPSADTBoolean `
 $reviewedPreferVisiblePrimaryUninstallRegistration = Get-StrictPSADTBoolean `
     -Config $psadtConfig `
     -Name 'reviewedPreferVisiblePrimaryUninstallRegistration'
+$reviewedRecoverCapturedUninstallByExactIdentity = Get-StrictPSADTBoolean `
+    -Config $psadtConfig `
+    -Name 'reviewedRecoverCapturedUninstallByExactIdentity'
 $reviewedRegistryUninstallDisplayName = ''
 if ($psadtConfig.Contains('reviewedRegistryUninstallDisplayName') -and
     $null -ne $psadtConfig['reviewedRegistryUninstallDisplayName']) {
@@ -3567,7 +3570,10 @@ if ($useManagedDirectoryLifecycle) {
         '    $configuredVersion = [string]$adtSession.AppVersion'
         '    $configuredVersionedAppName = if (-not [string]::IsNullOrWhiteSpace($configuredVersion)) { "$appName $configuredVersion" } else { $null }'
         ''
-        '    $capturedUninstallKey = (Get-ItemProperty -LiteralPath $markerProviderPath -ErrorAction SilentlyContinue).UninstallRegistryKey'
+        '    $markerValues = Get-ItemProperty -LiteralPath $markerProviderPath -ErrorAction SilentlyContinue'
+        '    $capturedUninstallKey = [string]$markerValues.UninstallRegistryKey'
+        '    $capturedUninstallName = [string]$markerValues.UninstallDisplayName'
+        "    `$expectedUninstallPublisher = '$publisherSingleQuoteEscaped'"
         '    $installedApps = if ($capturedUninstallKey) {'
         '        Write-ADTLogEntry -Message "Searching for captured vendor uninstall entry: $capturedUninstallKey" -Source ''Uninstall-ADTDeployment'''
         '        @(Get-ADTApplication -FilterScript { $_.PSChildName -eq $capturedUninstallKey })'
@@ -3601,6 +3607,29 @@ if ($useManagedDirectoryLifecycle) {
         '        }'
         '    }'
     )
+    if ($reviewedRecoverCapturedUninstallByExactIdentity) {
+        $lines += @(
+            '    if ($installedApps.Count -eq 0 -and $capturedUninstallKey -and $capturedUninstallName -and $expectedUninstallPublisher) {'
+            '        # This reviewed vendor replaces its ARP key after install. Recover only the exact observed'
+            '        # name and manifest publisher, require one visible non-MSI entry, and otherwise fail closed.'
+            '        $capturedIdentityMatches = @(Get-ADTApplication -Name $capturedUninstallName -NameMatch ''Exact'' | Where-Object {'
+            '            $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
+            '            $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
+            '            $isVisibleApplication -and'
+            '                -not $_.WindowsInstaller -and'
+            '                [string]::Equals([string]$_.DisplayName, $capturedUninstallName, [System.StringComparison]::OrdinalIgnoreCase) -and'
+            '                [string]::Equals([string]$_.Publisher, $expectedUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
+            '        })'
+            '        if ($capturedIdentityMatches.Count -eq 1) {'
+            '            $installedApps = $capturedIdentityMatches'
+            '            Write-ADTLogEntry -Message "Recovered replaced vendor uninstall entry [$($installedApps[0].PSChildName)] from captured key [$capturedUninstallKey] using exact name and publisher identity." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '        } elseif ($capturedIdentityMatches.Count -gt 0) {'
+            '            Write-ADTLogEntry -Message "Found $($capturedIdentityMatches.Count) exact captured-name and publisher matches; refusing ambiguous recovery." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '        }'
+            '    }'
+            ''
+        )
+    }
     if ($registeredInstallerTypeLower -in @('burn', 'exe')) {
         $lines += @(
             '    if ($installedApps.Count -gt 1) {'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1083,6 +1083,21 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual(['/DetainUninstall']);
   });
 
+  it('recovers iFun Screenshot only through its reviewed exact captured identity', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'iobit.ifunscreenshot',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedRecoverCapturedUninstallByExactIdentity).toBe(true);
+    expect(
+      applyApplicationPackagingAdapter('Example.App', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRecoverCapturedUninstallByExactIdentity: true,
+      }).reviewedRecoverCapturedUninstallByExactIdentity
+    ).toBeUndefined();
+  });
+
   it('uses ZeeDrive\'s documented no-ARP Intune lifecycle', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -35,6 +35,7 @@ interface ApplicationPackagingAdapter {
   uninstallCompletionTimeoutMinutes?: number;
   preserveVendorInstallationOnUninstall?: boolean;
   reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
+  reviewedRecoverCapturedUninstallByExactIdentity?: boolean;
   reviewedRegistryUninstallDisplayName?: string;
   reviewedManagedInstallDirectory?: string;
   reviewedManagedInstallEvidenceFile?: string;
@@ -915,6 +916,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     uninstallCompletionTimeoutMinutes: 3,
   },
   {
+    // iFun Screenshot's Inno bootstrapper initially registers the manifest ARP
+    // key, then replaces that key before a fresh LocalSystem removal starts.
+    // Recover only one visible non-MSI registration whose exact display name
+    // and publisher still match the identity observed during this installation.
+    // QA run 33185738401 proved the original key was gone while the app and one
+    // vendor registration remained. Broad name or publisher searches stay off.
+    wingetId: 'IObit.iFunScreenshot',
+    reviewedRecoverCapturedUninstallByExactIdentity: true,
+  },
+  {
     // IObit Uninstaller is published as an Inno Setup package, but its ARP
     // command contains only the uninstaller path. Standard Inno unattended
     // switches make the launcher exit without removing the product. IObit's
@@ -1763,6 +1774,7 @@ export function applyApplicationPackagingAdapter(
     if (
       !config.preserveVendorInstallationOnUninstall &&
       !config.reviewedPreferVisiblePrimaryUninstallRegistration &&
+      !config.reviewedRecoverCapturedUninstallByExactIdentity &&
       !config.reviewedRegistryUninstallDisplayName &&
       !config.reviewedInstallArgumentsOverride &&
       !config.reviewedArgumentlessInstall &&
@@ -1786,6 +1798,7 @@ export function applyApplicationPackagingAdapter(
       ...config,
       preserveVendorInstallationOnUninstall: undefined,
       reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
+      reviewedRecoverCapturedUninstallByExactIdentity: undefined,
       reviewedRegistryUninstallDisplayName: undefined,
       reviewedInstallArgumentsOverride: undefined,
       reviewedArgumentlessInstall: undefined,
@@ -1914,6 +1927,8 @@ export function applyApplicationPackagingAdapter(
       adapter.preserveVendorInstallationOnUninstall || undefined,
     reviewedPreferVisiblePrimaryUninstallRegistration:
       adapter.reviewedPreferVisiblePrimaryUninstallRegistration || undefined,
+    reviewedRecoverCapturedUninstallByExactIdentity:
+      adapter.reviewedRecoverCapturedUninstallByExactIdentity || undefined,
     reviewedRegistryUninstallDisplayName,
     reviewedManagedInstallDirectory:
       adapter.reviewedManagedInstallDirectory || undefined,

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1857,6 +1857,36 @@ describe('PSADT QA package identity', () => {
     ).toBe(true);
   });
 
+  it('binds iFun Screenshot exact captured-identity recovery to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'IObit.iFunScreenshot',
+      displayName: 'iFun Screenshot',
+      publisher: 'IObit',
+      version: '1.2.0.526',
+      architecture: 'x86',
+      installerSha256: 'e'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:iFun Screenshot_is1:iFun Screenshot',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: {
+        reviewedRecoverCapturedUninstallByExactIdentity?: boolean;
+      };
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      reviewedRecoverCapturedUninstallByExactIdentity: true,
+    });
+    expect(
+      profile.psadtConfig.reviewedRecoverCapturedUninstallByExactIdentity
+    ).toBe(true);
+  });
+
   it('binds reviewed .NET Framework registry evidence to the QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.DotNet.Framework.Runtime',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2714,6 +2714,22 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     );
   });
 
+  it('keeps replaced-key recovery opt-in, exact-name and publisher bound, and fail-closed', () => {
+    expect(packager).toContain(
+      "-Name 'reviewedRecoverCapturedUninstallByExactIdentity'"
+    );
+    expect(packager).toContain(
+      "Get-ADTApplication -Name $capturedUninstallName -NameMatch ''Exact''"
+    );
+    expect(packager).toContain(
+      '[string]::Equals([string]$_.Publisher, $expectedUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
+    );
+    expect(packager).toContain(
+      'if ($capturedIdentityMatches.Count -eq 1) {'
+    );
+    expect(packager).toContain('refusing ambiguous recovery');
+  });
+
   it.runIf(canRunWindowsPowerShellPackager)(
     'uses a reviewed renamed ARP identity instead of a stale transitional MSI ProductCode',
     () => {
@@ -2830,6 +2846,35 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         '$visiblePrimaryMatches = @($installedApps | Where-Object {'
       );
       expect(disabled).not.toContain('$visiblePrimaryMatches');
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'emits exact captured-identity recovery only when the reviewed adapter enables it',
+    () => {
+      const enabled = generateRegistryUninstallPackage(
+        'exe',
+        'iFun Screenshot',
+        [],
+        { reviewedRecoverCapturedUninstallByExactIdentity: true },
+        [],
+        'IObit.iFunScreenshot',
+        'iFun Screenshot',
+        '1.2.0.526',
+        'REGISTRY_UNINSTALL_KEY:iFun Screenshot_is1:iFun Screenshot'
+      );
+      const disabled = generateRegistryUninstallPackage('exe');
+
+      expect(enabled).toContain(
+        '$capturedUninstallName = [string]$markerValues.UninstallDisplayName'
+      );
+      expect(enabled).toContain("$expectedUninstallPublisher = 'IntuneGet'");
+      expect(enabled).toContain('$capturedIdentityMatches = @(');
+      expect(enabled).toContain(
+        'if ($capturedIdentityMatches.Count -eq 1) {'
+      );
+      expect(disabled).not.toContain('$capturedIdentityMatches');
     },
     30_000
   );

--- a/types/psadt.ts
+++ b/types/psadt.ts
@@ -276,6 +276,13 @@ export interface PSADTConfig {
   // adapters are the only trusted source for this value.
   reviewedPreferVisiblePrimaryUninstallRegistration?: boolean;
 
+  // Internal ARP recovery policy for a reviewed package whose vendor replaces
+  // its exact uninstall registry key after installation. The shared packager
+  // may recover only one visible non-MSI entry matching both the exact
+  // install-observed display name and the manifest publisher. Application
+  // adapters are the only trusted source for this value.
+  reviewedRecoverCapturedUninstallByExactIdentity?: boolean;
+
   // Internal exact ARP display identity for a reviewed package whose current
   // vendor installer no longer registers the MSI ProductCode or catalog name
   // published by WinGet. The shared packager still captures exactly one
@@ -434,6 +441,7 @@ export const DEFAULT_PSADT_CONFIG: PSADTConfig = {
   reviewedUninstallProcessGuard: undefined,
   reviewedUninstallServiceNames: undefined,
   reviewedPreferVisiblePrimaryUninstallRegistration: undefined,
+  reviewedRecoverCapturedUninstallByExactIdentity: undefined,
   reviewedRegistryUninstallDisplayName: undefined,
 };
 


### PR DESCRIPTION
## Summary
- add a reviewed adapter for IObit.iFunScreenshot after QA run 33185738401 showed its captured Inno ARP key disappearing before removal
- recover only one visible non-MSI registration matching the install-observed exact display name and manifest publisher
- keep customer configuration unable to enable this internal policy and preserve fail-closed behavior for ambiguity

## Verification
- 189 adapter and QA-profile tests passed
- 138 PSADT packager contract tests passed
- changed-file ESLint passed
- Create-PSADTPackage.ps1 parsed successfully

## Security
The installer remains separately flagged by VirusTotal (2 malicious, 0 suspicious, 75 engines) and issue ugurkocde/IntuneGet-Workflows#2729. This functional fix does not override that release block.