### PR TITLE
fix(qa): block unusable Retoolkit lifecycle

### DIFF
--- a/lib/qa/migration-contract.test.ts
+++ b/lib/qa/migration-contract.test.ts
@@ -976,6 +976,35 @@ describe('Y8 Browser machine-scope system-profile block contract', () => {
   });
 });
 
+describe('Retoolkit machine-scope system-profile block contract', () => {
+  const sql = readFileSync(
+    resolve(
+      process.cwd(),
+      'supabase/migrations/20260901004000_block_retoolkit_system_profile_install.sql'
+    ),
+    'utf8'
+  );
+
+  it('blocks only the exact payload with an unusable machine lifecycle', () => {
+    expect(sql).toContain("'mentebinaria.retoolkit'");
+    expect(sql).toContain("'2023.05'");
+    expect(sql).toContain("'x64'");
+    expect(sql).toContain(
+      "'1EB3511E8B816641D3EE6686BFC61329B54532BFD5CD8A65AA20F154EE55D120'"
+    );
+    expect(sql).toContain("'machine_scope_system_profile_install'");
+    expect(sql).toContain('LocalSystem profile');
+    expect(sql).toContain('reviewed 45-minute ceiling');
+    expect(sql).toContain('33428216044');
+    expect(sql).toContain('33434832863');
+    expect(sql).toContain('33441897643');
+    expect(sql).toContain(
+      'on conflict (winget_id, version, architecture, installer_sha256) do update'
+    );
+    expect(sql).not.toContain('update public.curated_apps');
+  });
+});
+
 describe('unsupported dependency shape compatibility block contract', () => {
   const sql = readFileSync(
     resolve(

--- a/supabase/migrations/20260901004000_block_retoolkit_system_profile_install.sql
+++ b/supabase/migrations/20260901004000_block_retoolkit_system_profile_install.sql
@@ -1,0 +1,46 @@
+-- Retoolkit 2023.05 is declared machine-scope by WinGet, but its official
+-- Inno package uses a per-user installation root. Under Intune's LocalSystem
+-- context the exact x64 payload therefore installs below the SYSTEM profile
+-- instead of providing a usable machine-wide application. Its large nested
+-- component bundle also kept the vendor process active beyond the reviewed
+-- 15-, 30-, and 45-minute ceilings in isolated runs 33428216044,
+-- 33434832863, and 33441897643. Keep only this immutable release out of QA
+-- and customer packaging so a corrected future release remains eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id,
+  version,
+  architecture,
+  installer_sha256,
+  block_code,
+  detail
+)
+values (
+  'mentebinaria.retoolkit',
+  '2023.05',
+  'x64',
+  '1EB3511E8B816641D3EE6686BFC61329B54532BFD5CD8A65AA20F154EE55D120',
+  'machine_scope_system_profile_install',
+  'The exact Inno payload is declared machine-scope but installs below the LocalSystem profile and its nested vendor installer does not complete within the reviewed 45-minute ceiling, so it cannot provide a usable machine-wide Intune lifecycle.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    observed_at = now(),
+    updated_at = now();


### PR DESCRIPTION
## Summary
- block only mentebinaria.retoolkit 2023.05 x64 with SHA-256 1EB3511E8B816641D3EE6686BFC61329B54532BFD5CD8A65AA20F154EE55D120
- record the LocalSystem profile mismatch and repeated 15/30/45-minute installer failures
- preserve eligibility for future versions or installer hashes

## Verification
- npx vitest run lib/qa/migration-contract.test.ts (115 passed)
- npx eslint lib/qa/migration-contract.test.ts
- git diff --check