### PR TITLE
fix(actions): unbreak daily manifest sync summary and weekly categorization

### DIFF
--- a/.github/scripts/categorize-apps.js
+++ b/.github/scripts/categorize-apps.js
@@ -199,15 +199,35 @@ async function callOpenAI(batch) {
   };
 
   for (let attempt = 1; attempt <= RETRIES; attempt += 1) {
-    const response = await fetch(OPENAI_API_URL, {
-      method: 'POST',
-      signal: AbortSignal.timeout(60_000),
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
+    // Content-level defects (missing text, invalid JSON, an incomplete
+    // classification set) and transport failures are as transient as a 429:
+    // a fresh request usually succeeds. Retrying them here is what keeps one
+    // bad sample from failing the batch, and the batch from failing the
+    // whole weekly run.
+    const retryContent = async (reason) => {
+      if (attempt < RETRIES) {
+        console.warn(`Batch attempt ${attempt} rejected (${reason}); retrying`);
+        await sleep(RETRY_DELAY_MS * attempt);
+        return true;
+      }
+      return false;
+    };
+
+    let response;
+    try {
+      response = await fetch(OPENAI_API_URL, {
+        method: 'POST',
+        signal: AbortSignal.timeout(60_000),
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      if (await retryContent(`request failed: ${error.message}`)) continue;
+      throw new Error(`OpenAI request failed: ${error.message}`);
+    }
 
     if (!response.ok) {
       const body = await response.text();
@@ -219,9 +239,21 @@ async function callOpenAI(batch) {
       throw new Error(`OpenAI request failed (${response.status}): ${body.slice(0, 600)}`);
     }
 
-    const parsed = await response.json();
+    let parsed;
+    try {
+      parsed = await response.json();
+    } catch (error) {
+      if (await retryContent(`unparseable response body: ${error.message}`)) continue;
+      throw new Error(`OpenAI response body was not valid JSON: ${error.message}`);
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      if (await retryContent('response body was not an object')) continue;
+      throw new Error('OpenAI response body was not an object');
+    }
+
     const text = extractTextResponse(parsed);
     if (!text) {
+      if (await retryContent('missing output_text')) continue;
       throw new Error('OpenAI response did not include output_text');
     }
 
@@ -229,6 +261,7 @@ async function callOpenAI(batch) {
     try {
       decoded = JSON.parse(text);
     } catch (error) {
+      if (await retryContent(`invalid JSON: ${error.message}`)) continue;
       throw new Error(`Invalid JSON in OpenAI output: ${error.message}`);
     }
 
@@ -240,6 +273,7 @@ async function callOpenAI(batch) {
       returnedIds.size !== expectedIds.size ||
       [...expectedIds].some((id) => !returnedIds.has(id))
     ) {
+      if (await retryContent('incomplete classification set')) continue;
       throw new Error('OpenAI response did not contain exactly one classification for every requested winget_id');
     }
     return {

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -604,6 +604,15 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+
+      # The aggregate step imports lib/winget-sync-resolution.mjs, which
+      # depends on the yaml package. Without installed dependencies the
+      # import fails with ERR_MODULE_NOT_FOUND, the summary job goes red
+      # even when every sync shard succeeded, and the snapshot job (which
+      # requires summary success) never rebuilds the self-hosted catalog.
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
 
       - name: Download all shard results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Why

Review of all scheduled workflows in this repo turned up three chronic failures. This PR fixes the two with unambiguous root causes; the third is a policy question (see bottom).

### 1. Sync Winget Manifests: red every day since Aug 22

Every daily run fails in the `summary` job with:

```
Failed to aggregate sync results: Error [ERR_MODULE_NOT_FOUND]:
Cannot find package 'yaml' imported from lib/winget-sync-resolution.mjs
```

All 30 sync shards succeed every day; only the aggregation dies, because the summary job runs `setup-node` but never installs dependencies, and the aggregate script imports `lib/winget-sync-resolution.mjs` (which imports `yaml`). **Real impact:** the `snapshot` job requires summary success, so the self-hosted `catalog-latest` SQLite release has not been rebuilt in 8 days — self-hosted instances are on a stale catalog. Fix: install dependencies in the summary job exactly like the shard job and snapshot job already do (`cache: npm` + `npm ci`).

### 2. Categorize Curated Apps: failed 3 of the last 4 weekly runs

```
Batch 2/10 failed and will be retried on a later run: OpenAI response did not
contain exactly one classification for every requested winget_id
```

The strict JSON schema already pins the array length, so the failing case is the model returning duplicate or wrong `winget_id`s inside a correctly-sized array — classic sampling noise. The retry loop (`RETRIES = 3`) only retried HTTP 429/5xx; a 200 response with defective content threw immediately, and one bad sample failed the entire run. Content defects, transport failures (fetch rejection / 60s abort), and unparseable response bodies are now retried within the same `RETRIES` budget. Exhausted retries still throw the original error, and the run still fails if a batch genuinely cannot be classified.

## Review

Codex `gpt-5.6-sol` reviewed the diff: no blocking findings; confirmed the retry placement re-sends an identical payload as a fresh sample, `retryContent` scoping is correct, and the summary-job install exactly matches the repo's other jobs. Its suggestions to retry transport-level failures and guard a null response body are included. Its suggestion to add retry-loop regression tests is deliberately not included: the script is a top-level runner with no exports, and restructuring it for testability is a larger change than this fix.

## Not fixed here: Scan App Installations (red weekly since Jul 15)

Diagnosed but intentionally left alone: 2-6 *different* apps fail their installer each week on the ephemeral Windows runners (installer flakiness, not a pipeline bug), the good results **are** uploaded to Supabase, and the validate job then deliberately exits 1 because `if (failed > 0) process.exitCode = 1`. Making that threshold-based (red only when the upload fails or failure rate is abnormal) is a policy change on alerting semantics, so it needs a maintainer decision rather than a drive-by fix.

## Testing

`node --check` on the script, YAML validated, and the workflow-lint CI check covers the workflow change. Honest caveat: both fixes' first real exercise is the next scheduled run (sync nightly ~02:00 UTC, categorize Saturday).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
