### PR TITLE
chore(qa): promote UniFi OS Server packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '772c3aae1cc5b4f13219c216bfc1220cab2bbd23',
+  packagerCommit: 'de218619eb0dafb2029f777f47ee6852612527f9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -537,6 +537,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Electron Builder ARP identity. Preserve every unrelated compatible pass
   // from the G.SKILL registered-identity release.
   'd7d0c2dc287851f151cc037022137bb3506f368d',
+  // UniFi OS Server now uses Electron Builder's machine-wide lifecycle under
+  // LocalSystem. Preserve every unrelated compatible pass from the AionUi
+  // registered-identity release.
+  '772c3aae1cc5b4f13219c216bfc1220cab2bbd23',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries UniFi OS Server only after activating its machine-wide lifecycle', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' UBIQUITI.UNIFIOSSERVER ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '772c3aae1cc5b4f13219c216bfc1220cab2bbd23',
+      { wingetId: 'Ubiquiti.UniFiOSServer', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries AionUi Community only after activating its exact upstream identity', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -522,7 +522,17 @@ const AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...GSKILL_TRIDENT_Z_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry UniFi OS Server with Electron Builder's machine-wide /allusers mode
+  // so LocalSystem installation and removal use the same registered path.
+  'Ubiquiti.UniFiOSServer',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'de218619eb0dafb2029f777f47ee6852612527f9':
+    UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   '772c3aae1cc5b4f13219c216bfc1220cab2bbd23':
     AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS,
   'd7d0c2dc287851f151cc037022137bb3506f368d':


### PR DESCRIPTION
## Summary
- atomically promote the QA packager to UniFi OS Server fix commit `de218619eb0dafb2029f777f47ee6852612527f9`
- retain compatible passes from the prior AionUi release
- schedule the failed UniFi OS Server candidate for a targeted retry under the new immutable pin

## Verification
- `npm test -- lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts` (261 passed)
- `npx eslint lib/qa/package-profile.ts lib/qa/toolchain-backfill.ts lib/qa/toolchain-backfill.test.ts`