### PR TITLE
chore(qa): activate Arvis user-scope packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'f6bff5d1879b5cd11e285b1f1f0d140349d82215',
+  packagerCommit: 'd33825c2b786af7c3f22f4b828108c4129299ef9',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -579,6 +579,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // JS8Call-improved now binds the official stable Inno AppId-derived key.
   // Preserve every unrelated compatible pass from the DSH Desktop release.
   '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc',
+  // Arvis now runs in the vendor-supported signed-in user context. Preserve
+  // every unrelated compatible pass from the JS8Call exact-identity release.
+  'f6bff5d1879b5cd11e285b1f1f0d140349d82215',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -62,7 +62,19 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
-  it('retries JS8Call-improved only after activating its exact Inno identity', () => {
+  it('retries Arvis only after activating its reviewed user scope', () => {
+    const wingetId = ' jopemachine.arvis ';
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId, status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'f6bff5d1879b5cd11e285b1f1f0d140349d82215',
+      { wingetId, status: 'failed' }
+    )).toBe(false);
+  });
+
+  it('keeps the JS8Call-improved retry available after the Arvis activation', () => {
     const wingetId = ' js8call-improved.js8call-improved ';
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,
@@ -652,6 +664,7 @@ describe('QA toolchain targeted retries', () => {
   it('exposes a defensive copy of current terminal retry targets', () => {
     const targets = terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit);
     expect(targets).toEqual(expect.arrayContaining([
+      'jopemachine.Arvis',
       'JS8Call-improved.JS8Call-improved',
       'HiramWong.zyfun',
       'Domino.MaxTo',
@@ -721,6 +734,7 @@ describe('QA toolchain targeted retries', () => {
 
     expect(terminalToolchainRetryTargets(QA_PSADT_TOOLCHAIN.packagerCommit)).toEqual(
       expect.arrayContaining([
+        'jopemachine.Arvis',
         'JS8Call-improved.JS8Call-improved',
         'HiramWong.zyfun',
         'Logitech.LGS',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -655,7 +655,19 @@ const JS8CALL_EXACT_IDENTITY_RELEASE_RETRY_TARGETS = [
   ...UNIFI_OS_SERVER_MACHINE_SCOPE_RELEASE_RETRY_TARGETS,
 ] as const;
 
+const ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
+  // Retry only the Arvis tuple that installed below LocalSystem's disposable
+  // systemprofile. The reviewed adapter now runs the same trusted bytes in the
+  // vendor-supported signed-in user context shared with customer packages.
+  'jopemachine.Arvis',
+  // JS8Call-improved passed its exact-key retry at the prior pin; carry every
+  // older still-unconsumed target without replaying it.
+  ...JS8CALL_EXACT_IDENTITY_RELEASE_RETRY_TARGETS,
+] as const;
+
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'd33825c2b786af7c3f22f4b828108c4129299ef9':
+    ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'f6bff5d1879b5cd11e285b1f1f0d140349d82215':
     JS8CALL_EXACT_IDENTITY_RELEASE_RETRY_TARGETS,
   '8395c85642b21b8cc23e2a4b50ebc377f9e46fbc':


### PR DESCRIPTION
Activates shared packager commit d33825c2b786af7c3f22f4b828108c4129299ef9 after #1081. Preserves prior compatible passes and scopes the new terminal retry to jopemachine.Arvis while carrying forward older unconsumed targets. Verification: package-profile and toolchain-backfill tests (284 passed), lint passed.