### PR TITLE
fix(qa): block WeSing user-elevation payload

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -846,6 +846,31 @@ describe('Divoom expired signing certificate block contract', () => {
   });
 });
 
+describe('WeSing user-scope elevation block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831162000_block_wesing_user_scope_elevation.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact rejected standard-user payload', () => {
+    expect(sql).toContain("'Tencent.WeSingLiveAssistant'");
+    expect(sql).toContain("'0.0.0.0'");
+    expect(sql).toContain("'x86'");
+    expect(sql).toContain(
+      "'0D009D4ACEB24BDC8220357E972B4D17B0B9D5BFA8B1E637EBC87BF8C5FADDCC'"
+    );
+    expect(sql).toContain("'user_scope_elevation_required'");
+    expect(sql).toContain('ERROR_CANCELLED');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831162000_block_wesing_user_scope_elevation.sql
+++ b/supabase/migrations/20260831162000_block_wesing_user_scope_elevation.sql
@@ -1,0 +1,29 @@
+-- WeSing Live Assistant 0.0.0.0 is declared as a per-user silent installer,
+-- but isolated standard-user QA proved that launching the exact payload with
+-- the published /s switch requests elevation and eventually returns Windows
+-- ERROR_CANCELLED. No vendor uninstall registration is created. Running this
+-- payload as LocalSystem would target the wrong user profile, so keep only
+-- this immutable release out of QA and customer deployment. A corrected
+-- future release remains independently eligible.
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'Tencent.WeSingLiveAssistant',
+  '0.0.0.0',
+  'x86',
+  '0D009D4ACEB24BDC8220357E972B4D17B0B9D5BFA8B1E637EBC87BF8C5FADDCC',
+  'user_scope_elevation_required',
+  'The vendor declares a per-user /s install, but the exact payload requests elevation under the standard-user Intune contract, returns ERROR_CANCELLED, and creates no authoritative uninstall registration.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();


### PR DESCRIPTION
## Summary
- block only Tencent.WeSingLiveAssistant 0.0.0.0 x86 with its exact installer SHA
- classify the payload as user_scope_elevation_required
- keep future vendor releases independently eligible for QA and deployment

## Evidence
- WinGet declares user scope and silent switch /s
- isolated standard-user lifecycle run 33399983466 failed 60001/1/60001/1
- bounded redacted PSADT diagnostic run 33401536165 recorded Start-ADTProcess failing because the launch requested elevation and Windows returned ERROR_CANCELLED
- no authoritative vendor uninstall registration was created
- VirusTotal: 0 malicious, 0 suspicious, 73 engines

## Verification
- migration contract suite: 110 tests passed
- focused ESLint passed