### PR TITLE
fix: run Ente Photos in reviewed user scope

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -651,6 +651,59 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('uses Ente Photos user scope consistently for customer PSADT packaging and QA', async () => {
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: 'https://example.com/setup.exe',
+      sha256: 'A'.repeat(64),
+      type: 'nullsoft',
+      silentArgs: '/S',
+      productCode: 'fb682768-51c6-5397-92da-171dc1777808',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'ente-io.photos-desktop',
+          displayName: 'Ente Photos',
+          version: '1.7.27',
+          installerType: 'nullsoft',
+          installScope: 'machine',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'ente-io.photos-desktop',
+        installScope: 'user',
+      }),
+      expect.any(Array)
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ install_scope: 'user' })
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'ente-io.photos-desktop',
+        installScope: 'user',
+      }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('uses TeamSpeak 6 Beta all-users MSI scope for QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -318,6 +318,12 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' saraansx.luniq ', undefined)).toBe(
       'user'
     );
+    expect(
+      resolveApplicationInstallScope('ente-io.photos-desktop', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' ENTE-IO.PHOTOS-DESKTOP ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
       resolveApplicationInstallScope(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -178,6 +178,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Ente Photos 1.7.27 is built with Electron Builder's one-click NSIS
+    // target and does not enable perMachine. Electron Builder therefore uses
+    // its per-user default. WinGet omits Scope; running the same installer as
+    // LocalSystem placed its registration below systemprofile and the captured
+    // uninstaller was unavailable by the removal cycle. Keep both QA and the
+    // shared customer PSADT package in the vendor-supported user context.
+    // https://github.com/ente/ente/blob/photos-desktop-v1.7.27/desktop/electron-builder.yml
+    wingetId: 'ente-io.photos-desktop',
+    requiredInstallScope: 'user',
+  },
+  {
     // ElegantClipboard's tagged Tauri v2 configuration explicitly builds its
     // NSIS installer with installMode=currentUser, while the WinGet manifest
     // omits Scope. The generic machine default installs below LocalSystem's

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -745,6 +745,44 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
+  it('tests Ente Photos in user context when its Electron Builder manifest omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'ente-io.photos-desktop',
+        name: 'Ente Photos',
+        publisher: 'Ente',
+        version: '1.7.27',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        ProductCode: 'fb682768-51c6-5397-92da-171dc1777808',
+        AppsAndFeaturesEntries: [
+          {
+            DisplayName: 'ente 1.7.27',
+            Publisher: 'Ente',
+            ProductCode: 'fb682768-51c6-5397-92da-171dc1777808',
+          },
+        ],
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{FB682768-51C6-5397-92DA-171DC1777808}:Ente Photos'
+    );
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\ente_io_photos_desktop',
+      }),
+    ]);
+  });
+
   it('tests Youdao in user context when its NSIS manifest omits scope', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- bind Ente Photos to Electron Builder's documented per-user NSIS lifecycle
- keep QA and customer PSADT packaging on the same shared scope adapter
- cover direct scope resolution, QA profile generation, and portal packaging propagation

## Evidence
- Ente's official photos-desktop-v1.7.27 build omits nsis.perMachine
- Electron Builder documents perMachine=false as the default
- isolated QA run 33230022711 installed under LocalSystem but captured a missing systemprofile uninstaller

## Verification
- 157 focused packaging/QA tests pass
- 153 package-profile/demand/enqueue tests pass
- ESLint passes on changed files
- full suite: 86 files / 1,586 tests pass; only pre-existing local native better-sqlite3 binding failures and one translation-provider timeout remain