### PR TITLE
Preserve MSI properties before quiet switches

### DIFF
--- a/lib/msp/silent-switches.test.ts
+++ b/lib/msp/silent-switches.test.ts
@@ -51,6 +51,20 @@ describe('extractSilentSwitches', () => {
     )).toBe('/qn /norestart OFFICE2016X64FOUND=1 EULA=1 ALLUSERS=1');
   });
 
+  it('keeps MSI properties that appear before the quiet switch', () => {
+    expect(extractSilentSwitches(
+      'msiexec /i "Macabacus-9.9.2.msi" EULA=1 /qn',
+      'wix'
+    )).toBe('EULA=1 /qn');
+  });
+
+  it('keeps an empty MSI property value before later switches', () => {
+    expect(extractSilentSwitches(
+      'msiexec.exe /i "dual-purpose.msi" MSIINSTALLPERUSER="" ALLUSERS=2 /qn',
+      'msi'
+    )).toBe('MSIINSTALLPERUSER="" ALLUSERS=2 /qn');
+  });
+
   it('fails closed for an archive with no nested installer type', () => {
     expect(extractSilentSwitches(
       'Expand-Archive -Path "app.zip" -DestinationPath "%ProgramFiles%\\App" -Force',

--- a/lib/msp/silent-switches.ts
+++ b/lib/msp/silent-switches.ts
@@ -55,7 +55,12 @@ export function extractSilentSwitches(
   // tokens. The executable token and MSI action target were removed above, so
   // everything remaining belongs to the vendor's install contract.
   cleaned = cleaned.trim();
-  if (/^(?:\/\S+|-{1,2}\S+)/.test(cleaned) && cleaned !== '-DeploymentType') {
+  const beginsWithVendorSwitch = /^(?:\/\S+|-{1,2}\S+)/.test(cleaned);
+  const beginsWithMsiProperty = /^[A-Za-z_][A-Za-z0-9_.-]*=(?:"[^"]*"|\S+)(?:\s|$)/.test(cleaned);
+  if (
+    (beginsWithVendorSwitch && cleaned !== '-DeploymentType') ||
+    (['msi', 'wix'].includes(effectiveType) && beginsWithMsiProperty)
+  ) {
     return cleaned;
   }
 


### PR DESCRIPTION
## Summary
- preserve trusted MSI/WiX property-first argument tails after removing the msiexec action target
- prevent customer commands such as EULA=1 /qn from collapsing to generic defaults
- add regression coverage for property-first and empty-value MSI properties

## Verification
- 63 focused tests passed
- targeted ESLint passed
- Next.js production build passed