### PR TITLE
fix(packaging): extend Retoolkit reviewed install wait

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -620,7 +620,7 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 15,
+      reviewedInstallCompletionTimeoutMinutes: 30,
     });
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -448,13 +448,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // Retoolkit's official Inno package installs a large, explicitly selected
-    // reverse-engineering toolset. Isolated LocalSystem QA run 33421632555
-    // observed the exact ARP registration and a successful exact uninstall,
-    // but the vendor process remained quiet beyond the generic inactivity
-    // window. Preserve WinGet's /VERYSILENT component contract and use the
-    // shared observable, fail-closed wait for QA and customer Intune packages.
+    // reverse-engineering toolset. Isolated LocalSystem QA run 33428216044
+    // showed that the exact vendor process was still active at 15 minutes and
+    // completed its ARP registration roughly 2.5 minutes later; its registered
+    // uninstaller then removed the app cleanly. Preserve WinGet's /VERYSILENT
+    // component contract and use the existing reviewed 30-minute ceiling to
+    // leave bounded headroom on slower Intune devices while keeping QA and
+    // customer packages observable and fail closed.
     wingetId: 'mentebinaria.retoolkit',
-    reviewedInstallCompletionTimeoutMinutes: 15,
+    reviewedInstallCompletionTimeoutMinutes: 30,
   },
   {
     // FlashPrint 5.8.3 is distributed as a ZIP containing an Advanced

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1415,11 +1415,11 @@ describe('PSADT QA package identity', () => {
       psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
     };
 
-    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(30);
     expect(profile.installer.silentArgs).toBe(silentSwitches);
     expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
     expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 15,
+      reviewedInstallCompletionTimeoutMinutes: 30,
     });
   });
 


### PR DESCRIPTION
## Summary
- extend only mentebinaria.retoolkit from the reviewed 15-minute wait to the existing 30-minute long-installer ceiling
- preserve the exact WinGet /VERYSILENT component command and registered Inno uninstall identity
- bind the same bounded, observable behavior to catalog QA and customer PSADT package generation

## Evidence
Bounded diagnostic for isolated LocalSystem run 33428216044 showed the exact vendor process still active at 15 minutes. The app registered roughly 2.5 minutes later and its exact registered uninstaller removed it cleanly in about 7 seconds. A 20-minute ceiling would leave little margin for slower Intune devices, so this uses the already-supported 30-minute reviewed ceiling while remaining fail-closed.

## Verification
- 357 focused tests passed
- ESLint passed
- git diff --check passed

Production QA remains paused until this packager commit and the protected workflow pin are promoted together and the exact Retoolkit profile is retested.