### PR TITLE
Promote SSMS 21 Preview uninstall packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e',
+  packagerCommit: '2a1930a201bef41c313606cf44ecd71ce1238c7a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -549,6 +549,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // launching the package as a Win32 executable. Preserve every unrelated
   // compatible pass from the Service Fabric Runtime release.
   'f48e73742c96773e2b4c8c2fed200363c7b5a805',
+  // SSMS 21 Preview now uses the reviewed unattended Visual Studio Installer
+  // uninstall lifecycle. Preserve every unrelated compatible pass from the
+  // nested AppX lifecycle release.
+  '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,19 +6,30 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries .NET Native Runtime only after activating its nested AppX lifecycle', () => {
+  it('retries SSMS 21 Preview only after activating its unattended uninstall lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
-      { wingetId: ' MICROSOFT.DOTNET.NATIVE.RUNTIME ', status: 'failed' }
+      { wingetId: ' MICROSOFT.SQLSERVERMANAGEMENTSTUDIO.21.PREVIEW ', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'f48e73742c96773e2b4c8c2fed200363c7b5a805',
-      { wingetId: 'Microsoft.DotNet.Native.Runtime', status: 'failed' }
+      '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e',
+      { wingetId: 'Microsoft.SQLServerManagementStudio.21.Preview', status: 'failed' }
     )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Unrelated.App', status: 'failed' }
     )).toBe(false);
+  });
+
+  it('does not replay the exhausted .NET Native Runtime retry at the next pin', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Microsoft.DotNet.Native.Runtime', status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e',
+      { wingetId: ' MICROSOFT.DOTNET.NATIVE.RUNTIME ', status: 'failed' }
+    )).toBe(true);
   });
 
   it('does not replay the exhausted Service Fabric Runtime retry at the next pin', () => {

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -548,7 +548,18 @@ const NESTED_APPX_LIFECYCLE_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const SSMS_21_PREVIEW_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry SSMS 21 Preview after its exact WinGet identity is bound to the
+  // reviewed unattended Visual Studio Installer uninstall lifecycle.
+  'Microsoft.SQLServerManagementStudio.21.Preview',
+  // .NET Native Runtime and Service Fabric Runtime exhausted their reviewed
+  // retries; carry every older still-unconsumed target without replaying them.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '2a1930a201bef41c313606cf44ecd71ce1238c7a':
+    SSMS_21_PREVIEW_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '122aa9726cd4e8ab028f3953f0a9ebac452fcb8e':
     NESTED_APPX_LIFECYCLE_RELEASE_RETRY_TARGETS,
   'f48e73742c96773e2b4c8c2fed200363c7b5a805':


### PR DESCRIPTION
## Summary
- promote shared packager commit 2a1930a201bef41c313606cf44ecd71ce1238c7a
- preserve unrelated compatible passes from the previous release
- schedule one bounded retry for Microsoft.SQLServerManagementStudio.21.Preview
- do not replay the exhausted .NET Native Runtime or Service Fabric Runtime retries

## Verification
- 265 focused tests passed
- ESLint passed for all changed files
- git diff --check passed
- feature deployment is Ready and aliased to www.intuneget.com
- IntuneGet-Workflows PR #2994 pins all three workflow/toolchain locations to the exact feature commit