### PR TITLE
Activate Simple Hydraulic Calculator QA fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'e139e4cc222576f34ca905b7180ac47ea548cbab',
+  packagerCommit: 'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -501,6 +501,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // hosted by Windows PowerShell. Preserve every unrelated compatible pass
   // from the Somiibo user-scope release.
   '493b141d093be4d3fa25b550c41d47f7b9a91a67',
+  // TeamSpeak 6 Beta now executes its reviewed all-users WiX command as
+  // LocalSystem while retaining the exact user-scoped manifest bytes.
+  // Preserve every unrelated compatible pass from the UTF-8 packager release.
+  'e139e4cc222576f34ca905b7180ac47ea548cbab',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1648,4 +1648,20 @@ describe('QA toolchain targeted retries', () => {
       '953d2ca467b8e800a143150871c5220682106aa2'
     )).not.toContain('TeamSpeakSystems.TeamSpeakClient.Beta.6');
   });
+
+  it('retries Simple Hydraulic Calculator only with its exact NSIS release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      {
+        wingetId: 'igneus.simplehydrauliccalculator',
+        status: 'failed',
+      }
+    )).toBe(true);
+    expect(terminalToolchainRetryTargets(
+      QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('Igneus.SimpleHydraulicCalculator');
+    expect(terminalToolchainRetryTargets(
+      'e139e4cc222576f34ca905b7180ac47ea548cbab'
+    )).not.toContain('Igneus.SimpleHydraulicCalculator');
+  });
 });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -473,7 +473,17 @@ const TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
   ...TRUSTED_MSI_ARGUMENTS_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry Simple Hydraulic Calculator after its exact NSIS uninstaller keeps
+  // the required in-place install-directory argument last.
+  'Igneus.SimpleHydraulicCalculator',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f':
+    SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   'e139e4cc222576f34ca905b7180ac47ea548cbab':
     TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   '953d2ca467b8e800a143150871c5220682106aa2':


### PR DESCRIPTION
## Summary
- pin the shared production and QA packager to d2ee075ff3c717dbadef7fa2c5f480c33d256d4f
- schedule the failed Simple Hydraulic Calculator lifecycle for one bounded retry
- retain prior compatible QA passes and outstanding retry targets

## Verification
- 286 focused tests passed
- changed-file ESLint passed