### PR TITLE
fix(packaging): extend Retoolkit bounded install wait

### DIFF
--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -620,7 +620,7 @@ describe('application packaging adapters', () => {
         DEFAULT_PSADT_CONFIG
       )
     ).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 30,
+      reviewedInstallCompletionTimeoutMinutes: 45,
     });
   });
 

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -448,15 +448,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
   },
   {
     // Retoolkit's official Inno package installs a large, explicitly selected
-    // reverse-engineering toolset. Isolated LocalSystem QA run 33428216044
-    // showed that the exact vendor process was still active at 15 minutes and
-    // completed its ARP registration roughly 2.5 minutes later; its registered
-    // uninstaller then removed the app cleanly. Preserve WinGet's /VERYSILENT
-    // component contract and use the existing reviewed 30-minute ceiling to
-    // leave bounded headroom on slower Intune devices while keeping QA and
-    // customer packages observable and fail closed.
+    // reverse-engineering toolset. Isolated LocalSystem QA runs 33428216044 and
+    // 33434832863 showed the exact vendor process active at the reviewed 15- and
+    // 30-minute ceilings respectively. In both cases its exact ARP entry appeared
+    // shortly after the timeout and its registered uninstaller removed the app
+    // cleanly. Preserve WinGet's /VERYSILENT component contract and use a
+    // reviewed 45-minute ceiling to leave bounded headroom on slower Intune
+    // devices while keeping QA and customer packages observable and fail closed.
     wingetId: 'mentebinaria.retoolkit',
-    reviewedInstallCompletionTimeoutMinutes: 30,
+    reviewedInstallCompletionTimeoutMinutes: 45,
   },
   {
     // FlashPrint 5.8.3 is distributed as a ZIP containing an Advanced

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1415,11 +1415,11 @@ describe('PSADT QA package identity', () => {
       psadtConfig: { reviewedInstallCompletionTimeoutMinutes?: number };
     };
 
-    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(30);
+    expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(45);
     expect(profile.installer.silentArgs).toBe(silentSwitches);
     expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
     expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject({
-      reviewedInstallCompletionTimeoutMinutes: 30,
+      reviewedInstallCompletionTimeoutMinutes: 45,
     });
   });
 


### PR DESCRIPTION
Exact-app follow-up for mentebinaria.retoolkit. Isolated LocalSystem QA run 33434832863 kept the reviewed vendor process observable through 30 minutes, then timed out; the bounded redacted diagnostic showed its exact ARP registration present roughly 2.5 minutes later and its registered uninstaller removed the app cleanly in 7 seconds. This changes only Retoolkit's shared customer/QA PSADT adapter from a 30- to 45-minute observable, fail-closed ceiling. Focused adapter/package-profile suite: 215 passed; focused ESLint and diff checks passed. Production QA remains paused until merge, deployment, protected workflow pin synchronization, and exact retest.