### PR TITLE
Fix JS8Call registry uninstall identity

### DIFF
--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -378,6 +378,31 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
   });
 
+  it('dispatches JS8Call-improved with the reviewed Inno key to the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'JS8Call-improved.JS8Call-improved',
+      displayName: 'JS8Call-improved',
+      publisher: 'JS8Call-improved',
+      version: '3.0.3',
+      architecture: 'x64',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand: 'REGISTRY_UNINSTALL:JS8Call-improved',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse(String(request.body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:{B5281957-28FD-4BAE-8D06-FC59898D850E}_is1:JS8Call 3.0.3'
+    );
+  });
+
   it('lets reconciliation strengthen a generated display-name uninstall fallback', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -132,6 +132,19 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('binds JS8Call-improved to its exact stable Inno key', () => {
+    expect(resolveApplicationUninstallCommand(
+      'JS8Call-improved.JS8Call-improved',
+      'REGISTRY_UNINSTALL:JS8Call-improved'
+    )).toBe(
+      'REGISTRY_UNINSTALL_KEY:{B5281957-28FD-4BAE-8D06-FC59898D850E}_is1:JS8Call 3.0.3'
+    );
+    expect(resolveApplicationUninstallCommand(
+      'js8call-improved.js8call-improved',
+      'vendor-uninstall.exe --custom'
+    )).toBe('vendor-uninstall.exe --custom');
+  });
+
   it('binds DSH Desktop to its exact unbraced NSIS key despite the catalog typo', () => {
     expect(resolveApplicationUninstallCommand(
       'JustGenius-s.DSHDesktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1785,6 +1785,16 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     registeredDisplayName: 'Google Chrome Beta',
     registeredRegistryKey: 'Google Chrome Beta',
   },
+  // JS8Call-improved's catalog title differs from the vendor's Inno AppName.
+  // The official installer source keeps a stable AppId while AppVerName adds
+  // the release version to the visible ARP name. QA run 33471597387 observed
+  // that exact entry alongside an unrelated Edge update, so bind the stable
+  // vendor key instead of widening selection across the install delta.
+  'js8call-improved.js8call-improved': {
+    generatedDisplayName: 'JS8Call-improved',
+    registeredDisplayName: 'JS8Call 3.0.3',
+    registeredRegistryKey: '{B5281957-28FD-4BAE-8D06-FC59898D850E}_is1',
+  },
   // DSH Desktop's WinGet locale has a `Decktop` typo and publishes its NSIS
   // ProductCode as a GUID. Electron Builder registers the same stable NSIS key
   // without braces and uses the versioned `DSH-Desktop 0.2.0` display name.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1452,6 +1452,38 @@ describe('PSADT QA package identity', () => {
     );
   });
 
+  it('binds JS8Call-improved QA to the exact Inno key used by customer packages', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'JS8Call-improved.JS8Call-improved',
+      displayName: 'JS8Call-improved',
+      publisher: 'JS8Call-improved',
+      version: '3.0.3',
+      architecture: 'x64',
+      installerSha256: 'AFFDFABB91D2AA59CB81D6859679CB19E09C18AC00EA1CE9AE0E2730A5A00285',
+      installerType: 'inno',
+      silentSwitches: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-',
+      uninstallCommand: 'REGISTRY_UNINSTALL:JS8Call-improved',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: {
+        installScope: string;
+        silentArgs: string;
+        uninstallCommand: string;
+      };
+    };
+
+    expect(profile.installer.installScope).toBe('machine');
+    expect(profile.installer.silentArgs).toBe(
+      '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+    );
+    expect(profile.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:{B5281957-28FD-4BAE-8D06-FC59898D850E}_is1:JS8Call 3.0.3'
+    );
+  });
+
   it('binds the bounded Retoolkit component wait to customer and QA packaging', () => {
     const silentSwitches =
       '/VERYSILENT /NORESTART /COMPONENTS="*android,*debuggers,*utilities,!network\\\\nmap"';


### PR DESCRIPTION
Binds JS8Call-improved to the vendor's stable Inno AppId-derived uninstall key observed in isolated QA run 33471597387 and confirmed by the official installer source. Adds regression coverage for the shared adapter, normalized QA profile, generated PSADT contract path, and customer packaging workflow payload. Verification: 1,716 tests passed; focused ESLint passed; production build passed.