### PR TITLE
Promote MPLAB XC16 packager release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '450123ff0f740dce8a4f7deee067dadd18739134',
+  packagerCommit: 'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,16 +6,28 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it.each([
-    'ReceitaFederaldoBrasil.ReceitanetBX',
-    'Microlife.WatchBPAnalyzer',
-  ])('retries %s only after activating its reviewed lifecycle repair', (wingetId) => {
+  it('retries MPLAB XC16 only after activating its unattended uninstall repair', () => {
+    const wingetId = 'Microchip.MPLABXC16CCompiler';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      '02334f8bff1ee97e68c81ef44fd4ed256df81397',
+      '450123ff0f740dce8a4f7deee067dadd18739134',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it.each([
+    'ReceitaFederaldoBrasil.ReceitanetBX',
+    'Microlife.WatchBPAnalyzer',
+  ])('keeps the exhausted %s retry scoped to its release', (wingetId) => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '450123ff0f740dce8a4f7deee067dadd18739134',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(false);
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -576,7 +576,18 @@ const RECEITANET_WATCHBP_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const MPLAB_XC16_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS = [
+  // Retry MPLAB XC16 with InstallBuilder's documented unattended mode added
+  // to the exact captured versioned uninstaller.
+  'Microchip.MPLABXC16CCompiler',
+  // The Receitanet and WatchBP retries reached terminal outcomes at the prior
+  // pin; carry every older still-unconsumed target without replaying them.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3':
+    MPLAB_XC16_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '450123ff0f740dce8a4f7deee067dadd18739134':
     RECEITANET_WATCHBP_RELEASE_RETRY_TARGETS,
   '02334f8bff1ee97e68c81ef44fd4ed256df81397':


### PR DESCRIPTION
## Summary
- pin production QA package profiles to packager 1f9ded94342bd3e27fe17b50e17f5b9474c01a3`n- schedule one exact terminal retry for Microchip.MPLABXC16CCompiler
- keep completed Receitanet/WatchBP retries scoped to their prior release

## Validation
- 
pm test -- --run lib/qa/package-profile.test.ts lib/qa/toolchain-backfill.test.ts (272 passed)