### PR TITLE
Keep customer uploads available during QA maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,3 +262,7 @@ BEEHIIV_API_KEY=
 # Note: This covers packaging jobs and upload history. Catalog browsing and
 # compact QA results use the verified public SQLite catalog snapshot when
 # Supabase is not configured (see docs/SELF_HOSTING.md).
+
+# Explicit operator maintenance: skip customer QA and hide the public live dashboard.
+# Set false and redeploy when the QA runner is ready. Automatic updates retain QA gating.
+QA_MAINTENANCE_MODE=false

--- a/.ugurlabs/entries/qa-maintenance-uploads.json
+++ b/.ugurlabs/entries/qa-maintenance-uploads.json
@@ -1,0 +1,5 @@
+{
+  "title": "Customer uploads remain available during QA maintenance",
+  "summary": "Customer uploads can proceed without waiting for an automated installation test while QA maintenance is active. New uploads do not add tests to the QA queue during this period. The QA page temporarily hides live testing, queued apps, and past results. Installer validation and existing security protections still apply; automatic updates continue to require QA coverage. Live testing and results will return when maintenance ends.",
+  "type": "maintenance"
+}

--- a/app/(marketing)/qa/page.tsx
+++ b/app/(marketing)/qa/page.tsx
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
@@ -25,6 +26,7 @@ const breadcrumbJsonLd = {
 };
 
 export default async function QaPage() {
+  const maintenance = isQaMaintenanceMode();
   const host = (await headers()).get('host');
   if (!isQaLivePublicEnabled(host)) notFound();
 
@@ -35,10 +37,15 @@ export default async function QaPage() {
       <main id="main-content" className="mx-auto min-h-svh w-full max-w-[1600px] flex-1 px-4 pb-16 pt-24 lg:px-8 lg:pt-28">
         <div className="mb-8 max-w-3xl space-y-3">
           <p className="text-sm font-semibold uppercase tracking-[0.18em] text-accent-cyan"><T>Application quality assurance</T></p>
-          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl"><T>See package QA as it happens</T></h1>
-          <p className="text-lg text-text-secondary"><T>Every update is installed, detected, uninstalled, and verified inside a clean Windows VM before it can be released through IntuneGet.</T></p>
+          <h1 className="text-3xl font-bold text-text-primary sm:text-4xl">{maintenance ? <T>Application QA</T> : <T>See package QA as it happens</T>}</h1>
+          <p className="text-lg text-text-secondary">{maintenance ? <T>Automated application testing is temporarily paused. Customer uploads remain available.</T> : <T>Every update is installed, detected, uninstalled, and verified inside a clean Windows VM before it can be released through IntuneGet.</T>}</p>
         </div>
-        <QaLiveClient />
+        {maintenance ? (
+          <section className="rounded-2xl border border-overlay/10 bg-bg-elevated p-6 sm:p-8" aria-labelledby="qa-maintenance-heading">
+            <h2 id="qa-maintenance-heading" className="text-xl font-semibold text-text-primary"><T>QA is temporarily paused</T></h2>
+            <p className="mt-3 max-w-2xl text-text-secondary"><T>Customer uploads can proceed without an automated installation test during this pause. Live testing and results will return when QA resumes.</T></p>
+          </section>
+        ) : <QaLiveClient />}
       </main>
       <Footer />
     </div>

--- a/app/api/cron/qa-dispatch/route.test.ts
+++ b/app/api/cron/qa-dispatch/route.test.ts
@@ -231,6 +231,7 @@ it('allows large installer preflight the same bounded window as customer packagi
 });
 
 afterEach(() => {
+  delete process.env.QA_MAINTENANCE_MODE;
   delete process.env.CRON_SECRET;
 });
 
@@ -249,6 +250,26 @@ describe('GET /api/cron/qa-dispatch', () => {
       dispatched: false,
       reason: 'maintenance_paused',
       maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(claimedIds).toEqual([]);
+    expect(dispatchQaCandidateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile or dispatch candidates while maintenance is paused by the server switch', async () => {
+    process.env.QA_MAINTENANCE_MODE = 'true';
+    const row = candidate('catalog-default');
+    const { client, claimedIds } = createSupabaseStub([row], [], { paused: false });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      dispatched: false,
+      reason: 'maintenance_paused',
+      maintenanceReason: null,
     });
     expect(claimedIds).toEqual([]);
     expect(dispatchQaCandidateMock).not.toHaveBeenCalled();

--- a/app/api/cron/qa-dispatch/route.ts
+++ b/app/api/cron/qa-dispatch/route.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { dispatchQaCandidate } from '@/lib/qa/dispatch';
@@ -48,7 +49,7 @@ export async function GET(request: Request) {
 
   const supabase = createServerClient();
   const control = await getQaPipelineControl(supabase);
-  if (control.paused) {
+  if (control.paused || isQaMaintenanceMode()) {
     return NextResponse.json({
       success: true,
       dispatched: false,

--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -373,6 +373,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env.QA_MAINTENANCE_MODE;
   delete process.env.CRON_SECRET;
   vi.restoreAllMocks();
 });
@@ -411,6 +412,33 @@ describe('GET /api/cron/qa-enqueue', () => {
       paused: true,
       reason: 'maintenance_paused',
       maintenanceReason: 'Golden VM maintenance',
+    });
+    expect(pollRunInserts).toHaveLength(0);
+    expect(candidateInserts).toHaveLength(0);
+    expect(detectWingetChangesMock).not.toHaveBeenCalled();
+    expect(pipelineControlUpdates).toEqual([
+      expect.objectContaining({
+        scheduler_packager_commit: QA_PSADT_TOOLCHAIN.packagerCommit,
+        scheduler_seen_at: expect.any(String),
+      }),
+    ]);
+  });
+
+  it('does not poll or mutate the queue while maintenance is paused by the server switch', async () => {
+    process.env.QA_MAINTENANCE_MODE = 'true';
+    const { client, pollRunInserts, candidateInserts, pipelineControlUpdates } =
+      createSupabaseStub({ paused: false });
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      paused: true,
+      reason: 'maintenance_paused',
+      maintenanceReason: null,
     });
     expect(pollRunInserts).toHaveLength(0);
     expect(candidateInserts).toHaveLength(0);

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import {
@@ -560,7 +561,7 @@ export async function GET(request: Request) {
       startedAt
     );
     const control = await getQaPipelineControl(supabase);
-    if (control.paused) {
+    if (control.paused || isQaMaintenanceMode()) {
       return NextResponse.json({
         success: true,
         paused: true,

--- a/app/api/cron/qa-resume/route.test.ts
+++ b/app/api/cron/qa-resume/route.test.ts
@@ -43,6 +43,7 @@ function chain(result: { data: unknown; error: unknown }) {
 describe('GET /api/cron/qa-resume', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_MAINTENANCE_MODE;
     delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     process.env.CRON_SECRET = 'secret';
     getFeatureFlagsMock.mockReturnValue({ localPackager: true });
@@ -181,7 +182,88 @@ describe('GET /api/cron/qa-resume', () => {
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps automatic updates waiting during a customer continuity window', async () => {
+  it('resumes existing customer uploads without querying or creating QA in maintenance', async () => {
+    process.env.QA_MAINTENANCE_MODE = 'true';
+    getFeatureFlagsMock.mockReturnValue({ localPackager: false });
+    triggerPackagingWorkflowMock.mockResolvedValue({
+      runId: 123,
+      runUrl: 'https://example.test/run/123',
+    });
+    const job = {
+      id: 'job-deferred-customer',
+      tenant_id: 'tenant-1',
+      qa_candidate_id: 'candidate-queued',
+      created_at: '2026-09-01T12:00:00Z',
+      winget_id: 'Example.App',
+      display_name: 'Example App',
+      publisher: 'Example',
+      version: '1.0.0',
+      architecture: 'x64',
+      installer_url: 'https://example.test/installer.exe',
+      installer_sha256: 'A'.repeat(64),
+      installer_type: 'exe',
+      install_command: 'installer.exe /silent',
+      uninstall_command: 'installer.exe /uninstall /silent',
+      install_scope: 'machine',
+      package_config: {
+        sourceType: 'winget',
+        displayName: 'Example App',
+        publisher: 'Example',
+        architecture: 'x64',
+        installerUrl: 'https://example.test/installer.exe',
+        installerSha256: 'A'.repeat(64),
+        installerType: 'exe',
+        installCommand: 'installer.exe /silent',
+        uninstallCommand: 'installer.exe /uninstall /silent',
+      },
+      is_auto_update: false,
+    };
+    const claimUpdate = chain({ data: { id: job.id }, error: null });
+    const provenanceUpdate = chain({ data: null, error: null });
+    let packagingCall = 0;
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'packaging_jobs') {
+          packagingCall++;
+          if (packagingCall === 1) return chain({ data: [job], error: null });
+          if (packagingCall === 2) return claimUpdate;
+          return provenanceUpdate;
+        }
+        if (table === 'qa_candidates') {
+          return chain({
+            data: {
+              id: 'candidate-queued',
+              status: 'queued',
+              failure_summary: null,
+              package_profile_sha256: 'B'.repeat(64),
+            },
+            error: null,
+          });
+        }
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    };
+    createServerClientMock.mockReturnValue(client);
+
+    const response = await GET(new Request('https://example.test/api/cron/qa-resume', {
+      headers: { authorization: 'Bearer secret' },
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ resumed: 1, failed: 0, waiting: 0 });
+    expect(claimUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'packaging',
+      status_message: 'Preparing deployment',
+      qa_completed_at: null,
+    }));
+    expect(triggerPackagingWorkflowMock).toHaveBeenCalledWith(expect.objectContaining({ qaOverride: true }));
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalledWith('qa_candidates');
+  });
+
+  it('keeps automatic updates waiting during customer continuity and maintenance', async () => {
+    process.env.QA_MAINTENANCE_MODE = 'true';
     process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL = new Date(
       Date.now() + 7 * 24 * 60 * 60 * 1000
     ).toISOString();

--- a/app/api/cron/qa-resume/route.ts
+++ b/app/api/cron/qa-resume/route.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import { getFeatureFlags } from '@/lib/features';
@@ -40,6 +41,7 @@ export async function GET(request: Request) {
   let waiting = 0;
 
   for (const job of jobs || []) {
+    const skipCustomerQa = !job.is_auto_update && isQaMaintenanceMode();
     let item = job.package_config as unknown as Win32CartItem;
     let candidate: {
       id: string;
@@ -47,7 +49,7 @@ export async function GET(request: Request) {
       failure_summary: string | null;
       package_profile_sha256: string | null;
     } | null = null;
-    if (job.qa_candidate_id) {
+    if (job.qa_candidate_id && !skipCustomerQa) {
       const { data, error: candidateError } = await supabase
         .from('qa_candidates')
         .select('id, status, failure_summary, package_profile_sha256')
@@ -61,7 +63,7 @@ export async function GET(request: Request) {
     let candidateFailureSummary = candidate?.failure_summary;
     let appVersionAlreadyPassed = false;
 
-    if (!candidate || candidateStatus === 'superseded') {
+    if (!skipCustomerQa && (!candidate || candidateStatus === 'superseded')) {
       // A waiting job can outlive the catalog metadata and packager revision
       // that created it. Reconcile the exact version against the trusted live
       // manifest before rebuilding QA demand, then persist that refreshed
@@ -137,7 +139,7 @@ export async function GET(request: Request) {
       if (relinkError) throw new Error(`Could not relink superseded QA demand: ${relinkError.message}`);
     }
 
-    if (!candidateStatus || ['failed', 'error'].includes(candidateStatus)) {
+    if (!skipCustomerQa && (!candidateStatus || ['failed', 'error'].includes(candidateStatus))) {
       const now = new Date().toISOString();
       const { data: updated } = await supabase
         .from('packaging_jobs')
@@ -164,9 +166,10 @@ export async function GET(request: Request) {
       }
       continue;
     }
-    const qaDeferred = !job.is_auto_update &&
-      isDeferredCustomerQaEnabled() &&
-      Boolean(candidateStatus && ['queued', 'dispatched', 'running'].includes(candidateStatus));
+    const qaDeferred = skipCustomerQa || (
+      !job.is_auto_update && isDeferredCustomerQaEnabled() &&
+      Boolean(candidateStatus && ['queued', 'dispatched', 'running'].includes(candidateStatus))
+    );
     if (candidateStatus !== 'passed' && !qaDeferred) {
       waiting++;
       continue;
@@ -194,7 +197,7 @@ export async function GET(request: Request) {
       .update({
         status: nextStatus,
         status_message: qaDeferred
-          ? 'Preparing deployment while installation validation remains scheduled'
+          ? skipCustomerQa ? 'Preparing deployment' : 'Preparing deployment while installation validation remains scheduled'
           : 'Installation test passed; packaging started automatically',
         qa_completed_at: qaDeferred ? null : now,
         packaging_started_at: features.localPackager ? null : now,
@@ -214,6 +217,7 @@ export async function GET(request: Request) {
     try {
       const installerSha256 = item.installerSha256 || job.installer_sha256 || '';
       const workflowInputs: WorkflowInputs = {
+        qaOverride: skipCustomerQa,
         jobId: job.id,
         tenantId: job.tenant_id || '',
         wingetId: job.winget_id,

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -139,6 +139,7 @@ function minutesAgo(minutes: number): string {
 describe('GET /api/package (userId listing)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_MAINTENANCE_MODE;
     delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     // The list path now authenticates and uses the token's userId.
     parseAccessTokenMock.mockResolvedValue({
@@ -284,6 +285,7 @@ describe('POST /api/package (workflow dispatch)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.QA_MAINTENANCE_MODE;
     delete process.env.QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL;
     getDatabaseMock.mockReturnValue({
       jobs: {
@@ -1515,6 +1517,34 @@ describe('POST /api/package (workflow dispatch)', () => {
       qa_completed_at: null,
     }));
     expect(triggerPackagingWorkflowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips QA demand entirely and authorizes customer dispatch during manual maintenance', async () => {
+    process.env.QA_MAINTENANCE_MODE = 'true';
+
+
+    const request = new NextRequest('http://localhost:3000/api/package', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ items: [makeWin32Item()] }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.jobs[0]).toMatchObject({ status: 'packaging' });
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'queued',
+      status_message: null,
+      qa_candidate_id: null,
+      qa_completed_at: null,
+    }));
+    expect(ensureQaDemandMock).not.toHaveBeenCalled();
+    expect(triggerPackagingWorkflowMock.mock.calls[0][0]).toMatchObject({ qaOverride: true });
   });
 
   it('calculates the hash in the workflow for a custom app without a supplied SHA256', async () => {

--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 /**
  * Package API Route
  * Queues packaging jobs by triggering GitHub Actions workflows
@@ -575,7 +576,7 @@ export async function POST(request: NextRequest) {
             }
             const jobId = crypto.randomUUID();
             const installerSha256 = item.installerSha256?.trim() || '';
-            const qaDemand = item.sourceType === 'custom' || !supabaseServerConfigured
+            const qaDemand = isQaMaintenanceMode() || item.sourceType === 'custom' || !supabaseServerConfigured
               ? null
               : await ensureQaDemand(createServerClient(), {
                   wingetId: item.wingetId,
@@ -751,7 +752,7 @@ export async function POST(request: NextRequest) {
                 : undefined,
               installScope: item.installScope,
               forceCreate: item.forceCreate || forceCreate,
-              qaOverride: item.qaOverride,
+              qaOverride: isQaMaintenanceMode() || item.qaOverride,
               sourceType: item.sourceType,
             };
 

--- a/app/api/qa/live/frame/route.test.ts
+++ b/app/api/qa/live/frame/route.test.ts
@@ -87,6 +87,13 @@ describe('/api/qa/live/frame ingest boundary', () => {
     expect(createServerClientMock).not.toHaveBeenCalled();
   });
 
+  it('suppresses existing frames during maintenance without querying storage', async () => {
+    vi.stubEnv('QA_MAINTENANCE_MODE', 'true');
+    const response = await GET(new Request(`https://intuneget.com/api/qa/live/frame?candidate=${candidateId}&sequence=1`));
+    expect(response.status).toBe(204);
+    expect(createServerClientMock).not.toHaveBeenCalled();
+  });
+
   it('requires a candidate-bound public frame request', async () => {
     const response = await GET(new Request('https://intuneget.com/api/qa/live/frame'));
     expect(response.status).toBe(400);

--- a/app/api/qa/live/frame/route.ts
+++ b/app/api/qa/live/frame/route.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 import {
@@ -75,6 +76,9 @@ async function authorizeCleanup(request: Request) {
 export async function GET(request: Request) {
   if (!isQaLivePublicEnabled(new URL(request.url).hostname)) {
     return NextResponse.json({ error: 'Not found' }, { status: 404, headers: noStoreHeaders() });
+  }
+  if (isQaMaintenanceMode()) {
+    return new NextResponse(null, { status: 204, headers: noStoreHeaders() });
   }
   const rateLimitResponse = await applyRateLimit(`qa-frame:${getIpKey(request)}`, QA_LIVE_FRAME_RATE_LIMIT);
   if (rateLimitResponse) return rateLimitResponse;

--- a/docs/qa-maintenance.md
+++ b/docs/qa-maintenance.md
@@ -1,0 +1,9 @@
+# Manual QA maintenance
+
+Set server-only `QA_MAINTENANCE_MODE=true` in the production Vercel environment and deploy. This setting has no timer: it remains active until explicitly disabled and redeployed.
+
+Customer uploads skip QA demand and prior QA outcomes, create no new QA candidates, and proceed through normal packaging validation. Existing customer jobs awaiting QA are resumed by the normal cron. No QA pass is fabricated. Automatic updates retain their QA gates. Catalog scanning and dispatch remain paused.
+
+The public QA page shows a maintenance message instead of current, queued, or historical apps. The live JSON returns no app data and frame GET returns 204. Existing candidates and results remain in storage.
+
+To resume: bring the runner online, verify its health and packager compatibility, set QA_MAINTENANCE_MODE=false and redeploy. Disable/remove QA_DEFERRED_CUSTOMER_UPLOADS_UNTIL to restore strict customer QA even if its old continuity window has not expired. Then explicitly clear the database qa_pipeline_control pause through the established operator procedure. Clearing maintenance alone does not clear that independent pause.

--- a/lib/msp/batch-orchestrator.ts
+++ b/lib/msp/batch-orchestrator.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 /**
  * MSP Batch Deployment Orchestrator
  * Processes pending batch deployments by creating packaging jobs and tracking completion.
@@ -280,6 +281,7 @@ async function startBatchItems(batchId: string): Promise<number> {
   if (installerDetails) {
     try {
       await enforceQaGate({
+        qaOverride: isQaMaintenanceMode(),
         wingetId: batch.winget_id,
         version: batch.version,
         architecture: installerDetails.architecture,
@@ -366,6 +368,7 @@ async function startBatchItems(batchId: string): Promise<number> {
 
       // Trigger GitHub Actions workflow
       const workflowInputs: WorkflowInputs = {
+        qaOverride: isQaMaintenanceMode(),
         jobId,
         tenantId: item.tenant_id,
         wingetId: batch.winget_id,

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -1,3 +1,4 @@
+import { isQaMaintenanceMode } from '@/lib/qa/maintenance';
 import 'server-only';
 
 import { createServerClient } from '@/lib/supabase';
@@ -407,6 +408,12 @@ export function countConsecutiveFailedPolls(
 }
 
 export async function getQaLiveSnapshot(): Promise<QaLiveResponse> {
+  if (isQaMaintenanceMode()) {
+    return buildQaLiveResponse({
+      now: new Date(), current: null, queuedCount: 0, queued: [], poll: null,
+      consecutivePollFailures: 0, recent: [], apps: [], frame: null,
+    });
+  }
   const supabase = createServerClient();
   const candidateColumns =
     'id, winget_id, version, architecture, status, priority, enqueued_at, dispatched_at, started_at, phase, phase_started_at, phase_updated_at, live_activity, activity_updated_at, live_log, log_updated_at, test_config';

--- a/lib/qa/maintenance.test.ts
+++ b/lib/qa/maintenance.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, expect, it, vi } from 'vitest';
+vi.mock('server-only', () => ({}));
+const { client } = vi.hoisted(() => ({ client: vi.fn(() => { throw new Error('Database must not be read'); }) }));
+vi.mock('@/lib/supabase', () => ({ createServerClient: client }));
+import { isQaMaintenanceMode } from './maintenance';
+import { getQaLiveSnapshot } from './live';
+afterEach(() => { vi.unstubAllEnvs(); vi.clearAllMocks(); });
+it('requires the explicit server setting and can be switched off', () => {
+  vi.stubEnv('QA_MAINTENANCE_MODE', 'true');
+  expect(isQaMaintenanceMode()).toBe(true);
+  vi.stubEnv('QA_MAINTENANCE_MODE', 'false');
+  expect(isQaMaintenanceMode()).toBe(false);
+  vi.stubEnv('QA_MAINTENANCE_MODE', '');
+  expect(isQaMaintenanceMode()).toBe(false);
+});
+it('returns no current, queued, historical, or frame data during maintenance', async () => {
+  vi.stubEnv('QA_MAINTENANCE_MODE', 'true');
+  const snapshot = await getQaLiveSnapshot();
+  expect(snapshot).toMatchObject({ active: false, current: null, activity: null, log: null, queue: { count: 0, next: [] }, recent: [], viewer: { available: false, candidateId: null } });
+  expect(client).not.toHaveBeenCalled();
+});

--- a/lib/qa/maintenance.ts
+++ b/lib/qa/maintenance.ts
@@ -1,0 +1,4 @@
+/** Explicit operator switch, independent of automatic failure pauses and timers. */
+export function isQaMaintenanceMode(): boolean {
+  return process.env.QA_MAINTENANCE_MODE === 'true';
+}


### PR DESCRIPTION
Customer uploads currently continue creating deferred QA tests while the runner is offline, and prior QA failures can still block dispatch. The public QA page also continues displaying queued and historical apps.

Add an explicit server-only QA_MAINTENANCE_MODE switch. While enabled, customer and MSP uploads skip installation QA, customer jobs awaiting QA can resume, and no new customer QA demand is created. The QA page shows a maintenance notice with no app lists; live JSON and frame reads expose no app activity. Scheduled QA enqueue/dispatch remain paused, automatic updates retain QA gating, and security/installer compatibility protections stay enforced. Existing results and candidates are preserved.

The production setting is enabled and will take effect when this code deploys. Operator instructions document disabling it and the older continuity timer before resuming the independent database pause.

Validation: 99 test files passed, 1,676 tests passed and 96 existing skips; full lint and isolated production build passed. Browser verification at 1440px, 390px, and 320px confirmed no app lists or horizontal overflow, keyboard access, and an empty public live response. Reviewed changelog entry validates.
