### PR TITLE
fix(qa): block Crypt payload without install identity

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -897,6 +897,32 @@ describe('Kangaroo machine-scope system-profile block contract', () => {
   });
 });
 
+describe('Crypt missing install identity block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831173000_block_crypt_missing_install_identity.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact payload without an authoritative lifecycle', () => {
+    expect(sql).toContain("'TheCryptTeam.Crypt'");
+    expect(sql).toContain("'1.6.0'");
+    expect(sql).toContain("'x64'");
+    expect(sql).toContain(
+      "'816DE63CB4F8E09C76B932EED6E92577CFCF97BD8FA9D29937BE88EBA49C9CC5'"
+    );
+    expect(sql).toContain("'missing_authoritative_install_identity'");
+    expect(sql).toContain('WebView2 runtime registration');
+    expect(sql).toContain('safe removal are impossible');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831173000_block_crypt_missing_install_identity.sql
+++ b/supabase/migrations/20260831173000_block_crypt_missing_install_identity.sql
@@ -1,0 +1,44 @@
+-- Crypt 1.6.0's Inno wrapper exits successfully but creates no authoritative
+-- Crypt uninstall registration. Isolated LocalSystem QA observed only a
+-- WebView2 runtime registration change, so the shared packager cannot prove
+-- that Crypt installed or remove it safely. Keep this immutable payload out
+-- of QA and customer packaging without disabling a future vendor release
+-- that exposes a complete managed lifecycle.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'TheCryptTeam.Crypt',
+  '1.6.0',
+  'x64',
+  '816DE63CB4F8E09C76B932EED6E92577CFCF97BD8FA9D29937BE88EBA49C9CC5',
+  'missing_authoritative_install_identity',
+  'The exact Inno payload exits successfully but creates no authoritative Crypt install or uninstall registration; only a WebView2 runtime registration changes, so install verification and safe removal are impossible.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();

--- a/types/database.ts
+++ b/types/database.ts
@@ -328,6 +328,7 @@ export interface Database {
             | 'user_scope_machine_dependencies'
             | 'user_scope_elevation_required'
             | 'machine_scope_system_profile_install'
+            | 'missing_authoritative_install_identity'
             | 'trusted_installer_tuple_unavailable'
             | 'unsupported_dependency_shape'
             | 'expired_signing_certificate'


### PR DESCRIPTION
## Summary

- add a fail-closed production block for the exact `TheCryptTeam.Crypt` 1.6.0 x64 installer payload
- add the typed `missing_authoritative_install_identity` block reason
- keep future vendor versions eligible for QA and packaging

## QA evidence

- candidate: `289d0446-c68f-432a-aa9a-41341fb65d7b`
- workflow: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33407559292
- installer SHA-256: `816DE63CB4F8E09C76B932EED6E92577CFCF97BD8FA9D29937BE88EBA49C9CC5`
- strict tuple: `60001/1/60001/1`
- VirusTotal: `0 malicious / 0 suspicious / 76 harmless`
- the Inno wrapper returned success but created no authoritative Crypt install/uninstall registration; the only changed ARP entry was WebView2 Runtime
- without a stable install identity or owned directory contract, install verification and safe uninstall cannot be guaranteed for Intune customers

## Scope

This blocks only the exact immutable tuple (WinGet ID, version, architecture, installer SHA). It does not disable the catalog app or block a corrected future release.

## Verification

- `npm test -- lib/qa/migration-contract.test.ts` - 112 passed
- `npm test -- lib/package-eligibility.test.ts lib/qa/gate.test.ts lib/qa/demand.test.ts` - 34 passed
- `npx eslint lib/qa/migration-contract.test.ts types/database.ts` - passed