### PR TITLE
fix(qa): block Y8 Browser system-profile payload

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -949,6 +949,33 @@ describe('StudioTrans machine-scope system-profile block contract', () => {
   });
 });
 
+describe('Y8 Browser machine-scope system-profile block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260831191500_block_y8browser_system_profile_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact payload with an unusable machine lifecycle', () => {
+    expect(sql).toContain("'Y8Games.Y8Browser'");
+    expect(sql).toContain("'1.0.11'");
+    expect(sql).toContain("'x86'");
+    expect(sql).toContain(
+      "'AE0FA64D18AE2423939AC7015A2CC2F6BC781DAD57760B1FED60BD76609991C8'"
+    );
+    expect(sql).toContain("'machine_scope_system_profile_install'");
+    expect(sql).toContain('LocalSystem profile');
+    expect(sql).toContain('missing vendor uninstaller');
+    expect(sql).toContain('33417125026');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260831191500_block_y8browser_system_profile_install.sql
+++ b/supabase/migrations/20260831191500_block_y8browser_system_profile_install.sql
@@ -1,0 +1,46 @@
+-- Y8 Browser 1.0.11 is an NSIS installer without an authoritative
+-- machine-scope contract. Isolated LocalSystem QA installed the exact x86
+-- payload below the SYSTEM profile and captured its vendor uninstall entry,
+-- but the registered Uninstall Y8 Browser.exe did not exist. The exact
+-- lifecycle failed closed in run 33417125026 and cannot provide a usable,
+-- removable machine-wide Intune deployment. Keep only this immutable release
+-- out of QA and customer packaging so a corrected future release remains
+-- independently eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'Y8Games.Y8Browser',
+  '1.0.11',
+  'x86',
+  'AE0FA64D18AE2423939AC7015A2CC2F6BC781DAD57760B1FED60BD76609991C8',
+  'machine_scope_system_profile_install',
+  'The exact NSIS payload installs below the LocalSystem profile and registers a missing vendor uninstaller, so it cannot satisfy a usable and removable machine-wide Intune lifecycle.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();


### PR DESCRIPTION
## Summary
- block only Y8Games.Y8Browser 1.0.11 x86 with SHA AE0FA64D18AE2423939AC7015A2CC2F6BC781DAD57760B1FED60BD76609991C8
- record the proven LocalSystem profile install with missing registered vendor uninstaller
- keep future Y8 Browser versions eligible

## Evidence
- lifecycle run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33417125026
- bounded diagnostic: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33418036923
- exact result: install 0, detect 0, uninstall 60001, removal detect 0
- VirusTotal: 0 malicious / 0 suspicious / 75 engines

## Verification
- 139 focused Vitest contracts passed
- ESLint passed
- git diff --check passed