### PR TITLE
chore(qa): promote Service Fabric Runtime packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'de218619eb0dafb2029f777f47ee6852612527f9',
+  packagerCommit: 'f48e73742c96773e2b4c8c2fed200363c7b5a805',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -541,6 +541,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // LocalSystem. Preserve every unrelated compatible pass from the AionUi
   // registered-identity release.
   '772c3aae1cc5b4f13219c216bfc1220cab2bbd23',
+  // Service Fabric Runtime now uses Microsoft's complete documented
+  // /accepteula install contract. Preserve every unrelated compatible pass
+  // from the UniFi OS Server machine-scope release.
+  'de218619eb0dafb2029f777f47ee6852612527f9',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,21 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Service Fabric Runtime only after activating its official install contract', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: ' MICROSOFT.SERVICEFABRICRUNTIME ', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'de218619eb0dafb2029f777f47ee6852612527f9',
+      { wingetId: 'Microsoft.ServiceFabricRuntime', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Unrelated.App', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries UniFi OS Server only after activating its machine-wide lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -530,7 +530,18 @@ const UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS = [
   ...AIONUI_COMMUNITY_IDENTITY_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SERVICE_FABRIC_RUNTIME_OFFICIAL_ARGS_RELEASE_RETRY_TARGETS = [
+  // Retry Service Fabric Runtime with Microsoft's complete documented
+  // /accepteula contract instead of the extra generic WinGet switches that
+  // made the signed bootstrapper exit before creating its vendor identity.
+  'Microsoft.ServiceFabricRuntime',
+  // Carry every still-unconsumed targeted retry across the atomic pin.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f48e73742c96773e2b4c8c2fed200363c7b5a805':
+    SERVICE_FABRIC_RUNTIME_OFFICIAL_ARGS_RELEASE_RETRY_TARGETS,
   'de218619eb0dafb2029f777f47ee6852612527f9':
     UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
   '772c3aae1cc5b4f13219c216bfc1220cab2bbd23':


### PR DESCRIPTION
Promotes the reviewed Service Fabric Runtime adapter commit f48e73742c96773e2b4c8c2fed200363c7b5a805 as the exact QA/customer PSADT toolchain and schedules only Microsoft.ServiceFabricRuntime for a terminal retry while carrying prior unconsumed targets.\n\nValidation: 357 targeted Vitest tests passed; git diff --check passed.