### PR TITLE
Fix Simple Hydraulic Calculator uninstall confirmation

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -738,6 +738,16 @@ describe('POST /api/package (workflow dispatch)', () => {
         arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
         completionTimeoutMinutes: 5,
       },
+      reviewedUninstallWindowAutomation: {
+        processName: 'shc2uninstall.exe',
+        steps: [
+          {
+            windowText: 'Simple Hydraulic Calculator',
+            buttonIndex: 1,
+            timeoutSeconds: 60,
+          },
+        ],
+      },
     };
     expect(JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)).toMatchObject(
       expectedAdapter

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1257,6 +1257,16 @@ describe('application packaging adapters', () => {
       completionTimeoutMinutes: 5,
     });
     expect(adapted.reviewedExactUninstall?.arguments).toHaveLength(1);
+    expect(adapted.reviewedUninstallWindowAutomation).toEqual({
+      processName: 'shc2uninstall.exe',
+      steps: [
+        {
+          windowText: 'Simple Hydraulic Calculator',
+          buttonIndex: 1,
+          timeoutSeconds: 60,
+        },
+      ],
+    });
   });
 
   it('uses JetBrains silent mode with the exact dotPeek ARP command', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -622,20 +622,32 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // Simple Hydraulic Calculator registers a small NSIS bootstrap uninstaller
-    // that returns immediately for a bare /S invocation without removing the
-    // application (QA runs 33219132479 and 33220015102). NSIS requires the
-    // special _?= install-directory tail to remain last and unquoted. PSADT
-    // quotes a multi-item argument array when this path contains spaces, so
-    // keep the complete vendor command line in one element; PSADT 4.1.8 passes
-    // a single element through verbatim. Bind that exact machine-wide command
-    // to both QA and customer packages while retaining the captured ARP key as
-    // authoritative completion evidence.
+    // that does not complete for a bare /S invocation (QA runs 33219132479 and
+    // 33220015102). NSIS requires the special _?= install-directory tail to
+    // remain last and unquoted. PSADT quotes a multi-item argument array when
+    // this path contains spaces, so keep the complete vendor command line in
+    // one element; PSADT 4.1.8 passes a single element through verbatim. Even
+    // with that exact command the vendor process remains blocked behind its
+    // product-specific confirmation in session 0 (run 33223161038). Drive only
+    // the first button on a window that contains the exact product name and is
+    // owned by the newly started, path-verified uninstaller. The captured ARP
+    // key remains the authoritative completion signal for QA and customers.
     wingetId: 'Igneus.SimpleHydraulicCalculator',
     reviewedExactUninstall: {
       executablePath:
         '%ProgramFiles(x86)%\\Igneus\\SHC\\shc2uninstall.exe',
       arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
       completionTimeoutMinutes: 5,
+    },
+    reviewedUninstallWindowAutomation: {
+      processName: 'shc2uninstall.exe',
+      steps: [
+        {
+          windowText: 'Simple Hydraulic Calculator',
+          buttonIndex: 1,
+          timeoutSeconds: 60,
+        },
+      ],
     },
   },
   {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3439,8 +3439,9 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
-    'emits the Simple Hydraulic Calculator NSIS command as one raw argument-list element',
+    'emits the Simple Hydraulic Calculator raw NSIS command and bounded confirmation automation',
     () => {
+      let embeddedAutomation: unknown;
       const generated = generateRegistryUninstallPackage(
         'nullsoft',
         'Simple Hydraulic Calculator',
@@ -3452,13 +3453,36 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
             arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
             completionTimeoutMinutes: 5,
           },
+          reviewedUninstallWindowAutomation: {
+            processName: 'shc2uninstall.exe',
+            steps: [
+              {
+                windowText: 'Simple Hydraulic Calculator',
+                buttonIndex: 1,
+                timeoutSeconds: 60,
+              },
+            ],
+          },
         },
         [],
         'Igneus.SimpleHydraulicCalculator',
         'Simple Hydraulic Calculator',
         '2.3.9',
         'REGISTRY_UNINSTALL_KEY:Simple Hydraulic Calculator:Simple Hydraulic Calculator',
-        '/S'
+        '/S',
+        'machine',
+        '',
+        '',
+        (packageDirectory) => {
+          embeddedAutomation = JSON.parse(readFileSync(
+            join(
+              packageDirectory,
+              'SupportFiles',
+              'ReviewedUninstallWindowAutomation.json'
+            ),
+            'utf8'
+          ));
+        }
       );
 
       expect(generated).toContain(
@@ -3470,6 +3494,19 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
       expect(generated).not.toContain(
         "$registeredUninstallArguments = @('/S', '_?=%ProgramFiles(x86)%\\Igneus\\SHC')"
       );
+      expect(generated).toContain(
+        'Starting reviewed window automation for the exact vendor uninstaller.'
+      );
+      expect(embeddedAutomation).toEqual({
+        processName: 'shc2uninstall.exe',
+        steps: [
+          {
+            windowText: 'Simple Hydraulic Calculator',
+            buttonIndex: 1,
+            timeoutSeconds: 60,
+          },
+        ],
+      });
     }
   );
 

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -75,6 +75,16 @@ describe('buildQaCatalogTestConfig', () => {
       arguments: ['/S _?=%ProgramFiles(x86)%\\Igneus\\SHC'],
       completionTimeoutMinutes: 5,
     });
+    expect(config.psadtConfig.reviewedUninstallWindowAutomation).toEqual({
+      processName: 'shc2uninstall.exe',
+      steps: [
+        {
+          windowText: 'Simple Hydraulic Calculator',
+          buttonIndex: 1,
+          timeoutSeconds: 60,
+        },
+      ],
+    });
   });
 
   it('prefers installer-specific silent switches and product metadata', () => {


### PR DESCRIPTION
## Summary
- keep the reviewed raw NSIS command line required by the vendor uninstaller
- drive one bounded confirmation click only on the exact newly started, path-verified uninstaller process
- bind the same adapter to catalog QA and customer PSADT packaging

## Evidence
- run 33223161038 proved the unquoted command was emitted exactly, but the vendor process stayed alive for the full five-minute ARP deadline
- exact ARP removal remains the authoritative completion condition

## Verification
- 294 focused tests passed
- npm run lint
- npm run build:ci