### PR TITLE
Increase idle QA catalog probing

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -468,7 +468,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     ]);
     expect(rpcCalls).toEqual([
       { name: 'qa_missing_demand_backfill_ids', args: { p_limit: 20 } },
-      { name: 'qa_idle_catalog_backfill_ids', args: { p_limit: 3 } },
+      { name: 'qa_idle_catalog_backfill_ids', args: { p_limit: 20 } },
     ]);
     expect(pollRunUpdates).toEqual([
       expect.objectContaining({
@@ -554,7 +554,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(rpcCalls).toContainEqual({
       name: 'qa_idle_catalog_backfill_ids',
-      args: { p_limit: 3 },
+      args: { p_limit: 20 },
     });
     expect(candidateInserts[0]).toMatchObject({
       winget_id: 'Missing.App',
@@ -602,7 +602,7 @@ describe('GET /api/cron/qa-enqueue', () => {
     });
     expect(rpcCalls).toContainEqual({
       name: 'qa_idle_catalog_backfill_ids',
-      args: { p_limit: 3 },
+      args: { p_limit: 20 },
     });
     expect(candidateInserts).toEqual([
       expect.objectContaining({

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -57,7 +57,11 @@ const TOOLCHAIN_BACKFILL_PAGE_SIZE = 1_000;
 // deployed-app demand per poll to avoid spending hours reclassifying known
 // payloads three at a time.
 const DEMAND_BACKFILL_BATCH_SIZE = 20;
-const IDLE_CATALOG_BACKFILL_BATCH_SIZE = 3;
+// Many catalog rows cannot currently resolve to a trusted Windows installer.
+// Probe enough idle candidates to keep the serialized VM supplied, while the
+// loop below still resolves manifests in bounded groups of BATCH_SIZE and the
+// database continues to enforce a single active lifecycle.
+const IDLE_CATALOG_BACKFILL_BATCH_SIZE = 20;
 const MAX_TARGETED_PACKAGE_IDS = 20;
 const TARGETED_QA_PRIORITY = 1_000;
 


### PR DESCRIPTION
## Summary
- probe up to 20 idle catalog IDs per scheduler poll instead of 3
- retain three-at-a-time manifest resolution and the database-enforced single active VM lifecycle
- update scheduler RPC contract expectations

## Verification
- npm test -- app/api/cron/qa-enqueue/route.test.ts (36 passed)
- npx eslint app/api/cron/qa-enqueue/route.ts app/api/cron/qa-enqueue/route.test.ts
- production RPC clamp verified to return at most 20 rows