### PR TITLE
Repair ReceitanetBX and WatchBP managed lifecycles

### DIFF
--- a/lib/__tests__/installer-preflight.test.ts
+++ b/lib/__tests__/installer-preflight.test.ts
@@ -151,6 +151,29 @@ describe('installer dispatch preflight', () => {
     expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts WatchBP Analyzer user manifest bytes for reviewed SYSTEM execution', async () => {
+    const watchBpRequest = {
+      ...request,
+      wingetId: 'Microlife.WatchBPAnalyzer',
+      architecture: 'x64',
+      installerUrl: 'https://example.test/watchbp-analyzer.exe',
+      installerType: 'nullsoft',
+    };
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: watchBpRequest.installerUrl,
+      sha256: expectedSha256,
+      type: 'nullsoft',
+      scope: 'user',
+    }]);
+
+    await expect(enforceInstallerPreflight(watchBpRequest)).resolves.toMatchObject({
+      status: 'healthy',
+      source: 'live',
+    });
+    expect(hashRemoteInstallerMock).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts NVM user manifest bytes for reviewed SYSTEM execution', async () => {
     const nvmRequest = {
       ...request,

--- a/lib/catalog-installer-reconciliation.test.ts
+++ b/lib/catalog-installer-reconciliation.test.ts
@@ -310,6 +310,35 @@ describe('catalog installer reconciliation', () => {
     expect(reconciled.item.installCommand).toBe('"logitech-presentation.exe" /S');
   });
 
+  it('selects WatchBP Analyzer user bytes for reviewed LocalSystem execution', async () => {
+    getLiveInstallersMock.mockResolvedValue([{
+      architecture: 'x64',
+      url: 'https://example.test/watchbp-analyzer.exe',
+      sha256,
+      type: 'nullsoft',
+      scope: 'user',
+      silentArgs: '/S',
+      productCode: 'WatchBP Analyzer',
+    } satisfies NormalizedInstaller]);
+
+    const reconciled = await reconcileCatalogInstaller(operaItem({
+      wingetId: 'Microlife.WatchBPAnalyzer',
+      displayName: 'WatchBP Analyzer',
+      version: '1.7.3.1',
+      architecture: 'x64',
+      installScope: 'user',
+      installerUrl: 'https://example.test/watchbp-analyzer.exe',
+      installCommand: '"watchbp-analyzer.exe" /S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:WatchBP Analyzer:WatchBP Analyzer',
+    }));
+
+    expect(reconciled.item.installScope).toBe('machine');
+    expect(reconciled.item.installerUrl).toBe(
+      'https://example.test/watchbp-analyzer.exe'
+    );
+    expect(reconciled.item.installCommand).toBe('"watchbp-analyzer.exe" /S');
+  });
+
   it('selects TeamSpeak 6 Beta user manifest bytes for all-users MSI execution', async () => {
     getLiveInstallersMock.mockResolvedValue([{
       architecture: 'x64',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -524,6 +524,18 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('runs WatchBP Analyzer elevated without weakening catalog scope matching', () => {
+    expect(resolveApplicationInstallScope(
+      'Microlife.WatchBPAnalyzer',
+      'user'
+    )).toBe('machine');
+    expect(resolveApplicationInstallerSelectionScope(
+      'Microlife.WatchBPAnalyzer',
+      'machine'
+    )).toBe('user');
+    expect(resolveApplicationInstallScope('Example.App', 'user')).toBe('user');
+  });
+
   it('runs NVM for Windows elevated from a deterministic machine directory', () => {
     expect(resolveApplicationInstallScope('CoreyButler.NVMforWindows', 'user')).toBe(
       'machine'
@@ -696,6 +708,12 @@ describe('application packaging adapters', () => {
       applyApplicationPackagingAdapter('Tricentis.NeoLoad', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['-q']);
+    expect(
+      applyApplicationPackagingAdapter(
+        'ReceitaFederaldoBrasil.ReceitanetBX',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['/mode', 'silent']);
     expect(
       applyApplicationPackagingAdapter(
         'Atlassian.ServiceManagementLTS',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1587,6 +1587,28 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/S'],
   },
   {
+    // Receita Federal publishes /mode silent for the exact ReceitanetBX
+    // executable. Isolated QA run 33369272908 proved installation and exact
+    // ARP capture, but the captured vendor uninstaller omitted that mode,
+    // printed an interactive key prompt, and retained its exact registration.
+    // Append only the publisher-declared silent mode to that captured command;
+    // the exact registry identity remains authoritative for completion.
+    // https://github.com/microsoft/winget-pkgs/blob/master/manifests/r/ReceitaFederaldoBrasil/ReceitanetBX/1.10.0/ReceitaFederaldoBrasil.ReceitanetBX.installer.yaml
+    wingetId: 'ReceitaFederaldoBrasil.ReceitanetBX',
+    reviewedUninstallArguments: ['/mode', 'silent'],
+  },
+  {
+    // Microlife publishes WatchBP Analyzer as a user-scope Nullsoft package,
+    // but its installer raises an elevation request even with /S. Isolated QA
+    // run 33374926585 therefore failed before registration in the standard-user
+    // context. Keep selecting and attesting the exact published user-scoped
+    // bytes while executing the managed lifecycle as LocalSystem.
+    // https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microlife/WatchBPAnalyzer/1.7.3.1/Microlife.WatchBPAnalyzer.installer.yaml
+    wingetId: 'Microlife.WatchBPAnalyzer',
+    requiredInstallScope: 'machine',
+    reviewedInstallerSelectionScope: 'user',
+  },
+  {
     // Webroot publishes both an MSI and a machine-scoped EXE. The EXE's
     // registered WRUNINST removal route is interactive, while the MSI has the
     // standard unattended Windows Installer lifecycle required by Intune.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1109,6 +1109,59 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('binds WatchBP Analyzer elevation handling to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Microlife.WatchBPAnalyzer',
+      displayName: 'WatchBP Analyzer',
+      publisher: 'Microlife',
+      version: '1.7.3.1',
+      architecture: 'x64',
+      installerSha256: 'a'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:WatchBP Analyzer:WatchBP Analyzer',
+      installScope: 'user',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string; silentArgs: string };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe('/S');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\IntuneGet\\Apps\\Microlife_WatchBPAnalyzer',
+      }),
+    ]);
+  });
+
+  it('binds ReceitanetBX silent removal to customer and QA packaging', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'ReceitaFederaldoBrasil.ReceitanetBX',
+      displayName: 'Receitanet BX',
+      publisher: 'Receita Federal do Brasil',
+      version: '1.10.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'exe',
+      silentSwitches: '/mode silent',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_KEY:EC016E3C-26D1-4DC8-9D8A-6AC06B3005A5:Receitanet BX',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      psadtConfig: { reviewedUninstallArguments?: string[] };
+    };
+
+    expect(profile.psadtConfig.reviewedUninstallArguments).toEqual(['/mode', 'silent']);
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['/mode', 'silent']);
+  });
+
   it('binds Logitech LGS to LocalSystem while retaining its catalog installer contract', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Logitech.LGS',


### PR DESCRIPTION
Adds two app-scoped shared customer/QA packaging adapters from isolated evidence. ReceitanetBX appends only the publisher-declared /mode silent tokens to the exact captured vendor uninstaller. WatchBP Analyzer retains the exact user-scoped catalog bytes but executes as LocalSystem because the installer requests elevation in a standard-user context. Validation: 353 adapter/profile/generated-PSADT tests passed; 244 adapter/profile/preflight/reconciliation tests passed; git diff --check passed.