### PR TITLE
fix(packaging): persist observed uninstall publisher

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2403,6 +2403,7 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         '    # Verify the adapter-reviewed Windows runtime signal instead of guessing an ARP identity.'
         '    $capturedUninstallKey = $null'
         '    $capturedUninstallName = $null'
+        '    $capturedUninstallPublisher = $null'
         '    $reviewedRegistryInstallationVerified = $false'
         '    function Test-IntuneGetReviewedRegistryInstallEvidence {'
         '        try {'
@@ -2434,6 +2435,7 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         "    `$configuredUninstallLocaleHint = '$registryUninstallLocaleHintEscaped'"
         '    $capturedUninstallKey = $null'
         '    $capturedUninstallName = $null'
+        '    $capturedUninstallPublisher = $null'
         '    $multiProductInstallationVerified = $false'
         ''
     )
@@ -3238,6 +3240,7 @@ if ($reviewedAppxInstallEvidenceConfigured) {
         '    if ($selectedApplications.Count -eq 1) {'
         '        $capturedUninstallKey = [string]$selectedApplications[0].PSChildName'
         '        $capturedUninstallName = [string]$selectedApplications[0].DisplayName'
+        '        $capturedUninstallPublisher = [string]$selectedApplications[0].Publisher'
         '        Write-ADTLogEntry -Message "Captured vendor uninstall entry [$capturedUninstallName] ($capturedUninstallKey)." -Source ''Install-ADTDeployment'''
         '    } elseif ($multiProductInstallationVerified) {'
         '        Write-ADTLogEntry -Message "Verified reviewed multi-product installation from $($reviewedMultiProductMatches.Count) matching vendor registrations." -Source ''Install-ADTDeployment'''
@@ -3343,11 +3346,13 @@ $machineUninstallMarkerLines = @()
 if ($useRegistryUninstall) {
     $userUninstallMarkerLines = @(
         '            if ($capturedUninstallKey) { Set-ADTRegistryKey -LiteralPath ''HKCU\' + $registryMarkerPathEscaped + '\' + $sanitizedWingetId + ''' -Name ''UninstallRegistryKey'' -Value $capturedUninstallKey -Type String -SID $_.SID }',
-        '            if ($capturedUninstallName) { Set-ADTRegistryKey -LiteralPath ''HKCU\' + $registryMarkerPathEscaped + '\' + $sanitizedWingetId + ''' -Name ''UninstallDisplayName'' -Value $capturedUninstallName -Type String -SID $_.SID }'
+        '            if ($capturedUninstallName) { Set-ADTRegistryKey -LiteralPath ''HKCU\' + $registryMarkerPathEscaped + '\' + $sanitizedWingetId + ''' -Name ''UninstallDisplayName'' -Value $capturedUninstallName -Type String -SID $_.SID }',
+        '            if ($capturedUninstallPublisher) { Set-ADTRegistryKey -LiteralPath ''HKCU\' + $registryMarkerPathEscaped + '\' + $sanitizedWingetId + ''' -Name ''UninstallPublisher'' -Value $capturedUninstallPublisher -Type String -SID $_.SID }'
     )
     $machineUninstallMarkerLines = @(
         '        if ($capturedUninstallKey) { Set-ADTRegistryKey -LiteralPath $regPath -Name ''UninstallRegistryKey'' -Value $capturedUninstallKey -Type String }',
-        '        if ($capturedUninstallName) { Set-ADTRegistryKey -LiteralPath $regPath -Name ''UninstallDisplayName'' -Value $capturedUninstallName -Type String }'
+        '        if ($capturedUninstallName) { Set-ADTRegistryKey -LiteralPath $regPath -Name ''UninstallDisplayName'' -Value $capturedUninstallName -Type String }',
+        '        if ($capturedUninstallPublisher) { Set-ADTRegistryKey -LiteralPath $regPath -Name ''UninstallPublisher'' -Value $capturedUninstallPublisher -Type String }'
     )
 }
 if ($IsUserScope) {
@@ -3573,6 +3578,7 @@ if ($useManagedDirectoryLifecycle) {
         '    $markerValues = Get-ItemProperty -LiteralPath $markerProviderPath -ErrorAction SilentlyContinue'
         '    $capturedUninstallKey = [string]$markerValues.UninstallRegistryKey'
         '    $capturedUninstallName = [string]$markerValues.UninstallDisplayName'
+        '    $capturedUninstallPublisher = [string]$markerValues.UninstallPublisher'
         "    `$expectedUninstallPublisher = '$publisherSingleQuoteEscaped'"
         '    $installedApps = if ($capturedUninstallKey) {'
         '        Write-ADTLogEntry -Message "Searching for captured vendor uninstall entry: $capturedUninstallKey" -Source ''Uninstall-ADTDeployment'''
@@ -3609,20 +3615,21 @@ if ($useManagedDirectoryLifecycle) {
     )
     if ($reviewedRecoverCapturedUninstallByExactIdentity) {
         $lines += @(
-            '    if ($installedApps.Count -eq 0 -and $capturedUninstallKey -and $capturedUninstallName -and $expectedUninstallPublisher) {'
+            '    $recoveryUninstallPublisher = if (-not [string]::IsNullOrWhiteSpace($capturedUninstallPublisher)) { $capturedUninstallPublisher } else { $expectedUninstallPublisher }'
+            '    if ($installedApps.Count -eq 0 -and $capturedUninstallKey -and $capturedUninstallName -and $recoveryUninstallPublisher) {'
             '        # This reviewed vendor replaces its ARP key after install. Recover only the exact observed'
-            '        # name and manifest publisher, require one visible non-MSI entry, and otherwise fail closed.'
+            '        # name and observed publisher, require one visible non-MSI entry, and otherwise fail closed.'
             '        $capturedIdentityMatches = @(Get-ADTApplication -Name $capturedUninstallName -NameMatch ''Exact'' | Where-Object {'
             '            $systemComponentProperty = $_.PSObject.Properties[''SystemComponent'']'
             '            $isVisibleApplication = -not $systemComponentProperty -or -not [bool]$systemComponentProperty.Value'
             '            $isVisibleApplication -and'
             '                -not $_.WindowsInstaller -and'
             '                [string]::Equals([string]$_.DisplayName, $capturedUninstallName, [System.StringComparison]::OrdinalIgnoreCase) -and'
-            '                [string]::Equals([string]$_.Publisher, $expectedUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
+            '                [string]::Equals([string]$_.Publisher, $recoveryUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
             '        })'
             '        if ($capturedIdentityMatches.Count -eq 1) {'
             '            $installedApps = $capturedIdentityMatches'
-            '            Write-ADTLogEntry -Message "Recovered replaced vendor uninstall entry [$($installedApps[0].PSChildName)] from captured key [$capturedUninstallKey] using exact name and publisher identity." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
+            '            Write-ADTLogEntry -Message "Recovered replaced vendor uninstall entry [$($installedApps[0].PSChildName)] from captured key [$capturedUninstallKey] using exact observed name and publisher identity." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
             '        } elseif ($capturedIdentityMatches.Count -gt 0) {'
             '            Write-ADTLogEntry -Message "Found $($capturedIdentityMatches.Count) exact captured-name and publisher matches; refusing ambiguous recovery." -Severity ''Warning'' -Source ''Uninstall-ADTDeployment'''
             '        }'

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -919,9 +919,10 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // iFun Screenshot's Inno bootstrapper initially registers the manifest ARP
     // key, then replaces that key before a fresh LocalSystem removal starts.
     // Recover only one visible non-MSI registration whose exact display name
-    // and publisher still match the identity observed during this installation.
-    // QA run 33185738401 proved the original key was gone while the app and one
-    // vendor registration remained. Broad name or publisher searches stay off.
+    // and publisher still match the ARP identity observed during this install.
+    // QA run 33189870114 proved the original key was gone and the manifest
+    // publisher did not identify the replacement. Broad name/publisher searches
+    // stay off; the generated package persists the observed publisher instead.
     wingetId: 'IObit.iFunScreenshot',
     reviewedRecoverCapturedUninstallByExactIdentity: true,
   },

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2722,7 +2722,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       "Get-ADTApplication -Name $capturedUninstallName -NameMatch ''Exact''"
     );
     expect(packager).toContain(
-      '[string]::Equals([string]$_.Publisher, $expectedUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
+      '[string]::Equals([string]$_.Publisher, $recoveryUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
     );
     expect(packager).toContain(
       'if ($capturedIdentityMatches.Count -eq 1) {'
@@ -2869,8 +2869,23 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       expect(enabled).toContain(
         '$capturedUninstallName = [string]$markerValues.UninstallDisplayName'
       );
+      expect(enabled).toContain(
+        '$capturedUninstallPublisher = [string]$markerValues.UninstallPublisher'
+      );
+      expect(enabled).toContain(
+        '$capturedUninstallPublisher = [string]$selectedApplications[0].Publisher'
+      );
+      expect(enabled).toContain(
+        "-Name 'UninstallPublisher' -Value $capturedUninstallPublisher"
+      );
       expect(enabled).toContain("$expectedUninstallPublisher = 'IntuneGet'");
+      expect(enabled).toContain(
+        '$recoveryUninstallPublisher = if (-not [string]::IsNullOrWhiteSpace($capturedUninstallPublisher))'
+      );
       expect(enabled).toContain('$capturedIdentityMatches = @(');
+      expect(enabled).toContain(
+        '[string]::Equals([string]$_.Publisher, $recoveryUninstallPublisher, [System.StringComparison]::OrdinalIgnoreCase)'
+      );
       expect(enabled).toContain(
         'if ($capturedIdentityMatches.Count -eq 1) {'
       );


### PR DESCRIPTION
## What changed
- persist the publisher from the exact ARP entry observed during installation
- recover IObit.iFunScreenshot's replaced uninstall key using the exact observed name and publisher
- retain a manifest-publisher fallback for packages created before the new marker field
- keep recovery app-specific, visible non-MSI only, singleton-only, and fail-closed

## Evidence
- QA run 33189870114: install 0, detection 0, uninstall 60001, removal detection 0; captured key disappeared and manifest publisher produced zero recovery matches
- PowerShell parser passed
- adapter + PSADT contract suites: 223/223 passed
- focused generated-package assertion passed
- changed-file ESLint passed

## Production parity
This changes the shared customer PSADT packager used by portal/catalog packaging and will be pinned into QA and customer workflows after merge.