### PR TITLE
chore: activate QTTabBar packager fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8e2e4217be6bd233907b879cc8c1c53c18fdf918',
+  packagerCommit: 'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1606,4 +1606,17 @@ describe('QA toolchain targeted retries', () => {
       '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a'
     )).toContain('IObit.iFunScreenshot');
   });
+
+  it('retries QTTabBar with the install-observed ARP identity release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'indiff.qttabbar', status: 'failed' }
+    )).toBe(true);
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('indiff.QTTabBar');
+    expect(terminalToolchainRetryTargets(
+      '8e2e4217be6bd233907b879cc8c1c53c18fdf918'
+    )).not.toContain('indiff.QTTabBar');
+  });
 });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -449,7 +449,17 @@ const IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS = [
   ...IOBIT_CAPTURED_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry QTTabBar after its reviewed adapter can match the exact ARP display
+  // name observed during installation and remove that same registered product.
+  'indiff.QTTabBar',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162':
+    QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS,
   '8e2e4217be6bd233907b879cc8c1c53c18fdf918':
     IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS,
   '4d9de9f4e1650f4ee5e9d428db88744a6f5e491a':


### PR DESCRIPTION
## Summary
- pin QA package profiles to the production QTTabBar observed-identity packager revision
- target the failed QTTabBar candidate for a bounded rebuild
- carry the existing unconsumed toolchain retry targets forward

## Verification
- npm test -- lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (247 passed)
- npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts