### PR TITLE
fix(actions): aggregate single-shard sync runs whose artifact extracts flat

### DIFF
--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -641,10 +641,19 @@ jobs:
             let allNewVersions = [], unavailableItems = [], failedItems = [];
 
             if (fs.existsSync(resultsDir)) {
-              const dirs = fs.readdirSync(resultsDir);
-              for (const dir of dirs) {
-                const filePath = path.join(resultsDir, dir, 'sync-results.json');
-                if (fs.existsSync(filePath)) {
+              // download-artifact places each artifact in its own subdirectory
+              // when a pattern matches several, but extracts FLAT into the
+              // target path when the pattern matches exactly one (observed on
+              // run 33243208914: a single-shard manual run produced
+              // results/sync-results.json and the subdirectory scan found 0
+              // shards). Accept both layouts.
+              const shardFiles = fs.readdirSync(resultsDir)
+                .map((entry) => path.join(resultsDir, entry, 'sync-results.json'))
+                .filter((filePath) => fs.existsSync(filePath));
+              const flatFile = path.join(resultsDir, 'sync-results.json');
+              if (shardFiles.length === 0 && fs.existsSync(flatFile)) shardFiles.push(flatFile);
+              for (const filePath of shardFiles) {
+                {
                   const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
                   totalSynced += data.synced || 0;
                   totalFailed += data.failed || 0;


### PR DESCRIPTION
## Why

Verification run 33243208914 (a `limit=25` manual dispatch to exercise #1026) got past the fixed dependency install, then failed with `Incomplete sync: expected 1 shard artifacts, found 0` even though the shard succeeded and uploaded its artifact.

Root cause from the run log: `actions/download-artifact` places each artifact in its own subdirectory when a pattern matches several, but extracts **flat** into the target path when it matches exactly one (`Starting download of artifact to: .../results`, and the subdirectory scan then finds nothing). Nightly 30-shard runs are unaffected; this only bites single-shard manual runs, which are exactly what you use for verification.

## What

The aggregate scan accepts both layouts: subdirectory shards first, and the flat `results/sync-results.json` only when no subdirectory shards exist, so the layouts cannot double count.

## Review

Codex `gpt-5.6-sol` focused pass: no blocker; confirmed brace/scope balance of the inline script and that the flat file flows through the normal per-shard aggregation. Its one caveat (theoretical double-count if both layouts coexisted) is addressed with the `shardFiles.length === 0` guard. The extracted inline script passes `node --check`.

## Verification plan

After merge, re-dispatch `sync-manifests.yml` with `limit=25`: expect plan, sync, summary, and snapshot all green, which also rebuilds the stale self-hosted catalog snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)