### PR TITLE
Activate TeamSpeak 6 machine-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '953d2ca467b8e800a143150871c5220682106aa2',
+  packagerCommit: 'e139e4cc222576f34ca905b7180ac47ea548cbab',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1632,4 +1632,20 @@ describe('QA toolchain targeted retries', () => {
       'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162'
     )).not.toContain('Macabacus.Macabacus');
   });
+
+  it('retries TeamSpeak 6 Beta with the reviewed machine-scope release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      {
+        wingetId: 'teamspeaksystems.teamspeakclient.beta.6',
+        status: 'failed',
+      }
+    )).toBe(true);
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('TeamSpeakSystems.TeamSpeakClient.Beta.6');
+    expect(terminalToolchainRetryTargets(
+      '953d2ca467b8e800a143150871c5220682106aa2'
+    )).not.toContain('TeamSpeakSystems.TeamSpeakClient.Beta.6');
+  });
 });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -465,7 +465,17 @@ const TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS = [
   ...QTTABBAR_OBSERVED_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry TeamSpeak 6 Beta after the reviewed adapter keeps its user-scoped
+  // WinGet bytes but executes the manifest's ALLUSERS=1 WiX contract as SYSTEM.
+  'TeamSpeakSystems.TeamSpeakClient.Beta.6',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'e139e4cc222576f34ca905b7180ac47ea548cbab':
+    TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   '953d2ca467b8e800a143150871c5220682106aa2':
     TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS,
   'ac0ccd9c0bd0c400a82cf2a0c729804e4c4c4162':


### PR DESCRIPTION
Pins catalog QA to reviewed packager commit e139e4cc222576f34ca905b7180ac47ea548cbab and targets the failed TeamSpeak 6 Beta lifecycle for a fresh machine-scope retry. Earlier unconsumed retry targets remain carried forward.\n\nVerification:\n- 315 focused tests passed\n- targeted ESLint passed\n- Next.js production build passed