### PR TITLE
Promote Quassel lifecycle repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3',
+  packagerCommit: '738d9f19baa44d2e1f0cf49c4fea5658915cefc9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,14 +6,26 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries MPLAB XC16 only after activating its unattended uninstall repair', () => {
-    const wingetId = 'Microchip.MPLABXC16CCompiler';
+  it('retries Quassel only after activating its exact uninstall identity', () => {
+    const wingetId = 'Quassel.QuasselIRC';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      '450123ff0f740dce8a4f7deee067dadd18739134',
+      'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('keeps the exhausted MPLAB XC16 retry scoped to its release', () => {
+    const wingetId = 'Microchip.MPLABXC16CCompiler';
+    expect(shouldRetryTerminalToolchainCandidate(
+      'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(false);
   });

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -585,7 +585,18 @@ const MPLAB_XC16_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const QUASSEL_EXACT_UNINSTALL_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry Quassel with its observed exact NSIS ARP key/display name while the
+  // captured vendor-created uninstaller remains authoritative for removal.
+  'Quassel.QuasselIRC',
+  // MPLAB XC16 exhausted its reviewed retry at the prior pin; carry every
+  // older still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '738d9f19baa44d2e1f0cf49c4fea5658915cefc9':
+    QUASSEL_EXACT_UNINSTALL_IDENTITY_RELEASE_RETRY_TARGETS,
   'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3':
     MPLAB_XC16_UNATTENDED_UNINSTALL_RELEASE_RETRY_TARGETS,
   '450123ff0f740dce8a4f7deee067dadd18739134':


### PR DESCRIPTION
Pins production and QA package profiles to reviewed packager commit 738d9f19baa44d2e1f0cf49c4fea5658915cefc9 and scopes a terminal retry to Quassel.QuasselIRC. Focused profile/backfill tests: 274 passed.