### PR TITLE
chore(qa): activate DSH Desktop identity fix

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '52e078efa416c2de3edbbe23eecd62079ce04223',
+  packagerCommit: '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -572,6 +572,10 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Notesnook now runs in the vendor-supported signed-in user context. Preserve
   // every unrelated compatible pass from the Retoolkit 45-minute release.
   '96c197e74589388d9091d89e1385bbbd318f7bf8',
+  // DSH Desktop now binds WinGet's braced ProductCode to the exact unbraced
+  // NSIS registry key observed in QA. Preserve every unrelated compatible pass
+  // from the Notesnook user-scope release.
+  '52e078efa416c2de3edbbe23eecd62079ce04223',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -33,11 +33,27 @@ describe('QA toolchain targeted retries', () => {
   it('retries Notesnook only after activating its per-user lifecycle', () => {
     const wingetId = ' streetwriters.notesnook ';
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '52e078efa416c2de3edbbe23eecd62079ce04223',
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '96c197e74589388d9091d89e1385bbbd318f7bf8',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries DSH Desktop only after activating its exact NSIS identity', () => {
+    const wingetId = ' justgenius-s.dshdesktop ';
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '52e078efa416c2de3edbbe23eecd62079ce04223',
       { wingetId, status: 'failed' }
     )).toBe(false);
   });
@@ -620,7 +636,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
-      'Streetwriters.Notesnook',
+      'JustGenius-s.DSHDesktop',
       'HiramWong.zyfun',
       'Domino.MaxTo',
       'Logitech.LGS',
@@ -689,7 +705,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
-        'Streetwriters.Notesnook',
+        'JustGenius-s.DSHDesktop',
         'HiramWong.zyfun',
         'Logitech.LGS',
         'IrfanSkiljan.IrfanView',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -635,7 +635,19 @@ const NOTESNOOK_USER_SCOPE_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const DSH_DESKTOP_EXACT_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry only the DSH Desktop tuple that exposed WinGet's display-name typo
+  // and braced ProductCode mismatch. The reviewed adapter binds the observed
+  // unbraced NSIS key without selecting the unrelated Edge ARP update.
+  'JustGenius-s.DSHDesktop',
+  // Notesnook passed its user-scope retry at the prior pin; carry every older
+  // still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc':
+    DSH_DESKTOP_EXACT_IDENTITY_RELEASE_RETRY_TARGETS,
   '52e078efa416c2de3edbbe23eecd62079ce04223':
     NOTESNOOK_USER_SCOPE_RELEASE_RETRY_TARGETS,
   '96c197e74589388d9091d89e1385bbbd318f7bf8':


### PR DESCRIPTION
## Summary
- activate exact packager commit 8395c85642b21b8cc23e2a4b50ebc377f9e46fbc
- preserve unrelated compatible QA passes from the prior release
- retry only JustGenius-s.DSHDesktop for the newly reviewed NSIS identity
- retire the already-successful Notesnook targeted retry

## Verification
- 403 focused tests passed
- focused ESLint passed