### PR TITLE
chore(qa): promote AionUi identity packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd7d0c2dc287851f151cc037022137bb3506f368d',
+  packagerCommit: '772c3aae1cc5b4f13219c216bfc1220cab2bbd23',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -533,6 +533,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // registry key observed during installation. Preserve every unrelated pass
   // from the zyfun all-users release.
   'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272',
+  // AionUi Community now binds its catalog title to the exact upstream
+  // Electron Builder ARP identity. Preserve every unrelated compatible pass
+  // from the G.SKILL registered-identity release.
+  'd7d0c2dc287851f151cc037022137bb3506f368d',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries AionUi Community only after activating its exact upstream identity', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' LUMYSIA.AIONUICOMMUNITY ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd7d0c2dc287851f151cc037022137bb3506f368d',
+      { wingetId: 'Lumysia.AionUiCommunity', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries G.SKILL Trident Z only after activating its exact Inno identity', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -514,7 +514,17 @@ const GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...ZYFUN_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry AionUi Community after binding the catalog label to the exact
+  // upstream Electron Builder `AionUi` uninstall identity.
+  'Lumysia.AionUiCommunity',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '772c3aae1cc5b4f13219c216bfc1220cab2bbd23':
+    AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS,
   'd7d0c2dc287851f151cc037022137bb3506f368d':
     GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS,
   'b62b2c4b3b8ccaa3497ff69661bf796af5a2e272':


### PR DESCRIPTION
## Summary
- activate immutable packager commit 772c3aae1cc5b4f13219c216bfc1220cab2bbd23
- retain d7d0c2dc287851f151cc037022137bb3506f368d as compatible for unaffected passes
- carry forward targeted retries and add Lumysia.AionUiCommunity for the new exact identity

## Verification
- 3 targeted test files passed, 294 tests
- ESLint passed for changed files
- git diff --check passed