### PR TITLE
fix(packaging): run zyfun assisted installer all-users

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -704,7 +704,7 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
-  it('uses zyfun user scope consistently for customer PSADT packaging and QA', async () => {
+  it('uses zyfun all-users mode consistently for customer PSADT packaging and QA', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',
       url: 'https://example.com/zyfun-setup.exe',
@@ -736,26 +736,36 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
       expect.objectContaining({
         wingetId: 'HiramWong.zyfun',
-        installScope: 'user',
+        installScope: 'machine',
       }),
       expect.any(Array)
     );
     expect(ensureQaDemandMock).toHaveBeenCalledWith(
       undefined,
-      expect.objectContaining({ installScope: 'user' })
+      expect.objectContaining({ installScope: 'machine' })
     );
     expect(createMock).toHaveBeenCalledWith(
-      expect.objectContaining({ install_scope: 'user' })
+      expect.objectContaining({ install_scope: 'machine' })
     );
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
       expect.objectContaining({
         wingetId: 'HiramWong.zyfun',
-        installScope: 'user',
+        installScope: 'machine',
         silentSwitches: '/S',
       }),
       undefined,
       expect.any(Object)
     );
+    const expectedAdapter = { reviewedInstallArguments: ['/allusers'] };
+    expect(
+      JSON.parse(ensureQaDemandMock.mock.calls[0][1].psadtConfig)
+    ).toMatchObject(expectedAdapter);
+    expect(
+      JSON.parse(triggerPackagingWorkflowMock.mock.calls[0][0].psadtConfig)
+    ).toMatchObject(expectedAdapter);
+    expect(createMock.mock.calls[0][0].package_config).toMatchObject({
+      psadtConfig: expectedAdapter,
+    });
   });
 
   it('uses TeamSpeak 6 Beta all-users MSI scope for QA and customer packaging', async () => {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -324,12 +324,6 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' ENTE-IO.PHOTOS-DESKTOP ', undefined)
     ).toBe('user');
-    expect(resolveApplicationInstallScope('HiramWong.zyfun', 'machine')).toBe(
-      'user'
-    );
-    expect(
-      resolveApplicationInstallScope(' hiramwong.zyfun ', undefined)
-    ).toBe('user');
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
       resolveApplicationInstallScope(
@@ -393,6 +387,23 @@ describe('application packaging adapters', () => {
     expect(resolveApplicationInstallScope(' torproject.torbrowser ', undefined)).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
     expect(resolveApplicationInstallScope('Example.App', 'machine')).toBe('machine');
+  });
+
+  it('runs zyfun assisted NSIS all-users so its VC++ prerequisite can complete', () => {
+    expect(resolveApplicationInstallScope('HiramWong.zyfun', 'user')).toBe(
+      'machine'
+    );
+    expect(
+      resolveApplicationInstallScope(' hiramwong.zyfun ', undefined)
+    ).toBe('machine');
+    expect(
+      applyApplicationPackagingAdapter(
+        'HiramWong.zyfun',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallArguments: ['/allusers'],
+    });
   });
 
   it('keeps Appium Inspector on its machine-labelled manifest bytes while executing per-user', () => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -189,15 +189,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
-    // zyfun is built with Electron Builder's NSIS target and does not enable
-    // perMachine. Electron Builder therefore uses its per-user default. WinGet
-    // omits Scope; running the same installer as LocalSystem placed its ARP
-    // registration below systemprofile and the captured uninstaller path was
-    // unavailable by the managed removal cycle. Keep QA, catalog packages, and
-    // customer uploads in the vendor-supported signed-in user context.
-    // https://github.com/Hiram-Wong/zyfun/blob/main/electron-builder.yml
+    // zyfun 3.4.7 uses Electron Builder's assisted NSIS mode and a custom
+    // installer hook that installs the machine-wide VC++ runtime when missing.
+    // Its default current-user silent path can therefore wait indefinitely on
+    // prerequisite elevation. Electron Builder 26.8.1 explicitly accepts
+    // /allusers for this assisted mode; run the signed installer as LocalSystem
+    // so the prerequisite and app both complete in a serviceable machine scope.
+    // https://github.com/Hiram-Wong/zyfun/blob/v3.4.7/electron-builder.yml
+    // https://github.com/Hiram-Wong/zyfun/blob/v3.4.7/build/nsis-installer.nsh
+    // https://github.com/electron-userland/electron-builder/blob/electron-builder%4026.8.1/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
     wingetId: 'HiramWong.zyfun',
-    requiredInstallScope: 'user',
+    requiredInstallScope: 'machine',
+    reviewedInstallArguments: ['/allusers'],
   },
   {
     // ElegantClipboard's tagged Tauri v2 configuration explicitly builds its

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -633,7 +633,7 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
-  it('normalizes zyfun to the same user-scoped customer and QA identity', () => {
+  it('normalizes zyfun to the same all-users customer and QA identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'HiramWong.zyfun',
       displayName: 'zyfun',
@@ -651,14 +651,16 @@ describe('PSADT QA package identity', () => {
     });
     const profile = normalized.identity.profile as {
       installer: { installScope: string; silentArgs: string };
+      psadtConfig: { reviewedInstallArguments?: string[] };
     };
 
-    expect(profile.installer.installScope).toBe('user');
+    expect(profile.installer.installScope).toBe('machine');
     expect(profile.installer.silentArgs).toBe('/S');
+    expect(profile.psadtConfig.reviewedInstallArguments).toEqual(['/allusers']);
     expect(normalized.detectionRules).toEqual([
       expect.objectContaining({
         keyPath:
-          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
       }),
     ]);
   });

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -783,7 +783,7 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
-  it('tests zyfun in user context when its Electron Builder manifest omits scope', () => {
+  it('tests zyfun in machine context with Electron Builder all-users mode', () => {
     const config = buildQaCatalogTestConfig({
       app: {
         wingetId: 'HiramWong.zyfun',
@@ -809,15 +809,16 @@ describe('buildQaCatalogTestConfig', () => {
       },
     });
 
-    expect(config.scope).toBe('user');
+    expect(config.scope).toBe('machine');
     expect(config.silentArgs).toBe('/S');
+    expect(config.psadtConfig.reviewedInstallArguments).toEqual(['/allusers']);
     expect(config.uninstallCommand).toBe(
       'REGISTRY_UNINSTALL_PRODUCT:{1CF4E394-3CB1-57F9-A0E2-D9ADD46AD139}:zyfun'
     );
     expect(config.detectionRules).toEqual([
       expect.objectContaining({
         keyPath:
-          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
+          'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\HiramWong_zyfun',
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- replace the stalled per-user zyfun adapter with Electron Builder's documented assisted NSIS `/allusers` mode
- keep QA, catalog, and customer PSADT packages on one machine-scoped internal contract
- preserve WinGet `/S` metadata and add `/allusers` only through the reviewed shared packager field

## Evidence
- zyfun 3.4.7 uses electron-builder 26.8.1 with `oneClick: false`
- its custom NSIS hook installs the machine-wide Microsoft VC++ runtime when absent
- electron-builder 26.8.1 explicitly parses `/allusers` and selects machine mode
- production QA's per-user retry stalled while waiting for that prerequisite/elevation path

## Verification
- 584 focused QA/PSADT/dispatch tests pass
- full suite: 1,650 tests pass
- ESLint passes
- production Next.js build and TypeScript pass