### PR TITLE
Fix SSMS 21 Preview unattended uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -1611,6 +1611,7 @@ describe('application packaging adapters', () => {
 
   it.each([
     'Microsoft.SQLServerManagementStudio.21',
+    'Microsoft.SQLServerManagementStudio.21.Preview',
     'Microsoft.SQLServerManagementStudio.22',
     'Microsoft.SQLServerManagementStudio.22.Preview',
   ])('applies the Visual Studio Installer lifecycle to %s', (wingetId) => {

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -126,6 +126,7 @@ const VISUAL_STUDIO_MANAGED_INSTALL_PATHS = {
 
 const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
   'Microsoft.SQLServerManagementStudio.21',
+  'Microsoft.SQLServerManagementStudio.21.Preview',
   'Microsoft.SQLServerManagementStudio.22',
   'Microsoft.SQLServerManagementStudio.22.Preview',
 ] as const;

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1808,6 +1808,34 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig).toMatchObject(expectedConfig);
   });
 
+  it('binds SSMS 21 Preview to the unattended Visual Studio Installer removal lifecycle', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microsoft.SQLServerManagementStudio.21.Preview',
+      displayName: 'Microsoft SQL Server Management Studio 21 Preview',
+      publisher: 'Microsoft',
+      version: '21.0.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '--quiet --norestart --wait',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL:Microsoft SQL Server Management Studio 21 Preview',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = {
+      reviewedUninstallArguments: ['--quiet', '--norestart', '--noweb'],
+      uninstallCompletionTimeoutMinutes: 15,
+    };
+    const profile = normalized.identity.profile as {
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+  });
+
   it('binds the Tor Browser extracted-folder lifecycle to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'TorProject.TorBrowser',


### PR DESCRIPTION
## Summary
- bind Microsoft.SQLServerManagementStudio.21.Preview to the reviewed Visual Studio Installer lifecycle
- pass --quiet --norestart --noweb and retain the 15-minute completion poll
- lock the behavior into adapter and customer/QA package-profile tests

## Failure evidence
Production QA run 33349527965 installed and detected successfully but uninstall returned 60001 and left ARP registration b0f03d2c. The generated setup.exe uninstall command was missing the reviewed unattended switches because this exact WinGet ID was absent from the shared adapter list.

## Verification
- 348 focused tests passed
- ESLint passed for all changed files
- git diff --check passed