### PR TITLE
fix(packaging): bind DSH Desktop uninstall identity

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -352,6 +352,32 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
   });
 
+  it('dispatches DSH Desktop with the reviewed NSIS key to the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'JustGenius-s.DSHDesktop',
+      displayName: 'DSH-Decktop',
+      publisher: 'JustGenius-s',
+      version: '0.2.0',
+      architecture: 'x64',
+      installerSha256: 'D'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'nullsoft',
+      silentSwitches: '/S /allusers',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{239D4E5C-394E-5607-BF11-8B5229505789}:DSH-Decktop',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:239d4e5c-394e-5607-bf11-8b5229505789:DSH-Desktop 0.2.0'
+    );
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -132,6 +132,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('binds DSH Desktop to its exact unbraced NSIS key despite the catalog typo', () => {
+    expect(resolveApplicationUninstallCommand(
+      'JustGenius-s.DSHDesktop',
+      'REGISTRY_UNINSTALL_PRODUCT:{239D4E5C-394E-5607-BF11-8B5229505789}:DSH-Decktop'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:239d4e5c-394e-5607-bf11-8b5229505789:DSH-Desktop 0.2.0'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'justgenius-s.dshdesktop',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('uses Greenshot Preview\'s exact shared Inno registry identity', () => {
     expect(resolveApplicationUninstallCommand(
       'Greenshot.Greenshot.Preview',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1785,6 +1785,17 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Google Chrome Beta',
     registeredRegistryKey: 'Google Chrome Beta',
   },
+  // DSH Desktop's WinGet locale has a `Decktop` typo and publishes its NSIS
+  // ProductCode as a GUID. Electron Builder registers the same stable NSIS key
+  // without braces and uses the versioned `DSH-Desktop 0.2.0` display name.
+  // QA run 33468742080 also observed an unrelated Edge ARP update, so bind the
+  // exact vendor key instead of guessing from the two-entry install delta.
+  'justgenius-s.dshdesktop': {
+    generatedDisplayName: 'DSH-Decktop',
+    manifestRegistryKey: '{239D4E5C-394E-5607-BF11-8B5229505789}',
+    registeredDisplayName: 'DSH-Desktop 0.2.0',
+    registeredRegistryKey: '239d4e5c-394e-5607-bf11-8b5229505789',
+  },
   // The legacy Edge-channel package is still named `Docker Desktop Edge` in
   // the catalog, but Docker registers the installed product as the ordinary
   // `Docker Desktop` ARP entry. Use that exact vendor identity so install
@@ -1921,8 +1932,14 @@ export function resolveApplicationUninstallCommand(
   const reviewed = REVIEWED_REGISTRY_UNINSTALL_IDENTITIES[wingetId.trim().toLowerCase()];
   if (!reviewed) return uninstallCommand;
   const expected = `REGISTRY_UNINSTALL:${reviewed.generatedDisplayName}`;
+  const exactRegistryIdentity = (registryKey: string, displayName: string) => {
+    const isMsiProductCode = /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$/.test(
+      registryKey
+    );
+    return `${isMsiProductCode ? 'REGISTRY_UNINSTALL_PRODUCT' : 'REGISTRY_UNINSTALL_KEY'}:${registryKey}:${displayName}`;
+  };
   const expectedManifestKey = reviewed.manifestRegistryKey
-    ? `REGISTRY_UNINSTALL_KEY:${reviewed.manifestRegistryKey}:${reviewed.generatedDisplayName}`
+    ? exactRegistryIdentity(reviewed.manifestRegistryKey, reviewed.generatedDisplayName)
     : undefined;
   const normalizedUninstallCommand = uninstallCommand.trim();
   if (
@@ -1932,11 +1949,10 @@ export function resolveApplicationUninstallCommand(
   if (!reviewed.registeredRegistryKey) {
     return `REGISTRY_UNINSTALL:${reviewed.registeredDisplayName}`;
   }
-  const reviewedKey = reviewed.registeredRegistryKey;
-  const isMsiProductCode = /^\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\}$/.test(
-    reviewedKey
+  return exactRegistryIdentity(
+    reviewed.registeredRegistryKey,
+    reviewed.registeredDisplayName
   );
-  return `${isMsiProductCode ? 'REGISTRY_UNINSTALL_PRODUCT' : 'REGISTRY_UNINSTALL_KEY'}:${reviewedKey}:${reviewed.registeredDisplayName}`;
 }
 
 function normalizeProcessName(name: string): string {

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1421,6 +1421,37 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
   });
 
+  it('binds DSH Desktop QA to the exact NSIS key used by customer packages', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'JustGenius-s.DSHDesktop',
+      displayName: 'DSH-Decktop',
+      publisher: 'JustGenius-s',
+      version: '0.2.0',
+      architecture: 'x64',
+      installerSha256: 'D08A195070FBD32D0CE2282A129145E758BFE2A28A86C0FD6F2EB2B3C6BE20CA',
+      installerType: 'nullsoft',
+      silentSwitches: '/S /allusers',
+      uninstallCommand:
+        'REGISTRY_UNINSTALL_PRODUCT:{239D4E5C-394E-5607-BF11-8B5229505789}:DSH-Decktop',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: {
+        installScope: string;
+        silentArgs: string;
+        uninstallCommand: string;
+      };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe('/S /allusers');
+    expect(profile.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:239d4e5c-394e-5607-bf11-8b5229505789:DSH-Desktop 0.2.0'
+    );
+  });
+
   it('binds the bounded Retoolkit component wait to customer and QA packaging', () => {
     const silentSwitches =
       '/VERYSILENT /NORESTART /COMPONENTS="*android,*debuggers,*utilities,!network\\\\nmap"';


### PR DESCRIPTION
## Summary
- bind DSH Desktop's catalog GUID to the exact unbraced NSIS registry key observed in QA
- correct the WinGet display-name typo without broadening ARP matching
- verify identical identity handling in QA profiles and customer workflow payloads

## Evidence
- QA run 33468742080 observed DSH-Desktop 0.2.0 at key 239d4e5c-394e-5607-bf11-8b5229505789 plus an unrelated Edge ARP update
- upstream Electron Builder productName is DSH-Desktop; WinGet default locale currently says DSH-Decktop

## Verification
- 1,712 tests passed
- focused ESLint passed
- production build passed