### PR TITLE
Preserve trusted MSI installer arguments

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -671,6 +671,58 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('passes trusted vendor MSI properties to both QA and customer packaging', async () => {
+    const installerUrl = 'https://downloads.example.com/Macabacus-9.9.2.msi';
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: installerUrl,
+      sha256: 'A'.repeat(64),
+      type: 'wix',
+      silentArgs: '/qn /norestart OFFICE2016X64FOUND=1 EULA=1',
+      productCode: '{0B0CCAB5-2957-4FB4-9F55-EAEE1A613023}',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Macabacus.Macabacus',
+          displayName: 'Macabacus',
+          version: '9.9.2',
+          installerType: 'wix',
+          installerUrl,
+          installerSha256: 'A'.repeat(64),
+          installScope: 'machine',
+          installCommand: 'msiexec /i "Macabacus-9.9.2.msi" /qn ALLUSERS=1 /norestart',
+          uninstallCommand:
+            'msiexec /x "{0B0CCAB5-2957-4FB4-9F55-EAEE1A613023}" /qn /norestart',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedSilentSwitches =
+      '/qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1';
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ silentSwitches: expectedSilentSwitches })
+    );
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      install_command:
+        'msiexec /i "Macabacus-9.9.2.msi" /qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1',
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ silentSwitches: expectedSilentSwitches }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('applies the reviewed Opera immediate-uninstall contract to QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/__tests__/custom-app.test.ts
+++ b/lib/__tests__/custom-app.test.ts
@@ -153,11 +153,24 @@ describe('buildCustomAppCartItem', () => {
     expect(burnItem.installCommand).toBe(`"setup.exe" ${CUSTOM_SILENT_SWITCH_DEFAULTS.burn}`);
   });
 
-  it('should build an msiexec install command for MSI installers', () => {
+  it('should build an msiexec command with the supplied MSI switches', () => {
     const item = buildCustomAppCartItem(
       validInput({ installerType: 'msi', installerUrl: 'https://example.com/app.msi' })
     );
-    expect(item.installCommand).toBe('msiexec /i "app.msi" /qn ALLUSERS=1 /norestart');
+    expect(item.installCommand).toBe(
+      'msiexec /i "app.msi" /vendor-silent ALLUSERS=1'
+    );
+  });
+
+  it('should use the managed MSI defaults when no switches are supplied', () => {
+    const item = buildCustomAppCartItem(validInput({
+      installerType: 'msi',
+      installerUrl: 'https://example.com/app.msi',
+      silentSwitches: '',
+    }));
+    expect(item.installCommand).toBe(
+      'msiexec /i "app.msi" /qn /norestart ALLUSERS=1'
+    );
   });
 
   it('should prefer user-provided silent switches over the defaults', () => {

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -570,6 +570,34 @@ describe('generateInstallCommand', () => {
     expect(command).toContain('ALLUSERS=""');
   });
 
+  it('preserves trusted WinGet custom properties in an MSI install command', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://downloads.example.com/Macabacus-9.9.2.msi',
+      sha256: 'abc123',
+      type: 'wix',
+      silentArgs: '/qn /norestart OFFICE2016X64FOUND=1 EULA=1',
+    };
+
+    expect(generateInstallCommand(installer, 'machine')).toBe(
+      'msiexec /i "Macabacus-9.9.2.msi" /qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1'
+    );
+  });
+
+  it('does not override a manifest-owned MSI scope property', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/installer.msi',
+      sha256: 'abc123',
+      type: 'msi',
+      silentArgs: '/qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=""',
+    };
+
+    expect(generateInstallCommand(installer, 'machine')).toBe(
+      'msiexec /i "installer.msi" /qn /norestart ALLUSERS=2 MSIINSTALLPERUSER=""'
+    );
+  });
+
   it('should generate MSIX install command', () => {
     const installer: NormalizedInstaller = {
       architecture: 'x64',

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -209,10 +209,36 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.item.installerType).toBe('msi');
     expect(reconciled.item.installerUrl).toBe('https://example.test/wsainstall.msi');
     expect(reconciled.item.installCommand).toBe(
-      'msiexec /i "wsainstall.msi" /qn ALLUSERS=1 /norestart'
+      'msiexec /i "wsainstall.msi" /qn /norestart ALLUSERS=1'
     );
     expect(reconciled.item.uninstallCommand).toBe(
       'REGISTRY_UNINSTALL:Webroot SecureAnywhere'
+    );
+  });
+
+  it('keeps vendor-required MSI properties when rebuilding a customer package', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x64',
+      url: 'https://downloads.example.test/Macabacus-9.9.2.msi',
+      sha256,
+      type: 'wix',
+      silentArgs: '/qn /norestart OFFICE2016X64FOUND=1 EULA=1',
+      productCode: '{0B0CCAB5-2957-4FB4-9F55-EAEE1A613023}',
+    }] satisfies NormalizedInstaller[]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Macabacus.Macabacus',
+      displayName: 'Macabacus',
+      version: '9.9.2',
+      installerType: 'wix',
+      installerUrl: 'https://downloads.example.test/Macabacus-9.9.2.msi',
+      installCommand: 'msiexec /i "Macabacus-9.9.2.msi" /qn ALLUSERS=1 /norestart',
+      uninstallCommand:
+        'msiexec /x "{0B0CCAB5-2957-4FB4-9F55-EAEE1A613023}" /qn /norestart',
+    }));
+
+    expect(reconciled.item.installCommand).toBe(
+      'msiexec /i "Macabacus-9.9.2.msi" /qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1'
     );
   });
 

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -305,6 +305,19 @@ function generateMsixDetectionScript(
 /**
  * Generate install command based on installer type
  */
+function appendMsiInstallScope(
+  silentArgs: string,
+  scope: WingetScope
+): string {
+  const normalizedArgs = silentArgs.trim() || '/qn /norestart';
+  if (/(?:^|\s)ALLUSERS\s*=/i.test(normalizedArgs)) {
+    return normalizedArgs;
+  }
+
+  const scopeProperty = scope === 'user' ? 'ALLUSERS=""' : 'ALLUSERS=1';
+  return `${normalizedArgs} ${scopeProperty}`;
+}
+
 export function generateInstallCommand(
   installer: NormalizedInstaller,
   scope: WingetScope = 'machine'
@@ -317,9 +330,10 @@ export function generateInstallCommand(
 
   switch (installer.type) {
     case 'msi':
-    case 'wix':
-      const msiScope = scope === 'user' ? 'ALLUSERS=""' : 'ALLUSERS=1';
-      return `msiexec /i "${installerName}" /qn ${msiScope} /norestart`;
+    case 'wix': {
+      const msiArgs = appendMsiInstallScope(silentArgs, scope);
+      return `msiexec /i "${installerName}" ${msiArgs}`.trim();
+    }
 
     case 'msix':
     case 'appx':
@@ -350,8 +364,8 @@ export function generateInstallCommand(
         switch (installer.nestedInstallerType) {
           case 'msi':
           case 'wix': {
-            const nestedMsiScope = scope === 'user' ? 'ALLUSERS=""' : 'ALLUSERS=1';
-            return `msiexec /i "${nestedPath}" ${silentArgs} ${nestedMsiScope}`.trim();
+            const nestedMsiArgs = appendMsiInstallScope(silentArgs, scope);
+            return `msiexec /i "${nestedPath}" ${nestedMsiArgs}`.trim();
           }
           case 'msix':
           case 'appx':

--- a/lib/msp/silent-switches.test.ts
+++ b/lib/msp/silent-switches.test.ts
@@ -44,6 +44,13 @@ describe('extractSilentSwitches', () => {
     )).toBe('/qn REBOOT=ReallySuppress ALLUSERS=1');
   });
 
+  it('keeps architecture-specific vendor MSI properties for packaging', () => {
+    expect(extractSilentSwitches(
+      'msiexec /i "Macabacus-9.9.2.msi" /qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1',
+      'wix'
+    )).toBe('/qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1');
+  });
+
   it('fails closed for an archive with no nested installer type', () => {
     expect(extractSilentSwitches(
       'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -36,6 +36,7 @@ export function extractSilentSwitches(
   // Strip executable path first (handles paths with hyphens like "7z2501-x64.exe")
   // This removes everything up to and including common installer extensions
   let cleaned = installCommand
+    .replace(/^msiexec(?:\.exe)?\s+/i, '') // Remove Windows Installer launcher with or without .exe
     .replace(/^"[^"]+"\s*/, '') // Remove quoted paths like "C:\path\installer.exe"
     .replace(/^\S+\.(exe|msi|msix|appx)\s*/i, ''); // Remove unquoted paths ending in installer extensions
 


### PR DESCRIPTION
## Summary
- preserve WinGet/vendor MSI properties when customer catalog commands are rebuilt
- parse both msiexec and msiexec.exe when extracting switches for QA and customer packaging
- keep explicit MSI scope properties authoritative and add scope only when absent

## Regression
Macabacus 9.9.2 x64 requires OFFICE2016X64FOUND=1 EULA=1. The old customer path discarded both properties and the MSI exited 1603 before registration.

## Verification
- 1,618 repository tests passed (translation-provider timeout test excluded as unrelated)
- 268 focused packaging tests passed
- targeted ESLint passed
- Next.js production build passed