### PR TITLE
chore(qa): activate Retoolkit extended install wait

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '92ddbf527ab5e698bb81937b97efc96523622a96',
+  packagerCommit: 'aafd4a7dd0787ea603c1c53bb8166369f81e39a7',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -562,6 +562,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // LocalSystem. Preserve every unrelated compatible pass from the ARES
   // Commander install-heartbeat release.
   '02334f8bff1ee97e68c81ef44fd4ed256df81397',
+  // Retoolkit's 30-minute ceiling changes only its previously failing long
+  // installer path. Preserve every unrelated compatible pass from the first
+  // Retoolkit heartbeat release.
+  '92ddbf527ab5e698bb81937b97efc96523622a96',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,10 +6,14 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Retoolkit only after activating bounded install heartbeats', () => {
+  it('retries Retoolkit after activating the extended bounded install wait', () => {
     const wingetId = 'mentebinaria.retoolkit';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '92ddbf527ab5e698bb81937b97efc96523622a96',
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -603,7 +603,20 @@ const RETOOLKIT_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const RETOOLKIT_EXTENDED_INSTALL_WAIT_RELEASE_RETRY_TARGETS = [
+  // The exact LocalSystem lifecycle proved that 15 minutes was insufficient,
+  // while the official installer registered roughly 2.5 minutes later and its
+  // registered uninstaller removed the app cleanly. Retry only Retoolkit with
+  // the existing observable, fail-closed 30-minute ceiling.
+  'mentebinaria.retoolkit',
+  // Retoolkit exhausted its first reviewed retry at the prior pin; carry every
+  // older still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'aafd4a7dd0787ea603c1c53bb8166369f81e39a7':
+    RETOOLKIT_EXTENDED_INSTALL_WAIT_RELEASE_RETRY_TARGETS,
   '92ddbf527ab5e698bb81937b97efc96523622a96':
     RETOOLKIT_INSTALL_HEARTBEAT_RELEASE_RETRY_TARGETS,
   '738d9f19baa44d2e1f0cf49c4fea5658915cefc9':


### PR DESCRIPTION
## Summary
- pin QA package generation to packager aafd4a7dd0787ea603c1c53bb8166369f81e39a7
- issue one exact Retoolkit retry with the evidence-backed 30-minute observable wait
- preserve unrelated compatible passes from the prior protected release

## Safety
Production QA remains paused after the 15-minute Retoolkit failure. The protected workflow pin will be promoted to this same immutable packager commit before guarded resume.

## Verification
- 276 focused tests passed
- ESLint passed
- git diff --check passed