### PR TITLE
chore(qa): activate IObit uninstall identity recovery

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '6d2de2aff5f192fe397a4ca2f53fb3f941d797d3',
+  packagerCommit: '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -141,6 +141,21 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('retries iFun Screenshot only after activating exact captured-identity recovery', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' iobit.ifunscreenshot ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '6d2de2aff5f192fe397a4ca2f53fb3f941d797d3',
+      { wingetId: 'IObit.iFunScreenshot', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry MD Editor after its managed install was disproven', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -432,7 +432,17 @@ const PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS = [
   ...SOMIIBO_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry iFun Screenshot after its reviewed adapter can recover the single
+  // exact name-and-publisher ARP identity that replaces the captured Inno key.
+  'IObit.iFunScreenshot',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a':
+    IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS,
   '6d2de2aff5f192fe397a4ca2f53fb3f941d797d3':
     PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS,
   'c2cd8a1db09d584e6f59e7e46cfe6bb6e39f82fd':


### PR DESCRIPTION
## Summary
- pin QA and customer PSADT packaging to protected packager commit 4d9de9f4e1650f4ee5e9d428db88744a6f5e491a
- make IObit.iFunScreenshot the bounded terminal retry introduced by this release
- carry forward existing unconsumed retry targets without widening terminal retries

## Verification
- 244 package-profile and toolchain-backfill tests passed
- changed-file ESLint passed
- diff validation passed