### PR TITLE
Add product updates bell and automatic changelog publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Validate public changelog entries
+        run: node scripts/publish-changelog.mjs --validate
+
       - name: Build packager
         working-directory: packager
         run: |

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -1,0 +1,47 @@
+name: Publish changelog
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-changelog
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish verified product updates
+    # Never execute PR/fork code with the publishing credential. Read the exact
+    # main commit that passed all CI jobs, including the Docker smoke test.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout verified commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26.5.0"
+
+      - name: Validate reviewed entries
+        run: node scripts/publish-changelog.mjs --validate
+
+      - name: Register product and publish queued entries
+        run: node scripts/publish-changelog.mjs
+        env:
+          CHANGELOG_PUBLISH_TOKEN: ${{ secrets.CHANGELOG_PUBLISH_TOKEN }}

--- a/.ugurlabs/changelog.json
+++ b/.ugurlabs/changelog.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "productId": "intuneget",
+  "productName": "IntuneGet",
+  "websiteUrl": "https://www.intuneget.com/",
+  "apiUrl": "https://changelog.ugurlabs.com/api/changelog",
+  "publishMode": "on-completion"
+}

--- a/.ugurlabs/entries/changelog-bell.json
+++ b/.ugurlabs/entries/changelog-bell.json
@@ -1,0 +1,5 @@
+{
+  "title": "Product updates, right in IntuneGet",
+  "summary": "Find product news and improvements from the new updates bell in IntuneGet's website and dashboard navigation. The panel shows recent announcements and links to the full changelog, with an unread indicator to help you spot new updates. On phones it opens full-screen, and keyboard users can open, browse, and close it without leaving their place.",
+  "type": "new"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Product changelog
+
+IntuneGet uses the central Ugurlabs changelog configured in `.ugurlabs/changelog.json`.
+Use the global `publish-changelog` skill when onboarding or completing an authorized public product update. If the skill is unavailable, report that limitation instead of inventing an API or publishing process.
+
+`publishMode: "on-completion"` guides agent work. This repository additionally runs `.github/workflows/publish-changelog.yml` after all push CI jobs succeed on `main`. It registers the product if needed and publishes reviewed JSON files in `.ugurlabs/entries/`. PR checks only validate entries and never publish them.
+
+For a public product change, add a uniquely named entry JSON file with `title`, `summary`, `type` (`new`, `improved`, `fixed`, or `maintenance`), and optionally a public `sourceUrl`. Describe the practical user impact. Keep published files and their names immutable; add a new file for a later announcement or correction. The publisher derives a stable product-scoped key, source commit, and date from each file's introducing commit. Reruns do not duplicate entries. A PR without an entry file creates no new announcement.
+
+Run `node scripts/publish-changelog.mjs --validate` before committing. Verify the **Publish changelog** workflow and public feed after merging. If the service is temporarily unavailable, rerun the failed workflow with the same files and keys. The repository Actions secret `CHANGELOG_PUBLISH_TOKEN` must match the central service's publisher credential. Do not publish pending PR changes manually through the global skill.
+
+The navigation bell reads the public API without credentials. Keep publisher tokens out of this repository and browser bundles. Preserve full-screen mobile behavior, keyboard access, the current design system, and entry titles without change-type labels.

--- a/app/(app)/dashboard/layout.tsx
+++ b/app/(app)/dashboard/layout.tsx
@@ -21,6 +21,7 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { TenantSwitcher } from '@/components/msp';
 import { UploadCart } from '@/components/UploadCart';
 import { NotificationBell } from '@/components/notifications';
+import { ChangelogBell } from '@/components/changelog/ChangelogBell';
 import { Sidebar, DeploymentStatusIndicator } from '@/components/dashboard';
 import { CommandPalette } from '@/components/dashboard/CommandPalette';
 import { springPresets } from '@/lib/animations/variants';
@@ -156,7 +157,7 @@ export default function DashboardLayout({
       >
         {/* Top bar */}
         <header className="sticky top-0 z-30 h-16 glass-light">
-          <div className="flex items-center justify-between h-full px-4 lg:px-6">
+          <div className="flex items-center justify-between h-full pl-14 pr-3 sm:pr-4 lg:px-6">
             {/* Command palette trigger */}
             <button
               onClick={handleOpenCommandPalette}
@@ -169,15 +170,16 @@ export default function DashboardLayout({
             </button>
             <div className="flex-1 lg:hidden" />
 
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 items-center gap-1 sm:gap-3">
               <TenantSwitcher />
               <DeploymentStatusIndicator />
+              <ChangelogBell />
               {hostedServices && <NotificationBell />}
               <Button
                 variant="ghost"
                 onClick={toggleCart}
                 aria-label={cartItemCount > 0 ? `Deployment cart, ${cartItemCount} items` : 'Deployment cart'}
-                className="relative text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all"
+                className="relative h-11 w-11 shrink-0 px-0 text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all"
               >
                 <ShoppingCart className="w-5 h-5" />
                 {cartItemCount > 0 && (

--- a/components/changelog/ChangelogBell.test.ts
+++ b/components/changelog/ChangelogBell.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ load: vi.fn(), storage: new Map<string, string>() }));
+vi.mock('gt-next', () => ({ useGT: () => (text: string) => text, useLocale: () => 'en', T: ({ children }: { children: React.ReactNode }) => children }));
+vi.mock('next/dynamic', async () => {
+  const { default: Panel } = await import('./ChangelogPanel');
+  return { default: () => Panel };
+});
+vi.mock('@/lib/product-changelog', async importOriginal => ({
+  ...await importOriginal<typeof import('@/lib/product-changelog')>(), fetchProductChangelog: mocks.load,
+}));
+import { ChangelogBell } from './ChangelogBell';
+import { CHANGELOG_SEEN_KEY } from '@/lib/product-changelog';
+
+const feed = { product: { id: 'intuneget', name: 'IntuneGet', websiteUrl: 'https://www.intuneget.com/' }, entries: [
+  { id: 'latest-update', title: '<b>A smoother catalog</b>', summary: 'Large catalogs are easier to browse.', publishedOn: '2026-09-05', type: 'improved' },
+] };
+let root: Root;
+let container: HTMLDivElement;
+const bell = () => container.querySelector('button')!;
+const flush = () => act(async () => { await Promise.resolve(); });
+const click = async (element: Element) => { await act(async () => { (element as HTMLElement).click(); }); await flush(); };
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.useFakeTimers();
+  mocks.storage.clear();
+  mocks.load.mockReset().mockResolvedValue(feed);
+  Object.defineProperty(window, 'localStorage', { configurable: true, value: {
+    getItem: vi.fn((key: string) => mocks.storage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { mocks.storage.set(key, value); }),
+  } });
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('changelog bell', () => {
+  it('defers badge work, keeps fetched entries unread until opened, and renders plain text without type labels', async () => {
+    await act(async () => root.render(createElement(ChangelogBell)));
+    expect(mocks.load).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(bell().getAttribute('aria-label')).toContain('unread');
+    expect(mocks.storage.has(CHANGELOG_SEEN_KEY)).toBe(false);
+    await click(bell());
+    const dialog = document.querySelector('[role="dialog"]')!;
+    expect(dialog).not.toBeNull();
+    expect(dialog.querySelector('h3')?.textContent).toBe(feed.entries[0].title);
+    expect(dialog.querySelector('h3 b')).toBeNull();
+    expect(dialog.textContent).not.toContain('improved');
+    expect(mocks.storage.get(CHANGELOG_SEEN_KEY)).toBe('latest-update');
+    expect(bell().getAttribute('aria-label')).toBe('Product updates');
+    expect(dialog.querySelector('a')?.getAttribute('href')).toContain('?product=intuneget#change-latest-update');
+  });
+
+  it('shows loading, recovers from failure with retry, and supports an empty feed', async () => {
+    let reject!: (reason: Error) => void;
+    mocks.load.mockImplementation(() => new Promise((_resolve, rejectLoad) => { reject = rejectLoad; }));
+    await act(async () => root.render(createElement(ChangelogBell)));
+    await click(bell());
+    expect(document.querySelector('[role="status"]')?.getAttribute('aria-label')).toBe('Loading product updates');
+    await act(async () => reject(new Error('offline')));
+    expect(document.body.textContent).toContain('Updates are temporarily unavailable');
+    mocks.load.mockResolvedValue({ ...feed, entries: [] });
+    await click(Array.from(document.querySelectorAll('button')).find(el => el.textContent === 'Try again')!);
+    expect(document.body.textContent).toContain('No updates published yet');
+    expect(mocks.storage.has(CHANGELOG_SEEN_KEY)).toBe(false);
+  });
+
+  it('synchronizes read state between mounted bells and remains usable when storage is blocked', async () => {
+    vi.mocked(window.localStorage.setItem).mockImplementation(() => { throw new Error('blocked'); });
+    await act(async () => root.render(createElement('div', null, createElement(ChangelogBell), createElement(ChangelogBell))));
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(container.querySelectorAll('[data-unread]')).toHaveLength(2);
+    await click(bell());
+    expect(container.querySelectorAll('[data-unread]')).toHaveLength(0);
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it('reflects cross-tab read events and cancels delayed work on unmount', async () => {
+    await act(async () => root.render(createElement(ChangelogBell)));
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    mocks.storage.set(CHANGELOG_SEEN_KEY, 'latest-update');
+    await act(async () => { window.dispatchEvent(new StorageEvent('storage', { key: CHANGELOG_SEEN_KEY })); });
+    expect(container.querySelector('[data-unread]')).toBeNull();
+    await act(async () => root.render(null));
+    mocks.load.mockClear();
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(mocks.load).not.toHaveBeenCalled();
+  });
+});

--- a/components/changelog/ChangelogBell.tsx
+++ b/components/changelog/ChangelogBell.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { BellRing } from 'lucide-react';
+import { useGT } from 'gt-next';
+import {
+  CHANGELOG_SEEN_EVENT, CHANGELOG_SEEN_KEY, fetchProductChangelog,
+  markChangelogSeen, readChangelogSeen, type ProductChangelogFeed,
+} from '@/lib/product-changelog';
+
+const ChangelogPanel = dynamic(() => import('./ChangelogPanel'), { ssr: false });
+
+export function ChangelogBell({ onOpen }: { onOpen?: () => void }) {
+  const t = useGT();
+  const panelId = useId();
+  const trigger = useRef<HTMLButtonElement>(null);
+  const mounted = useRef(false);
+  const [open, setOpen] = useState(false);
+  const [feed, setFeed] = useState<ProductChangelogFeed | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [seen, setSeen] = useState<string | null>(null);
+  const unread = Boolean(feed?.entries[0] && feed.entries[0].id !== seen);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const next = await fetchProductChangelog();
+      if (mounted.current) setFeed(next);
+    } catch {
+      if (mounted.current) setError(true);
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    setSeen(readChangelogSeen());
+    const syncSeen = (event: Event) => {
+      if (event instanceof StorageEvent && event.key !== CHANGELOG_SEEN_KEY && event.key !== null) return;
+      setSeen(event instanceof CustomEvent ? event.detail as string : readChangelogSeen());
+    };
+    // Defer the optional badge request until after critical page work. Hidden
+    // tabs wait until visible; there is no background polling interval.
+    const loadWhenVisible = () => {
+      if (document.hidden) return;
+      document.removeEventListener('visibilitychange', loadWhenVisible);
+      void load();
+    };
+    const timer = window.setTimeout(() => {
+      if (document.hidden) document.addEventListener('visibilitychange', loadWhenVisible);
+      else void load();
+    }, 5000);
+    window.addEventListener('storage', syncSeen);
+    window.addEventListener(CHANGELOG_SEEN_EVENT, syncSeen);
+    return () => {
+      mounted.current = false;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', loadWhenVisible);
+      window.removeEventListener('storage', syncSeen);
+      window.removeEventListener(CHANGELOG_SEEN_EVENT, syncSeen);
+    };
+  }, [load]);
+
+  const onRead = useCallback((id: string) => {
+    setSeen(id);
+    markChangelogSeen(id);
+  }, []);
+  const close = useCallback(() => setOpen(false), []);
+  const returnFocus = useCallback(() => trigger.current?.focus(), []);
+
+  return (
+    <>
+      <button
+        ref={trigger}
+        type="button"
+        title={t("What's new in IntuneGet")}
+        aria-label={unread ? t('Product updates, unread updates available') : t('Product updates')}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onFocus={() => { void load(); }}
+        onPointerEnter={() => { void load(); }}
+        onClick={() => { onOpen?.(); setOpen(true); void load(); }}
+        className="relative inline-flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-xl text-text-secondary transition-colors hover:bg-overlay/5 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-bg-elevated"
+      >
+        <BellRing className="h-5 w-5" aria-hidden="true" />
+        {unread && <span data-unread="true" className="absolute right-2 top-2 h-2 w-2 rounded-full bg-accent-cyan ring-2 ring-bg-elevated" aria-hidden="true" />}
+      </button>
+      {open && <ChangelogPanel id={panelId} feed={feed} loading={loading} error={error}
+        onClose={close} onRetry={load} onRead={onRead} returnFocus={returnFocus} />}
+    </>
+  );
+}

--- a/components/changelog/ChangelogPanel.tsx
+++ b/components/changelog/ChangelogPanel.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { BellRing, ExternalLink, RefreshCw, X } from 'lucide-react';
+import { T, useGT, useLocale } from 'gt-next';
+import { CHANGELOG_ARCHIVE_URL, changelogEntryUrl, type ProductChangelogFeed } from '@/lib/product-changelog';
+
+interface ChangelogPanelProps {
+  id: string;
+  feed: ProductChangelogFeed | null;
+  loading: boolean;
+  error: boolean;
+  onClose: () => void;
+  onRetry: () => Promise<void>;
+  onRead: (id: string) => void;
+  returnFocus: () => void;
+}
+
+export default function ChangelogPanel({ id, feed, loading, error, onClose, onRetry, onRead, returnFocus }: ChangelogPanelProps) {
+  const t = useGT();
+  const locale = useLocale();
+  const closeButton = useRef<HTMLButtonElement>(null);
+  const formatDate = useMemo(() => new Intl.DateTimeFormat(locale || 'en', {
+    year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC',
+  }), [locale]);
+  const latestId = feed?.entries[0]?.id;
+  useEffect(() => { if (latestId) onRead(latestId); }, [latestId, onRead]);
+
+  return (
+    <Dialog.Root open onOpenChange={(next) => { if (!next) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/40 backdrop-blur-sm" />
+        <Dialog.Content
+          id={id}
+          onOpenAutoFocus={(event) => { event.preventDefault(); closeButton.current?.focus(); }}
+          onCloseAutoFocus={(event) => { event.preventDefault(); returnFocus(); }}
+          className="fixed inset-0 z-[80] flex h-dvh w-full flex-col overflow-hidden bg-bg-elevated text-text-primary shadow-soft-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan sm:inset-auto sm:bottom-4 sm:right-4 sm:top-4 sm:h-[calc(100dvh-2rem)] sm:w-[28rem] sm:max-w-[calc(100vw-2rem)] sm:rounded-2xl sm:border sm:border-overlay/10"
+        >
+          <header className="shrink-0 border-b border-overlay/10 px-5 pb-5 pt-[max(1.25rem,env(safe-area-inset-top))] sm:px-6">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-accent-cyan/15 bg-accent-cyan/10 text-accent-cyan">
+                  <BellRing className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <div className="min-w-0">
+                  <Dialog.Title className="text-xl font-semibold tracking-tight"><T>What&apos;s new</T></Dialog.Title>
+                  <Dialog.Description className="mt-1 text-sm leading-5 text-text-secondary"><T>News and improvements from IntuneGet.</T></Dialog.Description>
+                </div>
+              </div>
+              <Dialog.Close ref={closeButton} aria-label={t('Close product updates')}
+                className="-mr-2 -mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-text-secondary transition-colors hover:bg-overlay/5 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan">
+                <X className="h-5 w-5" aria-hidden="true" />
+              </Dialog.Close>
+            </div>
+          </header>
+
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-6 sm:px-6">
+            {loading && !feed && !error && (
+              <div role="status" aria-label={t('Loading product updates')}>
+                <span className="sr-only"><T>Loading updates…</T></span>
+                <div className="space-y-8" aria-hidden="true">
+                  {[0, 1, 2].map(item => <div key={item} className="animate-pulse space-y-3 motion-reduce:animate-none">
+                    <div className="h-3 w-24 rounded bg-overlay/10" />
+                    <div className="h-5 w-4/5 rounded bg-overlay/10" />
+                    <div className="h-3 w-full rounded bg-overlay/5" />
+                    <div className="h-3 w-2/3 rounded bg-overlay/5" />
+                  </div>)}
+                </div>
+              </div>
+            )}
+            {error && <div role="status" className="mb-6 rounded-xl border border-overlay/10 bg-bg-surface p-5">
+              <p className="font-medium"><T>Updates are temporarily unavailable</T></p>
+              <p className="mt-2 text-sm leading-6 text-text-secondary"><T>Please try again in a moment.</T></p>
+              <button type="button" disabled={loading} onClick={() => { void onRetry(); }}
+                className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-lg border border-overlay/10 px-4 text-sm font-medium text-text-primary transition-colors hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan disabled:opacity-50">
+                <RefreshCw className="h-4 w-4" aria-hidden="true" /><T>Try again</T>
+              </button>
+            </div>}
+            {feed?.entries.length === 0 && <div className="rounded-xl border border-dashed border-overlay/15 px-5 py-10 text-center">
+              <p className="font-medium"><T>No updates published yet</T></p>
+              <p className="mt-2 text-sm leading-6 text-text-secondary"><T>Product news and improvements will appear here as they ship.</T></p>
+            </div>}
+            {Boolean(feed?.entries.length) && <ol className="space-y-6">
+              {feed!.entries.map(entry => <li key={entry.id} className="border-b border-overlay/10 pb-6 last:border-0 last:pb-0">
+                <article>
+                  <time dateTime={entry.publishedOn} className="text-xs font-medium tabular-nums text-text-muted">{formatDate.format(new Date(`${entry.publishedOn}T00:00:00Z`))}</time>
+                  <h3 className="mt-2 break-words text-base font-semibold leading-6">{entry.title}</h3>
+                  <p className="mt-2 whitespace-pre-line break-words text-sm leading-6 text-text-secondary">{entry.summary}</p>
+                  <a href={changelogEntryUrl(entry.id)} target="_blank" rel="noopener noreferrer"
+                    className="mt-2 inline-flex min-h-11 items-center gap-1.5 rounded-md text-sm font-medium text-accent-cyan transition-colors hover:text-accent-cyan-dim focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan">
+                    <T>Read update</T><ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  </a>
+                </article>
+              </li>)}
+            </ol>}
+          </div>
+
+          <footer className="shrink-0 border-t border-overlay/10 bg-bg-surface px-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-4 sm:px-6">
+            <a href={CHANGELOG_ARCHIVE_URL} target="_blank" rel="noopener noreferrer"
+              className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-accent-cyan px-4 py-2 text-sm font-medium text-white shadow-soft transition-colors hover:bg-accent-cyan-dim focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface">
+              <T>View all IntuneGet updates</T><ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </footer>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/dashboard/DeploymentStatusIndicator.tsx
+++ b/components/dashboard/DeploymentStatusIndicator.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { T } from 'gt-next';
 import Link from 'next/link';
 import { Rocket } from 'lucide-react';
 import { useDashboardStats } from '@/hooks/useAnalytics';
@@ -14,12 +13,12 @@ export function DeploymentStatusIndicator() {
   return (
     <Link
       href="/dashboard/uploads?status=pending"
-      className="relative flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all"
+      className="relative flex h-11 w-11 shrink-0 items-center justify-center gap-1.5 rounded-lg text-sm text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all sm:w-auto sm:px-2.5"
       title={`${pendingCount} active deployment${pendingCount !== 1 ? 's' : ''}`}
       aria-label={`${pendingCount} active deployment${pendingCount !== 1 ? 's' : ''}, view pending uploads`}
     >
       <Rocket className="w-4 h-4" />
-      <span className="text-xs font-medium tabular-nums">{pendingCount}</span>
+      <span className="sr-only text-xs font-medium tabular-nums sm:not-sr-only">{pendingCount}</span>
       <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-accent-cyan animate-pulse" />
     </Link>
   );

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -14,6 +14,7 @@ import { LocaleSwitcher } from "./LocaleSwitcher";
 import dynamic from "next/dynamic";
 import { useSharedGitHubStats } from "@/components/providers/LandingStatsProvider";
 import { useAuthHint } from "@/hooks/useAuthHint";
+import { ChangelogBell } from "@/components/changelog/ChangelogBell";
 
 // MSAL-backed avatar, loaded only for signed-in visitors so anonymous
 // visitors never download @azure/msal-browser on marketing pages.
@@ -219,6 +220,8 @@ export function Header() {
             )}
           </nav>
 
+          <div className="relative z-10 ml-2 flex shrink-0 items-center">
+          <ChangelogBell onOpen={() => setIsMenuOpen(false)} />
           {/* Mobile menu button */}
           <button
             ref={menuButtonRef}
@@ -234,6 +237,7 @@ export function Header() {
               <Menu className="h-6 w-6" />
             )}
           </button>
+          </div>
           </div>
         </div>
       </div>

--- a/components/msp/TenantSwitcher.tsx
+++ b/components/msp/TenantSwitcher.tsx
@@ -48,21 +48,23 @@ export function TenantSwitcher({ className }: TenantSwitcherProps) {
         onClick={() => setIsOpen(!isOpen)}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-overlay/5 hover:bg-overlay/10 border border-overlay/10 transition-all duration-200"
+        aria-label={`Switch tenant: ${selectedTenant?.display_name || 'Select Tenant'}`}
+        title={selectedTenant?.display_name || 'Select Tenant'}
+        className="flex h-11 w-11 shrink-0 items-center justify-center gap-2 rounded-lg bg-overlay/5 hover:bg-overlay/10 border border-overlay/10 transition-all duration-200 sm:w-auto sm:px-3"
       >
         <Building2 className="w-4 h-4 text-accent-cyan" />
-        <span className="text-sm font-medium text-text-primary max-w-[150px] truncate">
+        <span className="sr-only text-sm font-medium text-text-primary sm:not-sr-only sm:max-w-[150px] sm:truncate">
           {selectedTenant?.display_name || 'Select Tenant'}
         </span>
         <ChevronDown className={cn(
-          'w-4 h-4 text-text-secondary transition-transform duration-200',
+          'hidden w-4 h-4 text-text-secondary transition-transform duration-200 sm:block',
           isOpen && 'rotate-180'
         )} />
       </button>
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute top-full right-0 mt-2 w-64 bg-bg-surface border border-overlay/10 rounded-lg shadow-xl z-50 overflow-hidden animate-fade-in">
+        <div className="fixed left-4 right-4 top-16 bg-bg-surface border border-overlay/10 rounded-lg shadow-xl z-50 overflow-hidden animate-fade-in sm:absolute sm:left-auto sm:right-0 sm:top-full sm:mt-2 sm:w-64">
           <div className="p-2 border-b border-overlay/5">
             <p className="text-xs text-text-muted px-2 py-1">Switch tenant</p>
           </div>

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -54,7 +54,7 @@ export function NotificationBell() {
         variant="ghost"
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          'relative text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all',
+          'relative h-11 w-11 shrink-0 px-0 text-text-secondary hover:text-text-primary hover:bg-overlay/5 transition-all',
           isOpen && 'text-text-primary bg-overlay/5'
         )}
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}

--- a/lib/product-changelog.test.ts
+++ b/lib/product-changelog.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const entry = { id: 'entry-1', title: 'Faster browsing', summary: 'Browse the app catalog more smoothly.', type: 'improved', publishedOn: '2026-09-05' };
+const feed = { product: { id: 'intuneget', name: 'IntuneGet', websiteUrl: 'https://www.intuneget.com/' }, entries: [entry] };
+
+beforeEach(() => { vi.resetModules(); vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+
+describe('product changelog reads', () => {
+  it('coalesces concurrent navigation requests, caches success, and refreshes after five minutes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => feed });
+    vi.stubGlobal('fetch', fetchMock);
+    const api = await import('./product-changelog');
+    const first = api.fetchProductChangelog();
+    expect(api.fetchProductChangelog()).toBe(first);
+    expect((await first).entries[0]).not.toHaveProperty('type');
+    await api.fetchProductChangelog();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(api.CHANGELOG_FEED_URL, expect.objectContaining({ credentials: 'omit', headers: { Accept: 'application/json' } }));
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await api.fetchProductChangelog();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed requests and permits a successful retry', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false }).mockResolvedValue({ ok: true, json: async () => feed });
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchProductChangelog } = await import('./product-changelog');
+    await expect(fetchProductChangelog()).rejects.toThrow('temporarily unavailable');
+    await expect(fetchProductChangelog()).resolves.toHaveProperty('product.id', 'intuneget');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts stalled reads and allows the next attempt', async () => {
+    vi.stubGlobal('fetch', vi.fn((_url, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => reject(new Error('aborted')));
+    })));
+    const { fetchProductChangelog } = await import('./product-changelog');
+    const rejected = expect(fetchProductChangelog()).rejects.toThrow('aborted');
+    await vi.advanceTimersByTimeAsync(10_000);
+    await rejected;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => feed }));
+    await expect(fetchProductChangelog()).resolves.toHaveProperty('entries');
+  });
+
+  it.each([
+    null,
+    { ...feed, product: { ...feed.product, id: 'another-product' } },
+    { ...feed, entries: [entry, entry] },
+    { ...feed, entries: [{ ...entry, publishedOn: '2026-02-30' }] },
+    { ...feed, entries: [{ ...entry, title: null }] },
+    { ...feed, entries: [{ ...entry, summary: 'x'.repeat(2001) }] },
+  ])('rejects malformed or mismatched API data: %j', async value => {
+    const { parseProductChangelog } = await import('./product-changelog');
+    expect(() => parseProductChangelog(value)).toThrow();
+  });
+
+  it('accepts an empty product and encodes archive anchors', async () => {
+    const { parseProductChangelog, changelogEntryUrl } = await import('./product-changelog');
+    expect(parseProductChangelog({ ...feed, entries: [] }).entries).toEqual([]);
+    expect(changelogEntryUrl('A#B')).toBe('https://changelog.ugurlabs.com/?product=intuneget#change-a%23b');
+  });
+});

--- a/lib/product-changelog.ts
+++ b/lib/product-changelog.ts
@@ -1,0 +1,89 @@
+import config from '@/.ugurlabs/changelog.json';
+
+export const CHANGELOG_FEED_URL = `${config.apiUrl}/${config.productId}?limit=20`;
+export const CHANGELOG_ARCHIVE_URL = `https://changelog.ugurlabs.com/?product=${config.productId}`;
+export const CHANGELOG_SEEN_KEY = `ugurlabs:changelog:last-seen:${config.productId}`;
+export const CHANGELOG_SEEN_EVENT = 'intuneget:changelog-seen';
+const CACHE_TTL_MS = 5 * 60_000;
+
+export interface ProductChangelogEntry {
+  id: string;
+  title: string;
+  summary: string;
+  publishedOn: string;
+}
+
+export interface ProductChangelogFeed {
+  product: { id: string; name: string; websiteUrl: string };
+  entries: ProductChangelogEntry[];
+}
+
+let cachedFeed: { value: ProductChangelogFeed; expiresAt: number } | undefined;
+let pendingRequest: Promise<ProductChangelogFeed> | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseProductChangelog(value: unknown): ProductChangelogFeed {
+  if (!isRecord(value) || !isRecord(value.product) ||
+      value.product.id !== config.productId || typeof value.product.name !== 'string' ||
+      typeof value.product.websiteUrl !== 'string' || !Array.isArray(value.entries) || value.entries.length > 100) {
+    throw new Error('Invalid product updates response');
+  }
+  const ids = new Set<string>();
+  const entries = value.entries.map((entry): ProductChangelogEntry => {
+    if (!isRecord(entry) || typeof entry.id !== 'string' || !entry.id ||
+        typeof entry.title !== 'string' || !entry.title.trim() || entry.title.length > 160 ||
+        typeof entry.summary !== 'string' || entry.summary.length > 2000 ||
+        typeof entry.publishedOn !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.publishedOn)) {
+      throw new Error('Invalid product update');
+    }
+    const date = new Date(`${entry.publishedOn}T00:00:00Z`);
+    if (!Number.isFinite(date.valueOf()) || date.toISOString().slice(0, 10) !== entry.publishedOn || ids.has(entry.id)) {
+      throw new Error('Invalid product update date or ID');
+    }
+    ids.add(entry.id);
+    return { id: entry.id, title: entry.title, summary: entry.summary, publishedOn: entry.publishedOn };
+  });
+  return {
+    product: { id: value.product.id, name: value.product.name, websiteUrl: value.product.websiteUrl },
+    entries,
+  };
+}
+
+// Public, credential-free reads are shared across navigation instances. A
+// request belongs to this cache, so closing one panel does not abort another.
+export function fetchProductChangelog(): Promise<ProductChangelogFeed> {
+  if (cachedFeed && cachedFeed.expiresAt > Date.now()) return Promise.resolve(cachedFeed.value);
+  if (pendingRequest) return pendingRequest;
+  pendingRequest = (async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const response = await fetch(CHANGELOG_FEED_URL, {
+        headers: { Accept: 'application/json' }, credentials: 'omit', signal: controller.signal,
+      });
+      if (!response.ok) throw new Error('Product updates are temporarily unavailable');
+      const value = parseProductChangelog(await response.json());
+      cachedFeed = { value, expiresAt: Date.now() + CACHE_TTL_MS };
+      return value;
+    } finally {
+      clearTimeout(timeout);
+    }
+  })().finally(() => { pendingRequest = undefined; });
+  return pendingRequest;
+}
+
+export function readChangelogSeen(): string | null {
+  try { return window.localStorage.getItem(CHANGELOG_SEEN_KEY); } catch { return null; }
+}
+
+export function markChangelogSeen(id: string): void {
+  try { window.localStorage.setItem(CHANGELOG_SEEN_KEY, id); } catch { /* Keep the panel usable without storage. */ }
+  window.dispatchEvent(new CustomEvent(CHANGELOG_SEEN_EVENT, { detail: id }));
+}
+
+export function changelogEntryUrl(id: string): string {
+  return `${CHANGELOG_ARCHIVE_URL}#change-${encodeURIComponent(id.toLowerCase())}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.10",
+        "happy-dom": "20.14.0",
         "husky": "^9.1.7",
         "postcss": "^8.5.19",
         "tailwindcss": "^4.3.2",
@@ -3666,6 +3667,23 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.63.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
@@ -4818,6 +4836,19 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -5499,6 +5530,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6951,6 +6995,25 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.14.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.0.tgz",
+      "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -11056,6 +11119,16 @@
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11193,6 +11266,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.10",
+    "happy-dom": "20.14.0",
     "husky": "^9.1.7",
     "postcss": "^8.5.19",
     "tailwindcss": "^4.3.2",

--- a/scripts/publish-changelog.mjs
+++ b/scripts/publish-changelog.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const API = 'https://changelog.ugurlabs.com/api/changelog';
+const entriesDirectory = '.ugurlabs/entries';
+const delay = ms => new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+
+export function validateConfig(config) {
+  if (config?.schemaVersion !== 1 || config.apiUrl !== API || config.productId !== 'intuneget' ||
+      config.productName !== 'IntuneGet' || config.websiteUrl !== 'https://www.intuneget.com/') {
+    throw new Error('Unexpected IntuneGet changelog configuration');
+  }
+  return config;
+}
+
+export function validateEntry(entry, filename) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*\.json$/.test(filename) || filename.length > 150 ||
+      !entry || typeof entry !== 'object' || Array.isArray(entry) ||
+      Object.keys(entry).some(key => !['title', 'summary', 'type', 'sourceUrl'].includes(key))) {
+    throw new Error('Invalid changelog entry file');
+  }
+  for (const [key, min, max] of [['title', 3, 160], ['summary', 12, 2000]]) {
+    if (typeof entry[key] !== 'string' || entry[key] !== entry[key].trim() || entry[key].length < min || entry[key].length > max) {
+      throw new Error(`Invalid changelog ${key}`);
+    }
+  }
+  if (!['new', 'improved', 'fixed', 'maintenance'].includes(entry.type)) throw new Error('Invalid change type');
+  if (entry.sourceUrl !== undefined) {
+    // Only public project links belong in this repository's publication queue.
+    if (typeof entry.sourceUrl !== 'string' || entry.sourceUrl.length > 2000 ||
+        !/^https:\/\/(?:github\.com\/ugurkocde\/IntuneGet\/(?:pull\/\d+|releases\/tag\/[\w.-]+)|www\.intuneget\.com\/[\w/-]*)$/.test(entry.sourceUrl)) {
+      throw new Error('Invalid public source URL');
+    }
+  }
+  return entry;
+}
+
+export function publicationPayload(config, entry, filename, commit, date) {
+  validateConfig(config);
+  validateEntry(entry, filename);
+  if (!/^[a-f0-9]{40}$/.test(commit) || !/^\d{4}-\d{2}-\d{2}$/.test(date) ||
+      !Number.isFinite(Date.parse(`${date}T00:00:00Z`)) || new Date(`${date}T00:00:00Z`).toISOString().slice(0, 10) !== date) {
+    throw new Error('Invalid changelog source commit or date');
+  }
+  return { ...entry, publishedOn: date, sourceCommit: commit,
+    idempotencyKey: `${config.productId}:entry:${filename.slice(0, -5)}` };
+}
+
+export async function apiRequest(method, url, token, body, fetchImpl = fetch) {
+  if (url !== `${API}/intuneget` && url !== `${API}/intuneget?limit=100`) throw new Error('Unexpected API destination');
+  const response = await fetchImpl(url, {
+    method, redirect: 'error', signal: AbortSignal.timeout(20_000),
+    headers: { Accept: 'application/json', ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(method !== 'GET' && token ? { Authorization: `Bearer ${token}` } : {}) },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (method === 'GET' && response.status === 404) return null;
+  if (!response.ok) throw new Error(`Changelog API ${method} failed with HTTP ${response.status}`);
+  return response.json();
+}
+
+export async function publishEntry(url, token, payload, request = apiRequest) {
+  // A retry always retains the exact same product-scoped key and body.
+  let result;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      result = await request('POST', url, token, payload);
+      break;
+    } catch (error) {
+      if (attempt === 1 || /HTTP (?:400|401|403|404)/.test(error.message)) throw error;
+    }
+  }
+  if (!result || typeof result.id !== 'string' || !result.id || typeof result.created !== 'boolean') {
+    throw new Error('Unexpected publication result; inspect the public feed before retrying');
+  }
+  return result;
+}
+
+export async function main(validateOnly = false) {
+  const config = validateConfig(JSON.parse(await readFile('.ugurlabs/changelog.json', 'utf8')));
+  const files = (await readdir(entriesDirectory)).filter(file => file.endsWith('.json')).sort();
+  const entries = await Promise.all(files.map(async filename => ({ filename,
+    entry: validateEntry(JSON.parse(await readFile(`${entriesDirectory}/${filename}`, 'utf8')), filename) })));
+  if (validateOnly) {
+    console.log(`Validated ${entries.length} public changelog entries. No writes performed.`);
+    return;
+  }
+  const token = process.env.CHANGELOG_PUBLISH_TOKEN;
+  if (!token) throw new Error('Missing CHANGELOG_PUBLISH_TOKEN Actions secret');
+  const url = `${config.apiUrl}/${config.productId}`;
+  const feed = await apiRequest('GET', `${url}?limit=100`);
+  if (feed && (feed.product?.id !== config.productId || feed.product?.name !== config.productName || feed.product?.websiteUrl !== config.websiteUrl)) {
+    throw new Error('Existing product registration does not match this repository');
+  }
+  if (!feed) await apiRequest('PUT', url, token, { productName: config.productName, websiteUrl: config.websiteUrl });
+
+  const createdIds = [];
+  for (const { filename, entry } of entries) {
+    // The entry's introducing commit is stable across subsequent CI runs.
+    // Keep published files immutable, and add a new file for each later update.
+    const history = execFileSync('git', ['log', '--diff-filter=A', '--format=%H%n%cs', '--', `${entriesDirectory}/${filename}`], { encoding: 'utf8' }).trim().split('\n');
+    if (history.length !== 2) throw new Error(`Entry must have one introducing commit: ${filename}`);
+    const result = await publishEntry(url, token, publicationPayload(config, entry, filename, ...history));
+    console.log(`${result.created ? 'Published' : 'Already published'}: ${filename} (${result.id})`);
+    if (result.created) createdIds.push(result.id);
+  }
+  // Verify new writes through the same public API used by the bell. Previously
+  // published entries may eventually fall outside the latest 100 results.
+  for (let attempt = 0; attempt < 35; attempt++) {
+    const publicFeed = await apiRequest('GET', `${url}?limit=100`);
+    if (publicFeed?.product?.id === config.productId && Array.isArray(publicFeed.entries) &&
+        createdIds.every(id => publicFeed.entries.some(entry => entry.id === id))) {
+      console.log(`Verified public IntuneGet feed (${createdIds.length} new entries).`);
+      return;
+    }
+    if (attempt < 34) await delay(10_000);
+  }
+  throw new Error('Publication returned success, but the public feed could not be verified; rerun with unchanged entry files');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const args = process.argv.slice(2);
+  if (args.length > 1 || (args.length === 1 && args[0] !== '--validate')) throw new Error('Usage: publish-changelog.mjs [--validate]');
+  main(args[0] === '--validate').catch(error => {
+    // No response body, environment dump, or credential-bearing request details.
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/publish-changelog.test.ts
+++ b/scripts/publish-changelog.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parse } from 'yaml';
+import { apiRequest, publicationPayload, publishEntry, validateConfig, validateEntry } from './publish-changelog.mjs';
+import config from '../.ugurlabs/changelog.json';
+
+const entry = { title: 'A faster app catalog', summary: 'Browse large catalogs with smoother scrolling.', type: 'improved' };
+const filename = 'frontend-performance.json';
+const commit = 'a'.repeat(40);
+const url = 'https://changelog.ugurlabs.com/api/changelog/intuneget';
+
+describe('automatic changelog publication', () => {
+  it('uses stable product-scoped keys and commit dates across reruns', () => {
+    const payload = publicationPayload(config, entry, filename, commit, '2026-09-05');
+    expect(payload).toEqual({ ...entry, publishedOn: '2026-09-05', sourceCommit: commit, idempotencyKey: 'intuneget:entry:frontend-performance' });
+    expect(publicationPayload(config, entry, filename, commit, '2026-09-05')).toEqual(payload);
+    expect(() => publicationPayload(config, entry, filename, commit, '2026-02-30')).toThrow();
+  });
+
+  it.each([
+    { ...entry, summary: 'Short' }, { ...entry, type: 'breaking' },
+    { ...entry, sourceUrl: 'https://example.com/?token=private' },
+    { ...entry, secret: 'unexpected-field' },
+  ])('rejects invalid public entries: %j', value => {
+    expect(() => validateEntry(value, filename)).toThrow();
+  });
+
+  it('rejects alternate credential destinations and unsafe filenames', async () => {
+    expect(() => validateConfig({ ...config, apiUrl: 'https://example.com' })).toThrow();
+    expect(() => validateEntry(entry, '../unexpected.json')).toThrow();
+    await expect(apiRequest('POST', 'https://example.com', 'test-only', {})).rejects.toThrow('destination');
+  });
+
+  it('retries an ambiguous publication with the same body/key and accepts the duplicate response', async () => {
+    const payload = publicationPayload(config, entry, filename, commit, '2026-09-05');
+    const request = vi.fn().mockRejectedValueOnce(new Error('network timeout')).mockResolvedValue({ id: 'entry-id', created: false });
+    await expect(publishEntry(url, 'test-only', payload, request)).resolves.toEqual({ id: 'entry-id', created: false });
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[0]).toEqual(request.mock.calls[1]);
+  });
+
+  it('does not retry rejected credentials or treat malformed responses as success', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('Changelog API POST failed with HTTP 401'));
+    await expect(publishEntry(url, 'test-only', entry, request)).rejects.toThrow('401');
+    expect(request).toHaveBeenCalledTimes(1);
+    await expect(publishEntry(url, 'test-only', entry, vi.fn().mockResolvedValue({}))).rejects.toThrow('Unexpected publication');
+  });
+
+  it('omits credentials on public reads and refuses redirects on writes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) });
+    await apiRequest('GET', `${url}?limit=100`, 'test-only', undefined, fetchMock);
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+    await apiRequest('POST', url, 'test-only', entry, fetchMock);
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ redirect: 'error', headers: { Authorization: 'Bearer test-only' } });
+  });
+
+  it('gates credentialed publication on successful same-repository push CI for main', () => {
+    const workflow = parse(readFileSync('.github/workflows/publish-changelog.yml', 'utf8'));
+    expect(workflow.on).toEqual({ workflow_run: { workflows: ['CI'], types: ['completed'], branches: ['main'] } });
+    expect(workflow.permissions).toEqual({ contents: 'read' });
+    const job = workflow.jobs.publish;
+    for (const condition of ["conclusion == 'success'", "event == 'push'", "head_branch == 'main'", 'head_repository.full_name == github.repository']) expect(job.if).toContain(condition);
+    expect(job.steps[0].with.ref).toBe('${{ github.event.workflow_run.head_sha }}');
+    expect(job.steps[0].with['persist-credentials']).toBe(false);
+  });
+
+  it('registers a missing product, publishes committed entries, verifies the feed, and safely reruns', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'intuneget-changelog-test-'));
+    try {
+      mkdirSync(join(directory, '.ugurlabs/entries'), { recursive: true });
+      writeFileSync(join(directory, '.ugurlabs/changelog.json'), JSON.stringify(config));
+      writeFileSync(join(directory, '.ugurlabs/entries', filename), JSON.stringify(entry));
+      for (const args of [['init', '-q'], ['add', '.'], ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', '-c', 'core.hooksPath=/dev/null', 'commit', '-qm', 'Test entry']]) {
+        expect(spawnSync('git', args, { cwd: directory }).status).toBe(0);
+      }
+      const scriptUrl = pathToFileURL(resolve('scripts/publish-changelog.mjs')).href;
+      const result = spawnSync(process.execPath, ['--input-type=module', '-e', `
+        import assert from 'node:assert/strict';
+        import {main} from ${JSON.stringify(scriptUrl)};
+        let registered=false, publications=0, registrations=0, firstPayload;
+        globalThis.fetch=async (url, options)=>{
+          let value;
+          if(options.method==='GET') {
+            assert.equal(options.headers.Authorization, undefined);
+            if(!registered) return {ok:false,status:404};
+            value={product:{id:'intuneget',name:'IntuneGet',websiteUrl:'https://www.intuneget.com/'},entries:publications?[{id:'published-id'}]:[]};
+          } else {
+            assert.equal(options.headers.Authorization, 'Bearer test-only');
+            assert.equal(options.redirect, 'error');
+            if(options.method==='PUT') {registered=true;registrations++;value={product:{slug:'intuneget'}};}
+            else {
+              const payload=JSON.parse(options.body);
+              assert.equal(payload.idempotencyKey,'intuneget:entry:frontend-performance');
+              if(firstPayload) assert.deepEqual(payload,firstPayload);
+              firstPayload=payload;
+              value={id:'published-id',created:publications++===0};
+            }
+          }
+          return {ok:true,status:200,json:async()=>value};
+        };
+        await main(); await main();
+        assert.equal(registrations,1);
+        assert.equal(publications,2);
+      `], { cwd: directory, env: { ...process.env, CHANGELOG_PUBLISH_TOKEN: 'test-only' }, encoding: 'utf8' });
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Published: frontend-performance.json');
+      expect(result.stdout).toContain('Already published: frontend-performance.json');
+      expect(result.stdout).toContain('Verified public IntuneGet feed (1 new entries)');
+      expect(result.stdout).not.toContain('test-only');
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Add a product-updates bell to IntuneGet's persistent website and dashboard navigation, backed by the central Ugurlabs API. Recent updates open in a desktop panel or a full-screen mobile dialog, using the existing design tokens and showing dates, titles, and summaries without change-type labels.

## Changes

- Lazy-load the dialog, coalesce public reads, cache responses for five minutes, delay the optional badge request, and bound network waits. Validate the product and entry data before rendering it as text.
- Track unread updates only after they are displayed, synchronize read state across tabs and mounted navigation, and handle loading, empty feeds, failure/retry, and blocked browser storage.
- Reuse Radix dialog behavior for focus trapping, Escape, scroll locking, and focus restoration. Keep navigation usable at 320px with compact tenant/deployment controls and 44px action buttons.
- Configure the IntuneGet product and queue its first announcement in `.ugurlabs/entries/`. Add a non-mutating CI validation step and a **Publish changelog** workflow that runs only after successful same-repository push CI on `main`, checking out that exact verified commit.
- Register the product if needed and publish reviewed entry files with stable product-scoped idempotency keys. Verify new entries through the public feed. Reruns do not duplicate announcements, and pull requests never publish.
- Document the repository workflow in `AGENTS.md`. The reusable global `publish-changelog` skill was also created and validated locally; it is separate from this repository's committed automation.

## Validation

- Full suite: **93 test files passed, 1,659 tests passed, 96 existing skips**.
- Full ESLint, actionlint v1.7.12, secret pre-commit check, and production build passed.
- Browser checks: 1440px desktop panel; full-screen 390px and 320px mobile panels; scrolling and no horizontal overflow; Tab/Shift+Tab wrapping; 32 consecutive Tab presses; Escape and focus restoration; keyboard reopening; outside-click dismissal; error/retry and empty states.
- Dashboard navigation exercised at 320, 390, 768, and 1440px using exact top-bar markup and real controls with synthetic data hooks, including a long tenant name and 12,345 pending deployments. No real tenant data was used.
- Publisher tests cover registration, publication, public-feed verification, duplicate-safe reruns, ambiguous network retries, credential isolation, and the workflow's trusted-commit conditions. The global skill's five helper tests and skill validation also passed.

## Publication setup

A dedicated IntuneGet token is configured as the repository Actions secret `CHANGELOG_PUBLISH_TOKEN` and as the central service's production variable `CHANGELOG_PUBLISH_TOKEN_INTUNEGET`. The existing shared token remains unchanged. The central API change restricts the new credential to IntuneGet registration and publication; it will be deployed and verified before this PR merges.

Merge this PR before performance PR #1087. That PR includes its own user-facing entry, which this workflow publishes after its merge reaches successful main-branch CI. A PR without an entry file creates no new announcement.
