### PR TITLE
fix(qa): block Divoom expired MSIX payload

### DIFF
--- a/lib/auto-update/trigger.ts
+++ b/lib/auto-update/trigger.ts
@@ -46,7 +46,8 @@ interface TriggerResult {
   code?:
     | 'QA_FAILED_CURRENT_VERSION'
     | 'QA_NOT_PASSED_CURRENT_VERSION'
-    | 'QA_SECURITY_FLAGGED_CURRENT_VERSION';
+    | 'QA_SECURITY_FLAGGED_CURRENT_VERSION'
+    | 'QA_PACKAGE_COMPATIBILITY_BLOCKED';
 }
 
 export interface UpdateInfo {

--- a/lib/msp/batch-orchestrator.ts
+++ b/lib/msp/batch-orchestrator.ts
@@ -18,7 +18,12 @@ import { verifyTenantConsent } from '@/lib/msp/consent-verification';
 import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { queueWebhookDelivery } from '@/lib/msp/webhook-service';
 import { createAuditLog } from '@/lib/audit-logger';
-import { describeQaGateError, enforceQaGate, QaGateError } from '@/lib/qa/gate';
+import {
+  describeQaGateError,
+  enforceQaGate,
+  isQaGateError,
+  type AnyQaGateError,
+} from '@/lib/qa/gate';
 import { normalizeInstaller } from '@/lib/manifest-api';
 import { selectTrustedCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
 import type { WingetInstaller } from '@/types/winget';
@@ -271,16 +276,17 @@ async function startBatchItems(batchId: string): Promise<number> {
 
   // Evaluate the package tuple once before processing tenants. This avoids
   // creating one misleading job per tenant for a known current QA failure.
-  let qaGateError: QaGateError | null = null;
+  let qaGateError: AnyQaGateError | null = null;
   if (installerDetails) {
     try {
       await enforceQaGate({
         wingetId: batch.winget_id,
         version: batch.version,
         architecture: installerDetails.architecture,
+        installerSha256: installerDetails.installer_sha256,
       });
     } catch (error) {
-      if (error instanceof QaGateError) qaGateError = error;
+      if (isQaGateError(error)) qaGateError = error;
       else throw error;
     }
   }
@@ -404,7 +410,7 @@ async function startBatchItems(batchId: string): Promise<number> {
 
       started++;
     } catch (err) {
-      const isQaSkip = err instanceof QaGateError;
+      const isQaSkip = isQaGateError(err);
       const msg = isQaSkip
         ? describeQaGateError(err)
         : err instanceof Error ? err.message : 'Failed to trigger packaging workflow';

--- a/lib/package-eligibility.test.ts
+++ b/lib/package-eligibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   getCatalogExclusion,
+  getPackageCompatibilityBlock,
   getPackageEligibilityBlocks,
 } from '@/lib/package-eligibility';
 
@@ -28,6 +29,17 @@ function singleRowQuery(result: { data: unknown; error: { message: string } | nu
   builder.select.mockReturnValue(builder);
   builder.ilike.mockReturnValue(builder);
   builder.limit.mockReturnValue(builder);
+  return builder;
+}
+
+function exactTupleQuery(result: { data: unknown; error: { message: string } | null }) {
+  const builder = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+  builder.select.mockReturnValue(builder);
+  builder.eq.mockReturnValue(builder);
   return builder;
 }
 
@@ -115,5 +127,55 @@ describe('getPackageEligibilityBlocks', () => {
     await expect(
       getPackageEligibilityBlocks(client as never, ['Example.App'])
     ).rejects.toThrow('Could not verify package availability: database unavailable');
+  });
+});
+
+describe('getPackageCompatibilityBlock', () => {
+  it('matches the exact app, version, architecture, and installer hash', async () => {
+    const installerSha256 = 'A'.repeat(64);
+    const builder = exactTupleQuery({
+      data: {
+        winget_id: 'r12f.DivoomGateway',
+        version: '0.1.42.0',
+        architecture: 'x64',
+        installer_sha256: installerSha256,
+        block_code: 'expired_signing_certificate',
+        detail: 'The signing certificate is expired.',
+      },
+      error: null,
+    });
+    const client = { from: vi.fn(() => builder) };
+
+    const result = await getPackageCompatibilityBlock(client as never, {
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+      architecture: 'X64',
+      installerSha256: installerSha256.toLowerCase(),
+    });
+
+    expect(client.from).toHaveBeenCalledWith('qa_package_blocks');
+    expect(builder.eq).toHaveBeenCalledWith('winget_id', 'r12f.DivoomGateway');
+    expect(builder.eq).toHaveBeenCalledWith('version', '0.1.42.0');
+    expect(builder.eq).toHaveBeenCalledWith('architecture', 'x64');
+    expect(builder.eq).toHaveBeenCalledWith('installer_sha256', installerSha256);
+    expect(result).toMatchObject({
+      version: '0.1.42.0',
+      code: 'expired_signing_certificate',
+    });
+  });
+
+  it('returns null for a future version that has no exact block', async () => {
+    const builder = exactTupleQuery({ data: null, error: null });
+    const client = { from: vi.fn(() => builder) };
+
+    await expect(getPackageCompatibilityBlock(client as never, {
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.43.0',
+      architecture: 'x64',
+      installerSha256: 'B'.repeat(64),
+    })).resolves.toBeNull();
+
+    expect(builder.eq).toHaveBeenCalledWith('version', '0.1.43.0');
+    expect(builder.eq).toHaveBeenCalledWith('installer_sha256', 'B'.repeat(64));
   });
 });

--- a/lib/package-eligibility.ts
+++ b/lib/package-eligibility.ts
@@ -13,8 +13,23 @@ export interface PackageEligibilityBlock {
   code: PackageEligibilityBlockCode;
 }
 
+export type PackageCompatibilityBlockCode =
+  Database['public']['Tables']['qa_package_blocks']['Row']['block_code'];
+
+export interface PackageCompatibilityBlock {
+  wingetId: string;
+  version: string;
+  architecture: 'x64' | 'x86' | 'arm64';
+  installerSha256: string;
+  code: PackageCompatibilityBlockCode;
+  detail: string;
+}
+
 export const PACKAGE_UNAVAILABLE_MESSAGE =
   'This app is not available for automated deployment.';
+
+export const PACKAGE_VERSION_UNAVAILABLE_MESSAGE =
+  'This app version is not available for automated deployment.';
 
 export interface CatalogExclusion {
   wingetId: string;
@@ -69,4 +84,53 @@ export async function getPackageEligibilityBlocks(
     wingetId: row.winget_id,
     code: row.block_code,
   }));
+}
+
+/**
+ * Look up a reviewed compatibility block for one immutable installer payload.
+ * Exact tuple matching prevents a bad vendor release from reaching either QA
+ * or customer packaging without disabling a future corrected release.
+ */
+export async function getPackageCompatibilityBlock(
+  supabase: SupabaseClient<Database>,
+  input: {
+    wingetId: string;
+    version: string;
+    architecture: string;
+    installerSha256: string;
+  }
+): Promise<PackageCompatibilityBlock | null> {
+  const architecture = input.architecture.trim().toLowerCase();
+  const installerSha256 = input.installerSha256.trim().toUpperCase();
+  if (
+    !input.wingetId.trim() ||
+    !input.version.trim() ||
+    !['x64', 'x86', 'arm64'].includes(architecture) ||
+    !/^[A-F0-9]{64}$/.test(installerSha256)
+  ) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from('qa_package_blocks')
+    .select('winget_id, version, architecture, installer_sha256, block_code, detail')
+    .eq('winget_id', input.wingetId.trim())
+    .eq('version', input.version.trim())
+    .eq('architecture', architecture as 'x64' | 'x86' | 'arm64')
+    .eq('installer_sha256', installerSha256)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Could not verify package compatibility: ${error.message}`);
+  }
+
+  return data
+    ? {
+        wingetId: data.winget_id,
+        version: data.version,
+        architecture: data.architecture,
+        installerSha256: data.installer_sha256,
+        code: data.block_code,
+        detail: data.detail,
+      }
+    : null;
 }

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -3,8 +3,13 @@ import { ensureQaDemand, type QaDemandInput } from '@/lib/qa/demand';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { WingetDependencyCompatibilityError } from '@/lib/winget-dependencies';
 
-const { resolveWingetPackageDependenciesMock, getPackageEligibilityBlocksMock } = vi.hoisted(() => ({
+const {
+  resolveWingetPackageDependenciesMock,
+  getPackageCompatibilityBlockMock,
+  getPackageEligibilityBlocksMock,
+} = vi.hoisted(() => ({
   resolveWingetPackageDependenciesMock: vi.fn(),
+  getPackageCompatibilityBlockMock: vi.fn(),
   getPackageEligibilityBlocksMock: vi.fn(),
 }));
 
@@ -20,6 +25,7 @@ vi.mock('@/lib/package-eligibility', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/lib/package-eligibility')>();
   return {
     ...original,
+    getPackageCompatibilityBlock: getPackageCompatibilityBlockMock,
     getPackageEligibilityBlocks: getPackageEligibilityBlocksMock,
   };
 });
@@ -68,6 +74,8 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     resolveWingetPackageDependenciesMock.mockResolvedValue([]);
     getPackageEligibilityBlocksMock.mockReset();
     getPackageEligibilityBlocksMock.mockResolvedValue([]);
+    getPackageCompatibilityBlockMock.mockReset();
+    getPackageCompatibilityBlockMock.mockResolvedValue(null);
   });
 
   it('does not queue or resolve dependencies for a retired catalog app', async () => {
@@ -101,6 +109,38 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     });
     expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
     expect(getPackageEligibilityBlocksMock).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('blocks an exact reviewed installer tuple before resolving dependencies', async () => {
+    getPackageCompatibilityBlockMock.mockResolvedValue({
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+      architecture: 'x64',
+      installerSha256: 'A'.repeat(64),
+      code: 'expired_signing_certificate',
+      detail: 'The signing certificate is expired.',
+    });
+    const client = { from: vi.fn() };
+
+    const result = await ensureQaDemand(client as never, {
+      ...demandInput(),
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+    });
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      candidateId: null,
+      failureSummary: 'This app version is not available for automated deployment.',
+    });
+    expect(getPackageCompatibilityBlockMock).toHaveBeenCalledWith(client, {
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+      architecture: 'x64',
+      installerSha256: 'A'.repeat(64),
+    });
+    expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
     expect(client.from).not.toHaveBeenCalled();
   });
 

--- a/lib/qa/demand.ts
+++ b/lib/qa/demand.ts
@@ -17,8 +17,10 @@ import type { Json } from '@/types/database';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { resolveApplicationInstallScope } from '@/lib/packaging-adapters';
 import {
+  getPackageCompatibilityBlock,
   getPackageEligibilityBlocks,
   PACKAGE_UNAVAILABLE_MESSAGE,
+  PACKAGE_VERSION_UNAVAILABLE_MESSAGE,
 } from '@/lib/package-eligibility';
 import { shouldReactivateSupersededCandidate } from '@/lib/qa/candidate-reactivation';
 
@@ -74,6 +76,20 @@ export async function ensureQaDemand(
       candidateId: null,
       state: 'failed',
       failureSummary: PACKAGE_UNAVAILABLE_MESSAGE,
+    };
+  }
+  const compatibilityBlock = await getPackageCompatibilityBlock(supabase, {
+    wingetId: input.wingetId,
+    version: input.version,
+    architecture: input.architecture || 'x64',
+    installerSha256: input.installerSha256,
+  });
+  if (compatibilityBlock) {
+    return {
+      identity: normalizeQaWorkflowPackageInput(baseResolvedInput).identity,
+      candidateId: null,
+      state: 'failed',
+      failureSummary: PACKAGE_VERSION_UNAVAILABLE_MESSAGE,
     };
   }
   // Resolve at the QA-demand boundary as well as at final packaging dispatch.

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { QaResultRow } from '@/types/qa';
 
-const { getQaResultMock, getPackageResultMock, packageEqMock } = vi.hoisted(() => ({
+const {
+  getQaResultMock,
+  getPackageCompatibilityBlockMock,
+  getPackageResultMock,
+  packageEqMock,
+} = vi.hoisted(() => ({
   getQaResultMock: vi.fn(),
+  getPackageCompatibilityBlockMock: vi.fn(),
   getPackageResultMock: vi.fn(),
   packageEqMock: vi.fn(),
 }));
@@ -26,8 +32,21 @@ vi.mock('@/lib/supabase', () => ({
     },
   }),
 }));
+vi.mock('@/lib/package-eligibility', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/package-eligibility')>();
+  return {
+    ...original,
+    getPackageCompatibilityBlock: getPackageCompatibilityBlockMock,
+  };
+});
 
-import { enforceQaGate, QaGateError, QaGateNotPassedError, QaSecurityGateError } from './gate';
+import {
+  enforceQaGate,
+  QaCompatibilityGateError,
+  QaGateError,
+  QaGateNotPassedError,
+  QaSecurityGateError,
+} from './gate';
 
 const installerSha256 = 'A'.repeat(64);
 const packageProfileSha256 = 'B'.repeat(64);
@@ -71,6 +90,8 @@ const failedRow = {
 describe('enforceQaGate', () => {
   beforeEach(() => {
     getQaResultMock.mockReset();
+    getPackageCompatibilityBlockMock.mockReset();
+    getPackageCompatibilityBlockMock.mockResolvedValue(null);
     getPackageResultMock.mockReset();
     packageEqMock.mockReset();
   });
@@ -166,6 +187,27 @@ describe('enforceQaGate', () => {
         qaOverride: true,
       })
     ).rejects.toBeInstanceOf(QaSecurityGateError);
+  });
+
+  it('does not allow a QA override to bypass an exact compatibility block', async () => {
+    getPackageCompatibilityBlockMock.mockResolvedValueOnce({
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+      architecture: 'x64',
+      installerSha256,
+      code: 'expired_signing_certificate',
+      detail: 'The signing certificate is expired.',
+    });
+
+    await expect(enforceQaGate({
+      wingetId: 'r12f.DivoomGateway',
+      version: '0.1.42.0',
+      architecture: 'x64',
+      installerSha256,
+      qaOverride: true,
+    })).rejects.toBeInstanceOf(QaCompatibilityGateError);
+
+    expect(getPackageResultMock).not.toHaveBeenCalled();
   });
 
   it('blocks a flagged current version even when its installation test passed', async () => {

--- a/lib/qa/gate.ts
+++ b/lib/qa/gate.ts
@@ -1,6 +1,10 @@
 import { getCatalogSource } from '@/lib/catalog';
 import { classifyQaFailure } from '@/lib/qa/classify';
 import { createServerClient } from '@/lib/supabase';
+import {
+  getPackageCompatibilityBlock,
+  type PackageCompatibilityBlockCode,
+} from '@/lib/package-eligibility';
 import type { QaClassification } from '@/types/qa';
 
 export class QaGateError extends Error {
@@ -67,17 +71,44 @@ export class QaSecurityGateError extends Error {
   }
 }
 
-export type AnyQaGateError = QaGateError | QaGateNotPassedError | QaSecurityGateError;
+export class QaCompatibilityGateError extends Error {
+  readonly code = 'QA_PACKAGE_COMPATIBILITY_BLOCKED' as const;
+
+  constructor(
+    readonly details: {
+      wingetId: string;
+      version: string;
+      architecture: string;
+      installerSha256: string;
+      blockCode: PackageCompatibilityBlockCode;
+    }
+  ) {
+    super(
+      `Automated deployment is unavailable for ${details.wingetId} ${details.version} (${details.architecture})`
+    );
+    this.name = 'QaCompatibilityGateError';
+  }
+}
+
+export type AnyQaGateError =
+  | QaGateError
+  | QaGateNotPassedError
+  | QaSecurityGateError
+  | QaCompatibilityGateError;
 
 export function isQaGateError(error: unknown): error is AnyQaGateError {
   return (
     error instanceof QaGateError ||
     error instanceof QaGateNotPassedError ||
-    error instanceof QaSecurityGateError
+    error instanceof QaSecurityGateError ||
+    error instanceof QaCompatibilityGateError
   );
 }
 
 export function describeQaGateError(error: AnyQaGateError): string {
+  if (error instanceof QaCompatibilityGateError) {
+    return `${error.message}. This exact installer release has a reviewed compatibility block; a future corrected vendor release remains eligible for QA.`;
+  }
   if (error instanceof QaSecurityGateError) {
     return `${error.message}. Packaging is blocked for this version until the finding is reviewed. Earlier versions with a clean verdict remain available.`;
   }
@@ -108,6 +139,26 @@ export async function enforceQaGate(input: {
   const architecture = (input.architecture || 'x64').toLowerCase();
   const installerSha256 = input.installerSha256?.trim().toUpperCase() || '';
   const packageProfileSha256 = input.packageProfileSha256?.trim().toUpperCase() || '';
+
+  // Reviewed exact-payload compatibility blocks cannot be bypassed. These are
+  // upstream or platform safety boundaries, not ordinary QA failures.
+  if (installerSha256) {
+    const compatibilityBlock = await getPackageCompatibilityBlock(createServerClient(), {
+      wingetId: input.wingetId,
+      version: input.version,
+      architecture,
+      installerSha256,
+    });
+    if (compatibilityBlock) {
+      throw new QaCompatibilityGateError({
+        wingetId: input.wingetId,
+        version: input.version,
+        architecture,
+        installerSha256,
+        blockCode: compatibilityBlock.code,
+      });
+    }
+  }
 
   // Security gate: a malicious VirusTotal verdict for this exact installer
   // blocks packaging even when the installability gate is overridden.

--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -821,6 +821,31 @@ describe('QA package compatibility block expansion contract', () => {
   });
 });
 
+describe('Divoom expired signing certificate block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831152500_block_divoom_expired_signing_certificate.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact rejected vendor payload', () => {
+    expect(sql).toContain("'r12f.DivoomGateway'");
+    expect(sql).toContain("'0.1.42.0'");
+    expect(sql).toContain("'x64'");
+    expect(sql).toContain(
+      "'3C76B4F9B0539A6C617E424A333F857B61402BD001FCECB8E325D0134CD3C16A'"
+    );
+    expect(sql).toContain("'expired_signing_certificate'");
+    expect(sql).toContain('0x800B0101');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831152500_block_divoom_expired_signing_certificate.sql
+++ b/supabase/migrations/20260831152500_block_divoom_expired_signing_certificate.sql
@@ -1,0 +1,41 @@
+-- Divoom Gateway 0.1.42.0 is distributed as an MSIX whose signing
+-- certificate is outside its validity period. Windows provisioning rejects
+-- the exact vendor payload with CERT_E_EXPIRED (0x800B0101). Keep this
+-- immutable release out of QA and customer packaging without disabling a
+-- future vendor release signed with a valid certificate.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'r12f.DivoomGateway',
+  '0.1.42.0',
+  'x64',
+  '3C76B4F9B0539A6C617E424A333F857B61402BD001FCECB8E325D0134CD3C16A',
+  'expired_signing_certificate',
+  'Windows rejected the vendor MSIX during isolated machine provisioning with CERT_E_EXPIRED (0x800B0101). The exact installer is blocked until the vendor publishes a newly signed release.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();

--- a/types/database.ts
+++ b/types/database.ts
@@ -329,6 +329,7 @@ export interface Database {
             | 'user_scope_elevation_required'
             | 'trusted_installer_tuple_unavailable'
             | 'unsupported_dependency_shape'
+            | 'expired_signing_certificate'
             | 'unreviewed_dependency';
           detail: string;
           observed_at: string;

--- a/types/update-policies.ts
+++ b/types/update-policies.ts
@@ -216,7 +216,8 @@ export interface TriggerUpdateResponse {
     code?:
       | 'QA_FAILED_CURRENT_VERSION'
       | 'QA_NOT_PASSED_CURRENT_VERSION'
-      | 'QA_SECURITY_FLAGGED_CURRENT_VERSION';
+      | 'QA_SECURITY_FLAGGED_CURRENT_VERSION'
+      | 'QA_PACKAGE_COMPATIBILITY_BLOCKED';
     packaging_job_id?: string;
     error?: string;
   }[];


### PR DESCRIPTION
## Summary
- persist an exact app/version/architecture/SHA compatibility block for r12f.DivoomGateway 0.1.42.0
- enforce exact compatibility blocks at customer QA demand and final packaging dispatch, including QA overrides
- propagate the fail-closed result through manual, auto-update, and MSP packaging paths
- keep future Divoom versions and hashes eligible for normal QA

## Evidence
- isolated lifecycle run 33394641762 failed machine MSIX provisioning with 0x800B0101 / CERT_E_EXPIRED
- exact installer SHA256: 3C76B4F9B0539A6C617E424A333F857B61402BD001FCECB8E325D0134CD3C16A
- VirusTotal: 0 malicious, 0 suspicious (77 engines), so this is a signing-validity compatibility failure rather than a malware verdict

## Verification
- 171 focused tests passed across eligibility, QA demand/gates, MSP, auto-update, and migration contracts
- ESLint passed on all changed TypeScript files
- no TypeScript errors in changed production files