### PR TITLE
fix(packaging): bind IJe uninstall identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -138,6 +138,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses IJe\'s stable Inno registry key despite its versioned ARP name', () => {
+    expect(resolveApplicationUninstallCommand(
+      'IJe.IJe',
+      'REGISTRY_UNINSTALL:IJe Programming Language'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:{C626C8D8-8095-4654-8C2A-851532029011}_is1:IJe version 1.0.1'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'ije.ije',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses FSLogix\'s registered bundle display identity', () => {
     expect(resolveApplicationUninstallCommand(
       'Microsoft.FSLogix',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1671,6 +1671,16 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Greenshot',
     registeredRegistryKey: 'Greenshot_is1',
   },
+  // IJe's catalog name is `IJe Programming Language`, but its Inno installer
+  // registers the versioned display name `IJe version 1.0.1` below a stable
+  // AppId-derived `_is1` key. QA run 33227580169 observed exactly that one
+  // visible IJe Team registration. Bind the immutable key so capture,
+  // detection, and removal never rely on the versioned catalog/display rename.
+  'ije.ije': {
+    generatedDisplayName: 'IJe Programming Language',
+    registeredDisplayName: 'IJe version 1.0.1',
+    registeredRegistryKey: '{C626C8D8-8095-4654-8C2A-851532029011}_is1',
+  },
   // FSLogix is distributed as a ZIP containing Microsoft's Burn-style EXE.
   // WinGet publishes `Microsoft FSLogix Apps` in ProductCode, but the bundle
   // creates a generated GUID ARP key with that value as its DisplayName. Bind


### PR DESCRIPTION
## Summary
- bind IJe.IJe to the exact Inno AppId-derived uninstall key observed under LocalSystem
- preserve the catalog label only as the input contract while capturing/removing the vendor's exact registration
- keep custom uninstall commands untouched

## Evidence
- failing QA run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33227580169
- protected diagnostic: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33227864053
- observed one visible ARP entry: IJe version 1.0.1 / IJe Team / {C626C8D8-8095-4654-8C2A-851532029011}_is1

## Verification
- 5 related test files, 263 tests passed

## Security gate
VirusTotal issue https://github.com/ugurkocde/IntuneGet-Workflows/issues/2790 remains open. This PR fixes the lifecycle identity only; it does not mark the exact installer clean or bypass promotion controls.