### PR TITLE
fix(packaging): keep zyfun in user scope

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -704,6 +704,60 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('uses zyfun user scope consistently for customer PSADT packaging and QA', async () => {
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: 'https://example.com/zyfun-setup.exe',
+      sha256: 'A'.repeat(64),
+      type: 'nullsoft',
+      silentArgs: '/S',
+      productCode: '1cf4e394-3cb1-57f9-a0e2-d9add46ad139',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'HiramWong.zyfun',
+          displayName: 'zyfun',
+          version: '3.4.7',
+          installerType: 'nullsoft',
+          installScope: 'machine',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'HiramWong.zyfun',
+        installScope: 'user',
+      }),
+      expect.any(Array)
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ install_scope: 'user' })
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'HiramWong.zyfun',
+        installScope: 'user',
+        silentSwitches: '/S',
+      }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('uses TeamSpeak 6 Beta all-users MSI scope for QA and customer packaging', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -324,6 +324,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' ENTE-IO.PHOTOS-DESKTOP ', undefined)
     ).toBe('user');
+    expect(resolveApplicationInstallScope('HiramWong.zyfun', 'machine')).toBe(
+      'user'
+    );
+    expect(
+      resolveApplicationInstallScope(' hiramwong.zyfun ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
       resolveApplicationInstallScope(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -189,6 +189,17 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // zyfun is built with Electron Builder's NSIS target and does not enable
+    // perMachine. Electron Builder therefore uses its per-user default. WinGet
+    // omits Scope; running the same installer as LocalSystem placed its ARP
+    // registration below systemprofile and the captured uninstaller path was
+    // unavailable by the managed removal cycle. Keep QA, catalog packages, and
+    // customer uploads in the vendor-supported signed-in user context.
+    // https://github.com/Hiram-Wong/zyfun/blob/main/electron-builder.yml
+    wingetId: 'HiramWong.zyfun',
+    requiredInstallScope: 'user',
+  },
+  {
     // ElegantClipboard's tagged Tauri v2 configuration explicitly builds its
     // NSIS installer with installMode=currentUser, while the WinGet manifest
     // omits Scope. The generic machine default installs below LocalSystem's

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -633,6 +633,36 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('normalizes zyfun to the same user-scoped customer and QA identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'HiramWong.zyfun',
+      displayName: 'zyfun',
+      publisher: 'HiramWong',
+      version: '3.4.7',
+      architecture: 'x64',
+      installerSha256: '5'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{1CF4E394-3CB1-57F9-A0E2-D9ADD46AD139}:zyfun',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(profile.installer.silentArgs).toBe('/S');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
+      }),
+    ]);
+  });
+
   it('keeps ElegantClipboard out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Y-ASLant.ElegantClipboard',

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -783,6 +783,45 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
+  it('tests zyfun in user context when its Electron Builder manifest omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'HiramWong.zyfun',
+        name: 'zyfun',
+        publisher: 'HiramWong',
+        version: '3.4.7',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        ProductCode: '1cf4e394-3cb1-57f9-a0e2-d9add46ad139',
+        AppsAndFeaturesEntries: [
+          {
+            DisplayName: 'zyfun',
+            Publisher: 'HiramWong',
+            ProductCode: '1cf4e394-3cb1-57f9-a0e2-d9add46ad139',
+          },
+        ],
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.silentArgs).toBe('/S');
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{1CF4E394-3CB1-57F9-A0E2-D9ADD46AD139}:zyfun'
+    );
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
+      }),
+    ]);
+  });
+
   it('tests Youdao in user context when its NSIS manifest omits scope', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- keep HiramWong.zyfun in the Electron Builder/NSIS per-user scope supported by the vendor
- prevent LocalSystem installs from registering an unusable systemprofile uninstaller
- apply the same adapter to catalog QA, customer portal packages, and canonical PSADT identity

## Evidence
- production QA run 33310381210 installed successfully but captured an uninstaller below LocalSystem systemprofile that was absent during managed removal
- the WinGet manifest omits Scope
- the vendor Electron Builder configuration does not enable NSIS perMachine, so the documented default is per-user

## Verification
- 267 focused packaging/API/profile tests passed
- 175 shared PSADT/demand/auto-update tests passed
- full suite: 1,647 passed; one unrelated translation-provider timeout passed on isolated rerun (2/2)
- production Next.js build passed
- PowerShell packager parses without errors
- ESLint passed for all changed files