### PR TITLE
chore: activate Ente user-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '24ee5fb123c9817f4d2dabcbe11817472c82d1e1',
+  packagerCommit: '617c3f8801dac600fd86c4c743aa2b44a1a5061b',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -517,6 +517,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // uninstall key. Preserve every unrelated compatible pass from the bounded
   // Simple Hydraulic Calculator confirmation release.
   '5fcfe713cc45fa1c458acf895ec8827b94166dc4',
+  // Ente Photos now runs in Electron Builder's per-user NSIS context instead
+  // of LocalSystem's disposable systemprofile. Preserve every unrelated pass
+  // from the IJe registered-identity release.
+  '24ee5fb123c9817f4d2dabcbe11817472c82d1e1',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Ente Photos only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' ENTE-IO.PHOTOS-DESKTOP ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '24ee5fb123c9817f4d2dabcbe11817472c82d1e1',
+      { wingetId: 'ente-io.photos-desktop', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('does not retry ROBOTC after its managed-uninstall block release', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -482,7 +482,17 @@ const SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...TEAMSPEAK6_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry Ente Photos in the vendor-configured per-user NSIS context after
+  // LocalSystem installed it below the disposable systemprofile.
+  'ente-io.photos-desktop',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '617c3f8801dac600fd86c4c743aa2b44a1a5061b':
+    ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '24ee5fb123c9817f4d2dabcbe11817472c82d1e1':
     SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
   '5fcfe713cc45fa1c458acf895ec8827b94166dc4':


### PR DESCRIPTION
## Summary
- pin QA and production scheduling to shared packager commit 617c3f8801dac600fd86c4c743aa2b44a1a5061b
- preserve compatible passes from the prior IJe release
- retry Ente Photos only after the reviewed user-scope fix is active

## Verification
- 428 profile, generated-PSADT contract, enqueue, and retry tests pass
- ESLint passes on changed files