### PR TITLE
fix(qa): block dependency-bound .NET Native Runtime

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -1048,6 +1048,29 @@ describe('Open Live Writer unsupported managed install block migration contract'
   });
 });
 
+describe('.NET Native Runtime AppX framework managed uninstall block migration contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831011500_block_dotnet_native_runtime_unsupported_managed_uninstall.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks the dependency-bound framework across customer packaging and QA', () => {
+    expect(sql).toContain("'unsupported_managed_uninstall'");
+    expect(sql).toContain("'Microsoft.DotNet.Native.Runtime'");
+    expect(sql).toContain(
+      'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33346306805'
+    );
+    expect(sql).toContain('0x80073CF3 dependency/conflict validation');
+    expect(sql).toContain('package remains detected');
+    expect(sql).toContain('set is_verified = false');
+    expect(sql).toContain("status = 'superseded'");
+    expect(sql).toContain("status in ('queued', 'failed', 'error')");
+  });
+});
+
 describe('ReSharper EAP host-dependent install block migration contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831011500_block_dotnet_native_runtime_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260831011500_block_dotnet_native_runtime_unsupported_managed_uninstall.sql
@@ -1,0 +1,35 @@
+-- Microsoft .NET Native Runtime 2.2 is an AppX framework package. The exact
+-- machine-provisioned lifecycle installs and detects successfully, but Windows
+-- rejects all-user deregistration with 0x80073CF3 dependency/conflict
+-- validation and the exact package remains installed. Do not claim a managed
+-- uninstall lifecycle or ship an Intune package that cannot satisfy removal.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'Microsoft.DotNet.Native.Runtime',
+  'unsupported_managed_uninstall',
+  'The .NET Native Runtime 2.2 AppX framework installs and detects under LocalSystem, but Windows rejects exact all-user deregistration with 0x80073CF3 dependency/conflict validation and the package remains detected.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33346306805'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.DotNet.Native.Runtime';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'Microsoft.DotNet.Native.Runtime'
+  and status in ('queued', 'failed', 'error');


### PR DESCRIPTION
## Summary
- block Microsoft.DotNet.Native.Runtime as an unsupported managed uninstall
- prevent the dependency-bound AppX framework from reaching customer packaging and QA
- supersede existing failed/queued candidates with the generic availability message
- retain the shared nested-AppX lifecycle support for packages that can be removed safely

## Evidence
- exact isolated run 33346306805 installed and detected successfully
- Windows rejected exact all-user deregistration with 0x80073CF3 dependency/conflict validation
- the exact package remained detected after uninstall

## Verification
- 103 migration contract tests passed
- ESLint passed
- git diff --check passed