### PR TITLE
Block unsupported Maestro managed install

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1679,3 +1679,28 @@ describe('DirPrintOK managed uninstall block migration contract', () => {
     expect(sql).toContain("status in ('queued', 'failed', 'error')");
   });
 });
+
+describe('Maestro Arsoppgjor managed install block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260829064000_block_maestro_aarsoppgjoer_unsupported_managed_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the non-registering LocalSystem install across packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_install'");
+    expect(sql).toContain("'MaestroSoft.MaestroAarsoppgjoer.2025'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33238254434'
+    );
+    expect(sql).toContain('Two isolated PSADT runs');
+    expect(sql).toContain('38.05.21 and 38.05.22');
+    expect(sql).toContain('Microsoft Edge/WebView2 registrations');
+    expect(sql).toContain('managed detection or removal');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});

--- a/supabase/migrations/20260829064000_block_maestro_aarsoppgjoer_unsupported_managed_install.sql
+++ b/supabase/migrations/20260829064000_block_maestro_aarsoppgjoer_unsupported_managed_install.sql
@@ -1,0 +1,37 @@
+-- Maestro Arsoppgjor 2025 does not currently provide a verifiable unattended
+-- machine installation lifecycle. Two isolated PSADT runs used consecutive,
+-- exact WinGet payloads (38.05.21 and 38.05.22) with the published /s switch.
+-- Both ran for roughly 90 seconds under LocalSystem, changed only Microsoft
+-- Edge/WebView2 registrations, and created no Maestro application identity for
+-- managed detection or removal. Keep the package out of customer packaging and
+-- QA until the upstream manifest or vendor publishes a deterministic contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'MaestroSoft.MaestroAarsoppgjoer.2025',
+  'unsupported_managed_install',
+  'Two consecutive exact WinGet payloads (38.05.21 and 38.05.22) ran the published /s command under LocalSystem but changed only Microsoft Edge/WebView2 registrations and created no Maestro application identity for deterministic detection or managed removal.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33238254434'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'MaestroSoft.MaestroAarsoppgjoer.2025';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'MaestroSoft.MaestroAarsoppgjoer.2025'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Maestro Årsoppgjør 2025 from automated packaging and QA
- record matching failures from consecutive exact WinGet payloads
- supersede failed/queued candidates and mark the catalog entry unverified

## Evidence
- 38.05.21 and 38.05.22 both ran the published /s switch under LocalSystem for about 90 seconds
- both changed only Microsoft Edge/WebView2 registrations
- neither created a Maestro application identity for deterministic detection or managed removal

## Verification
- npx vitest run lib/qa/migration-contract.test.ts (102 passed)
- npx eslint lib/qa/migration-contract.test.ts
- git diff --check