### PR TITLE
Pass NSIS uninstall directory without quotes

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -735,7 +735,7 @@ describe('POST /api/package (workflow dispatch)', () => {
       reviewedExactUninstall: {
         executablePath:
           '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
-        arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+        arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
         completionTimeoutMinutes: 5,
       },
     };

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1253,12 +1253,10 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedExactUninstall).toEqual({
       executablePath:
         '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
-      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
       completionTimeoutMinutes: 5,
     });
-    expect(adapted.reviewedExactUninstall?.arguments.at(-1)).toBe(
-      '_?=%ProgramFiles(x86)%\\Igneus\\SHC'
-    );
+    expect(adapted.reviewedExactUninstall?.arguments).toHaveLength(1);
   });
 
   it('uses JetBrains silent mode with the exact dotPeek ARP command', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -624,15 +624,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     // Simple Hydraulic Calculator registers a small NSIS bootstrap uninstaller
     // that returns immediately for a bare /S invocation without removing the
     // application (QA runs 33219132479 and 33220015102). NSIS requires the
-    // special _?= install-directory argument to remain last when the
-    // uninstaller must execute in place. Bind that exact machine-wide command
+    // special _?= install-directory tail to remain last and unquoted. PSADT
+    // quotes a multi-item argument array when this path contains spaces, so
+    // keep the complete vendor command line in one element; PSADT 4.1.8 passes
+    // a single element through verbatim. Bind that exact machine-wide command
     // to both QA and customer packages while retaining the captured ARP key as
     // authoritative completion evidence.
     wingetId: 'Igneus.SimpleHydraulicCalculator',
     reviewedExactUninstall: {
       executablePath:
         '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
-      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
       completionTimeoutMinutes: 5,
     },
   },

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3439,7 +3439,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'keeps the Simple Hydraulic Calculator NSIS install directory argument last',
+    'emits the Simple Hydraulic Calculator NSIS command as one raw argument-list element',
     () => {
       const generated = generateRegistryUninstallPackage(
         'nullsoft',
@@ -3449,7 +3449,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
           reviewedExactUninstall: {
             executablePath:
               '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
-            arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+            arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
             completionTimeoutMinutes: 5,
           },
         },
@@ -3465,9 +3465,11 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         "[Environment]::ExpandEnvironmentVariables('%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe')"
       );
       expect(generated).toContain(
+        "$registeredUninstallArguments = @('/S _?=%ProgramFiles(x86)%\\Igneus\\SHC')"
+      );
+      expect(generated).not.toContain(
         "$registeredUninstallArguments = @('/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC')"
       );
-      expect(generated).not.toContain("$registeredUninstallArguments = @('/S')");
     }
   );
 

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -72,7 +72,7 @@ describe('buildQaCatalogTestConfig', () => {
     expect(config.psadtConfig.reviewedExactUninstall).toEqual({
       executablePath:
         '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
-      arguments: ['/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC'],
+      arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
       completionTimeoutMinutes: 5,
     });
   });


### PR DESCRIPTION
## Summary
- preserve Simple Hydraulic Calculator's NSIS _?= tail as an unquoted raw command line
- encode the full /S _?=... command as one PSADT 4.1.8 argument-list element
- keep QA and customer portal PSADT packages on the same adapter

## Evidence
- run 33221728679 proved the two-element form times out with 60001 because PSADT quotes the path-bearing _?= argument
- NSIS requires _?= to be last and unquoted

## Verification
- 294 focused tests passed
- changed-file ESLint passed
- production Next.js build passed