### PR TITLE
Fix MPLAB XC16 unattended uninstall

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -716,6 +716,12 @@ describe('application packaging adapters', () => {
     ).toEqual(['/mode', 'silent']);
     expect(
       applyApplicationPackagingAdapter(
+        'Microchip.MPLABXC16CCompiler',
+        DEFAULT_PSADT_CONFIG
+      ).reviewedUninstallArguments
+    ).toEqual(['--mode', 'unattended']);
+    expect(
+      applyApplicationPackagingAdapter(
         'Atlassian.ServiceManagementLTS',
         DEFAULT_PSADT_CONFIG
       ).reviewedUninstallArguments

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1598,6 +1598,18 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['/mode', 'silent'],
   },
   {
+    // MPLAB XC16 is built with VMware InstallBuilder and registers the exact
+    // versioned `Uninstall-xc16-<version>.exe` without unattended arguments.
+    // Production QA run 33384127456 observed that argumentless command exited
+    // after roughly ten seconds while leaving the exact ARP registration in
+    // place. InstallBuilder documents `--mode unattended` for automated
+    // uninstallation, so append only that vendor-family mode to the captured
+    // versioned command rather than guessing or replacing its path.
+    // https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html
+    wingetId: 'Microchip.MPLABXC16CCompiler',
+    reviewedUninstallArguments: ['--mode', 'unattended'],
+  },
+  {
     // Microlife publishes WatchBP Analyzer as a user-scope Nullsoft package,
     // but its installer raises an elevation request even with /S. Isolated QA
     // run 33374926585 therefore failed before registration in the standard-user


### PR DESCRIPTION
## Summary
- append InstallBuilder's documented --mode unattended to the exact captured MPLAB XC16 versioned uninstaller
- keep exact ARP identity/removal verification authoritative
- cover the production adapter in focused tests

## Evidence
- production QA run 33384127456: install/detect succeeded; argumentless Uninstall-xc16-v2.10.exe exited without removing registration
- VMware InstallBuilder documents --mode unattended for automated uninstallation

## Validation
- 
pm test -- --run lib/packaging-adapters.test.ts lib/qa/psadt-packager-contract.test.ts (240 passed)