### PR TITLE
chore(qa): promote Receitanet and WatchBP repairs

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '02334f8bff1ee97e68c81ef44fd4ed256df81397',
+  packagerCommit: '450123ff0f740dce8a4f7deee067dadd18739134',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -557,6 +557,11 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // bootstrapper completes. Preserve every unrelated compatible pass from the
   // SSMS 21 Preview unattended-uninstall release.
   '2a1930a201bef41c313606cf44ecd71ce1238c7a',
+  // ReceitanetBX now uses the vendor-declared silent uninstall mode, and
+  // WatchBP Analyzer executes its trusted user-scoped installer bytes as
+  // LocalSystem. Preserve every unrelated compatible pass from the ARES
+  // Commander install-heartbeat release.
+  '02334f8bff1ee97e68c81ef44fd4ed256df81397',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,13 +6,27 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries ARES Commander only after activating bounded install heartbeats', () => {
+  it.each([
+    'ReceitaFederaldoBrasil.ReceitanetBX',
+    'Microlife.WatchBPAnalyzer',
+  ])('retries %s only after activating its reviewed lifecycle repair', (wingetId) => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '02334f8bff1ee97e68c81ef44fd4ed256df81397',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries ARES Commander only after activating bounded install heartbeats', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '02334f8bff1ee97e68c81ef44fd4ed256df81397',
       { wingetId: ' GRAEBERT.ARESCOMMANDER.2022 ', status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      '2a1930a201bef41c313606cf44ecd71ce1238c7a',
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Graebert.AresCommander.2022', status: 'failed' }
     )).toBe(false);
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -566,7 +566,19 @@ const ARES_COMMANDER_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const RECEITANET_WATCHBP_RELEASE_RETRY_TARGETS = [
+  // Retry ReceitanetBX with its vendor-declared silent uninstall mode and
+  // WatchBP Analyzer with machine-context execution of the trusted manifest.
+  'ReceitaFederaldoBrasil.ReceitanetBX',
+  'Microlife.WatchBPAnalyzer',
+  // ARES Commander exhausted its reviewed retry at the prior pin; carry every
+  // older still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '450123ff0f740dce8a4f7deee067dadd18739134':
+    RECEITANET_WATCHBP_RELEASE_RETRY_TARGETS,
   '02334f8bff1ee97e68c81ef44fd4ed256df81397':
     ARES_COMMANDER_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '2a1930a201bef41c313606cf44ecd71ce1238c7a':


### PR DESCRIPTION
## Summary
- pin QA and customer packaging to the merged ReceitanetBX and WatchBP Analyzer adapter release
- retain the prior packager commit in compatible release history
- schedule bounded terminal retries only for the two repaired failures while carrying older unconsumed targets

## Validation
- npm exec -- vitest run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (271 passed)
- git diff --check