### PR TITLE
chore(qa): promote zyfun packaging release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd918567cb0990e546fbf92c528bbb0bf91c73525',
+  packagerCommit: 'f1664e5b6c12d95c6ecde7b0999bb75582307f11',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -521,6 +521,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // of LocalSystem's disposable systemprofile. Preserve every unrelated pass
   // from the IJe registered-identity release.
   '24ee5fb123c9817f4d2dabcbe11817472c82d1e1',
+  // MaxTo now uses a reviewed bounded installer heartbeat while retaining its
+  // vendor-supported per-user lifecycle. Preserve every unrelated pass from
+  // the Ente Photos user-scope release.
+  'd918567cb0990e546fbf92c528bbb0bf91c73525',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries zyfun only after activating its reviewed user scope', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' HIRAMWONG.ZYFUN ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd918567cb0990e546fbf92c528bbb0bf91c73525',
+      { wingetId: 'HiramWong.zyfun', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries MaxTo only after activating its reviewed per-user installer heartbeat', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -438,6 +453,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'HiramWong.zyfun',
       'Domino.MaxTo',
       'Logitech.LGS',
       'IrfanSkiljan.IrfanView',
@@ -505,6 +521,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'HiramWong.zyfun',
         'Logitech.LGS',
         'IrfanSkiljan.IrfanView',
         'Jamovi.Desktop.Current',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -498,7 +498,17 @@ const MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS = [
   ...ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ZYFUN_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry zyfun in Electron Builder's vendor-supported per-user context so
+  // the exact captured ARP identity remains available for managed removal.
+  'HiramWong.zyfun',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f1664e5b6c12d95c6ecde7b0999bb75582307f11':
+    ZYFUN_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'd918567cb0990e546fbf92c528bbb0bf91c73525':
     MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '617c3f8801dac600fd86c4c743aa2b44a1a5061b':


### PR DESCRIPTION
## Summary
- promote the shared PSADT packager to `f1664e5b6c12d95c6ecde7b0999bb75582307f11`
- retain compatible passes from the MaxTo release
- schedule one bounded retry of HiramWong.zyfun under the repaired user-scope profile

## Verification
- 280 focused toolchain, profile, dispatch, and route tests passed
- production Next.js build passed
- ESLint passed for all changed files

Production QA remains paused until this release is deployed and the protected QA and customer workflows are pinned to the same commit.