### PR TITLE
fix(qa): block Kangaroo system-profile payload

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -871,6 +871,32 @@ describe('WeSing user-scope elevation block contract', () => {
   });
 });
 
+describe('Kangaroo machine-scope system-profile block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831165500_block_kangaroo_system_profile_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact unusable machine-scope payload', () => {
+    expect(sql).toContain("'Taozuhong.KangarooMultiple'");
+    expect(sql).toContain("'9.7.1.801'");
+    expect(sql).toContain("'x64'");
+    expect(sql).toContain(
+      "'EFFD25236CD45111EB28E075C2AF4CD1CF9DEF23B9DEB2F728B355D8C62710E2'"
+    );
+    expect(sql).toContain("'machine_scope_system_profile_install'");
+    expect(sql).toContain('LocalSystem');
+    expect(sql).toContain('missing uninstaller');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831165500_block_kangaroo_system_profile_install.sql
+++ b/supabase/migrations/20260831165500_block_kangaroo_system_profile_install.sql
@@ -1,0 +1,44 @@
+-- Kangaroo Multiple 9.7.1.801 is declared as a machine-scope Nullsoft
+-- installer, but isolated LocalSystem QA proved that the exact payload
+-- registers its primary application below the SYSTEM profile and records an
+-- uninstall executable that does not exist. The payload therefore cannot
+-- satisfy a usable, removable machine-wide Intune lifecycle. Keep only this
+-- immutable release out of QA and customer packaging; a corrected future
+-- release remains independently eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'Taozuhong.KangarooMultiple',
+  '9.7.1.801',
+  'x64',
+  'EFFD25236CD45111EB28E075C2AF4CD1CF9DEF23B9DEB2F728B355D8C62710E2',
+  'machine_scope_system_profile_install',
+  'The vendor declares a machine-scope Nullsoft install, but the exact payload registers its primary application below the LocalSystem profile and references a missing uninstaller, so it cannot satisfy a machine-wide Intune lifecycle.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();

--- a/types/database.ts
+++ b/types/database.ts
@@ -327,6 +327,7 @@ export interface Database {
           block_code:
             | 'user_scope_machine_dependencies'
             | 'user_scope_elevation_required'
+            | 'machine_scope_system_profile_install'
             | 'trusted_installer_tuple_unavailable'
             | 'unsupported_dependency_shape'
             | 'expired_signing_certificate'


### PR DESCRIPTION
## Summary
- block only Taozuhong.KangarooMultiple 9.7.1.801 x64 with its exact immutable installer hash
- record the reviewed LocalSystem/system-profile incompatibility in the private QA compatibility table
- keep future corrected versions eligible while enforcing the existing customer and QA fail-closed gate

## Evidence
- isolated PSADT lifecycle: install 0, detection 0, uninstall 60001, removal detection 0
- exact ARP entry referenced a missing uninstaller below the LocalSystem profile
- official WinGet manifest declares this payload machine scope
- VirusTotal: 0 malicious, 0 suspicious across 75 engines

## Verification
- migration contract: 111 passed
- package eligibility, QA gate, and demand suites: 34 passed
- focused ESLint: passed
- repository-wide standalone tsc remains red on pre-existing test-global/type errors unrelated to this change