### PR TITLE
Fix Quassel uninstall identity

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -291,6 +291,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('uses Quassel IRC\'s exact NSIS registry identity', () => {
+    expect(resolveApplicationUninstallCommand(
+      'Quassel.QuasselIRC',
+      'REGISTRY_UNINSTALL:QuasselIRC'
+    )).toBe('REGISTRY_UNINSTALL_KEY:Quassel IRC:Quassel IRC');
+    expect(resolveApplicationUninstallCommand(
+      'quassel.quasselirc',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('forces reviewed per-user installers out of the LocalSystem profile', () => {
     expect(
       resolveApplicationInstallScope('Y-ASLant.ElegantClipboard', 'machine')

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1880,6 +1880,16 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'MSYS2 Installer',
     registeredDisplayName: 'MSYS2',
   },
+  // Quassel's WinGet ProductCode omits the space used by the application's
+  // actual NSIS ARP identity, and the registered build version is a Git
+  // revision instead of the manifest version. Bind the observed stable key so
+  // unrelated Edge servicing cannot enter capture selection while the exact
+  // vendor-created uninstaller remains authoritative for removal.
+  'quassel.quasselirc': {
+    generatedDisplayName: 'QuasselIRC',
+    registeredDisplayName: 'Quassel IRC',
+    registeredRegistryKey: 'Quassel IRC',
+  },
 };
 
 export function resolveApplicationUninstallCommand(

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -346,6 +346,29 @@ describe('PSADT QA package identity', () => {
       .toEqual(['/S']);
   });
 
+  it('binds Quassel customer and QA packages to the exact NSIS registry identity', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Quassel.QuasselIRC',
+      displayName: 'QuasselIRC',
+      publisher: 'Quassel Project',
+      version: '0.14.0',
+      architecture: 'x64',
+      installerSha256: 'b'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:QuasselIRC',
+      installScope: 'machine',
+    });
+    const profile = normalized.identity.profile as {
+      installer: { uninstallCommand: string };
+    };
+
+    expect(normalized.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:Quassel IRC:Quassel IRC'
+    );
+    expect(profile.installer.uninstallCommand).toBe(normalized.uninstallCommand);
+  });
+
   it('binds G.SKILL Trident Z customer and QA packages to one exact Inno key', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'GSKILL.TridentZLightingControl',


### PR DESCRIPTION
Binds Quassel.QuasselIRC to the exact observed NSIS ARP key and display name while retaining the captured vendor uninstaller. The shared customer and QA PSADT profile is covered by focused tests (269 passed). Clean-VM evidence showed Quassel IRC as the stable key/name and unrelated Edge/WebView ARP changes, so broad selection is intentionally avoided.