### PR TITLE
chore(qa): promote zyfun all-users packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f1664e5b6c12d95c6ecde7b0999bb75582307f11',
+  packagerCommit: 'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -525,6 +525,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // vendor-supported per-user lifecycle. Preserve every unrelated pass from
   // the Ente Photos user-scope release.
   'd918567cb0990e546fbf92c528bbb0bf91c73525',
+  // zyfun's first repair moved its assisted NSIS setup out of systemprofile.
+  // Preserve every unrelated pass from that user-scope release while the
+  // current release switches only zyfun to its documented all-users mode.
+  'f1664e5b6c12d95c6ecde7b0999bb75582307f11',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,13 +6,13 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries zyfun only after activating its reviewed user scope', () => {
+  it('retries zyfun only after activating reviewed all-users mode', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: ' HIRAMWONG.ZYFUN ', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'd918567cb0990e546fbf92c528bbb0bf91c73525',
+      'f1664e5b6c12d95c6ecde7b0999bb75582307f11',
       { wingetId: 'HiramWong.zyfun', status: 'failed' }
     )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -498,17 +498,21 @@ const MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS = [
   ...ENTE_PHOTOS_USER_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
-const ZYFUN_USER_SCOPE_RELEASE_RETRY_TARGETS = [
-  // Retry zyfun in Electron Builder's vendor-supported per-user context so
-  // the exact captured ARP identity remains available for managed removal.
+const ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry zyfun with Electron Builder's documented assisted-NSIS /allusers
+  // mode so its VC++ prerequisite and exact ARP identity remain manageable.
   'HiramWong.zyfun',
   // Carry every still-unconsumed targeted retry across the atomic pin.
   ...MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272':
+    ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+  // The user-scope strategy reached the normal user but stalled on zyfun's
+  // machine-wide VC++ prerequisite. Carry prior targets without replaying it.
   'f1664e5b6c12d95c6ecde7b0999bb75582307f11':
-    ZYFUN_USER_SCOPE_RELEASE_RETRY_TARGETS,
+    MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
   'd918567cb0990e546fbf92c528bbb0bf91c73525':
     MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '617c3f8801dac600fd86c4c743aa2b44a1a5061b':


### PR DESCRIPTION
## Summary
- pin QA package identities to shared packager commit `b62b2c4b3b8ccaa3497ff69661bf796af5a2e272`
- preserve unrelated passing profiles from the prior `f1664e5` release
- consume the disproven zyfun user-scope retry and schedule one bounded all-users retry on the new pin

## Verification
- promotion/packager suite: 423 tests pass
- full suite: 1,650 tests pass
- ESLint passes
- production Next.js build and TypeScript pass