### PR TITLE
fix(qa): run Arvis in user scope

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -757,6 +757,58 @@ describe('POST /api/package (workflow dispatch)', () => {
     );
   });
 
+  it('uses Arvis user scope consistently for customer PSADT packaging and QA', async () => {
+    getLiveInstallersMock.mockResolvedValueOnce([{
+      architecture: 'x64',
+      url: 'https://example.com/arvis-setup.exe',
+      sha256: 'A'.repeat(64),
+      type: 'nullsoft',
+      silentArgs: '/S',
+    }]);
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [makeWin32Item({
+          wingetId: 'jopemachine.Arvis',
+          displayName: 'Arvis',
+          version: '0.14.6',
+          installerType: 'nullsoft',
+          installScope: 'machine',
+        })],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(enforceInstallerPreflightMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'jopemachine.Arvis',
+        installScope: 'user',
+      }),
+      expect.any(Array)
+    );
+    expect(ensureQaDemandMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ installScope: 'user' })
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ install_scope: 'user' })
+    );
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wingetId: 'jopemachine.Arvis',
+        installScope: 'user',
+      }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it('uses zyfun all-users mode consistently for customer PSADT packaging and QA', async () => {
     getLiveInstallersMock.mockResolvedValueOnce([{
       architecture: 'x64',

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -383,6 +383,12 @@ describe('application packaging adapters', () => {
     expect(
       resolveApplicationInstallScope(' ENTE-IO.PHOTOS-DESKTOP ', undefined)
     ).toBe('user');
+    expect(resolveApplicationInstallScope('jopemachine.Arvis', 'machine')).toBe(
+      'user'
+    );
+    expect(
+      resolveApplicationInstallScope(' JOPEMACHINE.ARVIS ', undefined)
+    ).toBe('user');
     expect(resolveApplicationInstallScope('VNGCorp.Zalo', 'machine')).toBe('user');
     expect(
       resolveApplicationInstallScope('Streetwriters.Notesnook', 'machine')

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -190,6 +190,16 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     requiredInstallScope: 'user',
   },
   {
+    // Arvis 0.14.6 is built with Electron Builder's default one-click NSIS
+    // target and does not enable perMachine. WinGet omits Scope, so the generic
+    // machine default installs below LocalSystem's disposable systemprofile and
+    // captures an uninstaller path that is unavailable by the removal cycle.
+    // Keep QA and customer Intune packages in the vendor-supported user context.
+    // https://github.com/jopemachine/arvis/blob/v0.14.6/package.json
+    wingetId: 'jopemachine.Arvis',
+    requiredInstallScope: 'user',
+  },
+  {
     // zyfun 3.4.7 uses Electron Builder's assisted NSIS mode and a custom
     // installer hook that installs the machine-wide VC++ runtime when missing.
     // Its default current-user silent path can therefore wait indefinitely on

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -789,6 +789,34 @@ describe('PSADT QA package identity', () => {
     ]);
   });
 
+  it('keeps Arvis out of LocalSystem when WinGet omits its scope', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'jopemachine.Arvis',
+      displayName: 'Arvis',
+      publisher: 'jopemachine',
+      version: '0.14.6',
+      architecture: 'x64',
+      installerSha256: 'd'.repeat(64),
+      installerType: 'nullsoft',
+      silentSwitches: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Arvis',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const profile = normalized.identity.profile as {
+      installer: { installScope: string };
+    };
+
+    expect(profile.installer.installScope).toBe('user');
+    expect(normalized.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\jopemachine_Arvis',
+      }),
+    ]);
+  });
+
   it('keeps Android Apps Manager out of LocalSystem when WinGet omits its scope', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'SIMSDEV.AndroidAppsManager',

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -849,6 +849,34 @@ describe('buildQaCatalogTestConfig', () => {
     ]);
   });
 
+  it('tests Arvis in user context when its Electron Builder manifest omits scope', () => {
+    const config = buildQaCatalogTestConfig({
+      app: {
+        wingetId: 'jopemachine.Arvis',
+        name: 'Arvis',
+        publisher: 'jopemachine',
+        version: '0.14.6',
+      },
+      manifest: {
+        InstallerType: 'nullsoft',
+        AppsAndFeaturesEntries: [{ DisplayName: 'Arvis 0.14.6' }],
+      },
+      installer: {
+        Architecture: 'x64',
+        InstallerType: 'nullsoft',
+        InstallerSwitches: { Silent: '/S' },
+      },
+    });
+
+    expect(config.scope).toBe('user');
+    expect(config.detectionRules).toEqual([
+      expect.objectContaining({
+        keyPath:
+          'HKEY_CURRENT_USER\\SOFTWARE\\IntuneGet\\Apps\\jopemachine_Arvis',
+      }),
+    ]);
+  });
+
   it('tests zyfun in machine context with Electron Builder all-users mode', () => {
     const config = buildQaCatalogTestConfig({
       app: {


### PR DESCRIPTION
## Summary
- run jopemachine.Arvis in the signed-in user context instead of LocalSystem
- keep QA normalization and customer PSADT packaging on the same reviewed scope adapter
- cover adapter resolution, HKCU QA profile/detection, and customer workflow payloads

## Production evidence
Run 33504766782 installed Arvis 0.14.6 under LocalSystem's systemprofile. The exact captured registry entry pointed to an uninstaller that was already absent at managed removal, producing PSADT exit 60001. The tagged official Electron Builder configuration uses the default one-click NSIS target without enabling perMachine, while the WinGet manifest omits Scope.

## Verification
- focused: 4 files / 296 tests passed
- eslint passed
- production build passed
- full suite: 1719/1720 passed; the untouched PSADT fixture error-string assertion fails locally because PowerShell prepends directory-formatting output even though the expected text is present