### PR TITLE
Activate raw NSIS uninstall command

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f',
+  packagerCommit: '5998b0deba83c1e274e8a4249a7962f67dcb6073',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -505,6 +505,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // LocalSystem while retaining the exact user-scoped manifest bytes.
   // Preserve every unrelated compatible pass from the UTF-8 packager release.
   'e139e4cc222576f34ca905b7180ac47ea548cbab',
+  // Simple Hydraulic Calculator now binds its exact NSIS uninstaller and
+  // install-directory context. Preserve every unrelated compatible pass from
+  // the TeamSpeak machine-scope release.
+  'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -475,13 +475,15 @@ const TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
 
 const SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS = [
   // Retry Simple Hydraulic Calculator after its exact NSIS uninstaller keeps
-  // the required in-place install-directory argument last.
+  // the required in-place install-directory tail last and unquoted.
   'Igneus.SimpleHydraulicCalculator',
   // Carry every still-unconsumed targeted retry across the atomic pin.
   ...TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '5998b0deba83c1e274e8a4249a7962f67dcb6073':
+    SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f':
     SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   'e139e4cc222576f34ca905b7180ac47ea548cbab':


### PR DESCRIPTION
## Summary
- pin production and QA scheduler profiles to 5998b0deba83c1e274e8a4249a7962f67dcb6073
- carry the bounded Simple Hydraulic Calculator retry into the corrected release
- retain prior compatible passes for unaffected apps

## Verification
- 286 focused tests passed
- changed-file ESLint passed