### PR TITLE
Fix QTTabBar PSADT uninstall identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -79,6 +79,15 @@ describe('application packaging adapters', () => {
     ).toBe('jamovi');
   });
 
+  it('binds QTTabBar to the exact ARP identity registered by its nested MSI', () => {
+    expect(
+      applyApplicationPackagingAdapter('indiff.QTTabBar', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRegistryUninstallDisplayName: 'customer override',
+      }).reviewedRegistryUninstallDisplayName
+    ).toBe('QTTabBar 1.5.6.1 Beta(2024)');
+  });
+
   it('uses IrfanView\'s documented case-sensitive silent uninstall switch', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -568,6 +568,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedRegistryUninstallDisplayName: 'jamovi',
   },
   {
+    // The 1.5.6-beta.1 catalog metadata calls the product `QTTabBar`, while the
+    // nested MSI registers `QTTabBar 1.5.6.1 Beta(2024)`. QA run 33202083278
+    // observed exactly one visible indiff MSI registration with that identity.
+    // Bind both QA and customer packages to the exact ARP name so the stable
+    // key and uninstall command can be captured without widening matching.
+    wingetId: 'indiff.QTTabBar',
+    reviewedRegistryUninstallDisplayName: 'QTTabBar 1.5.6.1 Beta(2024)',
+  },
+  {
     // IrfanView registers iv_uninstall.exe without the vendor's case-sensitive
     // unattended switch. Under LocalSystem the interactive command exits while
     // IrfanView64 remains registered (QA run 32918339448). IrfanView's official

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -252,6 +252,29 @@ describe('PSADT QA package identity', () => {
       .toBe('jamovi');
   });
 
+  it('binds QTTabBar customer and QA packages to the observed nested-MSI ARP identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'indiff.QTTabBar',
+      displayName: 'QTTabBar',
+      publisher: 'indiff',
+      version: '1.5.6-beta.1',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'zip',
+      silentSwitches: '/qn /norestart ALLUSERS=1',
+      uninstallCommand: 'REGISTRY_UNINSTALL:QTTabBar',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedRegistryUninstallDisplayName?: string };
+    };
+
+    expect(profile.psadtConfig.reviewedRegistryUninstallDisplayName)
+      .toBe('QTTabBar 1.5.6.1 Beta(2024)');
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedRegistryUninstallDisplayName)
+      .toBe('QTTabBar 1.5.6.1 Beta(2024)');
+  });
+
   it('binds IrfanView customer and QA packages to the documented silent uninstall', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'IrfanSkiljan.IrfanView',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -2768,6 +2768,29 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'uses the observed QTTabBar nested-MSI ARP identity instead of its short catalog name',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'zip',
+        'QTTabBar',
+        [],
+        { reviewedRegistryUninstallDisplayName: 'QTTabBar 1.5.6.1 Beta(2024)' },
+        [],
+        'indiff.QTTabBar'
+      );
+
+      expect(generated).toContain(
+        "$configuredUninstallDisplayName = 'QTTabBar 1.5.6.1 Beta(2024)'"
+      );
+      expect(generated).toContain("$appName = 'QTTabBar 1.5.6.1 Beta(2024)'");
+      expect(generated).toContain(
+        'if ($selectedApplications.Count -eq 1) { break }'
+      );
+    },
+    30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'writes UTF-8 BOM scripts when process and PowerShell locations differ',
     () => {
       const displayName = '班级优化大师';


### PR DESCRIPTION
QA run 33202083278 observed the nested MSI registering QTTabBar 1.5.6.1 Beta(2024), while the catalog identity is QTTabBar. Add an internal application adapter so both customer packages and QA capture the exact ARP key and uninstall command without widening generic matching. Includes adapter, package-profile, and generated-PSADT contract coverage (330 focused tests passed).