### PR TITLE
feat(qa): add bounded customer continuity mode

### DIFF
--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -43,6 +43,7 @@ function chain(result: { data: unknown; error: unknown }) {
 describe('GET /api/cron/qa-resume', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     process.env.CRON_SECRET = 'secret';
     getFeatureFlagsMock.mockReturnValue({ localPackager: true });
     reconcileCatalogInstallerMock.mockImplementation(async (item) => ({
@@ -98,6 +99,124 @@ describe('GET /api/cron/qa-resume', () => {
       qa_completed_at: expect.any(String),
     }));
     expect(handleAutoUpdateJobCompletionMock).not.toHaveBeenCalled();
+  });
+
+  it('releases an existing customer upload while its queued QA lifecycle remains deferred', async () => {
+    process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    getFeatureFlagsMock.mockReturnValue({ localPackager: false });
+    triggerPackagingWorkflowMock.mockResolvedValue({
+      runId: 123,
+      runUrl: 'https://example.test/run/123',
+    });
+    const job = {
+      id: 'job-deferred-customer',
+      tenant_id: 'tenant-1',
+      qa_candidate_id: 'candidate-queued',
+      created_at: '2026-09-01T12:00:00Z',
+      winget_id: 'Example.App',
+      display_name: 'Example App',
+      publisher: 'Example',
+      version: '1.0.0',
+      architecture: 'x64',
+      installer_url: 'https://example.test/installer.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      install_command: 'installer.exe /silent',
+      uninstall_command: 'installer.exe /uninstall /silent',
+      install_scope: 'machine',
+      package_config: {
+        sourceType: 'winget',
+        displayName: 'Example App',
+        publisher: 'Example',
+        architecture: 'x64',
+        installerUrl: 'https://example.test/installer.exe',
+        installerSha256: 'A'.repeat(64),
+        installerType: 'exe',
+        installCommand: 'installer.exe /silent',
+        uninstallCommand: 'installer.exe /uninstall /silent',
+      },
+      is_auto_update: false,
+    };
+    const claimUpdate = chain({ data: { id: job.id }, error: null });
+    const provenanceUpdate = chain({ data: null, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          packagingCall++;
+          if (packagingCall === 1) return chain({ data: [job], error: null });
+          if (packagingCall === 2) return claimUpdate;
+          return provenanceUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-queued',
+              status: 'queued',
+              failure_summary: null,
+              package_profile_sha256: 'B'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 1, failed: 0, waiting: 0 });
+    expect(claimUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'packaging',
+      status_message: 'Preparing deployment while installation validation remains scheduled',
+      qa_completed_at: null,
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps automatic updates waiting during a customer continuity window', async () => {
+    process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const job = {
+      id: 'job-auto-update',
+      qa_candidate_id: 'candidate-queued',
+      created_at: '2026-09-01T12:00:00Z',
+      is_auto_update: true,
+    };
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') return chain({ data: [job], error: null });
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-queued',
+              status: 'queued',
+              failure_summary: null,
+              package_profile_sha256: 'B'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(body).toMatchObject({ resumed: 0, failed: 0, waiting: 1 });
+    expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
   it('finalizes auto-update tracking when the required QA candidate fails', async () => {

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -7,6 +7,7 @@ import { extractSilentSwitches } from '@/lib/msp/silent-switches';
 import { triggerPackagingWorkflow, type WorkflowInputs } from '@/lib/github-actions';
 import { handleAutoUpdateJobCompletion } from '@/lib/auto-update/cleanup';
 import { ensureQaDemand } from '@/lib/qa/demand';
+import { isDeferredCustomerQaEnabled } from '@/lib/qa/continuity';
 import { reconcileCatalogInstaller } from '@/lib/catalog-installer-reconciliation';
 import type { Win32CartItem } from '@/types/upload';
 import type { Json } from '@/types/database';
@@ -163,12 +164,15 @@ export async function GET(request: Request) {
       }
       continue;
     }
-    if (candidateStatus !== 'passed') {
+    const qaDeferred = !job.is_auto_update &&
+      isDeferredCustomerQaEnabled() &&
+      Boolean(candidateStatus && ['queued', 'dispatched', 'running'].includes(candidateStatus));
+    if (candidateStatus !== 'passed' && !qaDeferred) {
       waiting++;
       continue;
     }
 
-    if (!appVersionAlreadyPassed) {
+    if (!appVersionAlreadyPassed && !qaDeferred) {
       const { data: result, error: resultError } = candidate?.package_profile_sha256
         ? await supabase
             .from('qa_package_results')
@@ -189,8 +193,10 @@ export async function GET(request: Request) {
       .from('packaging_jobs')
       .update({
         status: nextStatus,
-        status_message: 'Installation test passed; packaging started automatically',
-        qa_completed_at: now,
+        status_message: qaDeferred
+          ? 'Preparing deployment while installation validation remains scheduled'
+          : 'Installation test passed; packaging started automatically',
+        qa_completed_at: qaDeferred ? null : now,
         packaging_started_at: features.localPackager ? null : now,
       })
       .eq('id', job.id)
@@ -259,7 +265,9 @@ export async function GET(request: Request) {
         .from('packaging_jobs')
         .update({
           status: 'failed',
-          status_message: 'Installation test passed, but packaging could not start automatically',
+          status_message: qaDeferred
+            ? 'Packaging could not start during the continuity window'
+            : 'Installation test passed, but packaging could not start automatically',
           error_code: 'QA_RESUME_DISPATCH_FAILED',
           error_stage: 'authenticate',
           error_category: 'network',

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -139,6 +139,7 @@ function minutesAgo(minutes: number): string {
 describe('GET /api/package (userId listing)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     // The list path now authenticates and uses the token's userId.
     parseAccessTokenMock.mockResolvedValue({
       userId: 'user-1',
@@ -283,6 +284,7 @@ describe('POST /api/package (workflow dispatch)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     getDatabaseMock.mockReturnValue({
       jobs: {
         create: createMock,
@@ -1478,6 +1480,43 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
+  it('dispatches a customer upload while its QA lifecycle remains durably queued during a bounded continuity window', async () => {
+    process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    ensureQaDemandMock.mockResolvedValueOnce({
+      state: 'waiting',
+      candidateId: 'candidate-deferred-1',
+      identity: {
+        executionProfileSha256: 'A'.repeat(64),
+        packageProfileSha256: 'A'.repeat(64),
+        presentationProfileSha256: 'B'.repeat(64),
+      },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ items: [makeWin32Item()] }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.jobs[0]).toMatchObject({ status: 'packaging' });
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'queued',
+      status_message: 'Preparing deployment while installation validation remains scheduled',
+      qa_candidate_id: 'candidate-deferred-1',
+      qa_completed_at: null,
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
+  });
+
   it('calculates the hash in the workflow for a custom app without a supplied SHA256', async () => {
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',
@@ -1639,6 +1678,9 @@ describe('POST /api/package (workflow dispatch)', () => {
   });
 
   it('creates an actionable blocked job for a failed execution profile', async () => {
+    process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
     ensureQaDemandMock.mockResolvedValueOnce({
       state: 'failed',
       candidateId: 'candidate-1',

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -39,6 +39,7 @@ import {
 } from '@/lib/installer-preflight';
 import { applyInstallerUrlOverride } from '@/lib/installer-url-overrides';
 import { ensureQaDemand } from '@/lib/qa/demand';
+import { isDeferredCustomerQaEnabled } from '@/lib/qa/continuity';
 import {
   applyApplicationPackagingAdapter,
   resolveApplicationInstallScope,
@@ -600,10 +601,11 @@ export async function POST(request: NextRequest) {
                   priority: 2000,
                   demandSource: 'customer',
                 });
+            const qaDeferred = qaDemand?.state === 'waiting' && isDeferredCustomerQaEnabled();
             // Self-hosted installs have no QA pipeline, so local jobs must remain pollable.
             const initialStatus = isLocalPackagerMode && !supabaseServerConfigured
               ? 'queued'
-              : qaDemand?.state === 'waiting'
+              : qaDemand?.state === 'waiting' && !qaDeferred
                 ? 'awaiting_qa'
                 : qaDemand?.state === 'failed'
                   ? 'qa_failed'
@@ -630,7 +632,9 @@ export async function POST(request: NextRequest) {
               package_config: item as unknown as import('@/types/database').Json,
               status: initialStatus,
               status_message: qaDemand?.state === 'waiting'
-                ? 'Running an isolated installation test to make sure this app works before deployment'
+                ? qaDeferred
+                  ? 'Preparing deployment while installation validation remains scheduled'
+                  : 'Running an isolated installation test to make sure this app works before deployment'
                 : qaDemand?.state === 'failed'
                   ? qaDemand.failureSummary
                   : null,
@@ -650,7 +654,7 @@ export async function POST(request: NextRequest) {
               continue;
             }
 
-            if (qaDemand?.state === 'waiting' || qaDemand?.state === 'failed') {
+            if ((qaDemand?.state === 'waiting' && !qaDeferred) || qaDemand?.state === 'failed') {
               jobs.push({
                 id: jobId,
                 user_id: userId,

--- a/lib/qa/continuity.test.ts
+++ b/lib/qa/continuity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isDeferredCustomerQaEnabled } from './continuity';
+
+describe('isDeferredCustomerQaEnabled', () => {
+  const now = new Date('2026-09-01T12:00:00.000Z');
+
+  it('enables an explicitly bounded future window', () => {
+    expect(isDeferredCustomerQaEnabled(now, '2026-09-08T11:59:59.000Z')).toBe(true);
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not-a-date',
+    '2026-09-01T12:00:00.000Z',
+    '2026-09-10T12:00:00.000Z',
+  ])('fails closed for missing, invalid, expired, or excessive values: %s', (value) => {
+    expect(isDeferredCustomerQaEnabled(now, value)).toBe(false);
+  });
+});

--- a/lib/qa/continuity.ts
+++ b/lib/qa/continuity.ts
@@ -1,0 +1,20 @@
+const MAX_CONTINUITY_WINDOW_MS = 8 * 24 * 60 * 60 * 1000;
+
+/**
+ * Allows an explicit customer upload to continue while its exact VM lifecycle
+ * remains queued. The server-only, expiring switch cannot be enabled from a
+ * client payload and cannot silently become a permanent QA bypass.
+ */
+export function isDeferredCustomerQaEnabled(
+  now = new Date(),
+  configuredUntil = process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL
+): boolean {
+  const value = configuredUntil?.trim();
+  if (!value) return false;
+
+  const expiresAt = Date.parse(value);
+  if (!Number.isFinite(expiresAt)) return false;
+
+  const remainingMs = expiresAt - now.getTime();
+  return remainingMs > 0 && remainingMs <= MAX_CONTINUITY_WINDOW_MS;
+}


### PR DESCRIPTION
## Summary
- allow explicit customer uploads to continue when exact VM QA remains queued during a server-only bounded continuity window
- retain the QA candidate and incomplete QA timestamp as the deferred audit trail
- keep normal waiting behavior outside the window and keep known failed profiles blocked
- reject missing, invalid, expired, or longer-than-eight-day continuity settings

## Verification
- focused route and continuity tests: 46 passed
- full suite: 1,728 tests; one unrelated translation-provider timeout passed on immediate isolated retry
- targeted ESLint: passed
- production Next.js build: passed

## Operational activation
The private production expiry is not committed and will be activated only after this PR is merged and deployed.