### PR TITLE
Fix Simple Hydraulic Calculator silent uninstall

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -332,6 +332,17 @@ describe('POST /api/package (workflow dispatch)', () => {
           productCode: '{7BC5AB94-97F7-480C-A8A0-3D334A3A56DC}',
         }];
       }
+      if (wingetId === 'Igneus.SimpleHydraulicCalculator') {
+        return [{
+          architecture: 'x86',
+          url: 'https://example.com/shc2_setup.exe',
+          sha256: 'A'.repeat(64),
+          type: 'nullsoft',
+          scope: 'machine',
+          silentArgs: '/S',
+          productCode: 'Simple Hydraulic Calculator',
+        }];
+      }
       if (wingetId === 'Opera.Opera') {
         return [
           {
@@ -691,6 +702,52 @@ describe('POST /api/package (workflow dispatch)', () => {
       undefined,
       expect.any(Object)
     );
+  });
+
+  it('applies the Simple Hydraulic Calculator NSIS removal to QA and customer packaging', async () => {
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Igneus.SimpleHydraulicCalculator',
+          displayName: 'Simple Hydraulic Calculator',
+          publisher: 'Igneus',
+          version: '2.3.9',
+          architecture: 'x86',
+          installerType: 'nullsoft',
+          installerUrl: 'https://example.com/shc2_setup.exe',
+          installCommand: 'shc2_setup.exe /S',
+          uninstallCommand:
+            'REGISTRY_UNINSTALL_KEY:Simple Hydraulic Calculator:Simple Hydraulic Calculator',
+          psadtConfig: { ...DEFAULT_PSADT_CONFIG },
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const expectedAdapter = {
+      reviewedExactUninstall: {
+        executablePath:
+          '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
+        arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+        completionTimeoutMinutes: 5,
+      },
+    };
+    expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)).toMatchObject(
+      expectedAdapter
+    );
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedAdapter,
+    });
   });
 
   it('rebuilds machine-scope commands before both QA and customer packaging', async () => {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1244,6 +1244,23 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
   });
 
+  it('runs the Simple Hydraulic Calculator NSIS uninstaller in place', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'igneus.simplehydrauliccalculator',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedExactUninstall).toEqual({
+      executablePath:
+        '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
+      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      completionTimeoutMinutes: 5,
+    });
+    expect(adapted.reviewedExactUninstall?.arguments.at(-1)).toBe(
+      '_?=%ProgramFiles(x86)%\\Igneus\\SHC'
+    );
+  });
+
   it('uses JetBrains silent mode with the exact dotPeek ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'jetbrains.dotpeek',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -621,6 +621,22 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallerSelectionScope: 'user',
   },
   {
+    // Simple Hydraulic Calculator registers a small NSIS bootstrap uninstaller
+    // that returns immediately for a bare /S invocation without removing the
+    // application (QA runs 33219132479 and 33220015102). NSIS requires the
+    // special _?= install-directory argument to remain last when the
+    // uninstaller must execute in place. Bind that exact machine-wide command
+    // to both QA and customer packages while retaining the captured ARP key as
+    // authoritative completion evidence.
+    wingetId: 'Igneus.SimpleHydraulicCalculator',
+    reviewedExactUninstall: {
+      executablePath:
+        '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
+      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      completionTimeoutMinutes: 5,
+    },
+  },
+  {
     // dotPeek registers a versioned JetBrains.Platform.Installer command with
     // /HostsToRemove and /PerMachine, but that command opens the interactive
     // removal path unless JetBrains' documented /Silent=True switch is also

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3439,6 +3439,39 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps the Simple Hydraulic Calculator NSIS install directory argument last',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'nullsoft',
+        'Simple Hydraulic Calculator',
+        [],
+        {
+          reviewedExactUninstall: {
+            executablePath:
+              '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
+            arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+            completionTimeoutMinutes: 5,
+          },
+        },
+        [],
+        'Igneus.SimpleHydraulicCalculator',
+        'Simple Hydraulic Calculator',
+        '2.3.9',
+        'REGISTRY_UNINSTALL_KEY:Simple Hydraulic Calculator:Simple Hydraulic Calculator',
+        '/S'
+      );
+
+      expect(generated).toContain(
+        "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe')"
+      );
+      expect(generated).toContain(
+        "$registeredUninstallArguments = @('/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC')"
+      );
+      expect(generated).not.toContain("$registeredUninstallArguments = @('/S')");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'uses Logi Bolt /silent instead of the generic Nullsoft /S fallback',
     () => {
       const generated = generateRegistryUninstallPackage(

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -52,6 +52,31 @@ describe('buildQaCatalogTestConfig', () => {
     });
   });
 
+  it('adds the Simple Hydraulic Calculator exact NSIS removal to catalog QA', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Igneus.SimpleHydraulicCalculator',
+        name: 'Simple Hydraulic Calculator',
+        publisher: 'Igneus',
+        version: '2.3.9',
+      },
+      manifest: { InstallerType: 'nullsoft', Scope: 'machine' },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'nullsoft',
+        Scope: 'machine',
+        ProductCode: 'Simple Hydraulic Calculator',
+      },
+    });
+
+    expect(config.psadtConfig.reviewedExactUninstall).toEqual({
+      executablePath:
+        '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
+      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      completionTimeoutMinutes: 5,
+    });
+  });
+
   it('prefers installer-specific silent switches and product metadata', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- bind Simple Hydraulic Calculator to its exact NSIS uninstaller
- keep the required _?= install-directory context as the final argument
- apply the adapter to both catalog QA and customer portal packaging

## Evidence
- QA runs 33219132479 and 33220015102 reproduced /S returning without removing the ARP registration
- live VM observation showed no interactive uninstall window

## Verification
- 294 focused tests passed
- changed-file ESLint passed
- production Next.js build passed