### PR TITLE
Fix TeamSpeak 6 beta machine-scope packaging

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -321,6 +321,17 @@ describe('POST /api/package (workflow dispatch)', () => {
           silentArgs: '/S',
         }];
       }
+      if (wingetId === 'TeamSpeakSystems.TeamSpeakClient.Beta.6') {
+        return [{
+          architecture: 'x64',
+          url: 'https://example.com/teamspeak-client.msi',
+          sha256: 'A'.repeat(64),
+          type: 'wix',
+          scope: 'user',
+          silentArgs: '/qn /norestart ALLUSERS=1',
+          productCode: '{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}',
+        }];
+      }
       if (wingetId === 'Opera.Opera') {
         return [
           {
@@ -624,6 +635,59 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
       expect.objectContaining({ installScope: 'user' }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
+  it('uses TeamSpeak 6 Beta all-users MSI scope for QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+          displayName: 'TeamSpeak 6 Beta',
+          version: '6.0.0-beta4.1',
+          installerType: 'wix',
+          installerUrl: 'https://example.com/teamspeak-client.msi',
+          installerSha256: 'A'.repeat(64),
+          installScope: 'user',
+          installCommand:
+            'msiexec /i "teamspeak-client.msi" /qn /norestart ALLUSERS=1',
+          uninstallCommand:
+            'msiexec /x "{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}" /qn /norestart',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({ installScope: 'machine' }),
+      expect.any(Array)
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        installScope: 'machine',
+        silentSwitches: '/qn /norestart ALLUSERS=1',
+      })
+    );
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      install_scope: 'machine',
+      install_command:
+        'msiexec /i "teamspeak-client.msi" /qn /norestart ALLUSERS=1',
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installScope: 'machine',
+        silentSwitches: '/qn /norestart ALLUSERS=1',
+      }),
       undefined,
       expect.any(Object)
     );

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -310,6 +310,38 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.item.installCommand).toBe('"logitech-presentation.exe" /S');
   });
 
+  it('selects TeamSpeak 6 Beta user manifest bytes for all-users MSI execution', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x64',
+      url: 'https://example.test/teamspeak-client.msi',
+      sha256,
+      type: 'wix',
+      scope: 'user',
+      silentArgs: '/qn /norestart ALLUSERS=1',
+      productCode: '{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+      displayName: 'TeamSpeak 6 Beta',
+      version: '6.0.0-beta4.1',
+      installScope: 'user',
+      installerType: 'wix',
+      installerUrl: 'https://example.test/teamspeak-client.msi',
+      installCommand: 'msiexec /i "teamspeak-client.msi" /qn /norestart ALLUSERS=1',
+      uninstallCommand:
+        'msiexec /x "{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}" /qn /norestart',
+    }));
+
+    expect(reconciled.item.installScope).toBe('machine');
+    expect(reconciled.item.installerUrl).toBe(
+      'https://example.test/teamspeak-client.msi'
+    );
+    expect(reconciled.item.installCommand).toBe(
+      'msiexec /i "teamspeak-client.msi" /qn /norestart ALLUSERS=1'
+    );
+  });
+
   it('selects NVM user bytes for reviewed LocalSystem execution', async () => {
     getLiveInstallersMock.mockResolvedValue([{
       architecture: 'x86',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1232,6 +1232,18 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('runs TeamSpeak 6 Beta all-users MSI contract as LocalSystem', () => {
+    expect(resolveApplicationInstallScope(
+      'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+      'user'
+    )).toBe('machine');
+    expect(resolveApplicationInstallerSelectionScope(
+      'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
+  });
+
   it('uses JetBrains silent mode with the exact dotPeek ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'jetbrains.dotpeek',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -608,6 +608,19 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'user',
   },
   {
+    // TeamSpeak 6 Beta's WinGet manifest declares Scope: user while its WiX
+    // command explicitly requests ALLUSERS=1 and its installation metadata
+    // targets Program Files. Running that contradictory contract as a standard
+    // user makes Windows Installer fail with 1603 before registering the
+    // product (QA run 33215101419). Keep selecting the exact user-scoped
+    // manifest entry, but execute its reviewed all-users MSI contract as
+    // LocalSystem so QA and customer Intune packages share the machine-wide
+    // lifecycle authored by the vendor command.
+    wingetId: 'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+  },
+  {
     // dotPeek registers a versioned JetBrains.Platform.Installer command with
     // /HostsToRemove and /PerMachine, but that command opens the interactive
     // removal path unless JetBrains' documented /Silent=True switch is also

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -21,6 +21,37 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.successCodes).toEqual([1223]);
   });
 
+  it('normalizes TeamSpeak 6 Beta contradictory user manifest to machine QA', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+        name: 'TeamSpeak 6 Beta',
+        publisher: 'TeamSpeakSystems',
+        version: '6.0.0-beta4.1',
+      },
+      manifest: {
+        InstallerType: 'wix',
+        Scope: 'user',
+        InstallerSwitches: { Custom: 'ALLUSERS=1' },
+        ProductCode: '{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'wix',
+        Scope: 'user',
+        ProductCode: '{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}',
+      },
+    });
+
+    expect(config.scope).toBe('machine');
+    expect(config.silentArgs).toBe('/qn /norestart ALLUSERS=1');
+    expect(config.detectionRules[0]).toMatchObject({
+      keyPath:
+        'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\TeamSpeakSystems_TeamSpeakClient_Beta_6',
+      detectionValue: '6.0.0-beta4.1',
+    });
+  });
+
   it('prefers installer-specific silent switches and product metadata', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
QA run 33215101419 showed the TeamSpeak 6 beta WiX package failing with MSI 1603 because its WinGet manifest declares user scope while the vendor command explicitly requests ALLUSERS=1 and targets Program Files. This adds a reviewed adapter that keeps the trusted user-scoped manifest selection but runs the PSADT package as LocalSystem with HKLM detection. The same effective scope is covered through catalog QA, reconciliation, persistence, and the customer web-portal packaging workflow.\n\nVerification:\n- 168 focused tests passed\n- targeted ESLint passed\n- Next.js production build passed