### PR TITLE
fix(packager): support nested AppX lifecycles

### DIFF
--- a/.github/scripts/Create-PSADTPackage.ps1
+++ b/.github/scripts/Create-PSADTPackage.ps1
@@ -1717,7 +1717,11 @@ if ($useRegistryUninstall) {
     Write-Host "Using portable uninstall (folder removal)"
 }
 
-if ($installerTypeLower -in @('msix', 'appx') -and
+$usesAppxLifecycle = $installerTypeLower -in @('msix', 'appx') -or
+    ($installerTypeLower -eq 'zip' -and
+     -not [string]::IsNullOrWhiteSpace($NestedInstallerType) -and
+     $NestedInstallerType.Trim().ToLowerInvariant() -in @('msix', 'appx'))
+if ($usesAppxLifecycle -and
     [string]::IsNullOrWhiteSpace($msixPackageName) -and
     ([string]::IsNullOrWhiteSpace($customInstallCommand) -or [string]::IsNullOrWhiteSpace($customUninstallCommand))) {
     throw "The MSIX/APPX package identity is missing; refusing to generate install or uninstall commands from a display-name guess."
@@ -2770,6 +2774,67 @@ if ($reviewedInstallShieldAdministrativeImageConfigured) {
                                 $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath -AdditionalArgumentList '$msiProperties'"
                             } else {
                                 $nestedExecuteLine = "        Start-ADTMsiProcess -Action 'Install' -FilePath `$nestedInstallerPath"
+                            }
+                        }
+                        { $_ -in 'msix', 'appx' } {
+                            if ($IsUserScope) {
+                                $nestedExecuteLine = @(
+                                    '        $msixPath = $nestedInstallerPath'
+                                    "        `$packageName = '$msixPackageName'"
+                                    "        `$targetVersion = '$versionSingleQuoteEscaped'"
+                                    '        Write-ADTLogEntry -Message "Registering nested user-scoped MSIX/APPX package: $msixPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                                    '        $existingPackage = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1'
+                                    '        $shouldInstallPackage = $true'
+                                    '        if ($existingPackage) {'
+                                    '            try { $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion }'
+                                    '            catch { $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion }'
+                                    '        }'
+                                    '        if ($shouldInstallPackage) {'
+                                    '            Add-AppxPackage -Path $msixPath -ForceApplicationShutdown -ErrorAction Stop'
+                                    '        } else {'
+                                    '            Write-ADTLogEntry -Message "Nested MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                                    '        }'
+                                )
+                            } else {
+                                $nestedExecuteLine = @(
+                                    '        $msixPath = $nestedInstallerPath'
+                                    "        `$packageName = '$msixPackageName'"
+                                    "        `$targetVersion = '$versionSingleQuoteEscaped'"
+                                    '        Write-ADTLogEntry -Message "Provisioning nested machine-scoped MSIX/APPX package for all users: $msixPath" -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                                    '        $existingPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $packageName } | Sort-Object Version -Descending | Select-Object -First 1'
+                                    '        $shouldInstallPackage = $true'
+                                    '        if ($existingPackage) {'
+                                    '            try { $shouldInstallPackage = [version]$existingPackage.Version -lt [version]$targetVersion }'
+                                    '            catch { $shouldInstallPackage = [string]$existingPackage.Version -ne $targetVersion }'
+                                    '        }'
+                                    '        if ($shouldInstallPackage) {'
+                                    '            $provisioningJob = Start-Job -ScriptBlock {'
+                                    '                param([string]$packagePath)'
+                                    '                $ErrorActionPreference = ''Stop'''
+                                    '                Add-AppxProvisionedPackage -Online -PackagePath $packagePath -SkipLicense -ErrorAction Stop | Out-Null'
+                                    '            } -ArgumentList $msixPath'
+                                    '            try {'
+                                    '                while ($provisioningJob.State -eq ''Running'') {'
+                                    '                    $null = Wait-Job -Job $provisioningJob -Timeout 30'
+                                    '                    if ($provisioningJob.State -eq ''Running'') {'
+                                    '                        Write-ADTLogEntry -Message "Nested machine-scoped MSIX/APPX provisioning is still in progress for [$packageName]." -Severity ''Info'' -Source ''Install-ADTDeployment'''
+                                    '                    }'
+                                    '                }'
+                                    '                if ($provisioningJob.State -ne ''Completed'') {'
+                                    '                    $provisioningFailure = $provisioningJob.ChildJobs | Select-Object -First 1 -ExpandProperty JobStateInfo | Select-Object -ExpandProperty Reason'
+                                    '                    if ($provisioningFailure) { throw $provisioningFailure }'
+                                    '                    throw "Nested machine-scoped MSIX/APPX provisioning failed with job state [$($provisioningJob.State)]."'
+                                    '                }'
+                                    '                Receive-Job -Job $provisioningJob -ErrorAction Stop | Out-Null'
+                                    '            }'
+                                    '            finally {'
+                                    '                if ($provisioningJob.State -eq ''Running'') { Stop-Job -Job $provisioningJob -ErrorAction SilentlyContinue }'
+                                    '                Remove-Job -Job $provisioningJob -Force -ErrorAction SilentlyContinue'
+                                    '            }'
+                                    '        } else {'
+                                    '            Write-ADTLogEntry -Message "Nested provisioned MSIX/APPX package [$packageName] version [$($existingPackage.Version)] already satisfies target [$targetVersion]." -Severity ''Success'' -Source ''Install-ADTDeployment'''
+                                    '        }'
+                                )
                             }
                         }
                         default {
@@ -4149,6 +4214,10 @@ if ($useManagedDirectoryLifecycle) {
             '            Write-ADTLogEntry -Message "Removing current-user package: $($pkg.PackageFullName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
             '            Remove-AppxPackage -Package $pkg.PackageFullName -ErrorAction Stop'
             '        }'
+            '        $remainingPackages = @(Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue)'
+            '        if ($remainingPackages.Count -gt 0) {'
+            '            throw "User-scoped MSIX/APPX removal verification failed for exact package identity [$packageName]."'
+            '        }'
             '        Write-ADTLogEntry -Message "User-scoped MSIX package removal completed" -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
             '    } catch {'
             '        Write-ADTLogEntry -Message "Failed to remove user-scoped MSIX package: $_" -Severity ''Error'' -Source ''Uninstall-ADTDeployment'''
@@ -4171,6 +4240,11 @@ if ($useManagedDirectoryLifecycle) {
             '        foreach ($pkg in @($packages)) {'
             '            Write-ADTLogEntry -Message "Removing installed package: $($pkg.PackageFullName)" -Severity ''Info'' -Source ''Uninstall-ADTDeployment'''
             '            Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop'
+            '        }'
+            '        $remainingProvPackages = @(Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $packageName })'
+            '        $remainingPackages = @(Get-AppxPackage -Name $packageName -AllUsers -ErrorAction SilentlyContinue)'
+            '        if ($remainingProvPackages.Count -gt 0 -or $remainingPackages.Count -gt 0) {'
+            '            throw "Machine-scoped MSIX/APPX removal verification failed for exact package identity [$packageName]."'
             '        }'
             '        Write-ADTLogEntry -Message "Machine-scoped MSIX package removal completed" -Severity ''Success'' -Source ''Uninstall-ADTDeployment'''
             '    } catch {'

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -375,6 +375,31 @@ describe('generateDetectionRules', () => {
       expect(rules[0].type).toBe('script');
     });
 
+    it('should detect a ZIP-wrapped AppX by its package family identity', () => {
+      const installer: NormalizedInstaller = {
+        architecture: 'x64',
+        url: 'https://example.com/dependencies.zip',
+        sha256: 'abc123',
+        type: 'zip',
+        nestedInstallerType: 'msix',
+        nestedInstallerPath: 'Dependencies\\x64\\Microsoft.NET.Native.Runtime.2.2.appx',
+        packageFamilyName: 'Microsoft.NET.Native.Runtime.2.2_8wekyb3d8bbwe',
+      };
+
+      const rules = generateDetectionRules(
+        installer,
+        'Microsoft .NET Native Runtime',
+        'Microsoft.DotNet.Native.Runtime',
+        '2.2.28604.0'
+      );
+
+      expect(rules).toHaveLength(1);
+      expect(rules[0].type).toBe('script');
+      expect((rules[0] as ScriptDetectionRule).scriptContent).toContain(
+        'Get-AppxPackage -Name "Microsoft.NET.Native.Runtime.2.2" -AllUsers'
+      );
+    });
+
     it('should query the current user and fall back only when running as SYSTEM', () => {
       const installer: NormalizedInstaller = {
         architecture: 'x64',
@@ -941,6 +966,22 @@ describe('generateUninstallCommand', () => {
     ).toBe(
       'REGISTRY_UNINSTALL_PRODUCT:{77B5BCDC-5496-48DA-8B16-5EE2AF08CA31}:BankID säkerhetsprogram'
     );
+  });
+
+  it('should preserve a nested AppX package identity for archive packages', () => {
+    const installer: NormalizedInstaller = {
+      architecture: 'x64',
+      url: 'https://example.com/dependencies.zip',
+      sha256: 'abc123',
+      type: 'zip',
+      nestedInstallerType: 'msix',
+      nestedInstallerPath: 'Dependencies\\x64\\Microsoft.NET.Native.Runtime.2.2.appx',
+      packageFamilyName: 'Microsoft.NET.Native.Runtime.2.2_8wekyb3d8bbwe',
+    };
+
+    expect(
+      generateUninstallCommand(installer, 'Microsoft .NET Native Runtime')
+    ).toBe('MSIX_UNINSTALL:Microsoft.NET.Native.Runtime.2.2');
   });
 
   it('should canonicalize a braceless product code and reject malformed GUID shapes', () => {

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -44,7 +44,14 @@ export function generateDetectionRules(
   version?: string,
   markerPath?: string
 ): DetectionRule[] {
-  switch (installer.type) {
+  // A ZIP is only the transport when WinGet declares a nested installer. Use
+  // the nested engine for lifecycle-specific detection so an archived AppX is
+  // verified by its package identity rather than by our wrapper marker alone.
+  const effectiveInstallerType = installer.type === 'zip' && installer.nestedInstallerType
+    ? installer.nestedInstallerType
+    : installer.type;
+
+  switch (effectiveInstallerType) {
     case 'msi':
     case 'wix':
       // MSI: Prefer registry marker (product codes go stale across versions),
@@ -431,6 +438,14 @@ export function generateUninstallCommand(
       return 'MSIX_UNINSTALL:{PACKAGE_NAME}';
 
     case 'zip':
+      // Archived MSIX/APPX packages retain their package family identity. A
+      // display name is not a safe substitute for provisioning or removal.
+      if (['msix', 'appx'].includes(installer.nestedInstallerType || '')) {
+        if (installer.packageFamilyName) {
+          return `MSIX_UNINSTALL:${installer.packageFamilyName.split('_')[0]}`;
+        }
+        return 'MSIX_UNINSTALL:{PACKAGE_NAME}';
+      }
       // Archive packages execute their nested installer, so a nested MSI/WiX
       // ProductCode is the authoritative installed-product identity. Preserve
       // it for post-install capture and removal instead of falling back to a

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -4034,7 +4034,8 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
     expect(repairedRegistryBranchIndex).toBeGreaterThan(repairIndex);
     expect(unresolvedSentinelIndex).toBeGreaterThan(repairedRegistryBranchIndex);
     expect(packager).toContain("$msixPackageName -notmatch '^[A-Za-z0-9.-]+$'");
-    expect(packager).toContain("$installerTypeLower -in @('msix', 'appx') -and");
+    expect(packager).toContain("$usesAppxLifecycle = $installerTypeLower -in @('msix', 'appx') -or");
+    expect(packager).toContain("$NestedInstallerType.Trim().ToLowerInvariant() -in @('msix', 'appx')");
     expect(packager).toContain('[string]::IsNullOrWhiteSpace($msixPackageName) -and');
     expect(packager).toContain('[string]::IsNullOrWhiteSpace($customUninstallCommand)');
   });
@@ -4046,6 +4047,42 @@ describe('PSADT nested archive contract', () => {
       'Zip package declares a nested installer path but no nested installer type; refusing unsafe default execution.'
     );
   });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'provisions a nested AppX with its exact package identity',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'zip',
+        'Microsoft .NET Native Runtime',
+        [],
+        {},
+        [],
+        'Microsoft.DotNet.Native.Runtime',
+        'Microsoft .NET Native Runtime',
+        '2.2.28604.0',
+        'MSIX_UNINSTALL:Microsoft.NET.Native.Runtime.2.2',
+        '',
+        'machine',
+        'msix',
+        'Dependencies\\x64\\Microsoft.NET.Native.Runtime.2.2.appx'
+      );
+
+      expect(generated).toContain('$msixPath = $nestedInstallerPath');
+      expect(generated).toContain(
+        "Add-AppxProvisionedPackage -Online -PackagePath $packagePath -SkipLicense"
+      );
+      expect(generated).toContain(
+        "$packageName = 'Microsoft.NET.Native.Runtime.2.2'"
+      );
+      expect(generated).toContain(
+        'Remove-AppxProvisionedPackage -Online -PackageName $provPackage.PackageName'
+      );
+      expect(generated).not.toContain(
+        'Start-ADTProcess -FilePath $nestedInstallerPath'
+      );
+    },
+    30_000
+  );
 });
 
 describe('PSADT MSIX scope contract', () => {
@@ -4062,6 +4099,9 @@ describe('PSADT MSIX scope contract', () => {
     expect(packager).toContain('MSIX/APPX provisioning is still in progress');
     expect(packager).toContain('Receive-Job -Job $provisioningJob -ErrorAction Stop');
     expect(packager).toContain('Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers');
+    expect(packager).toContain(
+      'Machine-scoped MSIX/APPX removal verification failed for exact package identity'
+    );
     expect(packager).toContain('if ($IsUserScope)');
   });
 });

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -661,6 +661,43 @@ describe('buildQaCatalogTestConfig', () => {
     );
   });
 
+  it('uses the root package identity for a machine-scoped nested AppX lifecycle', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'Microsoft.DotNet.Native.Runtime',
+        name: 'Microsoft .NET Native Runtime',
+        publisher: 'Microsoft',
+        version: '2.2.28604.0',
+      },
+      manifest: {
+        InstallerType: 'zip',
+        NestedInstallerType: 'msix',
+        Scope: 'machine',
+        PackageFamilyName: 'Microsoft.NET.Native.Runtime.2.2_8wekyb3d8bbwe',
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'zip',
+        NestedInstallerFiles: [{
+          RelativeFilePath: 'Dependencies\\x64\\Microsoft.NET.Native.Runtime.2.2.appx',
+        }],
+      },
+    });
+
+    expect(config.nestedInstallerType).toBe('msix');
+    expect(config.uninstallCommand).toBe(
+      'MSIX_UNINSTALL:Microsoft.NET.Native.Runtime.2.2'
+    );
+    expect(config.detectionRules[0]).toMatchObject({ type: 'script' });
+    const script = 'scriptContent' in config.detectionRules[0]
+      ? config.detectionRules[0].scriptContent
+      : '';
+    expect(script).toContain(
+      'Get-AppxPackage -Name "Microsoft.NET.Native.Runtime.2.2" -AllUsers'
+    );
+    expect(script).toContain('Get-AppxProvisionedPackage -Online');
+  });
+
   it('does not include the disproven Stream Deck uninstall guard in the catalog profile', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/packager/src/job-processor.ts
+++ b/packager/src/job-processor.ts
@@ -1410,7 +1410,11 @@ ${steps}
     return match?.[1] || null;
   }
 
-  private getMsixInstallCommand(job: PackagingJob, fileName: string): string {
+  private getMsixInstallCommand(
+    job: PackagingJob,
+    fileName: string,
+    resolvedPathExpression?: string
+  ): string {
     const packageName = this.getMsixPackageName(job);
     if (!packageName) {
       return 'throw "The MSIX/APPX package identity is missing or unsafe; refusing an ambiguous deployment."';
@@ -1418,7 +1422,10 @@ ${steps}
 
     const escapedFileName = fileName.replace(/'/g, "''");
     const escapedVersion = job.version.replace(/'/g, "''");
-    const common = `$msixPath = Join-Path $adtSession.DirFiles '${escapedFileName}'
+    const msixPathLine = resolvedPathExpression
+      ? `$msixPath = ${resolvedPathExpression}`
+      : `$msixPath = Join-Path $adtSession.DirFiles '${escapedFileName}'`;
+    const common = `${msixPathLine}
     $packageName = '${packageName}'
     $targetVersion = '${escapedVersion}'`;
 
@@ -1499,6 +1506,8 @@ ${steps}
       executeLine = msiProperties
         ? `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath -AdditionalArgumentList '${msiProperties}'`
         : `Start-ADTMsiProcess -Action 'Install' -FilePath $nestedInstallerPath`;
+    } else if (nestedType === 'msix' || nestedType === 'appx') {
+      executeLine = this.getMsixInstallCommand(job, '', '$nestedInstallerPath');
     } else {
       const reviewedTimeout = this.getReviewedInstallCompletionTimeoutMinutes(job);
       if (job.install_scope !== 'user' && reviewedTimeout) {
@@ -1637,6 +1646,10 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
         return `$packages = Get-AppxPackage -Name '${packageName}' -ErrorAction SilentlyContinue
     foreach ($pkg in @($packages)) {
         Remove-AppxPackage -Package $pkg.PackageFullName -ErrorAction Stop
+    }
+    $remainingPackages = @(Get-AppxPackage -Name '${packageName}' -ErrorAction SilentlyContinue)
+    if ($remainingPackages.Count -gt 0) {
+        throw "User-scoped MSIX/APPX removal verification failed for exact package identity [${packageName}]."
     }`;
       }
       return `$provPackages = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq '${packageName}' }
@@ -1646,6 +1659,11 @@ ${nestedPathEscaped ? `        $declaredNestedPath = [System.IO.Path]::GetFullPa
     $packages = Get-AppxPackage -Name '${packageName}' -AllUsers -ErrorAction SilentlyContinue
     foreach ($pkg in @($packages)) {
         Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers -ErrorAction Stop
+    }
+    $remainingProvPackages = @(Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq '${packageName}' })
+    $remainingPackages = @(Get-AppxPackage -Name '${packageName}' -AllUsers -ErrorAction SilentlyContinue)
+    if ($remainingProvPackages.Count -gt 0 -or $remainingPackages.Count -gt 0) {
+        throw "Machine-scoped MSIX/APPX removal verification failed for exact package identity [${packageName}]."
     }`;
     }
 

--- a/packager/tests/psadt-nested-portable.test.ts
+++ b/packager/tests/psadt-nested-portable.test.ts
@@ -1144,6 +1144,45 @@ describe('self-hosted MSIX PSADT generation', () => {
     expect(uninstall).toContain('Remove-AppxPackage -Package $pkg.PackageFullName -AllUsers');
   });
 
+  it('uses the MSIX lifecycle for a ZIP-wrapped AppX payload', () => {
+    const job = packagingJob({
+      winget_id: 'Microsoft.DotNet.Native.Runtime',
+      display_name: 'Microsoft .NET Native Runtime',
+      version: '2.2.28604.0',
+      installer_type: 'zip',
+      installer_url: 'https://example.com/Dependencies.zip',
+      uninstall_command: 'MSIX_UNINSTALL:Microsoft.NET.Native.Runtime.2.2',
+      install_scope: 'machine',
+      package_config: {
+        nestedInstallerType: 'msix',
+        nestedInstallerPath:
+          'Dependencies\\x64\\Microsoft.NET.Native.Runtime.2.2.appx',
+        psadtConfig: {},
+      },
+    });
+    const install = generator.getInstallCommand.call(
+      generator,
+      job,
+      'Dependencies.zip',
+      ''
+    );
+    const uninstall = generator.getUninstallCommand.call(
+      generator,
+      job,
+      'Dependencies.zip'
+    );
+
+    expect(install).toContain('$msixPath = $nestedInstallerPath');
+    expect(install).toContain('Add-AppxProvisionedPackage -Online');
+    expect(install).not.toContain('Start-ADTProcess -FilePath $nestedInstallerPath');
+    expect(uninstall).toContain(
+      "Get-AppxPackage -Name 'Microsoft.NET.Native.Runtime.2.2' -AllUsers"
+    );
+    expect(uninstall).toContain(
+      'Machine-scoped MSIX/APPX removal verification failed for exact package identity'
+    );
+  });
+
   it('refuses a display-name fallback that is not an exact package identity', () => {
     const job = msixJob('user');
     job.uninstall_command = 'MSIX_UNINSTALL:Windows Terminal';


### PR DESCRIPTION
## Summary
- route ZIP-wrapped MSIX/APPX payloads through supported AppX registration/provisioning instead of Win32 execution
- preserve the exact WinGet package-family identity for detection and uninstall
- verify exact AppX removal in both the GitHub Actions PSADT generator and hosted portal packager

## Production impact
This repairs the shared customer PSADT packaging path used by the web portal/catalog and the pinned QA packager. The exact failing catalog case was Microsoft.DotNet.Native.Runtime 2.2.28604.0 (Dependencies.zip -> nested .appx).

## Verification
- 311 focused lifecycle/packager tests passed
- 49 portal-boundary/catalog-detection tests passed
- ESLint passed on changed TypeScript
- PowerShell parser passed on Create-PSADTPackage.ps1