### PR TITLE
fix(packaging): bind AionUi registry identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -79,6 +79,15 @@ describe('application packaging adapters', () => {
     ).toBe('jamovi');
   });
 
+  it('binds AionUi Community to the upstream AionUi ARP identity', () => {
+    expect(
+      applyApplicationPackagingAdapter('Lumysia.AionUiCommunity', {
+        ...DEFAULT_PSADT_CONFIG,
+        reviewedRegistryUninstallDisplayName: 'customer override',
+      }).reviewedRegistryUninstallDisplayName
+    ).toBe('AionUi');
+  });
+
   it('binds QTTabBar to the exact ARP identity registered by its nested MSI', () => {
     expect(
       applyApplicationPackagingAdapter('indiff.QTTabBar', {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -602,6 +602,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedRegistryUninstallDisplayName: 'jamovi',
   },
   {
+    // AionUi Community 2.1.53 is rebuilt from the exact upstream AionUi tag,
+    // whose Electron Builder configuration fixes `productName` and
+    // `uninstallDisplayName` to `AionUi`. The community WinGet entry instead
+    // uses `AionUi Community` as its catalog title. QA run 33323249252 observed
+    // one added ARP entry but correctly refused to capture it through the
+    // mismatched catalog name. Bind QA and customer packages to the exact,
+    // vendor-defined `AionUi` identity while every broader match stays closed.
+    // https://github.com/iOfficeAI/AionUi/blob/v2.1.53/packages/desktop/electron-builder.yml
+    wingetId: 'Lumysia.AionUiCommunity',
+    reviewedRegistryUninstallDisplayName: 'AionUi',
+  },
+  {
     // The 1.5.6-beta.1 catalog metadata calls the product `QTTabBar`, while the
     // nested MSI registers `QTTabBar 1.5.6.1 Beta(2024)`. QA run 33202083278
     // observed exactly one visible indiff MSI registration with that identity.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -252,6 +252,28 @@ describe('PSADT QA package identity', () => {
       .toBe('jamovi');
   });
 
+  it('binds AionUi Community customer and QA packages to the upstream AionUi ARP identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Lumysia.AionUiCommunity',
+      displayName: 'AionUi Community',
+      publisher: 'Lumysia',
+      version: '2.1.53',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:AionUi Community',
+      installScope: 'user',
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedRegistryUninstallDisplayName?: string };
+    };
+
+    expect(profile.psadtConfig.reviewedRegistryUninstallDisplayName).toBe('AionUi');
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedRegistryUninstallDisplayName)
+      .toBe('AionUi');
+  });
+
   it('binds QTTabBar customer and QA packages to the observed nested-MSI ARP identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'indiff.QTTabBar',


### PR DESCRIPTION
## Summary
- bind Lumysia.AionUiCommunity to the exact upstream Electron Builder ARP identity AionUi
- keep broad registry matching fail-closed
- verify the reviewed identity is shared by catalog QA and customer PSADT packages

## Evidence
- production QA run 33323249252 installed one ARP entry but rejected catalog label AionUi Community with strict 60001 handling
- upstream v2.1.53 electron-builder.yml fixes productName and uninstallDisplayName to AionUi
- WinGet manifest declares the installer user-scoped

## Verification
- 5 targeted test files passed, 416 tests
- ESLint passed for changed files
- git diff --check passed