### PR TITLE
fix(packaging): install UniFi OS Server for all users

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1427,6 +1427,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual(['/allusers', '/S']);
   });
 
+  it('selects UniFi OS Server all-users mode for the full Intune lifecycle', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'ubiquiti.unifiosserver',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('/S /allusers');
+    expect(adapted.reviewedUninstallArguments).toEqual(['/allusers', '/S']);
+  });
+
   it('replaces Bitvise generic switches with its documented unattended mode', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Bitvise.SSH.Client',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -749,6 +749,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/allusers', '/S'],
   },
   {
+    // UniFi OS Server uses Electron Builder's assisted installer mode. Under
+    // Intune's LocalSystem account, a bare /S installs into the system profile
+    // and registers an uninstaller there. Force Electron Builder's documented
+    // all-users mode so installation and removal share the machine-wide path.
+    wingetId: 'Ubiquiti.UniFiOSServer',
+    reviewedInstallArgumentsOverride: '/S /allusers',
+    reviewedUninstallArguments: ['/allusers', '/S'],
+  },
+  {
     // Google documents that Drive for desktop must be removed through its
     // versioned registered uninstaller with both --silent and --force_stop.
     // The latter is required whenever Drive is running; without it the helper


### PR DESCRIPTION
## Summary
- force Ubiquiti UniFi OS Server's Electron Builder installer into machine-wide `/allusers` mode under LocalSystem
- preserve the same all-users scope for silent uninstall
- add a focused regression test for the full packaging lifecycle arguments

## QA evidence
- production QA candidate `f24e0bf9-316a-4442-9c1a-4ad352e30540` installed and detected successfully, but uninstall returned `60001`
- the captured uninstaller was registered below `C:\Windows\system32\config\systemprofile\AppData\Local\Programs`, proving the default per-user scope was tied to LocalSystem
- Electron Builder's NSIS contract uses `/allusers` for Program Files/HKLM and requires the same scope on uninstall

## Verification
- `npm test -- lib/packaging-adapters.test.ts` (94 passed)
- `npx eslint lib/packaging-adapters.ts lib/packaging-adapters.test.ts`