### PR TITLE
Keep ARES Commander install observable

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -590,6 +590,17 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('keeps the ARES Commander bootstrapper observable within a bounded wait', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'Graebert.AresCommander.2022',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('keeps the FlashPrint bootstrapper observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -425,6 +425,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     },
   },
   {
+    // ARES Commander 2022's signed 578 MB bootstrapper keeps its MSI
+    // transaction alive without PSADT log activity beyond the generic QA
+    // inactivity window. Production QA run 33353784275 observed the exact MSI
+    // registration while that transaction still owned Windows Installer. Keep
+    // the manifest-provided /silent contract and exact ARP lifecycle, but make
+    // the shared customer and QA wait observable and bounded.
+    wingetId: 'Graebert.AresCommander.2022',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // darktable's official CPack/NSIS installer writes its ARP registration
     // only after the complete application tree has been extracted. The signed
     // 5.6.0 package can therefore remain quiet longer than the generic QA

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1261,6 +1261,35 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds the bounded ARES Commander installer wait to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Graebert.AresCommander.2022',
+      displayName: 'ARES Commander 2022',
+      publisher: 'Graebert',
+      version: '21.3.4329',
+      architecture: 'x64',
+      installerSha256: '4'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL:ARES Commander 2022',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = { reviewedInstallCompletionTimeoutMinutes: 15 };
+    const profile = normalized.identity.profile as {
+      installer: { silentArgs: string; uninstallCommand: string };
+      psadtConfig: typeof expectedConfig;
+    };
+
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(profile.psadtConfig).toMatchObject(expectedConfig);
+    expect(profile.installer.silentArgs).toBe('/silent');
+    expect(profile.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL:ARES Commander 2022'
+    );
+  });
+
   it('binds MaxTo user scope and its bounded Velopack wait to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Domino.MaxTo',


### PR DESCRIPTION
## Summary
- bind Graebert.AresCommander.2022 to the reviewed 15-minute observable installer wait
- preserve the manifest-provided /silent command and exact ARP/MSI lifecycle
- lock the behavior into shared adapter and customer/QA profile tests

## Failure evidence
Production QA run 33353784275 transferred the signed 578 MB bootstrapper and launched it with /silent. The install stopped emitting PSADT activity after 285 seconds while its exact registered MSI transaction was still active; detection therefore failed and the immediate uninstall returned 1618. This change uses the packager's existing bounded no-wait poll with a progress heartbeat, rather than changing vendor arguments or guessing a product path.

## Verification
- 350 focused tests passed
- ESLint passed for all changed files
- git diff --check passed