### PR TITLE
fix(qa): block ReceitanetBX managed uninstall

### DIFF
--- a/supabase/migrations/20260831102500_block_receitanetbx_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260831102500_block_receitanetbx_unsupported_managed_uninstall.sql
@@ -1,0 +1,38 @@
+-- ReceitanetBX 1.10.0 installs silently and registers its exact application
+-- identity, but its captured vendor uninstaller is not a reliable unattended
+-- lifecycle. Two isolated PSADT runs waited more than five minutes: the first
+-- used the registered command and the second appended WinGet's published
+-- `/mode silent` argument. Both returned 60001 and left the app registered.
+-- Do not guess additional switches on customer devices; keep the package out
+-- of managed Intune packaging until the vendor publishes a verifiable removal
+-- contract.
+
+insert into public.package_eligibility_blocks (
+  winget_id,
+  block_code,
+  detail,
+  source_url
+)
+values (
+  'ReceitaFederaldoBrasil.ReceitanetBX',
+  'unsupported_managed_uninstall',
+  'ReceitanetBX installs silently, but two isolated PSADT lifecycle tests confirmed that its registered vendor uninstaller remains interactive even with the published /mode silent argument and leaves the application registered.',
+  'https://github.com/microsoft/winget-pkgs/blob/master/manifests/r/ReceitaFederaldoBrasil/ReceitanetBX/1.10.0/ReceitaFederaldoBrasil.ReceitanetBX.installer.yaml'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'ReceitaFederaldoBrasil.ReceitanetBX';
+
+update public.qa_candidates
+set status = 'superseded',
+    finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'ReceitaFederaldoBrasil.ReceitanetBX'
+  and status in ('queued', 'failed');


### PR DESCRIPTION
## Summary
- fail closed for ReceitanetBX managed packaging after two isolated uninstall failures
- record the unsupported managed-uninstall boundary in the shared eligibility gate
- clear failed/queued QA rows so the app cannot repeatedly consume the VM

## Evidence
- exact registered vendor command: install/detect/uninstall/removal = 0/0/60001/0 after 319 seconds
- WinGet-published /mode silent retry: 0/0/60001/0 after 319 seconds
- both exact installers were VirusTotal clean (0 malicious, 0 suspicious)

## Validation
- npm exec -- vitest run lib/qa/migration-contract.test.ts (108 passed)
- git diff --check