### PR TITLE
Activate Simple Hydraulic confirmation packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '5998b0deba83c1e274e8a4249a7962f67dcb6073',
+  packagerCommit: '5fcfe713cc45fa1c458acf895ec8827b94166dc4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -509,6 +509,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // install-directory context. Preserve every unrelated compatible pass from
   // the TeamSpeak machine-scope release.
   'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f',
+  // Simple Hydraulic Calculator now emits the required NSIS install-directory
+  // tail as one unquoted raw command-line element. Preserve every unrelated
+  // compatible pass from the first exact-uninstaller release.
+  '5998b0deba83c1e274e8a4249a7962f67dcb6073',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1649,7 +1649,7 @@ describe('QA toolchain targeted retries', () => {
     )).not.toContain('TeamSpeakSystems.TeamSpeakClient.Beta.6');
   });
 
-  it('retries Simple Hydraulic Calculator only with its exact NSIS release', () => {
+  it('retries Simple Hydraulic Calculator with its bounded confirmation release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       {
@@ -1659,6 +1659,9 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
     expect(terminalToolchainRetryTargets(
       QA_PSADT_TOOLCHAIN.packagerCommit
+    )).toContain('Igneus.SimpleHydraulicCalculator');
+    expect(terminalToolchainRetryTargets(
+      '5998b0deba83c1e274e8a4249a7962f67dcb6073'
     )).toContain('Igneus.SimpleHydraulicCalculator');
     expect(terminalToolchainRetryTargets(
       'e139e4cc222576f34ca905b7180ac47ea548cbab'

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -475,13 +475,16 @@ const TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
 
 const SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS = [
   // Retry Simple Hydraulic Calculator after its exact NSIS uninstaller keeps
-  // the required in-place install-directory tail last and unquoted.
+  // the required in-place install-directory tail last and unquoted, then
+  // drives the vendor confirmation on the path-verified process.
   'Igneus.SimpleHydraulicCalculator',
   // Carry every still-unconsumed targeted retry across the atomic pin.
   ...TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '5fcfe713cc45fa1c458acf895ec8827b94166dc4':
+    SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   '5998b0deba83c1e274e8a4249a7962f67dcb6073':
     SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   'd2ee075ff3c717dbadef7fa2c5f480c33d256d4f':


### PR DESCRIPTION
## Summary
- pin QA/catalog scheduling to packager commit 5fcfe713cc45fa1c458acf895ec8827b94166dc4
- preserve unrelated historical passes across the release boundary
- carry the targeted Simple Hydraulic retry into the confirmation release

## Verification
- 305 focused tests passed
- npm run lint
- npm run build:ci