### PR TITLE
Activate JS8Call identity release

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
+  packagerCommit: 'f6bff5d1879b5cd11e285b1f1f0d140349d82215',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -576,6 +576,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // NSIS registry key observed in QA. Preserve every unrelated compatible pass
   // from the Notesnook user-scope release.
   '52e078efa416c2de3edbbe23eecd62079ce04223',
+  // JS8Call-improved now binds the official stable Inno AppId-derived key.
+  // Preserve every unrelated compatible pass from the DSH Desktop release.
+  '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -49,11 +49,27 @@ describe('QA toolchain targeted retries', () => {
   it('retries DSH Desktop only after activating its exact NSIS identity', () => {
     const wingetId = ' justgenius-s.dshdesktop ';
     expect(shouldRetryTerminalToolchainCandidate(
-      QA_PSADT_TOOLCHAIN.packagerCommit,
+      '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
       { wingetId, status: 'failed' }
     )).toBe(true);
     expect(shouldRetryTerminalToolchainCandidate(
       '52e078efa416c2de3edbbe23eecd62079ce04223',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('retries JS8Call-improved only after activating its exact Inno identity', () => {
+    const wingetId = ' js8call-improved.js8call-improved ';
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
       { wingetId, status: 'failed' }
     )).toBe(false);
   });
@@ -636,7 +652,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
-      'JustGenius-s.DSHDesktop',
+      'JS8Call-improved.JS8Call-improved',
       'HiramWong.zyfun',
       'Domino.MaxTo',
       'Logitech.LGS',
@@ -705,7 +721,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
-        'JustGenius-s.DSHDesktop',
+        'JS8Call-improved.JS8Call-improved',
         'HiramWong.zyfun',
         'Logitech.LGS',
         'IrfanSkiljan.IrfanView',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -645,7 +645,19 @@ const DSH_DESKTOP_EXACT_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const JS8CALL_EXACT_IDENTITY_RELEASE_RETRY_TARGETS = [
+  // Retry only the JS8Call-improved tuple whose catalog title did not match
+  // the official versioned Inno ARP name. The stable AppId-derived key excludes
+  // the unrelated Edge update observed in the same installation window.
+  'JS8Call-improved.JS8Call-improved',
+  // DSH Desktop passed its exact-key retry at the prior pin; carry every older
+  // still-unconsumed target without replaying it.
+  ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'f6bff5d1879b5cd11e285b1f1f0d140349d82215':
+    JS8CALL_EXACT_IDENTITY_RELEASE_RETRY_TARGETS,
   '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc':
     DSH_DESKTOP_EXACT_IDENTITY_RELEASE_RETRY_TARGETS,
   '52e078efa416c2de3edbbe23eecd62079ce04223':


### PR DESCRIPTION
Activates exact shared packager commit f6bff5d1879b5cd11e285b1f1f0d140349d82215, preserves compatible passing history, retires the successful DSH Desktop retry, and targets only JS8Call-improved for the new exact lifecycle retest. Verification: 1,717 tests passed; focused ESLint passed; production build passed.