### PR TITLE
Activate trusted MSI argument packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162',
+  packagerCommit: '953d2ca467b8e800a143150871c5220682106aa2',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1619,4 +1619,17 @@ describe('QA toolchain targeted retries', () => {
       '8e2e4217be6bd233907b879cc8c1c53c18fdf918'
     )).not.toContain('indiff.QTTabBar');
   });
+
+  it('retries Macabacus with the trusted MSI argument release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'macabacus.macabacus', status: 'failed' }
+    )).toBe(true);
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('Macabacus.Macabacus');
+    expect(terminalToolchainRetryTargets(
+      'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162'
+    )).not.toContain('Macabacus.Macabacus');
+  });
 });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -457,7 +457,17 @@ const QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...IOBIT_OBSERVED_PUBLISHER_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS = [
+  // Retry Macabacus after the shared customer and QA paths preserve its
+  // architecture-specific Office and EULA MSI properties from WinGet.
+  'Macabacus.Macabacus',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '953d2ca467b8e800a143150871c5220682106aa2':
+    TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS,
   'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162':
     QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS,
   '8e2e4217be6bd233907b879cc8c1c53c18fdf918':


### PR DESCRIPTION
## Summary
- pin QA and customer packaging to the protected MSI argument fix
- target Macabacus for a repaired lifecycle retry
- carry pending targeted retries forward without accepting the prior generic MSI behavior as compatible

## Verification
- 308 focused QA/toolchain tests passed
- targeted ESLint passed