### PR TITLE
Activate Notesnook user-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '96c197e74589388d9091d89e1385bbbd318f7bf8',
+  packagerCommit: '52e078efa416c2de3edbbe23eecd62079ce04223',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -569,6 +569,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Retoolkit's 45-minute ceiling changes only its still-failing long installer
   // path. Preserve every unrelated compatible pass from the 30-minute release.
   'aafd4a7dd0787ea603c1c53bb8166369f81e39a7',
+  // Notesnook now runs in the vendor-supported signed-in user context. Preserve
+  // every unrelated compatible pass from the Retoolkit 45-minute release.
+  '96c197e74589388d9091d89e1385bbbd318f7bf8',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -9,7 +9,7 @@ describe('QA toolchain targeted retries', () => {
   it('retries Retoolkit after activating the 45-minute bounded install wait', () => {
     const wingetId = 'mentebinaria.retoolkit';
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '96c197e74589388d9091d89e1385bbbd318f7bf8',
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
@@ -22,6 +22,22 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '738d9f19baa44d2e1f0cf49c4fea5658915cefc9',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries Notesnook only after activating its per-user lifecycle', () => {
+    const wingetId = ' streetwriters.notesnook ';
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '96c197e74589388d9091d89e1385bbbd318f7bf8',
       { wingetId, status: 'failed' }
     )).toBe(false);
   });
@@ -604,7 +620,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
-      'mentebinaria.retoolkit',
+      'Streetwriters.Notesnook',
       'HiramWong.zyfun',
       'Domino.MaxTo',
       'Logitech.LGS',
@@ -673,7 +689,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
-        'mentebinaria.retoolkit',
+        'Streetwriters.Notesnook',
         'HiramWong.zyfun',
         'Logitech.LGS',
         'IrfanSkiljan.IrfanView',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -625,7 +625,19 @@ const RETOOLKIT_45_MINUTE_INSTALL_WAIT_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const NOTESNOOK_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry Notesnook in the persistent signed-in user profile used by its
+  // official per-user Electron/NSIS lifecycle. The prior machine default
+  // registered its uninstaller below LocalSystem's disposable systemprofile.
+  'Streetwriters.Notesnook',
+  // Retoolkit exhausted its 45-minute retry at the prior pin; carry every
+  // older still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '52e078efa416c2de3edbbe23eecd62079ce04223':
+    NOTESNOOK_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '96c197e74589388d9091d89e1385bbbd318f7bf8':
     RETOOLKIT_45_MINUTE_INSTALL_WAIT_RELEASE_RETRY_TARGETS,
   'aafd4a7dd0787ea603c1c53bb8166369f81e39a7':


### PR DESCRIPTION
## Summary
- promote tested packager commit 52e078efa416c2de3edbbe23eecd62079ce04223
- retry Notesnook exactly once with its reviewed per-user lifecycle
- preserve unrelated compatible QA passes from the prior release

## Validation
- 278 focused tests passed
- ESLint passed