### PR TITLE
chore(qa): promote nested AppX lifecycle packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f48e73742c96773e2b4c8c2fed200363c7b5a805',
+  packagerCommit: '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -545,6 +545,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // /accepteula install contract. Preserve every unrelated compatible pass
   // from the UniFi OS Server machine-scope release.
   'de218619eb0dafb2029f777f47ee6852612527f9',
+  // Nested AppX payloads now use the supported AppX lifecycle instead of
+  // launching the package as a Win32 executable. Preserve every unrelated
+  // compatible pass from the Service Fabric Runtime release.
+  'f48e73742c96773e2b4c8c2fed200363c7b5a805',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,19 +6,30 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Service Fabric Runtime only after activating its official install contract', () => {
+  it('retries .NET Native Runtime only after activating its nested AppX lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
-      { wingetId: ' MICROSOFT.SERVICEFABRICRUNTIME ', status: 'failed' }
+      { wingetId: ' MICROSOFT.DOTNET.NATIVE.RUNTIME ', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'de218619eb0dafb2029f777f47ee6852612527f9',
-      { wingetId: 'Microsoft.ServiceFabricRuntime', status: 'failed' }
+      'f48e73742c96773e2b4c8c2fed200363c7b5a805',
+      { wingetId: 'Microsoft.DotNet.Native.Runtime', status: 'failed' }
     )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Unrelated.App', status: 'failed' }
     )).toBe(false);
+  });
+
+  it('does not replay the exhausted Service Fabric Runtime retry at the next pin', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Microsoft.ServiceFabricRuntime', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f48e73742c96773e2b4c8c2fed200363c7b5a805',
+      { wingetId: ' MICROSOFT.SERVICEFABRICRUNTIME ', status: 'failed' }
+    )).toBe(true);
   });
 
   it('retries UniFi OS Server only after activating its machine-wide lifecycle', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -539,7 +539,18 @@ const SERVICE_FABRIC_RUNTIME_OFFICIAL_ARGS_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const NESTED_APPX_LIFECYCLE_RELEASE_RETRY_TARGETS = [
+  // Retry .NET Native Runtime through the supported AppX lifecycle instead
+  // of executing its nested .appx payload as a Win32 process.
+  'Microsoft.DotNet.Native.Runtime',
+  // Service Fabric Runtime exhausted its reviewed retry at the prior pin;
+  // carry every older still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e':
+    NESTED_APPX_LIFECYCLE_RELEASE_RETRY_TARGETS,
   'f48e73742c96773e2b4c8c2fed200363c7b5a805':
     SERVICE_FABRIC_RUNTIME_OFFICIAL_ARGS_RELEASE_RETRY_TARGETS,
   'de218619eb0dafb2029f777f47ee6852612527f9':


### PR DESCRIPTION
## Summary
- promote exact shared packager commit 122aa9726cd4e8ab028f3953f0a9ebac452fcb8e
- preserve unrelated compatible passes from the prior release
- retry Microsoft.DotNet.Native.Runtime only at the repaired pin
- do not replay the exhausted Service Fabric Runtime retry

## Verification
- 263 targeted QA profile/backfill tests passed
- ESLint passed for all changed TypeScript files
- git diff --check passed