### PR TITLE
Promote MaxTo packager release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '617c3f8801dac600fd86c4c743aa2b44a1a5061b',
+  packagerCommit: 'd918567cb0990e546fbf92c528bbb0bf91c73525',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries MaxTo only after activating its reviewed per-user installer heartbeat', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' DOMINO.MAXTO ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '617c3f8801dac600fd86c4c743aa2b44a1a5061b',
+      { wingetId: 'Domino.MaxTo', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries Ente Photos only after activating its reviewed user scope', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -423,6 +438,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'Domino.MaxTo',
       'Logitech.LGS',
       'IrfanSkiljan.IrfanView',
       'Jamovi.Desktop.Current',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -490,7 +490,17 @@ const ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...SIMPLE_HYDRAULIC_NSIS_UNINSTALL_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS = [
+  // Retry MaxTo after its reviewed per-user Velopack wait emits bounded PSADT
+  // heartbeats instead of being terminated by the generic inactivity ceiling.
+  'Domino.MaxTo',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd918567cb0990e546fbf92c528bbb0bf91c73525':
+    MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '617c3f8801dac600fd86c4c743aa2b44a1a5061b':
     ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '24ee5fb123c9817f4d2dabcbe11817472c82d1e1':


### PR DESCRIPTION
## Release
- Promotes immutable packager commit d918567cb0990e546fbf92c528bbb0bf91c73525, merged through PR #1031.
- Carries existing targeted terminal retries and adds Domino.MaxTo for one retry on the corrected profile.
- Production remains paused until this release is deployed and the database required pin matches.

## Verification
- 280 package-profile, terminal-backfill, dispatch, and GitHub workflow tests passed.
- ESLint passed for every changed TypeScript file.
- Unrelated apps are not added to the targeted retry set.