### PR TITLE
chore(qa): promote G.SKILL identity packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272',
+  packagerCommit: 'd7d0c2dc287851f151cc037022137bb3506f368d',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -529,6 +529,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Preserve every unrelated pass from that user-scope release while the
   // current release switches only zyfun to its documented all-users mode.
   'f1664e5b6c12d95c6ecde7b0999bb75582307f11',
+  // G.SKILL Trident Z now binds its catalog title to the exact visible Inno
+  // registry key observed during installation. Preserve every unrelated pass
+  // from the zyfun all-users release.
+  'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries G.SKILL Trident Z only after activating its exact Inno identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' GSKILL.TRIDENTZLIGHTINGCONTROL ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272',
+      { wingetId: 'GSKILL.TridentZLightingControl', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries zyfun only after activating reviewed all-users mode', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -506,7 +506,17 @@ const ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
   ...MAXTO_USER_INSTALLER_HEARTBEAT_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry G.SKILL Trident Z after binding capture, verification, and removal
+  // to the exact visible Inno AppId key observed among four changed ARP entries.
+  'GSKILL.TridentZLightingControl',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd7d0c2dc287851f151cc037022137bb3506f368d':
+    GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS,
   'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272':
     ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   // The user-scope strategy reached the normal user but stalled on zyfun's


### PR DESCRIPTION
## Summary
- promote the shared QA/customer PSADT toolchain to packager commit d7d0c2dc287851f151cc037022137bb3506f368d
- retain unrelated passes from the prior packager release
- retry G.SKILL Trident Z only under the repaired exact-key lifecycle

## Validation
- 1,654 tests passed
- ESLint passed
- production build passed