### PR TITLE
fix(qa): block StudioTrans system-profile payload

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -923,6 +923,32 @@ describe('Crypt missing install identity block contract', () => {
   });
 });
 
+describe('StudioTrans machine-scope system-profile block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831182500_block_studiotrans_system_profile_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact payload with an unusable machine lifecycle', () => {
+    expect(sql).toContain("'xinpianchang.StudioTrans'");
+    expect(sql).toContain("'1.2.4'");
+    expect(sql).toContain("'x64'");
+    expect(sql).toContain(
+      "'67E5BD9AB9774F386BFD4EBE06FC4A3F06EC00E0B8AF68A48FBF5CCB8E0ADD85'"
+    );
+    expect(sql).toContain("'machine_scope_system_profile_install'");
+    expect(sql).toContain('LocalSystem profile');
+    expect(sql).toContain('missing uninstaller');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831182500_block_studiotrans_system_profile_install.sql
+++ b/supabase/migrations/20260831182500_block_studiotrans_system_profile_install.sql
@@ -1,0 +1,45 @@
+-- StudioTrans 1.2.4 is a Nullsoft installer without an authoritative
+-- machine-scope contract. Isolated LocalSystem QA proved that the exact
+-- payload registers its primary application below the SYSTEM profile and
+-- references an uninstall executable that does not exist. The payload cannot
+-- satisfy a usable, removable machine-wide Intune lifecycle. Keep only this
+-- immutable release out of QA and customer packaging so a corrected future
+-- release remains independently eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'xinpianchang.StudioTrans',
+  '1.2.4',
+  'x64',
+  '67E5BD9AB9774F386BFD4EBE06FC4A3F06EC00E0B8AF68A48FBF5CCB8E0ADD85',
+  'machine_scope_system_profile_install',
+  'The exact Nullsoft payload registers its primary application below the LocalSystem profile and references a missing uninstaller, so it cannot satisfy a usable and removable machine-wide Intune lifecycle.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();


### PR DESCRIPTION
## Summary

- fail closed for the exact `xinpianchang.StudioTrans` 1.2.4 x64 installer payload
- reuse the existing `machine_scope_system_profile_install` classification
- keep future StudioTrans versions independently eligible for QA and packaging

## QA evidence

- candidate: `477d44af-6d79-4c80-9900-e9f0ccd7f74a`
- workflow: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33413119297
- bounded diagnostic: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33413791712
- installer SHA-256: `67E5BD9AB9774F386BFD4EBE06FC4A3F06EC00E0B8AF68A48FBF5CCB8E0ADD85`
- strict tuple: `0/0/60001/0`
- install registered the primary app below `systemprofile\\AppData\\Local\\Programs\\studiotrans`
- the registered uninstaller was missing, so safe removal and machine-wide lifecycle verification are impossible
- official WinGet manifest declares Nullsoft but no authoritative machine-scope contract: https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests/x/xinpianchang/StudioTrans/1.2.4/xinpianchang.StudioTrans.installer.yaml

## Scope

This blocks only the exact immutable tuple (WinGet ID, version, architecture, installer SHA). It does not disable the catalog app or block a corrected future release.

## Verification

- `npm test -- lib/qa/migration-contract.test.ts` - 113 passed
- `npm test -- lib/package-eligibility.test.ts lib/qa/gate.test.ts lib/qa/demand.test.ts` - 34 passed
- `npx eslint lib/qa/migration-contract.test.ts` - passed