### PR TITLE
fix(packaging): bind G.SKILL Trident Z registry identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -138,6 +138,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses G.SKILL Trident Z\'s exact vendor Inno registry identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'GSKILL.TridentZLightingControl',
+      'REGISTRY_UNINSTALL:G.SKILL Trident Z Lighting Control'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:{97CD7AFC-0ED3-41B8-9CCD-22717E8631D0}_is1:Trident Z Lighting Control'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'gskill.tridentzlightingcontrol',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses IJe\'s stable Inno registry key despite its versioned ARP name', () => {
     expect(resolveApplicationUninstallCommand(
       'IJe.IJe',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1705,6 +1705,16 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Greenshot',
     registeredRegistryKey: 'Greenshot_is1',
   },
+  // G.SKILL's ZIP-wrapped Inno installer registers the visible application as
+  // `Trident Z Lighting Control` from publisher `ENG`, not the catalog title
+  // `G.SKILL Trident Z Lighting Control`. QA run 33316792996 also observed
+  // three unrelated/hidden ARP changes, so bind the stable Inno AppId key and
+  // never guess among the install delta when capturing customer removal.
+  'gskill.tridentzlightingcontrol': {
+    generatedDisplayName: 'G.SKILL Trident Z Lighting Control',
+    registeredDisplayName: 'Trident Z Lighting Control',
+    registeredRegistryKey: '{97CD7AFC-0ED3-41B8-9CCD-22717E8631D0}_is1',
+  },
   // IJe's catalog name is `IJe Programming Language`, but its Inno installer
   // registers the versioned display name `IJe version 1.0.1` below a stable
   // AppId-derived `_is1` key. QA run 33227580169 observed exactly that one

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -324,6 +324,29 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/S']);
   });
 
+  it('binds G.SKILL Trident Z customer and QA packages to one exact Inno key', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'GSKILL.TridentZLightingControl',
+      displayName: 'G.SKILL Trident Z Lighting Control',
+      publisher: 'GSKILL',
+      version: '1.00.38',
+      architecture: 'x86',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'zip',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand: 'REGISTRY_UNINSTALL:G.SKILL Trident Z Lighting Control',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:{97CD7AFC-0ED3-41B8-9CCD-22717E8631D0}_is1:Trident Z Lighting Control'
+    );
+    expect(profile.installer.uninstallCommand).toBe(normalized.uninstallCommand);
+  });
+
   it('binds IDM reviewed window automation to customer and QA package identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Tonec.InternetDownloadManager',

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -192,6 +192,35 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('binds G.SKILL Trident Z QA to its observed visible Inno identity', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'GSKILL.TridentZLightingControl',
+        name: 'G.SKILL Trident Z Lighting Control',
+        publisher: 'GSKILL',
+        version: '1.00.38',
+      },
+      manifest: {
+        InstallerType: 'zip',
+        NestedInstallerType: 'inno',
+        ProductCode: 'G.SKILL Trident Z Lighting Control',
+        InstallerSwitches: {
+          Silent: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+        },
+      },
+      installer: {
+        Architecture: 'x86',
+        InstallerType: 'zip',
+        NestedInstallerType: 'inno',
+        ProductCode: 'G.SKILL Trident Z Lighting Control',
+      },
+    });
+
+    expect(config.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:{97CD7AFC-0ED3-41B8-9CCD-22717E8631D0}_is1:Trident Z Lighting Control'
+    );
+  });
+
   it.each([
     ['inno', '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'],
     ['nullsoft', '/S'],


### PR DESCRIPTION
## Summary
- bind G.SKILL Trident Z Lighting Control to the exact Inno ARP key observed in QA run 33316792996
- preserve fail-closed behavior for unrelated and ambiguous uninstall entries
- prove the same identity is used by catalog QA and customer PSADT packaging

## Validation
- 1,653 tests passed
- ESLint passed
- production build passed