### PR TITLE
Add catalog release history and restore reliable manifest sync

### DIFF
--- a/.github/scripts/scan-app.ps1
+++ b/.github/scripts/scan-app.ps1
@@ -5,6 +5,7 @@ param(
     [string]$WingetId,
 
     [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._+\-]*$')]
     [string]$ExpectedVersion,
 
     [Parameter(Mandatory = $true)]
@@ -67,7 +68,7 @@ try {
         $baseline = & "$PSScriptRoot\snapshot.ps1" -Mode baseline
         $timeout = [int]($env:APP_TIMEOUT_SECONDS ?? 900)
         $install = Invoke-Winget -Arguments @(
-            'install', '--id', $WingetId, '--exact', '--silent',
+            'install', '--id', $WingetId, '--exact', '--version', $ExpectedVersion, '--source', 'winget', '--silent',
             '--accept-package-agreements', '--accept-source-agreements', '--disable-interactivity'
         ) -TimeoutSeconds $timeout
 
@@ -83,7 +84,9 @@ try {
             throw "Detected registry entry was not created by this installation ($($changes.app_registry_entry.detection_method))"
         }
 
-        $result.version = if ($changes.version) { $changes.version } else { $ExpectedVersion }
+        # Keep the snapshot keyed to the exact WinGet version requested. The
+        # registry display version is preserved in app_registry_entry.
+        $result.version = $ExpectedVersion
         $result.install_path = $changes.install_path
         $result.uninstall_string = $changes.uninstall_string
         $result.quiet_uninstall_string = $changes.quiet_uninstall_string
@@ -97,12 +100,12 @@ try {
 } catch {
     $result.status = 'failed'
     $result.error = $_.Exception.Message
-    Write-Error $_
+    Write-Warning $result.error
 } finally {
     if ($installedByScan) {
-        $uninstall = Invoke-Winget -Arguments @('uninstall', '--id', $WingetId, '--exact', '--silent', '--disable-interactivity') -TimeoutSeconds 300
+        $uninstall = Invoke-Winget -Arguments @('uninstall', '--id', $WingetId, '--exact', '--silent', '--accept-source-agreements', '--disable-interactivity') -TimeoutSeconds 300
         if ($uninstall.ExitCode -ne 0) {
-            $cleanupMessage = "Cleanup failed with exit code $($uninstall.ExitCode)"
+            $cleanupMessage = "Cleanup failed with exit code $($uninstall.ExitCode): $($uninstall.Output)"
             if ($result.status -eq 'completed') {
                 $result.status = 'failed'
                 $result.error = $cleanupMessage

--- a/.github/workflows/build-app-list.yml
+++ b/.github/workflows/build-app-list.yml
@@ -2,8 +2,8 @@ name: Build Curated App List
 
 on:
   schedule:
-    # Run weekly on Sundays at 00:00 UTC
-    - cron: '0 0 * * 0'
+    # Refresh version discovery daily before the manifest sync
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       limit:

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -18,7 +18,7 @@ on:
       mode:
         description: "Sync mode"
         required: false
-        default: "all"
+        default: "incremental"
         type: choice
         options:
           - all # All apps (full refresh)
@@ -65,7 +65,8 @@ jobs:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           APP_IDS: ${{ github.event.inputs.app_ids || 'all' }}
           APP_LIMIT: ${{ github.event.inputs.limit || '0' }}
-          SYNC_MODE: ${{ github.event.inputs.mode || 'all' }}
+          FULL_CATALOG: ${{ (github.event.inputs.app_ids == '' || github.event.inputs.app_ids == 'all') && (github.event.inputs.limit == '' || github.event.inputs.limit == '0') }}
+          SYNC_MODE: ${{ github.event.inputs.mode || 'incremental' }}
         run: |
           node << 'PLANEOF'
           const fs = require('fs');
@@ -206,7 +207,8 @@ jobs:
           APP_IDS: ${{ github.event.inputs.app_ids || 'all' }}
           APP_OFFSET: ${{ matrix.offset }}
           APP_LIMIT: ${{ matrix.chunk_size }}
-          SYNC_MODE: ${{ github.event.inputs.mode || 'all' }}
+          FULL_CATALOG: ${{ (github.event.inputs.app_ids == '' || github.event.inputs.app_ids == 'all') && (github.event.inputs.limit == '' || github.event.inputs.limit == '0') }}
+          SYNC_MODE: ${{ github.event.inputs.mode || 'incremental' }}
           FORCE_REFRESH: ${{ github.event.inputs.force_refresh || 'false' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHARD: ${{ matrix.shard }}
@@ -234,8 +236,8 @@ jobs:
           }
 
           async function syncManifests() {
-            const { createWingetManifestClient, resolveWingetManifest } = await resolverModule;
-            const manifestClient = createWingetManifestClient({ token: GITHUB_TOKEN });
+            const { createWingetManifestClient, resolveWingetManifest, manifestReleaseDate, canSkipStoredManifest } = await resolverModule;
+            const manifestClient = createWingetManifestClient({ token: GITHUB_TOKEN, preferRaw: true });
             const appIds = process.env.APP_IDS;
             const appOffset = parseInt(process.env.APP_OFFSET || '0', 10);
             const chunkSize = parseInt(process.env.APP_LIMIT || '2000', 10);
@@ -263,6 +265,7 @@ jobs:
                 .eq('app_source', 'win32')
                 .eq('is_winget_verified', true)
                 .order('popularity_rank', { ascending: true, nullsFirst: false })
+                .order('winget_id')
                 .range(appOffset, appOffset + chunkSize - 1);
 
               const { data, error } = await query;
@@ -282,7 +285,7 @@ jobs:
 
             // Try the stored catalog version first. GitHub API enumeration is
             // reserved for missing or pruned versions and legacy null rows.
-            const batchSize = 10;
+            const batchSize = 3;
             const batchDelay = 750;
             const delay = ms => new Promise(r => setTimeout(r, ms));
 
@@ -293,17 +296,22 @@ jobs:
             for (let i = 0; i < apps.length; i += 100) {
               const ids = apps.slice(i, i + 100).map(app => app.winget_id);
               if (ids.length === 0) continue;
-              const { data, error } = await supabase
-                .from('version_history')
-                .select('winget_id, version, created_at')
-                .in('winget_id', ids)
-                .order('created_at', { ascending: false });
-              if (error) throw error;
-              for (const row of data || []) {
-                existingVersions.add(`${row.winget_id}\u0000${row.version}`);
-                if (!previousVersionByApp.has(row.winget_id)) {
-                  previousVersionByApp.set(row.winget_id, row.version);
+              for (let offset = 0; ; offset += 1000) {
+                const { data, error } = await supabase
+                  .from('version_history')
+                  .select('winget_id, version, created_at')
+                  .in('winget_id', ids)
+                  .order('created_at', { ascending: false })
+                  .order('id', { ascending: false })
+                  .range(offset, offset + 999);
+                if (error) throw error;
+                for (const row of data || []) {
+                  existingVersions.add(`${row.winget_id}\u0000${row.version}`);
+                  if (!previousVersionByApp.has(row.winget_id)) {
+                    previousVersionByApp.set(row.winget_id, row.version);
+                  }
                 }
+                if (!data || data.length < 1000) break;
               }
             }
 
@@ -331,6 +339,7 @@ jobs:
 
             for (let i = 0; i < apps.length; i += batchSize) {
               const batch = apps.slice(i, i + batchSize);
+              let fetchedInBatch = false;
 
               await Promise.all(batch.map(async (app) => {
                 try {
@@ -339,6 +348,16 @@ jobs:
                     return;
                   }
 
+                  if (canSkipStoredManifest({
+                    forceRefresh, mode: syncMode, version: app.latest_version,
+                    hasVersion: existingVersions.has(`${app.winget_id}\u0000${app.latest_version}`),
+                    description: app.description,
+                  })) {
+                    skippedExisting++;
+                    return;
+                  }
+
+                  fetchedInBatch = true;
                   const resolution = await resolveWingetManifest({
                     client: manifestClient,
                     wingetId: app.winget_id,
@@ -428,6 +447,7 @@ jobs:
                     platform: installerManifest.Platform || null,
                     upgrade_behavior: installerManifest.UpgradeBehavior || null,
                     release_notes: localeManifest?.ReleaseNotes || null,
+                    release_date: manifestReleaseDate(installerManifest),
                     manifest_yaml: yaml.stringify(installerManifest),
                     manifest_fetched_at: new Date().toISOString(),
                     updated_at: new Date().toISOString()
@@ -488,7 +508,7 @@ jobs:
                 }
               }));
 
-              if (i + batchSize < apps.length) {
+              if (fetchedInBatch && i + batchSize < apps.length) {
                 await delay(batchDelay);
               }
 
@@ -625,7 +645,8 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SYNC_MODE: ${{ github.event.inputs.mode || 'all' }}
+          FULL_CATALOG: ${{ (github.event.inputs.app_ids == '' || github.event.inputs.app_ids == 'all') && (github.event.inputs.limit == '' || github.event.inputs.limit == '0') }}
+          SYNC_MODE: ${{ github.event.inputs.mode || 'incremental' }}
           EXPECTED_SHARDS: ${{ needs.plan.outputs.expected_shards }}
         run: |
           node << 'SUMMARYEOF'
@@ -727,6 +748,8 @@ jobs:
                 last_run_completed_at: new Date().toISOString(),
                 last_run_status: classification.status,
                 items_processed: totalSynced,
+                ...(!classification.shouldFail && process.env.FULL_CATALOG === 'true' && syncMode !== 'new_only'
+                  ? { last_successful_sync_at: new Date().toISOString() } : {}),
                 error_message: errorMessage,
                 metadata: {
                   mode: syncMode,
@@ -767,7 +790,7 @@ jobs:
 
             echo "## Manifest Sync Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "- **Mode:** ${{ github.event.inputs.mode || 'all' }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Mode:** ${{ github.event.inputs.mode || 'incremental' }}" >> $GITHUB_STEP_SUMMARY
             echo "- **Status:** $STATUS" >> $GITHUB_STEP_SUMMARY
             echo "- **Synced:** $SYNCED" >> $GITHUB_STEP_SUMMARY
             echo "- **Failed:** $FAILED" >> $GITHUB_STEP_SUMMARY

--- a/.ugurlabs/entries/catalog-release-history.json
+++ b/.ugurlabs/entries/catalog-release-history.json
@@ -1,0 +1,5 @@
+{
+  "title": "Explore catalog release history",
+  "summary": "Browse app versions by date, search by app or publisher, and filter monthly catalog history. Records distinguish the first tracked version from later version changes and show publisher release dates when available. Daily version discovery and a more efficient manifest sync improve catalog freshness, with incomplete syncs shown explicitly. Historical coverage reflects versions observed by IntuneGet and may contain gaps.",
+  "type": "new"
+}

--- a/app/(marketing)/apps/page.tsx
+++ b/app/(marketing)/apps/page.tsx
@@ -99,6 +99,8 @@ export default async function AppsPage() {
             )}
           </div>
 
+          <Link href="/apps/releases" className="inline-flex items-center gap-2 text-sm font-medium text-accent-cyan hover:underline"><T>Explore catalog release history</T><ArrowRight aria-hidden="true" className="h-4 w-4" /></Link>
+
           {/* Search */}
           <CatalogSearch />
 

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-32" aria-busy="true">
+      <p role="status" className="text-text-secondary">
+        Loading catalog history…
+      </p>
+    </main>
+  );
+}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -1,0 +1,416 @@
+import type { Metadata } from "next";
+import { unstable_cache } from "next/cache";
+import Link from "next/link";
+import { ArrowRight, CalendarDays, Search } from "lucide-react";
+import { T, Var } from "gt-next";
+import { Header } from "@/components/landing/Header";
+import { Footer } from "@/components/landing/sections/Footer";
+import { getCatalogSource } from "@/lib/catalog";
+import {
+  historyUrl,
+  parseHistoryFilters,
+  type ReleaseHistoryFilters,
+} from "@/lib/catalog/release-history";
+
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const filters = parseHistoryFilters(await searchParams);
+  return {
+    title: "Catalog Release History - IntuneGet",
+    description:
+      "Explore app versions recorded in the IntuneGet catalog, with monthly history, publisher release dates, and sync status.",
+    alternates: { canonical: "https://intuneget.com/apps/releases" },
+    robots: {
+      index:
+        !filters.query &&
+        !filters.month &&
+        filters.kind === "all" &&
+        filters.page === 1,
+      follow: true,
+    },
+  };
+}
+const loadHistory = unstable_cache(
+  (filters: ReleaseHistoryFilters) =>
+    getCatalogSource().getReleaseHistory(filters),
+  ["catalog-release-history-v1"],
+  { revalidate: 300 },
+);
+const dateFormat = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+  timeZone: "UTC",
+});
+function dateLabel(value: string) {
+  return dateFormat.format(new Date(value));
+}
+const control =
+  "min-h-11 w-full rounded-lg border border-overlay/15 bg-bg-deepest px-3 py-2 text-sm text-text-primary focus-visible:outline-2 focus-visible:outline-accent-cyan";
+
+export default async function CatalogReleasesPage({ searchParams }: Props) {
+  const filters = parseHistoryFilters(await searchParams);
+  const result = await loadHistory(filters).catch(() => null);
+  const groups = new Map<string, NonNullable<typeof result>["rows"]>();
+  for (const row of result?.rows ?? []) {
+    const day = new Date(row.detected_at).toISOString().slice(0, 10);
+    groups.set(day, [...(groups.get(day) ?? []), row]);
+  }
+  const pages = Math.max(1, Math.ceil((result?.total ?? 0) / 40));
+  const sync = result?.sync;
+  const status =
+    sync?.status === "success"
+      ? "Last run completed successfully"
+      : sync?.status === "running"
+        ? "Catalog sync in progress"
+        : sync
+          ? "Latest sync is incomplete"
+          : "History from the catalog snapshot";
+
+  return (
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto w-full max-w-6xl flex-1 px-4 pb-20 pt-28 lg:px-8 lg:pt-36"
+      >
+        <header className="mb-10 grid gap-8 lg:grid-cols-[1fr_300px] lg:items-end">
+          <div>
+            <Link
+              href="/apps"
+              className="text-sm text-accent-cyan hover:underline"
+            >
+              <T>App catalog</T>
+            </Link>
+            <p className="mb-3 mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-text-muted">
+              <T>The catalog, over time</T>
+            </p>
+            <h1 className="text-balance text-4xl font-bold tracking-tight text-text-primary sm:text-5xl">
+              <T>Catalog release history</T>
+            </h1>
+            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-text-secondary">
+              <T>
+                Follow the app versions arriving in IntuneGet. Find an app,
+                explore a month, and see what changed.
+              </T>
+            </p>
+          </div>
+          {result && (
+            <aside className="rounded-xl border border-overlay/10 bg-bg-elevated p-5 text-sm">
+              <p className="flex items-center gap-2 font-medium text-text-primary">
+                <span
+                  aria-hidden="true"
+                  className={`h-2 w-2 shrink-0 rounded-full ${sync?.status === "success" ? "bg-emerald-500" : "bg-amber-500"}`}
+                />
+                <T>
+                  <Var>{status}</Var>
+                </T>
+              </p>
+              <p className="mt-3 leading-relaxed text-text-secondary">
+                <T>Last successful full sync:</T>{" "}
+                {sync?.lastSuccessfulAt ? (
+                  <time dateTime={sync.lastSuccessfulAt}>
+                    {dateLabel(sync.lastSuccessfulAt)} (UTC)
+                  </time>
+                ) : (
+                  <T>Not yet recorded</T>
+                )}
+              </p>
+              {sync?.completedAt && (
+                <p className="mt-2 text-xs text-text-muted">
+                  <T>Last attempt:</T>{" "}
+                  <time dateTime={sync.completedAt}>
+                    {dateLabel(sync.completedAt)} (UTC)
+                  </time>
+                </p>
+              )}
+            </aside>
+          )}
+        </header>
+
+        {result && (
+          <dl className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
+            {[
+              ["Versions recorded", result.total],
+              ["Apps represented", result.apps],
+              ["First tracked apps", result.firstTracked],
+            ].map(([label, value]) => (
+              <div key={label} className="px-3 py-5 sm:px-6">
+                <dt className="text-sm text-text-secondary">
+                  <T>
+                    <Var>{label}</Var>
+                  </T>
+                </dt>
+                <dd className="mt-2 text-2xl font-semibold tabular-nums sm:text-3xl text-text-primary">
+                  {Number(value).toLocaleString("en-US")}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        <form
+          action="/apps/releases"
+          className="mb-5 grid gap-4 rounded-xl border border-overlay/10 bg-bg-elevated p-5 sm:grid-cols-2 lg:grid-cols-[1fr_180px_190px_auto] lg:items-end"
+        >
+          <div>
+            <label
+              htmlFor="history-search"
+              className="mb-2 block text-sm font-medium text-text-primary"
+            >
+              <T>Search apps</T>
+            </label>
+            <div className="relative">
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-3 h-5 w-5 text-text-muted"
+              />
+              <input
+                id="history-search"
+                name="q"
+                type="search"
+                autoComplete="off"
+                maxLength={120}
+                defaultValue={filters.query}
+                placeholder="Name, publisher, or WinGet ID…"
+                className={`${control} pl-10`}
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="history-month"
+              className="mb-2 block text-sm font-medium text-text-primary"
+            >
+              <T>Month (UTC)</T>
+            </label>
+            <select
+              id="history-month"
+              name="month"
+              defaultValue={filters.month}
+              className={control}
+            >
+              <option value="">All months</option>
+              {[
+                ...new Set([
+                  ...(result?.months ?? []),
+                  ...(filters.month ? [filters.month] : []),
+                ]),
+              ]
+                .sort()
+                .reverse()
+                .map((month) => (
+                  <option key={month} value={month}>
+                    {new Intl.DateTimeFormat("en-GB", {
+                      month: "long",
+                      year: "numeric",
+                      timeZone: "UTC",
+                    }).format(new Date(`${month}-01T00:00:00Z`))}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor="history-kind"
+              className="mb-2 block text-sm font-medium text-text-primary"
+            >
+              <T>Record type</T>
+            </label>
+            <select
+              id="history-kind"
+              name="kind"
+              defaultValue={filters.kind}
+              className={control}
+            >
+              <option value="all">All records</option>
+              <option value="updated">Version changes</option>
+              <option value="first">First tracked</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="min-h-11 rounded-lg bg-accent-cyan px-6 py-2 text-sm font-semibold text-bg-deepest hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent-cyan"
+          >
+            <T>Apply filters</T>
+          </button>
+        </form>
+        <div className="mb-10 flex flex-wrap items-center justify-between gap-3 text-sm text-text-muted">
+          <p>
+            <T>
+              Counts reflect your filters. Dates show when IntuneGet first
+              recorded a version.
+            </T>
+          </p>
+          <Link
+            href="/apps/releases"
+            className="text-accent-cyan hover:underline"
+          >
+            <T>Clear filters</T>
+          </Link>
+        </div>
+
+        {!result ? (
+          <div role="alert" className="rounded-xl border border-overlay/15 p-8">
+            <h2 className="text-xl font-semibold text-text-primary">
+              <T>History is temporarily unavailable</T>
+            </h2>
+            <p className="mt-2 text-text-secondary">
+              <T>We could not load the catalog history. Please try again.</T>
+            </p>
+            <Link
+              href={historyUrl(filters, filters.page)}
+              className="mt-5 inline-flex min-h-11 items-center text-accent-cyan hover:underline"
+            >
+              <T>Try again</T>
+            </Link>
+          </div>
+        ) : result.rows.length === 0 ? (
+          <div className="rounded-xl border border-overlay/10 p-10 text-center">
+            <CalendarDays
+              aria-hidden="true"
+              className="mx-auto mb-4 h-8 w-8 text-text-muted"
+            />
+            <h2 className="text-xl font-semibold text-text-primary">
+              <T>No records to show</T>
+            </h2>
+            <p className="mt-2 text-text-secondary">
+              <T>Try another app or month, or clear your filters.</T>
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-10">
+            {[...groups].map(([day, rows]) => (
+              <section
+                key={day}
+                aria-labelledby={`day-${day}`}
+                className="grid gap-4 lg:grid-cols-[150px_1fr]"
+              >
+                <h2
+                  id={`day-${day}`}
+                  className="pt-4 text-sm font-semibold text-text-secondary"
+                >
+                  <time dateTime={day}>{dateLabel(day)}</time>
+                </h2>
+                <ul className="divide-y divide-overlay/10 overflow-hidden rounded-xl border border-overlay/10 bg-bg-elevated">
+                  {rows.map((row) => (
+                    <li
+                      key={`${row.winget_id}:${row.version}`}
+                      className="grid gap-4 p-5 sm:grid-cols-[1fr_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Link
+                            href={`/apps/${encodeURIComponent(row.winget_id)}`}
+                            className="break-words font-semibold text-text-primary hover:text-accent-cyan"
+                          >
+                            {row.name}
+                            <span className="sr-only"> {row.winget_id}</span>
+                          </Link>
+                          <span
+                            className={`rounded-md px-2 py-1 text-xs ${row.previous_version ? "bg-accent-cyan/10 text-accent-cyan" : "bg-overlay/5 text-text-secondary"}`}
+                          >
+                            {row.previous_version ? (
+                              <T>Version change</T>
+                            ) : (
+                              <T>First tracked</T>
+                            )}
+                          </span>
+                        </div>
+                        <p className="mt-2 break-all text-xs text-text-muted">
+                          {row.winget_id}
+                        </p>
+                        {row.release_date && (
+                          <p className="mt-2 text-xs text-text-secondary">
+                            <T>Publisher release:</T>{" "}
+                            <time dateTime={row.release_date}>
+                              {dateLabel(row.release_date)}
+                            </time>
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex min-w-0 flex-wrap items-center gap-2 font-mono text-sm tabular-nums sm:max-w-80 sm:justify-end">
+                        {row.previous_version && (
+                          <>
+                            <span className="break-all text-text-muted">
+                              {row.previous_version}
+                            </span>
+                            <ArrowRight
+                              aria-label="to"
+                              className="h-3 w-3 shrink-0 text-text-muted"
+                            />
+                          </>
+                        )}
+                        <span className="break-all font-semibold text-text-primary">
+                          {row.version}
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        )}
+        {result && (pages > 1 || filters.page > 1) && (
+          <nav
+            aria-label="Release history pagination"
+            className="mt-10 flex flex-wrap items-center justify-center gap-6 text-sm"
+          >
+            {filters.page > 1 && (
+              <Link
+                href={historyUrl(filters, filters.page - 1)}
+                className="inline-flex min-h-11 items-center text-accent-cyan hover:underline"
+              >
+                <T>Previous</T>
+              </Link>
+            )}
+            <p className="text-text-secondary">
+              <T>
+                Page <Var>{filters.page}</Var> of <Var>{pages}</Var>
+              </T>
+            </p>
+            {filters.page < pages && (
+              <Link
+                href={historyUrl(filters, filters.page + 1)}
+                className="inline-flex min-h-11 items-center text-accent-cyan hover:underline"
+              >
+                <T>Next</T>
+              </Link>
+            )}
+          </nav>
+        )}
+        <aside className="mt-14 border-t border-overlay/10 pt-6 text-sm leading-relaxed text-text-muted">
+          <h2 className="font-semibold text-text-secondary">
+            <T>About this history</T>
+          </h2>
+          <p className="mt-2">
+            <T>
+              This is an observation history, not a complete archive of
+              publisher releases. First tracked means the earliest version we
+              have recorded for an app, including apps imported when tracking
+              began. It does not necessarily mean a newly released product.
+              Versions missed between syncs may be absent. A version change may
+              also reflect an upstream rollback.
+            </T>
+          </p>
+          {result?.coverageStart && (
+            <p className="mt-2">
+              <T>Available records begin:</T>{" "}
+              <time dateTime={result.coverageStart}>
+                {dateLabel(result.coverageStart)}
+              </time>
+              .{" "}
+              <T>Publisher dates appear only when provided by the manifest.</T>
+            </p>
+          )}
+        </aside>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -40,6 +40,7 @@ export default async function sitemap({ id }: { id: Promise<number> }): Promise<
 
   // Static public pages
   const staticPages: MetadataRoute.Sitemap = [
+    { url: `${BASE_URL}/apps/releases`, changeFrequency: "daily", priority: 0.7 },
     {
       url: BASE_URL,
       lastModified: now,

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -38,6 +38,7 @@ const primaryNavLinks = [
 ];
 
 const secondaryNavLinks = [
+  { href: "/apps/releases", label: "Catalog History" },
   { href: "/pricing", label: "Pricing" },
   { href: "/#faq", label: "FAQ" },
   { href: "/blog", label: "Blog" },

--- a/components/landing/sections/Footer.tsx
+++ b/components/landing/sections/Footer.tsx
@@ -42,6 +42,7 @@ const footerGroups: Array<{ title: string; links: FooterLink[] }> = [
     title: "Deploy",
     links: [
       { label: "App catalog", href: "/apps" },
+      { label: "Catalog history", href: "/apps/releases" },
       { label: "How it works", href: "/#how-it-works" },
       { label: "Get started", href: "/#get-started" },
     ],

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -1,0 +1,15 @@
+# Catalog release history
+
+The public page is `/apps/releases`. The catalog source supports Supabase and self-hosted SQLite snapshots. Results are cached for five minutes and paginated in groups of 40. Search is literal, case insensitive, and limited to 120 characters. Month boundaries are UTC.
+
+`version_history.created_at` is the first time IntuneGet recorded that version, not the publisher release date. A database trigger preserves it across upserts. The earliest stored version for each app is labelled **First tracked**; subsequent observations are **Version change**, including rollbacks. Historical imports and missed versions prevent this from being a complete publisher archive. Locale variants are excluded from the feed and totals.
+
+Publisher dates come only from a valid WinGet `ReleaseDate` on the manifest or an installer. Existing dates are not inferred from import or fetch timestamps. Older SQLite snapshots remain readable with unknown publisher dates.
+
+The catalog index import now runs daily at 00:00 UTC, before manifest sync at 02:00 UTC. Scheduled manifest sync uses incremental mode and skips stored versions with descriptions before network requests. It reads public raw manifests; other manifest-client callers retain their existing authenticated API preference. Use the manual **all** mode or **force_refresh** to refresh unchanged manifests, including collecting newly available publisher dates.
+
+`curated_sync_status.last_successful_sync_at` is recorded only after a full-catalog run completes without operational errors. Known missing upstream packages still produce a partial status. Targeted, limited, and new-only runs do not advance this timestamp. Later failed runs preserve the previous successful timestamp. No success timestamp is backfilled from historical workflow completion dates.
+
+Apply migration `20260906052337_catalog_release_history.sql` before deploying the new workflow and page. `supabase/tests/catalog_release_history.sql` tests anonymous reads, month filtering, previous versions, pagination, and timestamp preservation inside a rolled-back transaction.
+
+The installation scanner is independent of release history. It now installs the exact requested WinGet version and preserves that version as its snapshot key; registry display versions stay in registry metadata. Cleanup failures remain failures, with command output retained for diagnosis. Publisher download failures and installers that cannot silently uninstall require app-specific investigation; this page does not claim installation validation.

--- a/lib/catalog/release-history.test.ts
+++ b/lib/catalog/release-history.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { historyUrl, parseHistoryFilters } from "./release-history";
+describe("release history navigation", () => {
+  it("bounds page numbers and rejects malformed filters", () => {
+    expect(
+      parseHistoryFilters({ page: "-1", month: "2026-13", kind: "bad" }),
+    ).toEqual({ query: "", month: "", kind: "all", page: 1 });
+    expect(parseHistoryFilters({ page: "1.5" }).page).toBe(1);
+    expect(parseHistoryFilters({ page: "999999" }).page).toBe(10000);
+    expect(parseHistoryFilters({ q: ["one", "two"] }).query).toBe("");
+  });
+  it("keeps filters through pagination and encodes literal search text", () => {
+    const filters = parseHistoryFilters({
+      q: " C++ & tools ",
+      month: "2026-09",
+      kind: "updated",
+    });
+    const url = new URL(historyUrl(filters, 2), "https://example.test");
+    expect(url.searchParams.get("q")).toBe("C++ & tools");
+    expect(url.searchParams.get("month")).toBe("2026-09");
+    expect(url.searchParams.get("kind")).toBe("updated");
+    expect(url.searchParams.get("page")).toBe("2");
+  });
+});

--- a/lib/catalog/release-history.ts
+++ b/lib/catalog/release-history.ts
@@ -1,0 +1,54 @@
+export interface ReleaseHistoryFilters {
+  query: string;
+  month: string;
+  kind: "all" | "first" | "updated";
+  page: number;
+}
+export interface CatalogRelease {
+  winget_id: string;
+  name: string;
+  publisher: string | null;
+  version: string;
+  previous_version: string | null;
+  detected_at: string;
+  release_date: string | null;
+}
+export interface ReleaseHistoryResult {
+  rows: CatalogRelease[];
+  total: number;
+  apps: number;
+  firstTracked: number;
+  months: string[];
+  coverageStart: string | null;
+  sync: {
+    status: string;
+    completedAt: string | null;
+    lastSuccessfulAt: string | null;
+  } | null;
+}
+export function parseHistoryFilters(
+  params: Record<string, string | string[] | undefined>,
+): ReleaseHistoryFilters {
+  const one = (key: string) =>
+    typeof params[key] === "string" ? (params[key] as string) : "";
+  const month = one("month");
+  const kind = one("kind");
+  const page = Number(one("page") || 1);
+  return {
+    query: one("q").trim().slice(0, 120),
+    month: /^\d{4}-(0[1-9]|1[0-2])$/.test(month) ? month : "",
+    kind: kind === "first" || kind === "updated" ? kind : "all",
+    page: Number.isInteger(page) && page > 0 ? Math.min(page, 10000) : 1,
+  };
+}
+export function historyUrl(
+  filters: ReleaseHistoryFilters,
+  page: number,
+): string {
+  const params = new URLSearchParams();
+  if (filters.query) params.set("q", filters.query);
+  if (filters.month) params.set("month", filters.month);
+  if (filters.kind !== "all") params.set("kind", filters.kind);
+  if (page > 1) params.set("page", String(page));
+  return `/apps/releases${params.size ? `?${params}` : ""}`;
+}

--- a/lib/catalog/snapshot-source.test.ts
+++ b/lib/catalog/snapshot-source.test.ts
@@ -381,3 +381,22 @@ describe('snapshot QA schema compatibility', () => {
     current.close();
   });
 });
+
+
+describe('catalog release history', () => {
+  it('filters observations and retains the previous version across month/type filters', async () => {
+    const source = new SnapshotCatalogSource();
+    const result = await source.getReleaseHistory({ query: 'Chrome', month: '2026-01', kind: 'updated', page: 1 });
+    expect(result.total).toBe(1);
+    expect(result.apps).toBe(1);
+    expect(result.firstTracked).toBe(0);
+    expect(result.rows[0]).toMatchObject({ version: '120.0', previous_version: '119.0', detected_at: '2026-01-02T00:00:00Z' });
+    expect(result.months).toEqual(['2026-01']);
+    expect(result.sync).toBeNull();
+  });
+  it('does not treat wildcard search characters as SQL patterns', async () => {
+    const result = await new SnapshotCatalogSource().getReleaseHistory({ query: '%', month: '', kind: 'all', page: 1 });
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -1,3 +1,4 @@
+import type { CatalogRelease, ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * SQLite-snapshot-backed CatalogSource (self-hosted / Supabase-less mode).
  *
@@ -179,6 +180,32 @@ function buildFtsMatch(query: string): string | null {
 }
 
 export class SnapshotCatalogSource implements CatalogSource {
+  async getReleaseHistory(filters: ReleaseHistoryFilters): Promise<ReleaseHistoryResult> {
+    return withDb((db) => {
+      // Older snapshots remain readable; release dates were not exported then.
+      const columns = db.prepare('PRAGMA table_info(version_history)').all() as { name: string }[];
+      const releaseDate = columns.some(c => c.name === 'release_date') ? 'v.release_date' : 'NULL';
+      const history = `WITH history AS (
+        SELECT v.winget_id, c.name, c.publisher, v.version, ${releaseDate} AS release_date,
+          v.created_at AS detected_at,
+          lag(v.version) OVER (PARTITION BY v.winget_id ORDER BY v.created_at, v.version) AS previous_version
+        FROM version_history v JOIN curated_apps c USING (winget_id)
+        WHERE coalesce(c.is_locale_variant, 0) = 0 AND v.created_at IS NOT NULL
+      )`;
+      const where = ` WHERE (@month = '' OR substr(detected_at, 1, 7) = @month)
+        AND (@query = '' OR instr(lower(name || ' ' || coalesce(publisher, '') || ' ' || winget_id), lower(@query)) > 0)
+        AND (@kind = 'all' OR (@kind = 'first' AND previous_version IS NULL) OR (@kind = 'updated' AND previous_version IS NOT NULL))`;
+      const params = { month: filters.month, query: filters.query, kind: filters.kind };
+      const rows = db.prepare(`${history} SELECT * FROM history ${where} ORDER BY detected_at DESC, winget_id, version DESC LIMIT 40 OFFSET @offset`)
+        .all({ ...params, offset: (filters.page - 1) * 40 }) as CatalogRelease[];
+      const stats = db.prepare(`${history} SELECT count(*) AS total, count(DISTINCT winget_id) AS apps,
+        coalesce(sum(previous_version IS NULL), 0) AS firstTracked FROM history ${where}`).get(params) as { total: number; apps: number; firstTracked: number };
+      const months = db.prepare(`${history} SELECT DISTINCT substr(detected_at, 1, 7) AS month FROM history ORDER BY month DESC`).all() as { month: string }[];
+      const coverage = db.prepare(`${history} SELECT min(detected_at) AS start FROM history`).get() as { start: string | null };
+      return { rows, ...stats, months: months.map(m => m.month), coverageStart: coverage.start, sync: null };
+    }, () => { throw new Error('Catalog snapshot unavailable'); });
+  }
+
   // ---------------------------------------------------------------------------
   // search / discovery
   // ---------------------------------------------------------------------------

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -1,3 +1,4 @@
+import type { ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * Supabase-backed CatalogSource.
  *
@@ -58,6 +59,17 @@ function serviceOrAnonClient() {
 let warnedMissingQaServiceRole = false;
 
 export class SupabaseCatalogSource implements CatalogSource {
+  async getReleaseHistory(filters: ReleaseHistoryFilters): Promise<ReleaseHistoryResult> {
+    const client = serviceOrAnonClient();
+    if (!client) throw new Error('Catalog unavailable');
+    const { data, error } = await client.rpc('get_catalog_release_history', {
+      search_text: filters.query, month_filter: filters.month,
+      kind_filter: filters.kind, page_number: filters.page,
+    }).abortSignal(AbortSignal.timeout(15_000));
+    if (error) throw new Error('Catalog history unavailable', { cause: error });
+    return data as ReleaseHistoryResult;
+  }
+
   // ---------------------------------------------------------------------------
   // search / discovery
   // ---------------------------------------------------------------------------

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -1,3 +1,4 @@
+import type { ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * Catalog Source abstraction
  *
@@ -156,6 +157,7 @@ export type SccmMappingResult = SccmMatchResult;
  * The catalog read surface. Every method maps 1:1 to a former direct query.
  */
 export interface CatalogSource {
+  getReleaseHistory(filters: ReleaseHistoryFilters): Promise<ReleaseHistoryResult>;
   // --- search / discovery ---
 
   /** RPC search_curated_apps. Returns the raw rows + error so each caller keeps

--- a/lib/winget-sync-resolution.mjs
+++ b/lib/winget-sync-resolution.mjs
@@ -36,6 +36,7 @@ export function createWingetManifestClient(options = {}) {
   const apiBase = options.apiBase || DEFAULT_API_BASE;
   const maxBytes = options.maxBytes || DEFAULT_MAX_BYTES;
   const maxRetries = options.maxRetries ?? 5;
+  const preferRaw = options.preferRaw === true;
 
   if (typeof fetchImpl !== 'function') {
     throw operationalError('FETCH_UNAVAILABLE', 'A fetch implementation is required for WinGet manifest sync');
@@ -53,7 +54,7 @@ export function createWingetManifestClient(options = {}) {
         if (useAuthenticatedApi) {
           headers.Authorization = `Bearer ${token}`;
         }
-        response = await fetchImpl(url, { headers, cache: 'no-store' });
+        response = await fetchImpl(url, { headers, cache: 'no-store', signal: AbortSignal.timeout(30_000) });
       } catch (error) {
         if (attempt < maxRetries) {
           await sleepImpl(Math.min(1000 * (attempt + 1), 5000));
@@ -129,11 +130,11 @@ export function createWingetManifestClient(options = {}) {
     // Prefer the authenticated Contents API when a token is available. Raw
     // content requests cannot use that token and share a much smaller IP quota
     // across all Vercel functions in the region.
-    let text = token
+    let text = token && !preferRaw
       ? await fetchContentsFile(relativePath)
       : await requestText(`${rawBase}/${relativePath}`);
     if (text === null) {
-      text = token
+      text = token && !preferRaw
         ? await requestText(`${rawBase}/${relativePath}`)
         : await fetchContentsFile(relativePath);
     }
@@ -254,4 +255,19 @@ export function classifyWingetSyncRun({ complete, failed = 0, unavailable = 0 })
     shouldFail,
     status: shouldFail ? 'failed' : unavailable > 0 ? 'partial' : 'success',
   };
+}
+
+/** WinGet ReleaseDate is a calendar date, never the fetch timestamp. */
+export function manifestReleaseDate(manifest) {
+  const values = [manifest?.ReleaseDate, ...(manifest?.Installers || []).map(i => i.ReleaseDate)];
+  for (const value of values) {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) continue;
+    const date = new Date(`${value}T00:00:00.000Z`);
+    if (Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value) return date.toISOString();
+  }
+  return null;
+}
+
+export function canSkipStoredManifest({ forceRefresh, mode, version, hasVersion, description }) {
+  return !forceRefresh && mode !== 'all' && Boolean(version && hasVersion && typeof description === 'string' && description.trim());
 }

--- a/lib/winget-sync-resolution.test.ts
+++ b/lib/winget-sync-resolution.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   WingetSyncOperationalError,
+  manifestReleaseDate,
+  canSkipStoredManifest,
   classifyWingetSyncRun,
   createWingetManifestClient,
   resolveWingetManifest,
@@ -172,5 +174,31 @@ describe('classifyWingetSyncRun', () => {
       shouldFail: true,
       status: 'failed',
     });
+  });
+});
+
+
+describe('bulk manifest sync', () => {
+  it('uses raw files with a token without spending Contents API quota', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('PackageIdentifier: Example.App\nPackageVersion: 2.0\nInstallers: []'));
+    const client = createWingetManifestClient({ fetchImpl, token: 'test-token', preferRaw: true });
+    await client.fetchInstallerManifest('Example.App', '2.0');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toContain('raw.githubusercontent.com');
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+  it('skips stored versions only for incremental syncs with complete descriptions', () => {
+    const input = { mode: 'incremental', forceRefresh: false, version: '1', hasVersion: true, description: 'App' };
+    expect(canSkipStoredManifest(input)).toBe(true);
+    for (const override of [{ mode: 'all' }, { forceRefresh: true }, { hasVersion: false }, { description: null }]) {
+      expect(canSkipStoredManifest({ ...input, ...override })).toBe(false);
+    }
+  });
+  it('preserves publisher calendar dates and rejects invalid dates', () => {
+    expect(manifestReleaseDate({ ReleaseDate: '2026-09-05' })).toBe('2026-09-05T00:00:00.000Z');
+    expect(manifestReleaseDate({ Installers: [{ ReleaseDate: '2026-09-04' }] })).toBe('2026-09-04T00:00:00.000Z');
+    expect(manifestReleaseDate({ ReleaseDate: '2026-02-30' })).toBeNull();
+    expect(manifestReleaseDate({ ReleaseDate: 'yesterday' })).toBeNull();
+    expect(manifestReleaseDate({})).toBeNull();
   });
 });

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -43,7 +43,7 @@ const CURATED_COLUMNS = [
 ];
 const VERSION_COLUMNS = [
   'winget_id', 'version', 'installer_url', 'installer_sha256', 'installer_type',
-  'installer_scope', 'silent_args', 'installers', 'created_at',
+  'installer_scope', 'silent_args', 'installers', 'created_at', 'release_date',
 ];
 const SCCM_COLUMNS = [
   'id', 'sccm_display_name_normalized', 'sccm_ci_id', 'sccm_product_code',
@@ -106,7 +106,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       CREATE TABLE version_history (
         winget_id TEXT, version TEXT, installer_url TEXT, installer_sha256 TEXT,
         installer_type TEXT, installer_scope TEXT, silent_args TEXT, installers TEXT,
-        created_at TEXT, PRIMARY KEY (winget_id, version)
+        created_at TEXT, release_date TEXT, PRIMARY KEY (winget_id, version)
       );
       CREATE INDEX idx_vh_winget ON version_history(winget_id);
 
@@ -147,9 +147,9 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       VALUES (@id, @name, @publisher, @description, @tags)`);
     const insVersion = db.prepare(`INSERT OR IGNORE INTO version_history
       (winget_id, version, installer_url, installer_sha256, installer_type, installer_scope,
-       silent_args, installers, created_at)
+       silent_args, installers, created_at, release_date)
       VALUES (@winget_id,@version,@installer_url,@installer_sha256,@installer_type,@installer_scope,
-       @silent_args,@installers,@created_at)`);
+       @silent_args,@installers,@created_at,@release_date)`);
     const insSccm = db.prepare(`INSERT OR IGNORE INTO sccm_winget_mappings
       (id, sccm_display_name_normalized, sccm_ci_id, sccm_product_code, winget_package_id,
        winget_package_name, confidence, is_verified)
@@ -195,7 +195,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           winget_id: v.winget_id, version: v.version, installer_url: v.installer_url ?? null,
           installer_sha256: v.installer_sha256 ?? null, installer_type: v.installer_type ?? null,
           installer_scope: v.installer_scope ?? null, silent_args: v.silent_args ?? null,
-          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null,
+          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null, release_date: v.release_date ?? null,
         });
       }
       for (const m of sccmMappings) {

--- a/supabase/migrations/20260906052337_catalog_release_history.sql
+++ b/supabase/migrations/20260906052337_catalog_release_history.sql
@@ -1,0 +1,45 @@
+-- Catalog observation timestamps survive metadata refreshes. No historical
+-- publisher dates or last-success timestamps are invented during migration.
+ALTER TABLE public.curated_sync_status ADD COLUMN IF NOT EXISTS last_successful_sync_at timestamptz;
+CREATE INDEX IF NOT EXISTS idx_version_history_observed ON public.version_history(created_at DESC, id DESC);
+
+CREATE OR REPLACE FUNCTION public.preserve_version_first_observed()
+RETURNS trigger LANGUAGE plpgsql SET search_path = '' AS $$
+BEGIN
+  NEW.created_at := OLD.created_at;
+  RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.preserve_version_first_observed() FROM PUBLIC;
+CREATE TRIGGER preserve_version_first_observed BEFORE UPDATE ON public.version_history
+FOR EACH ROW EXECUTE FUNCTION public.preserve_version_first_observed();
+
+CREATE OR REPLACE FUNCTION public.get_catalog_release_history(
+  search_text text DEFAULT '', month_filter text DEFAULT '', kind_filter text DEFAULT 'all', page_number integer DEFAULT 1
+) RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path = '' AS $$
+WITH history AS MATERIALIZED (
+  SELECT v.winget_id, c.name, c.publisher, v.version, v.release_date,
+    v.created_at AS detected_at, v.id,
+    lag(v.version) OVER (PARTITION BY v.winget_id ORDER BY v.created_at, v.id) AS previous_version
+  FROM public.version_history v JOIN public.curated_apps c USING (winget_id)
+  WHERE c.is_locale_variant IS NOT TRUE AND v.created_at IS NOT NULL
+), filtered AS MATERIALIZED (
+  SELECT * FROM history
+  WHERE (coalesce(month_filter, '') = '' OR to_char(detected_at AT TIME ZONE 'UTC', 'YYYY-MM') = month_filter)
+    AND (coalesce(search_text, '') = '' OR position(lower(left(search_text, 120)) in lower(name || ' ' || coalesce(publisher, '') || ' ' || winget_id)) > 0)
+    AND (kind_filter = 'all' OR (kind_filter = 'first' AND previous_version IS NULL) OR (kind_filter = 'updated' AND previous_version IS NOT NULL))
+), page_rows AS (
+  SELECT * FROM filtered ORDER BY detected_at DESC, id DESC LIMIT 40 OFFSET ((greatest(1, least(coalesce(page_number, 1), 10000)) - 1) * 40)
+)
+SELECT jsonb_build_object(
+  'rows', coalesce((SELECT jsonb_agg(to_jsonb(p) - 'id' ORDER BY detected_at DESC, id DESC) FROM page_rows p), '[]'::jsonb),
+  'total', (SELECT count(*) FROM filtered),
+  'apps', (SELECT count(DISTINCT winget_id) FROM filtered),
+  'firstTracked', (SELECT count(*) FROM filtered WHERE previous_version IS NULL),
+  'months', coalesce((SELECT jsonb_agg(m ORDER BY m DESC) FROM (SELECT DISTINCT to_char(detected_at AT TIME ZONE 'UTC', 'YYYY-MM') AS m FROM history) months), '[]'::jsonb),
+  'coverageStart', (SELECT min(detected_at) FROM history),
+  'sync', (SELECT jsonb_build_object('status', last_run_status, 'completedAt', last_run_completed_at, 'lastSuccessfulAt', last_successful_sync_at) FROM public.curated_sync_status WHERE id = 'sync-manifests')
+);
+$$;
+REVOKE ALL ON FUNCTION public.get_catalog_release_history(text, text, text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_catalog_release_history(text, text, text, integer) TO anon, authenticated, service_role;

--- a/supabase/tests/catalog_release_history.sql
+++ b/supabase/tests/catalog_release_history.sql
@@ -1,0 +1,31 @@
+-- Run against a migrated database with psql -v ON_ERROR_STOP=1 -f this-file.
+-- All fixtures and writes are rolled back.
+BEGIN;
+INSERT INTO public.curated_apps (winget_id, name, publisher, latest_version)
+VALUES ('IntuneGet.HistoryFixture', 'History Fixture', 'IntuneGet', '2.0');
+INSERT INTO public.version_history (winget_id, version, created_at, release_date)
+VALUES ('IntuneGet.HistoryFixture', '1.0', '2026-01-31T23:59:00Z', NULL),
+       ('IntuneGet.HistoryFixture', '2.0', '2026-02-01T00:01:00Z', '2026-01-30T00:00:00Z');
+UPDATE public.version_history SET created_at = now() WHERE winget_id = 'IntuneGet.HistoryFixture';
+SET LOCAL ROLE anon;
+DO $$
+DECLARE result jsonb;
+BEGIN
+  result := public.get_catalog_release_history('IntuneGet.HistoryFixture', '2026-02', 'updated', 1);
+  IF (result->>'total')::int <> 1 OR result->'rows'->0->>'previous_version' <> '1.0' THEN
+    RAISE EXCEPTION 'Month filter or previous version failed: %', result;
+  END IF;
+  IF (result->'rows'->0->>'detected_at')::timestamptz <> '2026-02-01T00:01:00Z'::timestamptz THEN
+    RAISE EXCEPTION 'First observation changed during refresh';
+  END IF;
+  result := public.get_catalog_release_history('IntuneGet.HistoryFixture', '', 'first', 1);
+  IF (result->>'firstTracked')::int <> 1 OR result->'rows'->0->>'version' <> '1.0' THEN
+    RAISE EXCEPTION 'First-tracked classification failed';
+  END IF;
+  result := public.get_catalog_release_history('IntuneGet.HistoryFixture', '', 'all', 2);
+  IF jsonb_array_length(result->'rows') <> 0 OR (result->>'total')::int <> 2 THEN
+    RAISE EXCEPTION 'Pagination changed totals';
+  END IF;
+END;
+$$;
+ROLLBACK;


### PR DESCRIPTION
Adds `/apps/releases`, a public, searchable catalog observation history with month/type filters, daily groups, version transitions, summary counts, pagination, and explicit sync status. The page uses the existing catalog abstraction and works with Supabase and self-hosted SQLite snapshots.

The daily manifest job previously fetched thousands of files through the Contents API and exhausted GitHub's quota. Scheduled sync now reads raw manifests, skips known versions before network access, paginates stored-version lookups, and limits request concurrency. Catalog version discovery runs daily instead of weekly. Full refresh remains available manually.

Dates distinguish first observation from publisher release dates. A trigger preserves observation timestamps; the sync extracts valid manifest release dates and records the last successful full-catalog check separately from later failures. First-tracked records and historical gaps are explained on the page. No security/CVE classification is inferred.

The installation scanner now pins the requested WinGet version, retains that version as its snapshot key, and preserves cleanup diagnostics. Vendor download and uninstall failures remain failures.

Validation:
- Full suite: 1,683 passed, 96 skipped; ESLint and production build passed.
- Workflow lint and PowerShell syntax validation passed.
- SQL transaction tests passed for anonymous reads, literal search, month boundaries, previous versions, pagination, and timestamp preservation.
- Desktop/mobile browser checks passed for filters, empty results, pagination, and horizontal overflow.

Deployment: migration `20260906052337_catalog_release_history.sql` has been applied and verified on the IntuneGet Supabase project. Older snapshots remain compatible. The CI-gated public changelog entry is included. Installation scanning is independent of the history page; existing upstream download and app-specific uninstall failures are not represented as fixed.
