### PR TITLE
chore(qa): activate observed IObit uninstall identity

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a',
+  packagerCommit: '8e2e4217be6bd233907b879cc8c1c53c18fdf918',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1596,4 +1596,14 @@ describe('QA toolchain targeted retries', () => {
       { wingetId: 'Unrelated.App', status: 'superseded' }
     )).toBe(true);
   });
+
+  it('retries iFun Screenshot with the install-observed publisher release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'iobit.ifunscreenshot', status: 'failed' }
+    )).toBe(true);
+    expect(terminalToolchainRetryTargets(
+      '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a'
+    )).toContain('IObit.iFunScreenshot');
+  });
 });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -440,7 +440,18 @@ const IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...PSADT_UTF8_BOM_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS = [
+  // Retry iFun Screenshot after its generated PSADT package persists the
+  // publisher from the exact ARP entry observed during installation. The
+  // replacement key must match that exact observed name and publisher.
+  'IObit.iFunScreenshot',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '8e2e4217be6bd233907b879cc8c1c53c18fdf918':
+    IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS,
   '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a':
     IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS,
   '6d2de2aff5f192fe397a4ca2f53fb3f941d797d3':


### PR DESCRIPTION
## What changed
- pin the scheduler/package profile to merged customer packager commit 8e2e4217be6bd233907b879cc8c1c53c18fdf918
- schedule IObit.iFunScreenshot for a terminal lifecycle retry under the new profile
- carry all still-unconsumed release retry targets across the atomic pin

## Verification
- package-profile + toolchain-backfill tests: 245/245 passed
- changed-file ESLint passed

This is the scheduler half of production parity; the customer and QA GitHub workflows will be pinned to the same exact commit in the companion workflow PR.