### PR TITLE
Keep reviewed per-user installers observable

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -2893,8 +2893,46 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                     ''
                     '    try {'
                     '        Write-ADTLogEntry -Message "Running per-user installer from user temp directory" -Severity ''Info'' -Source ''Install-ADTDeployment'''
-                    '        # Use -UseShellExecute for shell context which inherits environment variables'
-                    "        Start-ADTProcess -FilePath `$installerDest$installerArgumentListFragment -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
+                )
+                if ($reviewedInstallCompletionTimeoutMinutes -gt 0) {
+                    $lines += @(
+                        '        # Keep the reviewed per-user installer observable while preserving its shell environment.'
+                        "        `$installDeadline = [DateTime]::UtcNow.AddMinutes($reviewedInstallCompletionTimeoutMinutes)"
+                        "        `$installHandle = Start-ADTProcess -FilePath `$installerDest$installerArgumentListFragment -UseShellExecute -WaitForMsiExec -NoWait -PassThru"
+                        '        $nextInstallProgressLog = [DateTime]::UtcNow'
+                        '        while (-not $installHandle.Task.IsCompleted) {'
+                        '            if ([DateTime]::UtcNow -ge $installDeadline) {'
+                        '                try {'
+                        '                    if (-not $installHandle.Process.HasExited) {'
+                        '                        $installHandle.Process.Kill($true)'
+                        '                        $installHandle.Process.WaitForExit()'
+                        '                    }'
+                        '                } catch {'
+                        '                    Write-ADTLogEntry -Message "Could not stop the reviewed per-user vendor installer after its bounded timeout: $_" -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+                        '                }'
+                        "                throw 'The reviewed per-user vendor installer did not complete within $reviewedInstallCompletionTimeoutMinutes minutes.'"
+                        '            }'
+                        '            if ([DateTime]::UtcNow -ge $nextInstallProgressLog) {'
+                        '                Write-ADTLogEntry -Message "The reviewed per-user vendor installer is still working." -Source ''Install-ADTDeployment'''
+                        '                $nextInstallProgressLog = [DateTime]::UtcNow.AddSeconds(15)'
+                        '            }'
+                        '            Start-Sleep -Seconds 5'
+                        '        }'
+                        '        $installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+                        '        if ($installProcessExitCode -in @(1641, 3010)) {'
+                        '            $script:InstallRebootExitCode = 3010'
+                        '            Write-ADTLogEntry -Message "The reviewed per-user vendor installer requested a reboot with exit code [$installProcessExitCode]." -Severity ''Warning'' -Source ''Install-ADTDeployment'''
+                        '        } elseif ($installProcessExitCode -ne 0) {'
+                        '            throw "The reviewed per-user vendor installer exited with code [$installProcessExitCode]."'
+                        '        }'
+                    )
+                } else {
+                    $lines += @(
+                        '        # Use -UseShellExecute for shell context which inherits environment variables'
+                        "        Start-ADTProcess -FilePath `$installerDest$installerArgumentListFragment -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15) -TimeoutAction Stop"
+                    )
+                }
+                $lines += @(
                     '    }'
                     '    finally {'
                     '        # Cleanup temp directory'

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1328,6 +1328,16 @@ describe('application packaging adapters', () => {
     );
   });
 
+  it('keeps MaxTo in user scope with a reviewed observable installer wait', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'domino.maxto',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(resolveApplicationInstallScope('Domino.MaxTo', 'machine')).toBe('user');
+    expect(adapted.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+  });
+
   it('uses Mozilla NSIS silent mode with the exact Zen Browser ARP command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'zen-team.zen-browser',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -432,6 +432,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallCompletionTimeoutMinutes: 15,
   },
   {
+    // MaxTo 3 uses Velopack's documented per-user Setup.exe contract. Its
+    // --silent installation can remain quiet beyond the generic QA inactivity
+    // window while app hooks finish. Keep that vendor command and user scope,
+    // but opt the shared QA/customer package into the observable, bounded wait.
+    wingetId: 'Domino.MaxTo',
+    requiredInstallScope: 'user',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // SEGGER Embedded Studio's official unattended command created the full
     // application tree and ARP registration during QA, but the vendor process
     // remained quiet longer than the generic inactivity window. Preserve the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1184,6 +1184,31 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds MaxTo user scope and its bounded Velopack wait to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Domino.MaxTo',
+      displayName: 'MaxTo',
+      publisher: 'Domino',
+      version: '3.0.1',
+      architecture: 'x64',
+      installerSha256: '6'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:MaxTo:MaxTo',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(profile.installer.silentArgs).toBe('--silent');
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+  });
+
   it('binds the bounded FlashPrint nested EXE wait to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Flashforge.FlashPrint',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3185,6 +3185,49 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'keeps the reviewed MaxTo per-user installer observable and bounded',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe',
+        'MaxTo',
+        [],
+        { reviewedInstallCompletionTimeoutMinutes: 15 },
+        [],
+        'Domino.MaxTo',
+        'MaxTo',
+        '3.0.1',
+        'REGISTRY_UNINSTALL_KEY:MaxTo:MaxTo',
+        '--silent',
+        'user'
+      );
+
+      expect(generated).toContain(
+        '$installDeadline = [DateTime]::UtcNow.AddMinutes(15)'
+      );
+      expect(generated).toContain(
+        "Start-ADTProcess -FilePath $installerDest -ArgumentList '--silent' -UseShellExecute -WaitForMsiExec -NoWait -PassThru"
+      );
+      expect(generated).toContain(
+        'Write-ADTLogEntry -Message "The reviewed per-user vendor installer is still working."'
+      );
+      expect(generated).toContain(
+        '$installProcessExitCode = $installHandle.Task.GetAwaiter().GetResult().ExitCode'
+      );
+      expect(generated).toContain(
+        "throw 'The reviewed per-user vendor installer did not complete within 15 minutes.'"
+      );
+      expect(generated).toContain('$installHandle.Process.Kill($true)');
+      expect(generated).toContain('$installHandle.Process.WaitForExit()');
+      expect(generated).toContain(
+        'Remove-Item -Path $userTempDir -Recurse -Force -ErrorAction SilentlyContinue'
+      );
+      expect(generated).not.toContain(
+        "Start-ADTProcess -FilePath $installerDest -ArgumentList '--silent' -UseShellExecute -WaitForMsiExec -Timeout (New-TimeSpan -Minutes 15)"
+      );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'keeps the reviewed Logitech G HUB bootstrapper observable and removes it silently',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
## Failure evidence
- Production QA run 33305966730 for Domino.MaxTo 3.0.1 reached the 281-second no-activity ceiling while the documented Velopack --silent per-user installer was still running.
- Fail-closed detection and uninstall behaved correctly: no managed marker was accepted and broad removal was refused.

## Shared fix
- Add a reviewed MaxTo adapter that keeps user scope and opts into the existing 15-minute installer ceiling.
- Honor reviewedInstallCompletionTimeoutMinutes in the per-user EXE branch with 15-second PSADT heartbeats.
- Preserve the shell environment, exact vendor arguments, explicit exit-code handling, process-tree termination at the bound, and temp cleanup.
- The same generated PSADT path is used by QA and customer IntuneGet packages.

## Verification
- 337 focused adapter/profile/generated-package tests passed.
- 141 generated PSADT contract tests passed after the final timeout hardening.
- 173 dispatch/toolchain/GitHub workflow tests passed.
- ESLint passed for all changed TypeScript files.
- PowerShell parser passed for Create-PSADTPackage.ps1.