### PR TITLE
Improve release history navigation, details and sync clarity

### DIFF
--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -47,6 +47,14 @@ try {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal]::new($identity)
     if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Retry unexpectedly has administrator privileges' }
+    # CreateProcessWithLogonW inherited the administrator's environment.
+    # Resolve this account's profile and keep temporary output in its own directory.
+    $env:USERPROFILE = [Environment]::GetFolderPath('UserProfile')
+    $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
+    $env:APPDATA = [Environment]::GetFolderPath('ApplicationData')
+    $env:TEMP = Join-Path $PSScriptRoot 'temp'
+    $env:TMP = $env:TEMP
+    New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
     Start-Transcript -Path "$PSScriptRoot\bootstrap.log" | Out-Null
     foreach ($manifest in (Get-Content "$PSScriptRoot\manifests.json" -Raw | ConvertFrom-Json)) {
         "Registering $manifest" | Set-Content "$PSScriptRoot\stage.txt"

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -47,11 +47,14 @@ try {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal]::new($identity)
     if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Retry unexpectedly has administrator privileges' }
+    Start-Transcript -Path "$PSScriptRoot\bootstrap.log" | Out-Null
     foreach ($manifest in (Get-Content "$PSScriptRoot\manifests.json" -Raw | ConvertFrom-Json)) {
+        "Registering $manifest" | Set-Content "$PSScriptRoot\stage.txt"
         Add-AppxPackage -Register $manifest -DisableDevelopmentMode
     }
     $package = Get-AppxPackage -Name Microsoft.DesktopAppInstaller
     $env:PATH = "$($package.InstallLocation);$env:PATH"
+    New-Item -ItemType File -Path "$PSScriptRoot\ready" | Out-Null
     $arguments = Get-Content "$PSScriptRoot\arguments.json" -Raw | ConvertFrom-Json
     & "$PSScriptRoot\scan-app.ps1" -WingetId $arguments.id -ExpectedVersion $arguments.version -OutputPath "$PSScriptRoot\result.json"
 } catch {
@@ -65,8 +68,13 @@ try {
     Register-ScheduledTask -TaskName $taskName -Action $action -User "$env:COMPUTERNAME\$userName" -Password $password -RunLevel Limited -Settings $settings | Out-Null
     Start-ScheduledTask -TaskName $taskName
     $deadline = (Get-Date).AddMinutes(23)
+    $setupDeadline = (Get-Date).AddMinutes(3)
     do {
         Start-Sleep -Seconds 2
+        if ((Get-Date) -gt $setupDeadline -and -not (Test-Path "$work\ready")) {
+            $stage = Get-Content "$work\stage.txt" -Raw -ErrorAction SilentlyContinue
+            throw "Standard-user setup exceeded three minutes. Last stage: $stage"
+        }
         $task = Get-ScheduledTask -TaskName $taskName
         $info = Get-ScheduledTaskInfo -TaskName $taskName
         if ($task.State -ne 'Running' -and (Test-Path -LiteralPath $retryOutput)) { break }
@@ -88,6 +96,7 @@ try {
 } finally {
     Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+    if (Test-Path "$work\bootstrap.log") { Copy-Item "$work\bootstrap.log" 'scan-standard-user.log' -Force }
     Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -40,6 +40,8 @@ try {
     # Reuse runner-installed, signed packages; no extra software downloads.
     $manifests = @($appInstaller.Dependencies | ForEach-Object { Join-Path $_.InstallLocation 'AppxManifest.xml' })
     $manifests += Join-Path $appInstaller.InstallLocation 'AppxManifest.xml'
+    $sourcePackage = Get-AppxPackage -Name Microsoft.Winget.Source
+    if ($sourcePackage) { $manifests += Join-Path $sourcePackage.InstallLocation 'AppxManifest.xml' }
     $manifests | ConvertTo-Json -AsArray | Set-Content -LiteralPath (Join-Path $work 'manifests.json')
     @'
 $ErrorActionPreference = 'Stop'
@@ -56,6 +58,7 @@ try {
     $env:TEMP = Join-Path $PSScriptRoot 'temp'
     $env:TMP = $env:TEMP
     New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
+    $env:LOCALAPPDATA | Set-Content "$PSScriptRoot\localappdata.txt"
     Start-Transcript -Path "$PSScriptRoot\bootstrap.log" | Out-Null
     foreach ($manifest in (Get-Content "$PSScriptRoot\manifests.json" -Raw | ConvertFrom-Json)) {
         "Registering $manifest" | Set-Content "$PSScriptRoot\stage.txt"
@@ -102,6 +105,11 @@ try {
 } finally {
     if ($process -and -not $process.HasExited) { & taskkill.exe /PID $process.Id /T /F | Out-Null }
     if (Test-Path "$work\bootstrap.log") { Copy-Item "$work\bootstrap.log" 'scan-standard-user.log' -Force }
+    if (Test-Path "$work\localappdata.txt") {
+        $localData = (Get-Content "$work\localappdata.txt" -Raw).Trim()
+        $diagnostics = Join-Path $localData 'Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\DiagOutputDir'
+        if (Test-Path $diagnostics) { Copy-Item $diagnostics 'scan-standard-user-diagnostics' -Recurse -Force }
+    }
     Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -49,9 +49,10 @@ try {
     if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Retry unexpectedly has administrator privileges' }
     # CreateProcessWithLogonW inherited the administrator's environment.
     # Resolve this account's profile and keep temporary output in its own directory.
-    $env:USERPROFILE = [Environment]::GetFolderPath('UserProfile')
-    $env:LOCALAPPDATA = [Environment]::GetFolderPath('LocalApplicationData')
-    $env:APPDATA = [Environment]::GetFolderPath('ApplicationData')
+    $profileKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($identity.User.Value)"
+    $env:USERPROFILE = (Get-ItemProperty -LiteralPath $profileKey).ProfileImagePath
+    $env:LOCALAPPDATA = Join-Path $env:USERPROFILE 'AppData\Local'
+    $env:APPDATA = Join-Path $env:USERPROFILE 'AppData\Roaming'
     $env:TEMP = Join-Path $PSScriptRoot 'temp'
     $env:TMP = $env:TEMP
     New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
@@ -61,7 +62,10 @@ try {
         Add-AppxPackage -Register $manifest -DisableDevelopmentMode
     }
     $package = Get-AppxPackage -Name Microsoft.DesktopAppInstaller
-    $env:PATH = "$($package.InstallLocation);$env:PATH"
+    $userAliases = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+    $env:PATH = "$userAliases;$($package.InstallLocation);$env:PATH"
+    Write-Host "Standard-user profile: $env:USERPROFILE"
+    Write-Host "WinGet executable: $((Get-Command winget).Source)"
     New-Item -ItemType File -Path "$PSScriptRoot\ready" | Out-Null
     $arguments = Get-Content "$PSScriptRoot\arguments.json" -Raw | ConvertFrom-Json
     & "$PSScriptRoot\scan-app.ps1" -WingetId $arguments.id -ExpectedVersion $arguments.version -OutputPath "$PSScriptRoot\result.json"

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -1,0 +1,56 @@
+# Keep installation, registry snapshots and cleanup in the same Windows context.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*\.[A-Za-z0-9][A-Za-z0-9._+-]*$')][string]$WingetId,
+    [Parameter(Mandatory)][ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._+\-]*$')][string]$ExpectedVersion,
+    [Parameter(Mandatory)][string]$OutputPath
+)
+$ErrorActionPreference = 'Stop'
+$scanner = Join-Path $PSScriptRoot 'scan-app.ps1'
+$pwsh = (Get-Process -Id $PID).Path
+$output = [IO.Path]::GetFullPath($OutputPath)
+& $pwsh -NoProfile -File $scanner -WingetId $WingetId -ExpectedVersion $ExpectedVersion -OutputPath $output
+$scanExit = $LASTEXITCODE
+if ($scanExit -eq 0) { exit 0 }
+if (-not (Test-Path -LiteralPath $output)) { exit $scanExit }
+$result = Get-Content -LiteralPath $output -Raw | ConvertFrom-Json
+# APPINSTALLER_CLI_ERROR_INSTALLER_PROHIBITS_ELEVATION: no installer ran.
+# Do not retry crashes, timeouts, or partially completed installations.
+if ($result.error -notmatch 'WinGet install failed with exit code -1978335146:') { exit $scanExit }
+
+$taskName = "IntuneGetScan-$([Guid]::NewGuid())"
+$retryOutput = "$output.standard-user.json"
+Remove-Item -LiteralPath $retryOutput -Force -ErrorAction SilentlyContinue
+try {
+    Write-Host 'Installer prohibits elevation. Retrying the complete scan with a limited token for the same user.'
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel Limited
+    $arguments = "-NoProfile -File `"$scanner`" -WingetId `"$WingetId`" -ExpectedVersion `"$ExpectedVersion`" -OutputPath `"$retryOutput`""
+    $action = New-ScheduledTaskAction -Execute $pwsh -Argument $arguments -WorkingDirectory (Get-Location).Path
+    $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 22)
+    Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Settings $settings | Out-Null
+    Start-ScheduledTask -TaskName $taskName
+    $deadline = (Get-Date).AddMinutes(23)
+    do {
+        Start-Sleep -Seconds 2
+        $task = Get-ScheduledTask -TaskName $taskName
+        $info = Get-ScheduledTaskInfo -TaskName $taskName
+        if ($task.State -ne 'Running' -and (Test-Path -LiteralPath $retryOutput)) { break }
+        if ($task.State -ne 'Running' -and $info.LastRunTime -gt (Get-Date).AddMinutes(-24) -and $info.LastTaskResult -ne 267009) {
+            throw "Limited-context task ended without a result (code $($info.LastTaskResult))"
+        }
+    } while ((Get-Date) -lt $deadline)
+    if (-not (Test-Path -LiteralPath $retryOutput)) { throw 'Limited-context scan timed out or no interactive user session was available' }
+    $retry = Get-Content -LiteralPath $retryOutput -Raw | ConvertFrom-Json
+    Copy-Item -LiteralPath $retryOutput -Destination $output -Force
+    if ($retry.status -eq 'failed') { Write-Warning $retry.error; exit 1 }
+    exit 0
+} catch {
+    $result.error += "; Standard-user retry failed: $($_.Exception.Message)"
+    $result | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $output -Encoding utf8NoBOM
+    Write-Warning $result.error
+    exit 1
+} finally {
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -63,26 +63,20 @@ try {
 }
 '@ | Set-Content -LiteralPath (Join-Path $work 'bootstrap.ps1')
     @{ id = $WingetId; version = $ExpectedVersion } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $work 'arguments.json')
-    $action = New-ScheduledTaskAction -Execute $pwsh -Argument "-NoProfile -File `"$(Join-Path $work 'bootstrap.ps1')`"" -WorkingDirectory $work
-    $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 22)
-    Register-ScheduledTask -TaskName $taskName -Action $action -User "$env:COMPUTERNAME\$userName" -Password $password -RunLevel Limited -Settings $settings | Out-Null
-    Start-ScheduledTask -TaskName $taskName
+    $credential = [PSCredential]::new("$env:COMPUTERNAME\$userName", $securePassword)
+    $process = Start-Process -FilePath $pwsh -ArgumentList "-NoProfile -File `"$(Join-Path $work 'bootstrap.ps1')`"" -WorkingDirectory $work -Credential $credential -LoadUserProfile -PassThru
     $deadline = (Get-Date).AddMinutes(23)
     $setupDeadline = (Get-Date).AddMinutes(3)
     do {
         Start-Sleep -Seconds 2
+        $process.Refresh()
         if ((Get-Date) -gt $setupDeadline -and -not (Test-Path "$work\ready")) {
             $stage = Get-Content "$work\stage.txt" -Raw -ErrorAction SilentlyContinue
             throw "Standard-user setup exceeded three minutes. Last stage: $stage"
         }
-        $task = Get-ScheduledTask -TaskName $taskName
-        $info = Get-ScheduledTaskInfo -TaskName $taskName
-        if ($task.State -ne 'Running' -and (Test-Path -LiteralPath $retryOutput)) { break }
-        if (Test-Path "$work\bootstrap-error.txt") { throw (Get-Content "$work\bootstrap-error.txt" -Raw) }
-        if ($task.State -ne 'Running' -and $info.LastRunTime -gt (Get-Date).AddMinutes(-24) -and $info.LastTaskResult -ne 267009) {
-            throw "Standard-user task ended without a result (code $($info.LastTaskResult))"
-        }
+        if ($process.HasExited) { break }
     } while ((Get-Date) -lt $deadline)
+    if (Test-Path "$work\bootstrap-error.txt") { throw (Get-Content "$work\bootstrap-error.txt" -Raw) }
     if (-not (Test-Path -LiteralPath $retryOutput)) { throw 'Standard-user scan timed out' }
     $retry = Get-Content -LiteralPath $retryOutput -Raw | ConvertFrom-Json
     Copy-Item -LiteralPath $retryOutput -Destination $output -Force
@@ -94,8 +88,7 @@ try {
     Write-Warning $result.error
     exit 1
 } finally {
-    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
-    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+    if ($process -and -not $process.HasExited) { & taskkill.exe /PID $process.Id /T /F | Out-Null }
     if (Test-Path "$work\bootstrap.log") { Copy-Item "$work\bootstrap.log" 'scan-standard-user.log' -Force }
     Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue

--- a/.github/scripts/run-app-scan.ps1
+++ b/.github/scripts/run-app-scan.ps1
@@ -19,16 +19,50 @@ $result = Get-Content -LiteralPath $output -Raw | ConvertFrom-Json
 if ($result.error -notmatch 'WinGet install failed with exit code -1978335146:') { exit $scanExit }
 
 $taskName = "IntuneGetScan-$([Guid]::NewGuid())"
-$retryOutput = "$output.standard-user.json"
-Remove-Item -LiteralPath $retryOutput -Force -ErrorAction SilentlyContinue
+$userName = "igscan$([Guid]::NewGuid().ToString('N').Substring(0, 10))"
+$work = Join-Path $env:ProgramData $taskName
+$retryOutput = Join-Path $work 'result.json'
 try {
-    Write-Host 'Installer prohibits elevation. Retrying the complete scan with a limited token for the same user.'
-    $identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
-    $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel Limited
-    $arguments = "-NoProfile -File `"$scanner`" -WingetId `"$WingetId`" -ExpectedVersion `"$ExpectedVersion`" -OutputPath `"$retryOutput`""
-    $action = New-ScheduledTaskAction -Execute $pwsh -Argument $arguments -WorkingDirectory (Get-Location).Path
+    # Hosted runners can have UAC disabled, so Limited for runneradmin still
+    # produces an administrator token. Use a genuinely non-administrator account.
+    Write-Host 'Installer prohibits elevation. Retrying the complete scan as a temporary standard user.'
+    $password = "Ig1!$([Guid]::NewGuid().ToString('N'))$([Guid]::NewGuid().ToString('N'))"
+    $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+    $user = New-LocalUser -Name $userName -Password $securePassword -AccountNeverExpires
+    Add-LocalGroupMember -Group (Get-LocalGroup -SID 'S-1-5-32-545') -Member $user
+    New-Item -ItemType Directory -Path $work | Out-Null
+    Copy-Item -LiteralPath $scanner, (Join-Path $PSScriptRoot 'snapshot.ps1') -Destination $work
+    $acl = Get-Acl -LiteralPath $work
+    $acl.AddAccessRule([Security.AccessControl.FileSystemAccessRule]::new($user.SID, 'Modify', 'ContainerInherit,ObjectInherit', 'None', 'Allow'))
+    Set-Acl -LiteralPath $work -AclObject $acl
+    $appInstaller = Get-AppxPackage -Name Microsoft.DesktopAppInstaller
+    if (-not $appInstaller) { throw 'Desktop App Installer package was not found' }
+    # Reuse runner-installed, signed packages; no extra software downloads.
+    $manifests = @($appInstaller.Dependencies | ForEach-Object { Join-Path $_.InstallLocation 'AppxManifest.xml' })
+    $manifests += Join-Path $appInstaller.InstallLocation 'AppxManifest.xml'
+    $manifests | ConvertTo-Json -AsArray | Set-Content -LiteralPath (Join-Path $work 'manifests.json')
+    @'
+$ErrorActionPreference = 'Stop'
+try {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    if ($principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Retry unexpectedly has administrator privileges' }
+    foreach ($manifest in (Get-Content "$PSScriptRoot\manifests.json" -Raw | ConvertFrom-Json)) {
+        Add-AppxPackage -Register $manifest -DisableDevelopmentMode
+    }
+    $package = Get-AppxPackage -Name Microsoft.DesktopAppInstaller
+    $env:PATH = "$($package.InstallLocation);$env:PATH"
+    $arguments = Get-Content "$PSScriptRoot\arguments.json" -Raw | ConvertFrom-Json
+    & "$PSScriptRoot\scan-app.ps1" -WingetId $arguments.id -ExpectedVersion $arguments.version -OutputPath "$PSScriptRoot\result.json"
+} catch {
+    $_.Exception.Message | Set-Content "$PSScriptRoot\bootstrap-error.txt"
+    exit 1
+}
+'@ | Set-Content -LiteralPath (Join-Path $work 'bootstrap.ps1')
+    @{ id = $WingetId; version = $ExpectedVersion } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $work 'arguments.json')
+    $action = New-ScheduledTaskAction -Execute $pwsh -Argument "-NoProfile -File `"$(Join-Path $work 'bootstrap.ps1')`"" -WorkingDirectory $work
     $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 22)
-    Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Settings $settings | Out-Null
+    Register-ScheduledTask -TaskName $taskName -Action $action -User "$env:COMPUTERNAME\$userName" -Password $password -RunLevel Limited -Settings $settings | Out-Null
     Start-ScheduledTask -TaskName $taskName
     $deadline = (Get-Date).AddMinutes(23)
     do {
@@ -36,11 +70,12 @@ try {
         $task = Get-ScheduledTask -TaskName $taskName
         $info = Get-ScheduledTaskInfo -TaskName $taskName
         if ($task.State -ne 'Running' -and (Test-Path -LiteralPath $retryOutput)) { break }
+        if (Test-Path "$work\bootstrap-error.txt") { throw (Get-Content "$work\bootstrap-error.txt" -Raw) }
         if ($task.State -ne 'Running' -and $info.LastRunTime -gt (Get-Date).AddMinutes(-24) -and $info.LastTaskResult -ne 267009) {
-            throw "Limited-context task ended without a result (code $($info.LastTaskResult))"
+            throw "Standard-user task ended without a result (code $($info.LastTaskResult))"
         }
     } while ((Get-Date) -lt $deadline)
-    if (-not (Test-Path -LiteralPath $retryOutput)) { throw 'Limited-context scan timed out or no interactive user session was available' }
+    if (-not (Test-Path -LiteralPath $retryOutput)) { throw 'Standard-user scan timed out' }
     $retry = Get-Content -LiteralPath $retryOutput -Raw | ConvertFrom-Json
     Copy-Item -LiteralPath $retryOutput -Destination $output -Force
     if ($retry.status -eq 'failed') { Write-Warning $retry.error; exit 1 }
@@ -53,4 +88,6 @@ try {
 } finally {
     Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+    Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/.github/scripts/scan-app.ps1
+++ b/.github/scripts/scan-app.ps1
@@ -69,7 +69,7 @@ try {
         $timeout = [int]($env:APP_TIMEOUT_SECONDS ?? 900)
         $install = Invoke-Winget -Arguments @(
             'install', '--id', $WingetId, '--exact', '--version', $ExpectedVersion, '--source', 'winget', '--silent',
-            '--accept-package-agreements', '--accept-source-agreements', '--disable-interactivity'
+            '--accept-package-agreements', '--accept-source-agreements', '--disable-interactivity', '--verbose-logs'
         ) -TimeoutSeconds $timeout
 
         if ($install.TimedOut) { throw "Installation timed out after $timeout seconds" }

--- a/.github/workflows/scan-apps.yml
+++ b/.github/workflows/scan-apps.yml
@@ -144,7 +144,7 @@ jobs:
           WINGET_ID: ${{ matrix.winget_id }}
           EXPECTED_VERSION: ${{ matrix.expected_version }}
           APP_TIMEOUT_SECONDS: "900"
-        run: .github/scripts/scan-app.ps1 -WingetId $env:WINGET_ID -ExpectedVersion $env:EXPECTED_VERSION -OutputPath scan-result.json
+        run: .github/scripts/run-app-scan.ps1 -WingetId $env:WINGET_ID -ExpectedVersion $env:EXPECTED_VERSION -OutputPath scan-result.json
 
       - name: Upload scan result
         if: always()
@@ -154,6 +154,17 @@ jobs:
           path: scan-result.json
           if-no-files-found: error
           retention-days: 2
+
+      - name: Preserve WinGet diagnostics for failed installs
+        if: always() && steps.scan.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-diagnostics-${{ matrix.winget_id }}
+          path: |
+            ~/AppData/Local/Packages/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe/LocalState/DiagOutputDir/
+            ~/AppData/Local/Microsoft/WinGet/Logs/
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Propagate scanner failure
         if: steps.scan.outcome == 'failure'

--- a/.github/workflows/scan-apps.yml
+++ b/.github/workflows/scan-apps.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           name: scan-diagnostics-${{ matrix.winget_id }}
           path: |
+            scan-standard-user.log
             ~/AppData/Local/Packages/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe/LocalState/DiagOutputDir/
             ~/AppData/Local/Microsoft/WinGet/Logs/
           if-no-files-found: warn

--- a/.github/workflows/scan-apps.yml
+++ b/.github/workflows/scan-apps.yml
@@ -155,15 +155,26 @@ jobs:
           if-no-files-found: error
           retention-days: 2
 
+      - name: Collect failed scan diagnostics
+        if: always() && steps.scan.outcome == 'failure'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path scan-diagnostics -Force | Out-Null
+          $paths = @(
+            'scan-standard-user.log',
+            "$env:LOCALAPPDATA/Packages/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe/LocalState/DiagOutputDir",
+            "$env:LOCALAPPDATA/Microsoft/WinGet/Logs"
+          )
+          foreach ($path in $paths) {
+            if (Test-Path $path) { Copy-Item $path scan-diagnostics -Recurse -Force }
+          }
+
       - name: Preserve WinGet diagnostics for failed installs
         if: always() && steps.scan.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scan-diagnostics-${{ matrix.winget_id }}
-          path: |
-            scan-standard-user.log
-            ~/AppData/Local/Packages/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe/LocalState/DiagOutputDir/
-            ~/AppData/Local/Microsoft/WinGet/Logs/
+          path: scan-diagnostics/
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/scan-apps.yml
+++ b/.github/workflows/scan-apps.yml
@@ -162,6 +162,7 @@ jobs:
           New-Item -ItemType Directory -Path scan-diagnostics -Force | Out-Null
           $paths = @(
             'scan-standard-user.log',
+            'scan-standard-user-diagnostics',
             "$env:LOCALAPPDATA/Packages/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe/LocalState/DiagOutputDir",
             "$env:LOCALAPPDATA/Microsoft/WinGet/Logs"
           )

--- a/.ugurlabs/entries/catalog-navigation-status.json
+++ b/.ugurlabs/entries/catalog-navigation-status.json
@@ -1,5 +1,5 @@
 {
   "title": "Clearer catalog status and easier navigation",
-  "summary": "Release History now has a direct navigation link. A simpler header groups secondary destinations under Resources, and the mobile menu supports keyboard focus and full-screen browsing. The history page shows a matching loading skeleton and precise UTC sync times, distinguishing completed checks with unavailable upstream packages from failed syncs.",
+  "summary": "Release History now has a direct navigation link. A simpler header groups secondary destinations under Resources, and the mobile menu supports keyboard focus and full-screen browsing. The history page shows a matching loading skeleton and precise UTC sync times, distinguishing completed checks with unavailable upstream packages from failed syncs. Expand release notes where provided and see recorded VirusTotal results matched to the exact app version and installer hash, with scan dates and links to the reports.",
   "type": "improved"
 }

--- a/.ugurlabs/entries/catalog-navigation-status.json
+++ b/.ugurlabs/entries/catalog-navigation-status.json
@@ -1,0 +1,5 @@
+{
+  "title": "Clearer catalog status and easier navigation",
+  "summary": "Release History now has a direct navigation link. A simpler header groups secondary destinations under Resources, and the mobile menu supports keyboard focus and full-screen browsing. The history page shows a matching loading skeleton and precise UTC sync times, distinguishing completed checks with unavailable upstream packages from failed syncs.",
+  "type": "improved"
+}

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -61,6 +61,10 @@ export default function Loading() {
                     <div className={`${bone} mt-2 h-4 w-2/5`} />
                   </div>
                   <div className={`${bone} h-5 w-28`} />
+                  <div className="space-y-3 sm:col-span-2">
+                    <div className={`${bone} h-4 w-1/2`} />
+                    <div className={`${bone} h-4 w-24`} />
+                  </div>
                 </div>
               ))}
             </div>

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -1,9 +1,73 @@
+import { Header } from "@/components/landing/Header";
+import { Footer } from "@/components/landing/sections/Footer";
+import { T } from "gt-next";
+
+const bone = "rounded-md bg-overlay/[0.08] motion-safe:animate-pulse";
 export default function Loading() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-32" aria-busy="true">
-      <p role="status" className="text-text-secondary">
-        Loading catalog history…
-      </p>
-    </main>
+    <div className="flex min-h-screen flex-col bg-bg-deepest">
+      <Header />
+      <main
+        id="main-content"
+        aria-busy="true"
+        className="mx-auto w-full max-w-6xl flex-1 px-4 pb-20 pt-28 lg:px-8 lg:pt-36"
+      >
+        <p role="status" className="sr-only">
+          <T>Loading catalog release history</T>
+        </p>
+        <div aria-hidden="true">
+          <div className="mb-10 grid gap-8 lg:grid-cols-[1fr_300px] lg:items-end">
+            <div>
+              <div className={`${bone} h-5 w-24`} />
+              <div className={`${bone} mb-3 mt-6 h-4 w-44`} />
+              <div className={`${bone} h-12 w-full max-w-lg`} />
+              <div className={`${bone} mt-5 h-6 w-full`} />
+              <div className={`${bone} mt-2 h-6 w-3/4`} />
+            </div>
+            <div className="space-y-4 rounded-xl border border-overlay/10 bg-bg-elevated p-5">
+              <div className={`${bone} h-5 w-full`} />
+              <div className={`${bone} h-4 w-4/5`} />
+              <div className={`${bone} h-4 w-3/5`} />
+            </div>
+          </div>
+          <div className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="px-3 py-5 sm:px-6">
+                <div className={`${bone} h-5 w-4/5`} />
+                <div className={`${bone} mt-2 h-9 w-2/3`} />
+              </div>
+            ))}
+          </div>
+          <div className="mb-5 grid gap-4 rounded-xl border border-overlay/10 bg-bg-elevated p-5 sm:grid-cols-2 lg:grid-cols-[1fr_180px_190px_auto] lg:items-end">
+            {[0, 1, 2].map((i) => (
+              <div key={i}>
+                <div className={`${bone} mb-2 h-5 w-24`} />
+                <div className={`${bone} h-11 w-full`} />
+              </div>
+            ))}
+            <div className={`${bone} h-11 w-full lg:w-32`} />
+          </div>
+          <div className={`${bone} mb-10 h-5 w-3/4`} />
+          <div className="grid gap-4 lg:grid-cols-[150px_1fr]">
+            <div className={`${bone} mt-4 h-5 w-28`} />
+            <div className="divide-y divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div
+                  key={i}
+                  className="grid gap-4 p-5 sm:grid-cols-[1fr_auto] sm:items-center"
+                >
+                  <div>
+                    <div className={`${bone} h-6 w-3/5`} />
+                    <div className={`${bone} mt-2 h-4 w-2/5`} />
+                  </div>
+                  <div className={`${bone} h-5 w-28`} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -333,15 +333,11 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                             {row.name}
                             <span className="sr-only"> {row.winget_id}</span>
                           </Link>
-                          <span
-                            className={`rounded-md px-2 py-1 text-xs ${row.previous_version ? "bg-accent-cyan/10 text-accent-cyan" : "bg-overlay/5 text-text-secondary"}`}
-                          >
-                            {row.previous_version ? (
-                              <T>Version change</T>
-                            ) : (
+                          {!row.previous_version && (
+                            <span className="rounded-md bg-overlay/5 px-2 py-1 text-xs text-text-secondary">
                               <T>First tracked</T>
-                            )}
-                          </span>
+                            </span>
+                          )}
                         </div>
                         <p className="mt-2 break-all text-xs text-text-muted">
                           {row.winget_id}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -46,6 +46,15 @@ const dateFormat = new Intl.DateTimeFormat("en-GB", {
   year: "numeric",
   timeZone: "UTC",
 });
+const syncDateFormat = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+  timeZone: "UTC",
+});
 function dateLabel(value: string) {
   return dateFormat.format(new Date(value));
 }
@@ -67,9 +76,11 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
       ? "Last run completed successfully"
       : sync?.status === "running"
         ? "Catalog sync in progress"
-        : sync
-          ? "Latest sync is incomplete"
-          : "History from the catalog snapshot";
+        : sync?.status === "partial"
+          ? "Completed with unavailable packages"
+          : sync
+            ? "Latest sync failed"
+            : "History from the catalog snapshot";
 
   return (
     <div className="flex min-h-screen flex-col bg-bg-deepest">
@@ -111,23 +122,34 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                 </T>
               </p>
               <p className="mt-3 leading-relaxed text-text-secondary">
-                <T>Last successful full sync:</T>{" "}
+                <T>Last completed catalog check:</T>{" "}
                 {sync?.lastSuccessfulAt ? (
                   <time dateTime={sync.lastSuccessfulAt}>
-                    {dateLabel(sync.lastSuccessfulAt)} (UTC)
+                    {syncDateFormat.format(new Date(sync.lastSuccessfulAt))}{" "}
+                    (UTC)
                   </time>
                 ) : (
                   <T>Not yet recorded</T>
                 )}
               </p>
-              {sync?.completedAt && (
-                <p className="mt-2 text-xs text-text-muted">
-                  <T>Last attempt:</T>{" "}
-                  <time dateTime={sync.completedAt}>
-                    {dateLabel(sync.completedAt)} (UTC)
-                  </time>
+              {sync?.status === "partial" && (
+                <p className="mt-3 text-xs leading-relaxed text-text-secondary">
+                  <T>
+                    The check completed, but some manifests were unavailable
+                    from WinGet. Existing records are retained and retried on
+                    the next sync.
+                  </T>
                 </p>
               )}
+              {sync?.completedAt &&
+                sync.completedAt !== sync.lastSuccessfulAt && (
+                  <p className="mt-2 text-xs text-text-muted">
+                    <T>Last attempt:</T>{" "}
+                    <time dateTime={sync.completedAt}>
+                      {syncDateFormat.format(new Date(sync.completedAt))} (UTC)
+                    </time>
+                  </p>
+                )}
             </aside>
           )}
         </header>

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -417,6 +417,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                   )}
                                   {row.virusTotal.scannedAt && (
                                     <time dateTime={row.virusTotal.scannedAt}>
+                                      <T>Checked</T>{" "}
                                       {dateLabel(row.virusTotal.scannedAt)}
                                     </time>
                                   )}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
 const loadHistory = unstable_cache(
   (filters: ReleaseHistoryFilters) =>
     getCatalogSource().getReleaseHistory(filters),
-  ["catalog-release-history-v1"],
+  ["catalog-release-history-v2"],
   { revalidate: 300 },
 );
 const dateFormat = new Intl.DateTimeFormat("en-GB", {
@@ -367,6 +367,81 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                           {row.version}
                         </span>
                       </div>
+                      <div className="min-w-0 space-y-3 text-xs text-text-muted sm:col-span-2">
+                        {row.detailsUnavailable ? (
+                          <p>
+                            <T>
+                              Release notes and scan details are temporarily
+                              unavailable.
+                            </T>
+                          </p>
+                        ) : (
+                          <>
+                            <p className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                              <span className="font-medium text-text-secondary">
+                                VirusTotal:
+                              </span>
+                              {row.virusTotal ? (
+                                <>
+                                  <a
+                                    href={`https://www.virustotal.com/gui/file/${row.virusTotal.hash}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-accent-cyan hover:underline"
+                                  >
+                                    {[
+                                      "clean",
+                                      "flagged",
+                                      "suspicious",
+                                    ].includes(row.virusTotal.status) &&
+                                    row.virusTotal.total != null &&
+                                    row.virusTotal.total > 0 &&
+                                    row.virusTotal.malicious != null &&
+                                    row.virusTotal.suspicious != null ? (
+                                      <T>
+                                        <Var>{row.virusTotal.malicious}</Var>/
+                                        <Var>{row.virusTotal.total}</Var>{" "}
+                                        malicious,{" "}
+                                        <Var>{row.virusTotal.suspicious}</Var>{" "}
+                                        suspicious
+                                      </T>
+                                    ) : row.virusTotal.status ===
+                                      "not_found" ? (
+                                      <T>No report found</T>
+                                    ) : (
+                                      <T>Scan unavailable</T>
+                                    )}
+                                  </a>
+                                  {row.virusTotal.architecture && (
+                                    <span>({row.virusTotal.architecture})</span>
+                                  )}
+                                  {row.virusTotal.scannedAt && (
+                                    <time dateTime={row.virusTotal.scannedAt}>
+                                      {dateLabel(row.virusTotal.scannedAt)}
+                                    </time>
+                                  )}
+                                </>
+                              ) : (
+                                <T>Not scanned for this installer</T>
+                              )}
+                            </p>
+                            {row.release_notes ? (
+                              <details className="group">
+                                <summary className="w-fit cursor-pointer rounded-sm py-1 font-medium text-accent-cyan focus-visible:outline-2 focus-visible:outline-accent-cyan">
+                                  <T>Release notes</T>
+                                </summary>
+                                <p className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-lg border border-overlay/10 bg-bg-deepest p-4 text-sm leading-relaxed text-text-secondary">
+                                  {row.release_notes}
+                                </p>
+                              </details>
+                            ) : (
+                              <p>
+                                <T>Release notes not provided</T>
+                              </p>
+                            )}
+                          </>
+                        )}
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -408,7 +483,9 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
           </h2>
           <p className="mt-2">
             <T>
-              This is an observation history, not a complete archive of
+              VirusTotal results apply to the exact installer hash shown and
+              reflect the recorded scan date. Zero detections do not guarantee
+              safety. This is an observation history, not a complete archive of
               publisher releases. First tracked means the earliest version we
               have recorded for an app, including apps imported when tracking
               began. It does not necessarily mean a newly released product.

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,353 +1,213 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { motion, AnimatePresence, useScroll, useTransform, useReducedMotion } from "framer-motion";
-import { Menu, X, Star, Book } from "lucide-react";
-import { Github } from "@/components/icons/brand-icons";
-import { cn } from "@/lib/utils";
-import { DocsDropdown } from "./DocsDropdown";
-import { ResourcesDropdown } from "./ResourcesDropdown";
-import { T, useGT, useLocale } from "gt-next";
-import { LocaleSwitcher } from "./LocaleSwitcher";
+import { usePathname } from "next/navigation";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Menu, X } from "lucide-react";
+import { T, useGT } from "gt-next";
 import dynamic from "next/dynamic";
-import { useSharedGitHubStats } from "@/components/providers/LandingStatsProvider";
+import { cn } from "@/lib/utils";
 import { useAuthHint } from "@/hooks/useAuthHint";
 import { ChangelogBell } from "@/components/changelog/ChangelogBell";
+import { DocsDropdown } from "./DocsDropdown";
+import { ResourcesDropdown, resourceLinks } from "./ResourcesDropdown";
+import { LocaleSwitcher } from "./LocaleSwitcher";
 
-// MSAL-backed avatar, loaded only for signed-in visitors so anonymous
-// visitors never download @azure/msal-browser on marketing pages.
 const AuthedAvatar = dynamic(
   () => import("./AuthedAvatar").then((m) => m.AuthedAvatar),
   {
     ssr: false,
-    loading: () => (
-      <div className="relative flex-shrink-0">
-        <div className="relative w-8 h-8 rounded-full bg-overlay/[0.06]" />
-      </div>
-    ),
-  }
+    loading: () => <div className="h-8 w-8 rounded-full bg-overlay/[0.06]" />,
+  },
 );
-
-const primaryNavLinks = [
-  { href: "/apps", label: "Apps" },
-  { href: "/qa", label: "Live Packaging", isLive: true },
-  { href: "/#how-it-works", label: "How It Works" },
-  { href: "/security", label: "Security" },
+const primaryLinks = [
+  { href: "/apps", label: "App Catalog" },
+  { href: "/apps/releases", label: "Release History" },
+  { href: "/qa", label: "Live Packaging" },
 ];
-
-const secondaryNavLinks = [
-  { href: "/apps/releases", label: "Catalog History" },
-  { href: "/pricing", label: "Pricing" },
-  { href: "/#faq", label: "FAQ" },
-  { href: "/blog", label: "Blog" },
-  { href: "/changelog", label: "Changelog" },
-];
+const focus =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2";
 
 export function Header() {
   const t = useGT();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [hasScrolled, setHasScrolled] = useState(false);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const shouldReduceMotion = useReducedMotion();
-
-  const isAuthenticated = useAuthHint();
-
-  // Star count is fetched client-side and hidden until loaded, so the
-  // server-rendered markup never contains a number that could mismatch.
-  const localeTag = useLocale() || undefined;
-  const { stars, isLoading: starsLoading } = useSharedGitHubStats();
-  const starsDisplay = new Intl.NumberFormat(localeTag, {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(stars);
-
-  const { scrollY } = useScroll();
-  const headerOpacity = useTransform(scrollY, [0, 100], [0, 1]);
-
+  const pathname = usePathname();
+  const authenticated = useAuthHint();
+  const [open, setOpen] = useState(false);
   useEffect(() => {
-    const handleScroll = () => {
-      setHasScrolled(window.scrollY > 50);
+    const desktop = window.matchMedia("(min-width: 1280px)");
+    const closeOnDesktop = () => {
+      if (desktop.matches) setOpen(false);
     };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    desktop.addEventListener("change", closeOnDesktop);
+    return () => desktop.removeEventListener("change", closeOnDesktop);
   }, []);
-
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setIsMenuOpen(false);
-        menuButtonRef.current?.focus();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isMenuOpen]);
-
-  return (
-    <motion.header
-      className="fixed top-0 left-0 right-0 z-50 pointer-events-none"
-      initial={{ y: -100 }}
-      animate={{ y: 0 }}
-      transition={{
-        duration: shouldReduceMotion ? 0 : 0.5,
-        ease: [0.25, 0.46, 0.45, 0.94],
-      }}
+  const active = (href: string) =>
+    href === "/apps"
+      ? pathname.startsWith("/apps") && !pathname.startsWith("/apps/releases")
+      : pathname === href || pathname.startsWith(`${href}/`);
+  const account = (mobile = false) => (
+    <Link
+      href={authenticated ? "/dashboard" : "/auth/signin"}
+      onClick={() => setOpen(false)}
+      aria-label={authenticated ? t("Go to dashboard") : undefined}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center gap-3 rounded-lg text-sm font-medium",
+        focus,
+        mobile
+          ? "min-h-11 w-full bg-accent-cyan px-4 py-3 text-white"
+          : authenticated
+            ? "p-1"
+            : "bg-accent-cyan px-4 py-2.5 text-white hover:bg-accent-cyan-dim",
+      )}
     >
-      <div
-        className={cn(
-          "pointer-events-auto relative mx-auto transition-all duration-500 ease-spring",
-          hasScrolled
-            ? "mt-3 w-fit max-w-[calc(100%-2rem)] rounded-2xl border border-overlay/[0.06] shadow-soft-md"
-            : "max-w-full"
-        )}
-      >
-        {/* Animated background */}
-        <motion.div
-          className={cn(
-            "absolute inset-0 backdrop-blur-xl transition-[background-color,border-radius] duration-500",
-            hasScrolled
-              ? "bg-bg-elevated/75 rounded-2xl"
-              : "bg-bg-deepest/80"
-          )}
-          style={{
-            opacity: shouldReduceMotion ? (hasScrolled ? 1 : 0) : headerOpacity,
-          }}
-        />
-
-        <div className={cn(
-          "relative mx-auto px-4 md:px-6 transition-all duration-500",
-          hasScrolled ? "" : "max-w-7xl"
-        )}>
-          <div className="flex h-14 items-center justify-between">
-          {/* Logo */}
-          <Link href="/" className="flex items-center gap-2 group z-10">
-            <motion.div
-              className="relative"
-              whileHover={
-                shouldReduceMotion
-                  ? {}
-                  : {
-                      scale: 1.1,
-                      transition: { duration: 0.2 },
-                    }
-              }
+      {authenticated ? (
+        <>
+          <AuthedAvatar size="sm" />
+          {mobile && <T>Dashboard</T>}
+        </>
+      ) : (
+        <T id="nav.get-started">Get Started</T>
+      )}
+    </Link>
+  );
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-overlay/[0.08] bg-bg-deepest/95 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 max-w-7xl items-center gap-6 px-4 md:px-6">
+        <Link
+          href="/"
+          className={cn("flex shrink-0 items-center gap-2 rounded-sm", focus)}
+        >
+          <Image
+            src="/favicon.svg"
+            alt=""
+            width={28}
+            height={28}
+            className="h-7 w-7"
+          />
+          <span className="text-xl font-semibold text-text-primary">
+            IntuneGet
+          </span>
+        </Link>
+        <nav
+          aria-label={t("Main navigation")}
+          className="ml-4 hidden items-center gap-6 whitespace-nowrap xl:flex"
+        >
+          {primaryLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              aria-current={active(link.href) ? "page" : undefined}
+              className={cn(
+                "relative inline-flex h-16 items-center border-b-2 text-sm font-medium transition-colors",
+                focus,
+                active(link.href)
+                  ? "border-accent-cyan text-accent-cyan"
+                  : "border-transparent text-text-secondary hover:text-text-primary",
+              )}
             >
-              <Image
-                src="/favicon.svg"
-                alt="IntuneGet Logo"
-                width={28}
-                height={28}
-                className="h-7 w-7"
-              />
-            </motion.div>
-            <span className="text-xl font-semibold text-text-primary">IntuneGet</span>
-          </Link>
-
-          {/* Desktop navigation */}
-          <nav className={cn(
-            "ml-6 hidden min-w-0 items-center whitespace-nowrap transition-all duration-500 xl:flex",
-            hasScrolled ? "gap-4" : "gap-5"
-          )}>
-            {primaryNavLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={cn(
-                  "group relative inline-flex items-center gap-2 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-4 focus-visible:ring-offset-bg-deepest",
-                  link.isLive
-                    ? "rounded-full border border-red-500/25 bg-red-500/[0.08] px-2.5 py-1 text-text-primary shadow-[0_0_16px_rgba(239,68,68,0.12)] hover:border-red-500/40 hover:bg-red-500/[0.12]"
-                    : "rounded-sm text-text-secondary hover:text-text-primary"
-                )}
-              >
-                {link.isLive && (
-                  <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden="true">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-60 motion-reduce:animate-none" />
-                    <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.85)]" />
-                  </span>
-                )}
-                <T>{link.label}</T>
-                {!link.isLive && (
-                  <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-accent-cyan transition-all duration-300 group-hover:w-full" />
-                )}
-              </Link>
-            ))}
-            <DocsDropdown />
-            <ResourcesDropdown />
-            <a
-              href="https://github.com/ugurkocde/IntuneGet"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={t("View IntuneGet on GitHub")}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-overlay/10 px-2.5 py-1.5 text-sm font-medium text-text-secondary transition-colors duration-200 hover:border-overlay/15 hover:bg-overlay/[0.04] hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
-            >
-              <Github className="h-4 w-4" />
-              <span className="flex items-center gap-1 text-xs text-text-muted min-w-[2.25rem]">
-                <Star className="h-3 w-3 fill-amber-400 text-amber-400" aria-hidden="true" />
-                {!starsLoading && (
-                  <>
-                    <span className="tabular-nums">{starsDisplay}</span>
-                    <span className="sr-only">{t("GitHub stars")}</span>
-                  </>
-                )}
-              </span>
-            </a>
+              <T>{link.label}</T>
+            </Link>
+          ))}
+          <DocsDropdown />
+          <ResourcesDropdown />
+        </nav>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <div className="hidden xl:block">
             <LocaleSwitcher />
-            {isAuthenticated ? (
-              <Link
-                href="/dashboard"
-                aria-label={t("Go to dashboard")}
-                className="group"
-              >
-                <AuthedAvatar size="sm" />
-              </Link>
-            ) : (
-              <Link
-                href="/auth/signin"
+          </div>
+          <ChangelogBell onOpen={() => setOpen(false)} />
+          <div className="ml-2 hidden xl:block">{account()}</div>
+          <Dialog.Root open={open} onOpenChange={setOpen}>
+            <Dialog.Trigger asChild>
+              <button
+                type="button"
+                aria-label={t("Open menu")}
                 className={cn(
-                  "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-lg px-4 py-2",
-                  "text-sm font-medium text-white bg-accent-cyan",
-                  "transition-all duration-200",
-                  "hover:bg-accent-cyan-dim shadow-soft hover:shadow-soft-md",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deepest"
+                  "flex h-11 w-11 items-center justify-center rounded-lg text-text-secondary xl:hidden",
+                  focus,
                 )}
               >
-                <T id="nav.get-started">Get Started</T>
-              </Link>
-            )}
-          </nav>
-
-          <div className="relative z-10 ml-2 flex shrink-0 items-center">
-          <ChangelogBell onOpen={() => setIsMenuOpen(false)} />
-          {/* Mobile menu button */}
-          <button
-            ref={menuButtonRef}
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
-            className="relative z-10 flex min-h-[44px] min-w-[44px] items-center justify-center p-2 text-text-secondary transition-colors hover:text-text-primary xl:hidden"
-            aria-label={isMenuOpen ? t("Close menu") : t("Open menu")}
-            aria-expanded={isMenuOpen}
-            aria-controls="mobile-menu"
-          >
-            {isMenuOpen ? (
-              <X className="h-6 w-6" />
-            ) : (
-              <Menu className="h-6 w-6" />
-            )}
-          </button>
-          </div>
-          </div>
+                <Menu className="h-6 w-6" />
+              </button>
+            </Dialog.Trigger>
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/30" />
+              <Dialog.Content
+                aria-describedby={undefined}
+                className="fixed inset-0 z-[61] flex flex-col overflow-y-auto bg-bg-deepest px-6 pb-8 pt-4"
+              >
+                <div className="mb-8 flex items-center justify-between">
+                  <Dialog.Title className="text-xl font-semibold text-text-primary">
+                    IntuneGet
+                  </Dialog.Title>
+                  <Dialog.Close asChild>
+                    <button
+                      type="button"
+                      aria-label={t("Close menu")}
+                      className={cn(
+                        "flex h-11 w-11 items-center justify-center rounded-lg text-text-secondary",
+                        focus,
+                      )}
+                    >
+                      <X className="h-6 w-6" />
+                    </button>
+                  </Dialog.Close>
+                </div>
+                <nav aria-label={t("Mobile navigation")}>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    <T>Explore</T>
+                  </p>
+                  {[
+                    ...primaryLinks,
+                    { href: "/docs", label: "Documentation" },
+                  ].map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      onClick={() => setOpen(false)}
+                      aria-current={active(link.href) ? "page" : undefined}
+                      className={cn(
+                        "block rounded-lg px-3 py-3 text-xl font-medium",
+                        focus,
+                        active(link.href)
+                          ? "bg-accent-cyan/10 text-accent-cyan"
+                          : "text-text-primary hover:bg-overlay/5",
+                      )}
+                    >
+                      <T>{link.label}</T>
+                    </Link>
+                  ))}
+                  <div className="my-6 border-t border-overlay/10" />
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    <T>Resources</T>
+                  </p>
+                  <div className="grid grid-cols-2 gap-x-4">
+                    {resourceLinks.map((link) => (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        onClick={() => setOpen(false)}
+                        className={cn(
+                          "rounded-lg py-3 text-sm font-medium text-text-secondary hover:text-accent-cyan",
+                          focus,
+                        )}
+                      >
+                        <T>{link.label}</T>
+                      </Link>
+                    ))}
+                  </div>
+                </nav>
+                <div className="mt-auto space-y-5 pt-8">
+                  <LocaleSwitcher />
+                  {account(true)}
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
         </div>
       </div>
-
-      {/* Mobile menu */}
-      <AnimatePresence>
-        {isMenuOpen && (
-          <motion.div
-            className={cn(
-              "pointer-events-auto mx-auto mt-2 transition-[max-width] duration-500 xl:hidden",
-              hasScrolled
-                ? "max-w-5xl px-0"
-                : "max-w-full px-0"
-            )}
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -20 }}
-            transition={{
-              duration: shouldReduceMotion ? 0 : 0.2,
-            }}
-          >
-            <nav
-              id="mobile-menu"
-              className={cn(
-                "mx-4 flex flex-col gap-1 rounded-2xl border border-overlay/[0.06] bg-bg-elevated/90 px-4 py-4 shadow-soft-lg backdrop-blur-xl"
-              )}
-            >
-              <span className="px-1 text-xs font-semibold uppercase tracking-wider text-text-muted"><T>Explore</T></span>
-              {primaryNavLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setIsMenuOpen(false)}
-                  className={cn(
-                    "inline-flex items-center gap-2.5 text-base font-medium transition-all duration-200",
-                    link.isLive
-                      ? "w-fit rounded-full border border-red-500/25 bg-red-500/[0.08] px-3 py-2.5 text-text-primary shadow-[0_0_16px_rgba(239,68,68,0.12)] hover:border-red-500/40 hover:bg-red-500/[0.12]"
-                      : "py-2.5 text-text-secondary hover:text-accent-cyan"
-                  )}
-                >
-                  {link.isLive && (
-                    <span className="relative flex h-2.5 w-2.5 shrink-0" aria-hidden="true">
-                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-60 motion-reduce:animate-none" />
-                      <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.85)]" />
-                    </span>
-                  )}
-                  <T>{link.label}</T>
-                </Link>
-              ))}
-              <Link
-                href="/docs"
-                onClick={() => setIsMenuOpen(false)}
-                className="inline-flex items-center gap-2 py-2.5 text-base font-medium text-text-secondary transition-colors hover:text-accent-cyan"
-              >
-                <Book className="h-5 w-5" />
-                <span><T id="nav.documentation">Documentation</T></span>
-              </Link>
-              <div className="my-2 border-t border-overlay/[0.06]" />
-              <span className="px-1 text-xs font-semibold uppercase tracking-wider text-text-muted"><T>Resources</T></span>
-              {secondaryNavLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setIsMenuOpen(false)}
-                  className="py-2 text-base font-medium text-text-secondary transition-colors hover:text-accent-cyan"
-                >
-                  <T>{link.label}</T>
-                </Link>
-              ))}
-              <a
-                href="https://github.com/ugurkocde/IntuneGet"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => setIsMenuOpen(false)}
-                className="inline-flex items-center gap-2 py-2.5 text-base font-medium text-text-secondary transition-colors hover:text-accent-cyan"
-              >
-                <Github className="h-5 w-5" />
-                <span><T id="nav.github">GitHub</T></span>
-              </a>
-              <div className="flex items-center gap-2">
-                <LocaleSwitcher />
-              </div>
-              {isAuthenticated ? (
-                <Link
-                  href="/dashboard"
-                  onClick={() => setIsMenuOpen(false)}
-                  className="group inline-flex items-center gap-3 px-4 py-3 rounded-lg mt-2 bg-text-primary hover:bg-text-primary/90 transition-all duration-200"
-                >
-                  <AuthedAvatar size="md" />
-                  <span className="text-sm font-medium text-bg-elevated"><T id="nav.dashboard">Dashboard</T></span>
-                </Link>
-              ) : (
-                <Link
-                  href="/auth/signin"
-                  onClick={() => setIsMenuOpen(false)}
-                  className={cn(
-                    "inline-flex items-center justify-center px-4 py-3 rounded-lg mt-2",
-                    "text-sm font-medium text-white bg-accent-cyan",
-                    "transition-all duration-200",
-                    "hover:bg-accent-cyan-dim shadow-soft hover:shadow-soft-md"
-                  )}
-                >
-                  <T id="nav.get-started">Get Started</T>
-                </Link>
-              )}
-            </nav>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </motion.header>
+    </header>
   );
 }

--- a/components/landing/ResourcesDropdown.tsx
+++ b/components/landing/ResourcesDropdown.tsx
@@ -1,141 +1,48 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { ChevronDown, CircleHelp, FileClock, Newspaper, Tag } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { T } from "gt-next";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 
-const OPEN_DELAY = 150;
-const CLOSE_DELAY = 200;
-
-const resourceLinks = [
-  {
-    href: "/pricing",
-    label: "Pricing",
-    description: "Simple and transparent",
-    icon: Tag,
-  },
-  {
-    href: "/#faq",
-    label: "FAQ",
-    description: "Common questions answered",
-    icon: CircleHelp,
-  },
-  {
-    href: "/blog",
-    label: "Blog",
-    description: "Guides and product stories",
-    icon: Newspaper,
-  },
-  {
-    href: "/changelog",
-    label: "Changelog",
-    description: "See what is new",
-    icon: FileClock,
-  },
+export const resourceLinks = [
+  { href: "/#how-it-works", label: "How It Works" },
+  { href: "/security", label: "Security" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/#faq", label: "FAQ" },
+  { href: "/blog", label: "Blog" },
+  { href: "/changelog", label: "Changelog" },
+  { href: "https://github.com/ugurkocde/IntuneGet", label: "GitHub" },
 ];
-
 export function ResourcesDropdown() {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const shouldReduceMotion = useReducedMotion();
-
-  const clearTimers = useCallback(() => {
-    if (openTimer.current) clearTimeout(openTimer.current);
-    if (closeTimer.current) clearTimeout(closeTimer.current);
-  }, []);
-
-  const handleMouseEnter = useCallback(() => {
-    clearTimers();
-    openTimer.current = setTimeout(() => setIsOpen(true), OPEN_DELAY);
-  }, [clearTimers]);
-
-  const handleMouseLeave = useCallback(() => {
-    clearTimers();
-    closeTimer.current = setTimeout(() => setIsOpen(false), CLOSE_DELAY);
-  }, [clearTimers]);
-
-  useEffect(() => clearTimers, [clearTimers]);
-
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setIsOpen(false);
-    };
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handlePointerDown);
-      document.addEventListener("keydown", handleEscape);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isOpen]);
-
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <button
-        type="button"
-        onClick={() => setIsOpen((current) => !current)}
-        className="group relative inline-flex items-center gap-1 whitespace-nowrap rounded-sm text-sm font-medium text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-4 focus-visible:ring-offset-bg-deepest"
-        aria-expanded={isOpen}
-        aria-haspopup="true"
+    <DropdownMenu>
+      <DropdownMenuTrigger className="inline-flex items-center gap-1 rounded-sm text-sm font-medium text-text-secondary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-4">
+        <T>Resources</T>
+        <ChevronDown aria-hidden="true" className="h-3.5 w-3.5" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={20}
+        className="w-52 rounded-xl p-2"
       >
-        <span><T>Resources</T></span>
-        <motion.span
-          animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
-        >
-          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-        </motion.span>
-        <span className="absolute -bottom-1 left-0 h-0.5 w-0 bg-accent-cyan transition-all duration-300 group-hover:w-full" />
-      </button>
-
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            className="absolute right-0 top-full z-50 mt-3 w-72 rounded-xl border border-overlay/[0.06] bg-bg-elevated/95 p-2 shadow-soft-lg backdrop-blur-xl"
-            initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+        {resourceLinks.map((link) => (
+          <DropdownMenuItem
+            key={link.href}
+            asChild
+            className="rounded-lg px-3 py-2.5"
           >
-            {resourceLinks.map((link) => {
-              const Icon = link.icon;
-
-              return (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setIsOpen(false)}
-                  className="flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors duration-150 hover:bg-overlay/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
-                >
-                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
-                  <span>
-                    <span className="block text-sm font-medium text-text-primary"><T>{link.label}</T></span>
-                    <span className="block text-xs text-text-muted"><T>{link.description}</T></span>
-                  </span>
-                </Link>
-              );
-            })}
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
+            <Link href={link.href}>
+              <T>{link.label}</T>
+            </Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -23,9 +23,8 @@ UTC. The next scheduled manifest sync retries unavailable records.
 
 Installation scanning is independent of version-history ingestion. The scanner
 retries only WinGet error `-1978335146` (installer prohibits elevation) using a
-limited scheduled task for the same Windows user. The entire scan, including
-HKCU snapshots and cleanup, runs in that context. This requires an interactive
-session for that user. If the context is unavailable, the scan still fails and
-preserves the reason. Crashes, timeouts and partially completed installs are not
+temporary standard Windows user. The entire scan, including
+HKCU snapshots and cleanup, runs in that context. The account is removed afterward.
+If that context cannot be prepared, the scan still fails and preserves the reason. Crashes, timeouts and partially completed installs are not
 retried automatically. Failed scans preserve verbose WinGet diagnostic logs as
 separate artifacts for seven days; they are never reported as successful metadata.

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -13,3 +13,19 @@ The catalog index import now runs daily at 00:00 UTC, before manifest sync at 02
 Apply migration `20260906052337_catalog_release_history.sql` before deploying the new workflow and page. `supabase/tests/catalog_release_history.sql` tests anonymous reads, month filtering, previous versions, pagination, and timestamp preservation inside a rolled-back transaction.
 
 The installation scanner is independent of release history. It now installs the exact requested WinGet version and preserves that version as its snapshot key; registry display versions stay in registry metadata. Cleanup failures remain failures, with command output retained for diagnosis. Publisher download failures and installers that cannot silently uninstall require app-specific investigation; this page does not claim installation validation.
+
+## Sync status and installation scans
+
+A `partial` manifest sync means the check finished with unavailable upstream
+manifests, not an operational failure. The release page labels this separately
+from `failed`, retains existing records, and shows the completed check time in
+UTC. The next scheduled manifest sync retries unavailable records.
+
+Installation scanning is independent of version-history ingestion. The scanner
+retries only WinGet error `-1978335146` (installer prohibits elevation) using a
+limited scheduled task for the same Windows user. The entire scan, including
+HKCU snapshots and cleanup, runs in that context. This requires an interactive
+session for that user. If the context is unavailable, the scan still fails and
+preserves the reason. Crashes, timeouts and partially completed installs are not
+retried automatically. Failed scans preserve verbose WinGet diagnostic logs as
+separate artifacts for seven days; they are never reported as successful metadata.

--- a/lib/catalog/release-enrichment.test.ts
+++ b/lib/catalog/release-enrichment.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { enrichRelease, type ReleaseScan } from "./release-enrichment";
+const row = {
+  winget_id: "Example.App",
+  name: "Example",
+  publisher: null,
+  version: "2.0",
+  previous_version: "1.0",
+  detected_at: "2026-09-06T00:00:00Z",
+  release_date: null,
+};
+const metadata = [
+  {
+    winget_id: row.winget_id,
+    version: "2.0",
+    release_notes: "Fixed startup",
+    installer_sha256: "a".repeat(64),
+  },
+];
+const scan: ReleaseScan = {
+  winget_id: row.winget_id,
+  tested_version: "2.0",
+  installer_sha256: "a".repeat(64),
+  architecture: "x64",
+  virustotal_status: "clean",
+  virustotal_malicious: 0,
+  virustotal_suspicious: 0,
+  virustotal_total_engines: 72,
+  virustotal_scanned_at_utc: "2026-09-06T01:00:00Z",
+};
+describe("release evidence", () => {
+  it("matches the app, version and exact installer hash", () => {
+    expect(enrichRelease(row, metadata, [scan]).virusTotal?.total).toBe(72);
+    expect(
+      enrichRelease(row, metadata, [{ ...scan, tested_version: "1.0" }])
+        .virusTotal,
+    ).toBeNull();
+    expect(
+      enrichRelease(row, metadata, [
+        { ...scan, installer_sha256: "b".repeat(64) },
+      ]).virusTotal,
+    ).toBeNull();
+    expect(
+      enrichRelease(row, metadata, [{ ...scan, winget_id: "Another.App" }])
+        .virusTotal,
+    ).toBeNull();
+  });
+  it("uses the latest matching check, including an unavailable result", () => {
+    const newer = {
+      ...scan,
+      virustotal_status: "error",
+      virustotal_scanned_at_utc: "2026-09-06T02:00:00Z",
+    };
+    expect(enrichRelease(row, metadata, [scan, newer]).virusTotal?.status).toBe(
+      "error",
+    );
+  });
+  it("does not invent notes or scans for missing metadata", () => {
+    expect(enrichRelease(row, [], [scan])).toMatchObject({
+      release_notes: null,
+      virusTotal: null,
+    });
+    expect(enrichRelease(row, metadata, []).release_notes).toBe(
+      "Fixed startup",
+    );
+  });
+});

--- a/lib/catalog/release-enrichment.ts
+++ b/lib/catalog/release-enrichment.ts
@@ -1,0 +1,60 @@
+import type { CatalogRelease } from "./release-history";
+
+export interface ReleaseMetadata {
+  winget_id: string;
+  version: string;
+  release_notes: string | null;
+  installer_sha256: string | null;
+}
+export interface ReleaseScan {
+  winget_id: string;
+  tested_version: string;
+  installer_sha256: string | null;
+  architecture: string | null;
+  virustotal_status: string | null;
+  virustotal_malicious: number | null;
+  virustotal_suspicious: number | null;
+  virustotal_total_engines: number | null;
+  virustotal_scanned_at_utc: string | null;
+}
+export function enrichRelease(
+  row: CatalogRelease,
+  metadata: ReleaseMetadata[],
+  scans: ReleaseScan[],
+): CatalogRelease {
+  const version = metadata.find(
+    (v) => v.winget_id === row.winget_id && v.version === row.version,
+  );
+  const hash = version?.installer_sha256?.toLowerCase();
+  const scan =
+    hash && /^[a-f0-9]{64}$/.test(hash)
+      ? scans
+          .filter(
+            (q) =>
+              q.winget_id === row.winget_id &&
+              q.tested_version === row.version &&
+              q.installer_sha256?.toLowerCase() === hash &&
+              q.virustotal_status,
+          )
+          .sort((a, b) =>
+            (b.virustotal_scanned_at_utc ?? "").localeCompare(
+              a.virustotal_scanned_at_utc ?? "",
+            ),
+          )[0]
+      : undefined;
+  return {
+    ...row,
+    release_notes: version?.release_notes || null,
+    virusTotal: scan
+      ? {
+          status: scan.virustotal_status!,
+          hash: hash!,
+          architecture: scan.architecture,
+          malicious: scan.virustotal_malicious,
+          suspicious: scan.virustotal_suspicious,
+          total: scan.virustotal_total_engines,
+          scannedAt: scan.virustotal_scanned_at_utc,
+        }
+      : null,
+  };
+}

--- a/lib/catalog/release-history.ts
+++ b/lib/catalog/release-history.ts
@@ -12,6 +12,17 @@ export interface CatalogRelease {
   previous_version: string | null;
   detected_at: string;
   release_date: string | null;
+  release_notes?: string | null;
+  detailsUnavailable?: boolean;
+  virusTotal?: {
+    status: string;
+    hash: string;
+    architecture: string | null;
+    malicious: number | null;
+    suspicious: number | null;
+    total: number | null;
+    scannedAt: string | null;
+  } | null;
 }
 export interface ReleaseHistoryResult {
   rows: CatalogRelease[];

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -1,3 +1,4 @@
+import { enrichRelease, type ReleaseMetadata, type ReleaseScan } from './release-enrichment';
 import type { CatalogRelease, ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * SQLite-snapshot-backed CatalogSource (self-hosted / Supabase-less mode).
@@ -202,7 +203,16 @@ export class SnapshotCatalogSource implements CatalogSource {
         coalesce(sum(previous_version IS NULL), 0) AS firstTracked FROM history ${where}`).get(params) as { total: number; apps: number; firstTracked: number };
       const months = db.prepare(`${history} SELECT DISTINCT substr(detected_at, 1, 7) AS month FROM history ORDER BY month DESC`).all() as { month: string }[];
       const coverage = db.prepare(`${history} SELECT min(detected_at) AS start FROM history`).get() as { start: string | null };
-      return { rows, ...stats, months: months.map(m => m.month), coverageStart: coverage.start, sync: null };
+      const notesColumn = columns.some(c => c.name === 'release_notes') ? 'release_notes' : 'NULL AS release_notes';
+      const metadataQuery = db.prepare(`SELECT winget_id, version, installer_sha256, ${notesColumn} FROM version_history WHERE winget_id = ? AND version = ?`);
+      const qaExists = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'qa_results'").get();
+      const scanQuery = qaExists ? db.prepare('SELECT * FROM qa_results WHERE winget_id = ? AND tested_version = ?') : null;
+      const enriched = rows.map(row => {
+        const metadata = metadataQuery.get(row.winget_id, row.version) as ReleaseMetadata | undefined;
+        const scans = scanQuery?.all(row.winget_id, row.version) as ReleaseScan[] | undefined;
+        return enrichRelease(row, metadata ? [metadata] : [], scans ?? []);
+      });
+      return { rows: enriched, ...stats, months: months.map(m => m.month), coverageStart: coverage.start, sync: null };
     }, () => { throw new Error('Catalog snapshot unavailable'); });
   }
 

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -1,3 +1,4 @@
+import { enrichRelease, type ReleaseMetadata, type ReleaseScan } from './release-enrichment';
 import type { ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * Supabase-backed CatalogSource.
@@ -67,7 +68,21 @@ export class SupabaseCatalogSource implements CatalogSource {
       kind_filter: filters.kind, page_number: filters.page,
     }).abortSignal(AbortSignal.timeout(15_000));
     if (error) throw new Error('Catalog history unavailable', { cause: error });
-    return data as ReleaseHistoryResult;
+    const result = data as ReleaseHistoryResult;
+    if (!result.rows.length) return result;
+    const ids = [...new Set(result.rows.map(row => row.winget_id))];
+    const versions = [...new Set(result.rows.map(row => row.version))];
+    const scanColumns = 'winget_id,tested_version,installer_sha256,architecture,virustotal_status,virustotal_malicious,virustotal_suspicious,virustotal_total_engines,virustotal_scanned_at_utc';
+    const extras = await Promise.allSettled([
+      client.from('version_history').select('winget_id,version,release_notes,installer_sha256').in('winget_id', ids).in('version', versions).limit(1600).abortSignal(AbortSignal.timeout(5000)),
+      client.from('qa_results').select(scanColumns).in('winget_id', ids).in('tested_version', versions).limit(1000).abortSignal(AbortSignal.timeout(5000)),
+      client.from('qa_package_results').select(scanColumns).in('winget_id', ids).in('tested_version', versions).order('virustotal_scanned_at_utc', {ascending: false, nullsFirst: false}).limit(1000).abortSignal(AbortSignal.timeout(5000)),
+    ]);
+    if (extras.some(response => response.status === 'rejected' || response.value.error)) {
+      return {...result, rows: result.rows.map(row => ({...row, detailsUnavailable: true}))};
+    }
+    const payloads = extras.map(response => response.status === 'fulfilled' ? response.value.data ?? [] : []);
+    return {...result, rows: result.rows.map(row => enrichRelease(row, payloads[0] as ReleaseMetadata[], [...payloads[1], ...payloads[2]] as ReleaseScan[]))};
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -10,7 +10,7 @@
  * Deliberately EXCLUDED from the snapshot:
  *  - Internal/curation + icon bookkeeping columns, and the Postgres `fts`
  *    tsvector (FTS5 is rebuilt locally).
- *  - version_history.manifest_yaml / release_notes / changes_from_previous
+ *  - version_history.manifest_yaml / changes_from_previous
  *    (large "asset" text never read by the catalog code).
  *  - sccm_winget_mappings.created_by / tenant_id and any tenant-scoped rows -
  *    only global mappings (tenant_id IS NULL) are included, so no user/tenant
@@ -43,7 +43,7 @@ const CURATED_COLUMNS = [
 ];
 const VERSION_COLUMNS = [
   'winget_id', 'version', 'installer_url', 'installer_sha256', 'installer_type',
-  'installer_scope', 'silent_args', 'installers', 'created_at', 'release_date',
+  'installer_scope', 'silent_args', 'installers', 'created_at', 'release_date', 'release_notes',
 ];
 const SCCM_COLUMNS = [
   'id', 'sccm_display_name_normalized', 'sccm_ci_id', 'sccm_product_code',
@@ -106,7 +106,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       CREATE TABLE version_history (
         winget_id TEXT, version TEXT, installer_url TEXT, installer_sha256 TEXT,
         installer_type TEXT, installer_scope TEXT, silent_args TEXT, installers TEXT,
-        created_at TEXT, release_date TEXT, PRIMARY KEY (winget_id, version)
+        created_at TEXT, release_date TEXT, release_notes TEXT, PRIMARY KEY (winget_id, version)
       );
       CREATE INDEX idx_vh_winget ON version_history(winget_id);
 
@@ -147,9 +147,9 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       VALUES (@id, @name, @publisher, @description, @tags)`);
     const insVersion = db.prepare(`INSERT OR IGNORE INTO version_history
       (winget_id, version, installer_url, installer_sha256, installer_type, installer_scope,
-       silent_args, installers, created_at, release_date)
+       silent_args, installers, created_at, release_date, release_notes)
       VALUES (@winget_id,@version,@installer_url,@installer_sha256,@installer_type,@installer_scope,
-       @silent_args,@installers,@created_at,@release_date)`);
+       @silent_args,@installers,@created_at,@release_date,@release_notes)`);
     const insSccm = db.prepare(`INSERT OR IGNORE INTO sccm_winget_mappings
       (id, sccm_display_name_normalized, sccm_ci_id, sccm_product_code, winget_package_id,
        winget_package_name, confidence, is_verified)
@@ -195,7 +195,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           winget_id: v.winget_id, version: v.version, installer_url: v.installer_url ?? null,
           installer_sha256: v.installer_sha256 ?? null, installer_type: v.installer_type ?? null,
           installer_scope: v.installer_scope ?? null, silent_args: v.silent_args ?? null,
-          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null, release_date: v.release_date ?? null,
+          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null, release_date: v.release_date ?? null, release_notes: v.release_notes ?? null,
         });
       }
       for (const m of sccmMappings) {


### PR DESCRIPTION
Release History was missing from desktop navigation, and completed catalog checks with unavailable upstream manifests appeared incomplete. The simpler header makes Release History a primary link and groups secondary links under Resources, with a full-screen accessible mobile menu. The history page now has a matching loading skeleton, precise UTC sync times and clearer completion states. Redundant version-change badges are removed.

Expandable publisher release notes and VirusTotal results are shown where recorded. VirusTotal evidence must match the app ID, exact version and installer SHA-256, with scan date, architecture and a link to the report. Missing and unavailable scans are explicit. Snapshot exports include release notes while older snapshots remain readable.

Installation scans retry only WinGet's explicit elevation-prohibited error using a temporary standard Windows account. Installation, snapshot detection and cleanup stay in that account, which is removed afterward. Other installer errors still fail; verbose diagnostics are retained for seven days.

Validation: lint and production build passed; 73 catalog tests passed, including exact-version/hash matching. Browser checks at 390, 1024, 1280 and 1440 pixels found no horizontal overflow, Escape restores focus from both menus, and the skeleton was verified during a delayed response. Windows standard-account retry passed for Flowscripter 1.2.26, including installation, detection, cleanup and validated metadata upload (run 34018451277). Actual Budget 26.9.0 still crashes in its upstream installer with code 3221225477 and is not marked successful.
