### PR TITLE
fix(qa): show ready runner as healthy

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -34,7 +34,7 @@ import { cn } from '@/lib/utils';
 import type { QaLivePhase, QaLiveResponse, QaVirusTotalStatus } from '@/types/qa';
 
 function healthTone(state: string): StatusTone {
-  if (state === 'healthy' || state === 'testing') return 'success';
+  if (state === 'healthy' || state === 'testing' || state === 'idle') return 'success';
   if (state === 'degraded') return 'warning';
   if (state === 'stalled') return 'error';
   return 'neutral';


### PR DESCRIPTION
## Summary
- render the idle Ready runner badge with the success tone
- keep degraded and stalled states unchanged

## Verification
- npm exec eslint -- app/(marketing)/qa/QaLiveClient.tsx
- npm test -- --run lib/qa/live.test.ts