### PR TITLE
Fix Service Fabric Runtime unattended install arguments

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1201,6 +1201,16 @@ describe('application packaging adapters', () => {
     expect(adapted.reviewedUninstallArguments).toEqual([]);
   });
 
+  it('uses Microsoft\'s documented Service Fabric runtime install contract', () => {
+    const adapted = applyApplicationPackagingAdapter(
+      'Microsoft.ServiceFabricRuntime',
+      DEFAULT_PSADT_CONFIG
+    );
+
+    expect(adapted.reviewedInstallArgumentsOverride).toBe('/accepteula');
+    expect(adapted.reviewedUninstallArguments).toEqual([]);
+  });
+
   it('uses PDFsam\'s documented managed MSI command', () => {
     const adapted = applyApplicationPackagingAdapter(
       'PDFsam.PDFsam',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -870,6 +870,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallServiceNames: ['AzureMonitorAgent'],
   },
   {
+    // Microsoft documents /accepteula as the complete Service Fabric Runtime
+    // command-line install contract. The WinGet manifest's additional
+    // /quiet /qn switches make the signed 11.3.475.1 bootstrapper exit 1 before
+    // it creates an exact vendor identity (isolated QA run 33341797950).
+    // Replace that manifest command for both QA and customer PSADT packages.
+    // https://learn.microsoft.com/azure/service-fabric/service-fabric-get-started
+    wingetId: 'Microsoft.ServiceFabricRuntime',
+    reviewedInstallArgumentsOverride: '/accepteula',
+  },
+  {
     // Logi Bolt's dedicated uninstaller is not a conventional NSIS helper:
     // the generic /S fallback returns while leaving the exact LogiBolt ARP
     // registration installed. Its unattended removal verb is /silent. Bind


### PR DESCRIPTION
## Summary
- override the WinGet manifest's combined /quiet /qn /AcceptEULA command for Microsoft.ServiceFabricRuntime
- use Microsoft's documented /accepteula runtime install contract in both QA and customer PSADT packages
- retain the existing exact-identity uninstall path

## Evidence
- isolated QA run 33341797950: signed vendor EXE exited 1 immediately with /quiet /qn /AcceptEULA; no exact vendor identity was created
- Microsoft Learn documents MicrosoftServiceFabric.<version>.exe /accepteula: https://learn.microsoft.com/azure/service-fabric/service-fabric-get-started
- current WinGet manifest declares the additional generic switches: https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/ServiceFabricRuntime/11.3.475.1/Microsoft.ServiceFabricRuntime.installer.yaml

## Verification
- 204 tests passed across lib/packaging-adapters.test.ts and lib/qa/package-profile.test.ts
- git diff --check passed