### PR TITLE
chore(qa): activate Retoolkit 45-minute packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'aafd4a7dd0787ea603c1c53bb8166369f81e39a7',
+  packagerCommit: '96c197e74589388d9091d89e1385bbbd318f7bf8',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -566,6 +566,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // installer path. Preserve every unrelated compatible pass from the first
   // Retoolkit heartbeat release.
   '92ddbf527ab5e698bb81937b97efc96523622a96',
+  // Retoolkit's 45-minute ceiling changes only its still-failing long installer
+  // path. Preserve every unrelated compatible pass from the 30-minute release.
+  'aafd4a7dd0787ea603c1c53bb8166369f81e39a7',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,10 +6,14 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
-  it('retries Retoolkit after activating the extended bounded install wait', () => {
+  it('retries Retoolkit after activating the 45-minute bounded install wait', () => {
     const wingetId = 'mentebinaria.retoolkit';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'aafd4a7dd0787ea603c1c53bb8166369f81e39a7',
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -614,7 +614,20 @@ const RETOOLKIT_EXTENDED_INSTALL_WAIT_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const RETOOLKIT_45_MINUTE_INSTALL_WAIT_RELEASE_RETRY_TARGETS = [
+  // The exact LocalSystem lifecycle proved the vendor process still active at
+  // the 30-minute ceiling, while its exact ARP entry appeared shortly after and
+  // its registered uninstaller removed it cleanly. Retry only Retoolkit with
+  // the observable, fail-closed 45-minute ceiling.
+  'mentebinaria.retoolkit',
+  // Retoolkit exhausted its 30-minute retry at the prior pin; carry every older
+  // still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '96c197e74589388d9091d89e1385bbbd318f7bf8':
+    RETOOLKIT_45_MINUTE_INSTALL_WAIT_RELEASE_RETRY_TARGETS,
   'aafd4a7dd0787ea603c1c53bb8166369f81e39a7':
     RETOOLKIT_EXTENDED_INSTALL_WAIT_RELEASE_RETRY_TARGETS,
   '92ddbf527ab5e698bb81937b97efc96523622a96':


### PR DESCRIPTION
Promotes reviewed packager commit 96c197e74589388d9091d89e1385bbbd318f7bf8, preserves compatible pass history because the change is exact-app scoped, and grants mentebinaria.retoolkit one exact terminal retry with its observable, fail-closed 45-minute wait. The 30-minute run 33434832863 timed out while the vendor process remained active; its exact ARP entry appeared shortly afterward and its registered uninstaller removed it cleanly. Focused package-profile/toolchain suite: 276 passed; focused ESLint and diff checks passed. Production QA remains paused until deployment, protected workflow synchronization, and exact retest.