### PR TITLE
chore(qa): activate Retoolkit install heartbeat adapter

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '738d9f19baa44d2e1f0cf49c4fea5658915cefc9',
+  packagerCommit: '92ddbf527ab5e698bb81937b97efc96523622a96',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,14 +6,26 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Quassel only after activating its exact uninstall identity', () => {
-    const wingetId = 'Quassel.QuasselIRC';
+  it('retries Retoolkit only after activating bounded install heartbeats', () => {
+    const wingetId = 'mentebinaria.retoolkit';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
-      'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3',
+      '738d9f19baa44d2e1f0cf49c4fea5658915cefc9',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('keeps the exhausted Quassel retry scoped to its release', () => {
+    const wingetId = 'Quassel.QuasselIRC';
+    expect(shouldRetryTerminalToolchainCandidate(
+      '738d9f19baa44d2e1f0cf49c4fea5658915cefc9',
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId, status: 'failed' }
     )).toBe(false);
   });
@@ -584,6 +596,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'mentebinaria.retoolkit',
       'HiramWong.zyfun',
       'Domino.MaxTo',
       'Logitech.LGS',
@@ -652,6 +665,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'mentebinaria.retoolkit',
         'HiramWong.zyfun',
         'Logitech.LGS',
         'IrfanSkiljan.IrfanView',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -594,7 +594,18 @@ const QUASSEL_EXACT_UNINSTALL_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const RETOOLKIT_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS = [
+  // Retry Retoolkit with the shared, observable 15-minute installer wait so
+  // its large official component bundle is not mistaken for an inactive guest.
+  'mentebinaria.retoolkit',
+  // Quassel exhausted its reviewed retry at the prior pin; carry every older
+  // still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '92ddbf527ab5e698bb81937b97efc96523622a96':
+    RETOOLKIT_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '738d9f19baa44d2e1f0cf49c4fea5658915cefc9':
     QUASSEL_EXACT_UNINSTALL_IDENTITY_RELEASE_RETRY_TARGETS,
   'b1f9ded94342bd3e27fe17b50e17f5b9474c01a3':


### PR DESCRIPTION
## Summary
- pin QA package generation to packager commit 92ddbf527ab5e698bb81937b97efc96523622a96
- target Retoolkit for one exact toolchain retry at this release
- preserve prior release retry exhaustion for unrelated applications

## Evidence
The failed Retoolkit lifecycle registered its exact ARP identity and later uninstalled cleanly. Its official Inno installer remained quiet longer than the generic inactivity guard while installing the selected component bundle. The promoted shared adapter adds observable bounded install heartbeats without changing manifest switches or customer settings.

## Verification
- 276 focused tests passed
- ESLint passed
- git diff --check passed

Production QA remains paused until this promotion is deployed, the scheduler and required pin match, and the exact Retoolkit retest is queued.