### PR TITLE
Fix Notesnook per-user PSADT lifecycle

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -651,6 +651,59 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('uses Notesnook user scope consistently for customer PSADT packaging and QA', async () => {
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: 'https://github.com/streetwriters/notesnook/releases/download/v3.4.5/notesnook_win_x64.exe',
+      sha256: 'A'.repeat(64),
+      type: 'nullsoft',
+      silentArgs: '/S',
+      productCode: 'a05a6719-4910-5e6c-a2aa-9af71cd1063b',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'Streetwriters.Notesnook',
+          displayName: 'Notesnook',
+          version: '3.4.5',
+          installerType: 'nullsoft',
+          installScope: 'machine',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'Streetwriters.Notesnook',
+        installScope: 'user',
+      }),
+      expect.any(Array)
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ install_scope: 'user' })
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'Streetwriters.Notesnook',
+        installScope: 'user',
+      }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('uses Ente Photos user scope consistently for customer PSADT packaging and QA', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',

--- a/lib/auto-update/__tests__/trigger.test.ts
+++ b/lib/auto-update/__tests__/trigger.test.ts
@@ -616,6 +616,55 @@ describe('AutoUpdateTrigger psadtConfig handling', () => {
     expect(storedConfig.installScope).toBe('machine');
   });
 
+  it('uses Notesnook user scope for auto-update QA and packaging without mutating stored configuration', async () => {
+    const supabase = createSupabaseMock({});
+    const trigger = makeTrigger(supabase);
+    const storedConfig: DeploymentConfig = {
+      displayName: 'Notesnook',
+      publisher: 'Streetwriters',
+      architecture: 'x64',
+      installerType: 'nullsoft',
+      installCommand: 'notesnook_win_x64.exe /S',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{A05A6719-4910-5E6C-A2AA-9AF71CD1063B}:Notesnook',
+      installScope: 'machine',
+      detectionRules: [],
+      psadtConfig: DEFAULT_PSADT_CONFIG,
+    };
+    const policy = makePolicy(storedConfig);
+    policy.original_upload_history_id = 'prior-upload';
+    policy.consecutive_failures = 0;
+
+    vi.spyOn(trigger as never, 'verifyTenantConsent' as never).mockResolvedValue(true as never);
+    vi.spyOn(trigger as never, 'ensurePsadtConfig' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'ensureCurrentPackageDefaults' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'createHistoryRecord' as never)
+      .mockResolvedValue({ id: 'history-notesnook' } as never);
+    const createPackagingJobSpy = vi.spyOn(trigger as never, 'createPackagingJob' as never)
+      .mockResolvedValue({ id: 'job-notesnook' } as never);
+    vi.spyOn(trigger as never, 'updateHistoryRecord' as never).mockResolvedValue(undefined as never);
+    vi.spyOn(trigger as never, 'updatePolicyTracking' as never).mockResolvedValue(undefined as never);
+
+    const result = await trigger.triggerAutoUpdate(policy, {
+      ...UPDATE_INFO,
+      wingetId: 'Streetwriters.Notesnook',
+      displayName: 'Notesnook',
+      installerType: 'nullsoft',
+      installScope: 'machine',
+    }, { skipRateLimits: true });
+
+    expect(result).toMatchObject({ success: true, packagingJobId: 'job-notesnook' });
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ installScope: 'user' })
+    );
+    const effectivePolicy = createPackagingJobSpy.mock.calls[0][0] as AppUpdatePolicy;
+    expect((effectivePolicy.deployment_config as DeploymentConfig).installScope).toBe('user');
+    const effectiveUpdate = createPackagingJobSpy.mock.calls[0][1] as { installScope?: string };
+    expect(effectiveUpdate.installScope).toBe('user');
+    expect(storedConfig.installScope).toBe('machine');
+  });
+
   describe('ensurePsadtConfig', () => {
     it('backfills psadtConfig from the most recent packaging job and persists it', async () => {
       const updateSpy = vi.fn();

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -359,6 +359,12 @@ describe('application packaging adapters', () => {
     ).toBe('user');
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
+      resolveApplicationInstallScope('Streetwriters.Notesnook', 'machine')
+    ).toBe('user');
+    expect(
+      resolveApplicationInstallScope(' streetwriters.notesnook ', undefined)
+    ).toBe('user');
+    expect(
       resolveApplicationInstallScope(
         'AppiumDevelopers.AppiumInspector',
         'machine'

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -271,6 +271,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Notesnook's official Electron Builder configuration uses one-click NSIS
+    // without enabling perMachine. Its WinGet manifest omits Scope, so the
+    // generic machine default registers an uninstaller below LocalSystem's
+    // disposable systemprofile. Keep QA, portal packages, and auto-updates in
+    // the vendor-supported signed-in user context.
+    // https://github.com/streetwriters/notesnook/blob/v3.4.5/apps/desktop/electron-builder.config.js
+    wingetId: 'Streetwriters.Notesnook',
+    requiredInstallScope: 'user',
+  },
+  {
     // Youdao's signed NSIS installer requests `asInvoker` and its WinGet
     // manifest omits Scope. Treating that omission as machine scope launches
     // the per-user bootstrapper under LocalSystem, where it exits immediately

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1391,6 +1391,36 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig.reviewedInstallCompletionTimeoutMinutes).toBe(15);
   });
 
+  it('binds Notesnook user scope to customer and QA packaging without changing its vendor commands', () => {
+    const uninstallCommand =
+      'REGISTRY_UNINSTALL_PRODUCT:{A05A6719-4910-5E6C-A2AA-9AF71CD1063B}:Notesnook';
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Streetwriters.Notesnook',
+      displayName: 'Notesnook',
+      publisher: 'Streetwriters',
+      version: '3.4.5',
+      architecture: 'x64',
+      installerSha256: '1C487EAB412C101D6F82D3E1718BB3D9CF13508A664ABDDD8CA7247A594DC6FA',
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand,
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: {
+        installScope: string;
+        silentArgs: string;
+        uninstallCommand: string;
+      };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(profile.installer.silentArgs).toBe('/S');
+    expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
+  });
+
   it('binds the bounded Retoolkit component wait to customer and QA packaging', () => {
     const silentSwitches =
       '/VERYSILENT /NORESTART /COMPONENTS="*android,*debuggers,*utilities,!network\\\\nmap"';


### PR DESCRIPTION
## Summary
- run Streetwriters.Notesnook in its vendor-supported per-user NSIS context
- apply the adapter consistently to QA, portal PSADT packaging, and auto-updates
- add regression coverage for package identity and every production packaging entry point

## Evidence
- QA run 33464937882 installed and detected Notesnook 3.4.5, then failed because LocalSystem registered the uninstaller below systemprofile
- the official Electron Builder config uses one-click NSIS without perMachine
- installer SHA 1C487EAB412C101D6F82D3E1718BB3D9CF13508A664ABDDD8CA7247A594DC6FA was clean (0/0/75)

## Validation
- 277 focused tests passed
- ESLint passed
- production build passed
- full suite: 1707 passed; one unrelated translation-provider timeout test failed