### PR TITLE
fix(packager): keep Retoolkit install observable

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -613,6 +613,17 @@ describe('application packaging adapters', () => {
     });
   });
 
+  it('keeps the Retoolkit component bundle observable within a bounded wait', () => {
+    expect(
+      applyApplicationPackagingAdapter(
+        'mentebinaria.retoolkit',
+        DEFAULT_PSADT_CONFIG
+      )
+    ).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('keeps the ARES Commander bootstrapper observable within a bounded wait', () => {
     expect(
       applyApplicationPackagingAdapter(

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -447,6 +447,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedInstallCompletionTimeoutMinutes: 15,
   },
   {
+    // Retoolkit's official Inno package installs a large, explicitly selected
+    // reverse-engineering toolset. Isolated LocalSystem QA run 33421632555
+    // observed the exact ARP registration and a successful exact uninstall,
+    // but the vendor process remained quiet beyond the generic inactivity
+    // window. Preserve WinGet's /VERYSILENT component contract and use the
+    // shared observable, fail-closed wait for QA and customer Intune packages.
+    wingetId: 'mentebinaria.retoolkit',
+    reviewedInstallCompletionTimeoutMinutes: 15,
+  },
+  {
     // FlashPrint 5.8.3 is distributed as a ZIP containing an Advanced
     // Installer bootstrapper. Its manifest-provided unattended command stays
     // alive without observable file-system activity for longer than the

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1391,6 +1391,38 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
   });
 
+  it('binds the bounded Retoolkit component wait to customer and QA packaging', () => {
+    const silentSwitches =
+      '/VERYSILENT /NORESTART /COMPONENTS="*android,*debuggers,*utilities,!network\\\\nmap"';
+    const uninstallCommand =
+      "REGISTRY_UNINSTALL_KEY:{BB46345D-F5E9-408E-AA39-64A5EDD92E30}_is1:Reverse Engineer's Toolkit (retoolkit)";
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'mentebinaria.retoolkit',
+      displayName: "Reverse Engineer's Toolkit (retoolkit)",
+      publisher: 'mentebinaria',
+      version: '2023.05',
+      architecture: 'x64',
+      installerSha256: '1'.repeat(64),
+      installerType: 'inno',
+      silentSwitches,
+      uninstallCommand,
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { silentArgs: string; uninstallCommand: string };
+      psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
+    };
+
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.installer.silentArgs).toBe(silentSwitches);
+    expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
+      reviewedInstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('binds the bounded FlashPrint nested EXE wait to customer and QA packaging', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Flashforge.FlashPrint',


### PR DESCRIPTION
## Summary
- add a reviewed 15-minute observable install-completion ceiling for mentebinaria.retoolkit
- preserve WinGet's exact /VERYSILENT component selection and exact ARP uninstall identity
- bind the adapter to both customer PSADT packaging and QA execution-profile identity

## Evidence
- failed lifecycle: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33421632555
- bounded diagnostic: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33423461468
- exact ARP registration existed and exact vendor uninstall completed successfully
- failure was the 459-second generic no-activity guard before marker publication

## Verification
- 357 focused adapter/profile/PSADT contract tests passed
- ESLint passed
- git diff --check passed