### PR TITLE
Show official release links and independent VirusTotal hash reports

### DIFF
--- a/.github/workflows/backfill-release-note-links.yml
+++ b/.github/workflows/backfill-release-note-links.yml
@@ -1,0 +1,34 @@
+name: Backfill Release Note Links
+on:
+  schedule:
+    - cron: '43 * * * *'
+  workflow_dispatch:
+    inputs:
+      max_versions:
+        description: 'Maximum versions to backfill (1-1000)'
+        default: '200'
+permissions:
+  contents: read
+concurrency:
+  group: release-note-link-backfill
+  cancel-in-progress: false
+jobs:
+  backfill:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - name: Save official release-note URLs from WinGet
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          MAX_VERSIONS: ${{ inputs.max_versions || '200' }}
+        run: node scripts/backfill-release-note-links.mjs

--- a/.github/workflows/sync-manifests.yml
+++ b/.github/workflows/sync-manifests.yml
@@ -236,7 +236,7 @@ jobs:
           }
 
           async function syncManifests() {
-            const { createWingetManifestClient, resolveWingetManifest, manifestReleaseDate, canSkipStoredManifest } = await resolverModule;
+            const { createWingetManifestClient, resolveWingetManifest, manifestReleaseDate, manifestReleaseNotesUrl, canSkipStoredManifest } = await resolverModule;
             const manifestClient = createWingetManifestClient({ token: GITHUB_TOKEN, preferRaw: true });
             const appIds = process.env.APP_IDS;
             const appOffset = parseInt(process.env.APP_OFFSET || '0', 10);
@@ -447,6 +447,8 @@ jobs:
                     platform: installerManifest.Platform || null,
                     upgrade_behavior: installerManifest.UpgradeBehavior || null,
                     release_notes: localeManifest?.ReleaseNotes || null,
+                    release_notes_url: manifestReleaseNotesUrl(localeManifest),
+                    release_notes_url_checked_at: new Date().toISOString(),
                     release_date: manifestReleaseDate(installerManifest),
                     manifest_yaml: yaml.stringify(installerManifest),
                     manifest_fetched_at: new Date().toISOString(),

--- a/.ugurlabs/entries/catalog-release-links-reputation.json
+++ b/.ugurlabs/entries/catalog-release-links-reputation.json
@@ -1,0 +1,5 @@
+{
+  "title": "Official release notes and installer hash reports",
+  "summary": "Release History now links directly to the publisher's release notes where WinGet provides an official URL. VirusTotal findings are retrieved by the exact installer SHA-256, independently of installation testing, and shared through a background cache. Reports show malicious and suspicious detection counts with the analysis date. Pending lookups, missing reports, and unavailable lookups have distinct labels, and every known hash links to its VirusTotal report. Background lookups do not install or upload applications.",
+  "type": "improved"
+}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
 const loadHistory = unstable_cache(
   (filters: ReleaseHistoryFilters) =>
     getCatalogSource().getReleaseHistory(filters),
-  ["catalog-release-history-v2"],
+  ["catalog-release-history-v3"],
   { revalidate: 300 },
 );
 const dateFormat = new Intl.DateTimeFormat("en-GB", {
@@ -389,11 +389,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                     rel="noopener noreferrer"
                                     className="text-accent-cyan hover:underline"
                                   >
-                                    {[
-                                      "clean",
-                                      "flagged",
-                                      "suspicious",
-                                    ].includes(row.virusTotal.status) &&
+                                    {row.virusTotal.status === "found" &&
                                     row.virusTotal.total != null &&
                                     row.virusTotal.total > 0 &&
                                     row.virusTotal.malicious != null &&
@@ -408,8 +404,12 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                     ) : row.virusTotal.status ===
                                       "not_found" ? (
                                       <T>No report found</T>
+                                    ) : row.virusTotal.status === "pending" ? (
+                                      <T>Lookup queued</T>
+                                    ) : row.virusTotal.status === "error" ? (
+                                      <T>Lookup unavailable</T>
                                     ) : (
-                                      <T>Scan unavailable</T>
+                                      <T>View report</T>
                                     )}
                                   </a>
                                   {row.virusTotal.architecture && (
@@ -417,28 +417,24 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                   )}
                                   {row.virusTotal.scannedAt && (
                                     <time dateTime={row.virusTotal.scannedAt}>
-                                      <T>Checked</T>{" "}
+                                      <T>Analyzed</T>{" "}
                                       {dateLabel(row.virusTotal.scannedAt)}
                                     </time>
                                   )}
                                 </>
                               ) : (
-                                <T>Not scanned for this installer</T>
+                                <T>Installer hash unavailable</T>
                               )}
                             </p>
-                            {row.release_notes ? (
-                              <details className="group">
-                                <summary className="w-fit cursor-pointer rounded-sm py-1 font-medium text-accent-cyan focus-visible:outline-2 focus-visible:outline-accent-cyan">
-                                  <T>Release notes</T>
-                                </summary>
-                                <p className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-lg border border-overlay/10 bg-bg-deepest p-4 text-sm leading-relaxed text-text-secondary">
-                                  {row.release_notes}
-                                </p>
-                              </details>
-                            ) : (
-                              <p>
-                                <T>Release notes not provided</T>
-                              </p>
+                            {row.release_notes_url && (
+                              <a
+                                href={row.release_notes_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex min-h-8 items-center font-medium text-accent-cyan hover:underline"
+                              >
+                                <T>Official release notes</T>
+                              </a>
                             )}
                           </>
                         )}
@@ -484,7 +480,8 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
           </h2>
           <p className="mt-2">
             <T>
-              VirusTotal results apply to the exact installer hash shown and
+              VirusTotal reports are looked up by the WinGet installer hash
+              without installing or uploading the app. Results are cached and
               reflect the recorded scan date. Zero detections do not guarantee
               safety. This is an observation history, not a complete archive of
               publisher releases. First tracked means the earliest version we

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -2,7 +2,7 @@
 
 The public page is `/apps/releases`. The catalog source supports Supabase and self-hosted SQLite snapshots. Results are cached for five minutes and paginated in groups of 40. Search is literal, case insensitive, and limited to 120 characters. Month boundaries are UTC.
 
-`version_history.created_at` is the first time IntuneGet recorded that version, not the publisher release date. A database trigger preserves it across upserts. The earliest stored version for each app is labelled **First tracked**; subsequent observations are **Version change**, including rollbacks. Historical imports and missed versions prevent this from being a complete publisher archive. Locale variants are excluded from the feed and totals.
+`version_history.created_at` is the first time IntuneGet recorded that version, not the publisher release date. A database trigger preserves it across upserts. The earliest stored version for each app is labelled **First tracked**; subsequent observations show the previous and new versions, including rollbacks. Historical imports and missed versions prevent this from being a complete publisher archive. Locale variants are excluded from the feed and totals.
 
 Publisher dates come only from a valid WinGet `ReleaseDate` on the manifest or an installer. Existing dates are not inferred from import or fetch timestamps. Older SQLite snapshots remain readable with unknown publisher dates.
 
@@ -28,3 +28,13 @@ HKCU snapshots and cleanup, runs in that context. The account is removed afterwa
 If that context cannot be prepared, the scan still fails and preserves the reason. Crashes, timeouts and partially completed installs are not
 retried automatically. Failed scans preserve verbose WinGet diagnostic logs as
 separate artifacts for seven days; they are never reported as successful metadata.
+
+## Vendor links and hash reputation
+
+Release History displays the official `ReleaseNotesUrl` from the exact WinGet locale manifest, with no inline release-note body. Manifest sync saves this URL for new records. **Backfill Release Note Links** checks up to 200 older records hourly, newest first. Manual dispatch accepts 1-1000 versions. Missing vendor URLs remain absent; operational errors stay eligible for retry.
+
+VirusTotal evidence lives in the public `catalog_file_reputation` table, keyed by the exact installer SHA-256. Page reads queue only hashes already in version history, using the server service role. Anonymous users can read reports but cannot write or queue hashes. The independent **Refresh Catalog File Reputation** workflow in `IntuneGet-Workflows` uses its existing VirusTotal secret. It performs eight lookups hourly, 20 seconds apart, and caches successful or missing reports for 24 hours. Manual batches allow up to 40 lookups. Page requests never call VirusTotal directly, install software, or upload files.
+
+Findings include malicious and suspicious counts and the original analysis date. Pending, missing, and unavailable reports are distinct from zero detections. Existing findings survive lookup errors and rate limits; errors retry after an hour. A known hash always links to the VirusTotal report. Quota limits can delay queued results. This describes the selected WinGet installer file, not every installer architecture or an already installed application on a device.
+
+Snapshots include vendor URLs and cached reports. Older snapshots can reuse legacy QA findings by hash, but cannot queue live lookups. Deploy the additive database migration before the website and worker.

--- a/lib/catalog/release-enrichment.test.ts
+++ b/lib/catalog/release-enrichment.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { enrichRelease, type ReleaseScan } from "./release-enrichment";
+import {
+  enrichRelease,
+  officialReleaseNotesUrl,
+  type FileReputation,
+} from "./release-enrichment";
+import { manifestReleaseNotesUrl } from "../winget-sync-resolution.mjs";
 const row = {
   winget_id: "Example.App",
   name: "Example",
@@ -9,59 +14,79 @@ const row = {
   detected_at: "2026-09-06T00:00:00Z",
   release_date: null,
 };
+const hash = "a".repeat(64);
 const metadata = [
   {
     winget_id: row.winget_id,
-    version: "2.0",
-    release_notes: "Fixed startup",
-    installer_sha256: "a".repeat(64),
+    version: row.version,
+    release_notes_url: "https://example.com/releases/2.0",
+    installer_sha256: hash,
+    installers: [
+      { Architecture: "arm64", InstallerSha256: "b".repeat(64) },
+      { Architecture: "x64", InstallerSha256: hash },
+    ],
   },
 ];
-const scan: ReleaseScan = {
-  winget_id: row.winget_id,
-  tested_version: "2.0",
-  installer_sha256: "a".repeat(64),
-  architecture: "x64",
-  virustotal_status: "clean",
-  virustotal_malicious: 0,
-  virustotal_suspicious: 0,
-  virustotal_total_engines: 72,
-  virustotal_scanned_at_utc: "2026-09-06T01:00:00Z",
+const report: FileReputation = {
+  sha256: hash,
+  status: "found",
+  malicious: 0,
+  suspicious: 1,
+  total_engines: 72,
+  analyzed_at: "2026-09-06T01:00:00Z",
 };
 describe("release evidence", () => {
-  it("matches the app, version and exact installer hash", () => {
-    expect(enrichRelease(row, metadata, [scan]).virusTotal?.total).toBe(72);
+  it("reuses an exact hash report across apps and versions", () => {
+    const other = { ...row, winget_id: "Another.App", version: "3.0" };
     expect(
-      enrichRelease(row, metadata, [{ ...scan, tested_version: "1.0" }])
+      enrichRelease(
+        other,
+        [
+          {
+            ...metadata[0],
+            winget_id: other.winget_id,
+            version: other.version,
+          },
+        ],
+        [report],
+      ).virusTotal,
+    ).toMatchObject({ total: 72, suspicious: 1, architecture: "x64" });
+  });
+  it("does not substitute findings from a different installer", () => {
+    expect(
+      enrichRelease(row, metadata, [{ ...report, sha256: "b".repeat(64) }])
         .virusTotal,
-    ).toBeNull();
+    ).toMatchObject({ status: "unknown", hash, total: null });
+  });
+  it("keeps the hash available when a lookup is pending or absent", () => {
+    expect(enrichRelease(row, metadata, []).virusTotal).toMatchObject({
+      status: "unknown",
+      hash,
+    });
     expect(
       enrichRelease(row, metadata, [
-        { ...scan, installer_sha256: "b".repeat(64) },
-      ]).virusTotal,
-    ).toBeNull();
-    expect(
-      enrichRelease(row, metadata, [{ ...scan, winget_id: "Another.App" }])
-        .virusTotal,
-    ).toBeNull();
+        { ...report, status: "pending", total_engines: null },
+      ]).virusTotal?.status,
+    ).toBe("pending");
   });
-  it("uses the latest matching check, including an unavailable result", () => {
-    const newer = {
-      ...scan,
-      virustotal_status: "error",
-      virustotal_scanned_at_utc: "2026-09-06T02:00:00Z",
-    };
-    expect(enrichRelease(row, metadata, [scan, newer]).virusTotal?.status).toBe(
-      "error",
-    );
-  });
-  it("does not invent notes or scans for missing metadata", () => {
-    expect(enrichRelease(row, [], [scan])).toMatchObject({
-      release_notes: null,
+  it("does not invent a hash or vendor link without metadata", () => {
+    expect(enrichRelease(row, [], [report])).toMatchObject({
+      release_notes_url: null,
       virusTotal: null,
     });
-    expect(enrichRelease(row, metadata, []).release_notes).toBe(
-      "Fixed startup",
+  });
+  it("accepts only safe official URLs in display and ingestion", () => {
+    for (const value of [
+      "javascript:alert(1)",
+      "https://user:password@example.com",
+      "not a url",
+      null,
+    ]) {
+      expect(officialReleaseNotesUrl(value)).toBeNull();
+      expect(manifestReleaseNotesUrl({ ReleaseNotesUrl: value })).toBeNull();
+    }
+    expect(enrichRelease(row, metadata, []).release_notes_url).toBe(
+      metadata[0].release_notes_url,
     );
   });
 });

--- a/lib/catalog/release-enrichment.ts
+++ b/lib/catalog/release-enrichment.ts
@@ -3,57 +3,74 @@ import type { CatalogRelease } from "./release-history";
 export interface ReleaseMetadata {
   winget_id: string;
   version: string;
-  release_notes: string | null;
+  release_notes_url: string | null;
   installer_sha256: string | null;
+  installers?: unknown;
 }
-export interface ReleaseScan {
-  winget_id: string;
-  tested_version: string;
-  installer_sha256: string | null;
-  architecture: string | null;
-  virustotal_status: string | null;
-  virustotal_malicious: number | null;
-  virustotal_suspicious: number | null;
-  virustotal_total_engines: number | null;
-  virustotal_scanned_at_utc: string | null;
+export interface FileReputation {
+  sha256: string;
+  status: string;
+  malicious: number | null;
+  suspicious: number | null;
+  total_engines: number | null;
+  analyzed_at: string | null;
+}
+export function officialReleaseNotesUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length > 2048) return null;
+  try {
+    const url = new URL(value);
+    return ["http:", "https:"].includes(url.protocol) &&
+      !url.username &&
+      !url.password
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
 }
 export function enrichRelease(
   row: CatalogRelease,
   metadata: ReleaseMetadata[],
-  scans: ReleaseScan[],
+  reputations: FileReputation[],
 ): CatalogRelease {
   const version = metadata.find(
     (v) => v.winget_id === row.winget_id && v.version === row.version,
   );
   const hash = version?.installer_sha256?.toLowerCase();
-  const scan =
-    hash && /^[a-f0-9]{64}$/.test(hash)
-      ? scans
-          .filter(
-            (q) =>
-              q.winget_id === row.winget_id &&
-              q.tested_version === row.version &&
-              q.installer_sha256?.toLowerCase() === hash &&
-              q.virustotal_status,
-          )
-          .sort((a, b) =>
-            (b.virustotal_scanned_at_utc ?? "").localeCompare(
-              a.virustotal_scanned_at_utc ?? "",
-            ),
-          )[0]
-      : undefined;
+  const validHash = hash && /^[a-f0-9]{64}$/.test(hash) ? hash : null;
+  const reputation = validHash
+    ? reputations.find((r) => r.sha256.toLowerCase() === validHash)
+    : null;
+  let installers = version?.installers;
+  if (typeof installers === "string") {
+    try {
+      installers = JSON.parse(installers);
+    } catch {
+      installers = [];
+    }
+  }
+  const installer = Array.isArray(installers)
+    ? installers.find(
+        (i) =>
+          typeof i?.InstallerSha256 === "string" &&
+          i.InstallerSha256.toLowerCase() === validHash,
+      )
+    : null;
   return {
     ...row,
-    release_notes: version?.release_notes || null,
-    virusTotal: scan
+    release_notes_url: officialReleaseNotesUrl(version?.release_notes_url),
+    virusTotal: validHash
       ? {
-          status: scan.virustotal_status!,
-          hash: hash!,
-          architecture: scan.architecture,
-          malicious: scan.virustotal_malicious,
-          suspicious: scan.virustotal_suspicious,
-          total: scan.virustotal_total_engines,
-          scannedAt: scan.virustotal_scanned_at_utc,
+          status: reputation?.status ?? "unknown",
+          hash: validHash,
+          architecture:
+            typeof installer?.Architecture === "string"
+              ? installer.Architecture
+              : null,
+          malicious: reputation?.malicious ?? null,
+          suspicious: reputation?.suspicious ?? null,
+          total: reputation?.total_engines ?? null,
+          scannedAt: reputation?.analyzed_at ?? null,
         }
       : null,
   };

--- a/lib/catalog/release-history.ts
+++ b/lib/catalog/release-history.ts
@@ -12,7 +12,7 @@ export interface CatalogRelease {
   previous_version: string | null;
   detected_at: string;
   release_date: string | null;
-  release_notes?: string | null;
+  release_notes_url?: string | null;
   detailsUnavailable?: boolean;
   virusTotal?: {
     status: string;

--- a/lib/catalog/snapshot-source.ts
+++ b/lib/catalog/snapshot-source.ts
@@ -1,4 +1,4 @@
-import { enrichRelease, type ReleaseMetadata, type ReleaseScan } from './release-enrichment';
+import { enrichRelease, type ReleaseMetadata, type FileReputation } from './release-enrichment';
 import type { CatalogRelease, ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * SQLite-snapshot-backed CatalogSource (self-hosted / Supabase-less mode).
@@ -203,14 +203,17 @@ export class SnapshotCatalogSource implements CatalogSource {
         coalesce(sum(previous_version IS NULL), 0) AS firstTracked FROM history ${where}`).get(params) as { total: number; apps: number; firstTracked: number };
       const months = db.prepare(`${history} SELECT DISTINCT substr(detected_at, 1, 7) AS month FROM history ORDER BY month DESC`).all() as { month: string }[];
       const coverage = db.prepare(`${history} SELECT min(detected_at) AS start FROM history`).get() as { start: string | null };
-      const notesColumn = columns.some(c => c.name === 'release_notes') ? 'release_notes' : 'NULL AS release_notes';
-      const metadataQuery = db.prepare(`SELECT winget_id, version, installer_sha256, ${notesColumn} FROM version_history WHERE winget_id = ? AND version = ?`);
-      const qaExists = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'qa_results'").get();
-      const scanQuery = qaExists ? db.prepare('SELECT * FROM qa_results WHERE winget_id = ? AND tested_version = ?') : null;
+      const notesColumn = columns.some(c => c.name === 'release_notes_url') ? 'release_notes_url' : 'NULL AS release_notes_url';
+      const metadataQuery = db.prepare(`SELECT winget_id, version, installer_sha256, installers, ${notesColumn} FROM version_history WHERE winget_id = ? AND version = ?`);
+      const reputationExists = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'catalog_file_reputation'").get();
+      const reputationQuery = reputationExists ? db.prepare('SELECT * FROM catalog_file_reputation WHERE sha256 = ?') : null;
+      const qaColumns = db.prepare('PRAGMA table_info(qa_results)').all() as {name: string}[];
+      const legacyQuery = qaColumns.some(c => c.name === 'virustotal_status') ? db.prepare("SELECT lower(installer_sha256) AS sha256, 'found' AS status, virustotal_malicious AS malicious, virustotal_suspicious AS suspicious, virustotal_total_engines AS total_engines, virustotal_scanned_at_utc AS analyzed_at FROM qa_results WHERE lower(installer_sha256) = ? AND virustotal_status IN ('clean', 'flagged', 'suspicious') ORDER BY virustotal_scanned_at_utc DESC LIMIT 1") : null;
       const enriched = rows.map(row => {
         const metadata = metadataQuery.get(row.winget_id, row.version) as ReleaseMetadata | undefined;
-        const scans = scanQuery?.all(row.winget_id, row.version) as ReleaseScan[] | undefined;
-        return enrichRelease(row, metadata ? [metadata] : [], scans ?? []);
+        const hash = metadata?.installer_sha256?.toLowerCase() ?? '';
+        const reputation = (reputationQuery ?? legacyQuery)?.get(hash) as FileReputation | undefined;
+        return enrichRelease(row, metadata ? [metadata] : [], reputation ? [reputation] : []);
       });
       return { rows: enriched, ...stats, months: months.map(m => m.month), coverageStart: coverage.start, sync: null };
     }, () => { throw new Error('Catalog snapshot unavailable'); });

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -1,4 +1,4 @@
-import { enrichRelease, type ReleaseMetadata, type ReleaseScan } from './release-enrichment';
+import { enrichRelease, type ReleaseMetadata, type FileReputation } from './release-enrichment';
 import type { ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * Supabase-backed CatalogSource.
@@ -70,19 +70,20 @@ export class SupabaseCatalogSource implements CatalogSource {
     if (error) throw new Error('Catalog history unavailable', { cause: error });
     const result = data as ReleaseHistoryResult;
     if (!result.rows.length) return result;
-    const ids = [...new Set(result.rows.map(row => row.winget_id))];
-    const versions = [...new Set(result.rows.map(row => row.version))];
-    const scanColumns = 'winget_id,tested_version,installer_sha256,architecture,virustotal_status,virustotal_malicious,virustotal_suspicious,virustotal_total_engines,virustotal_scanned_at_utc';
-    const extras = await Promise.allSettled([
-      client.from('version_history').select('winget_id,version,release_notes,installer_sha256').in('winget_id', ids).in('version', versions).limit(1600).abortSignal(AbortSignal.timeout(5000)),
-      client.from('qa_results').select(scanColumns).in('winget_id', ids).in('tested_version', versions).limit(1000).abortSignal(AbortSignal.timeout(5000)),
-      client.from('qa_package_results').select(scanColumns).in('winget_id', ids).in('tested_version', versions).order('virustotal_scanned_at_utc', {ascending: false, nullsFirst: false}).limit(1000).abortSignal(AbortSignal.timeout(5000)),
-    ]);
-    if (extras.some(response => response.status === 'rejected' || response.value.error)) {
-      return {...result, rows: result.rows.map(row => ({...row, detailsUnavailable: true}))};
+    const pairs = result.rows.map(row => `and(winget_id.eq.${quotePostgrestValue(row.winget_id)},version.eq.${quotePostgrestValue(row.version)})`).join(',');
+    const metadata = await client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(40).abortSignal(AbortSignal.timeout(5000));
+    if (metadata.error || !metadata.data) return {...result, rows: result.rows.map(row => ({...row, detailsUnavailable: true}))};
+    const hashes = [...new Set(metadata.data.map(v => v.installer_sha256?.toLowerCase()).filter((hash): hash is string => typeof hash === 'string' && /^[a-f0-9]{64}$/.test(hash)))];
+    let reputations: FileReputation[] = [];
+    if (hashes.length) {
+      const responses = await Promise.allSettled([
+        client.from('catalog_file_reputation').select('sha256,status,malicious,suspicious,total_engines,analyzed_at').in('sha256', hashes).abortSignal(AbortSignal.timeout(5000)),
+        process.env.SUPABASE_SERVICE_ROLE_KEY ? client.rpc('request_catalog_file_reputation', {hashes, prioritized: true}).abortSignal(AbortSignal.timeout(5000)) : Promise.resolve(null),
+      ]);
+      const cached = responses[0];
+      if (cached.status === 'fulfilled' && cached.value && !cached.value.error) reputations = (cached.value.data ?? []) as FileReputation[];
     }
-    const payloads = extras.map(response => response.status === 'fulfilled' ? response.value.data ?? [] : []);
-    return {...result, rows: result.rows.map(row => enrichRelease(row, payloads[0] as ReleaseMetadata[], [...payloads[1], ...payloads[2]] as ReleaseScan[]))};
+    return {...result, rows: result.rows.map(row => enrichRelease(row, metadata.data as ReleaseMetadata[], reputations))};
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/winget-sync-resolution.mjs
+++ b/lib/winget-sync-resolution.mjs
@@ -271,3 +271,13 @@ export function manifestReleaseDate(manifest) {
 export function canSkipStoredManifest({ forceRefresh, mode, version, hasVersion, description }) {
   return !forceRefresh && mode !== 'all' && Boolean(version && hasVersion && typeof description === 'string' && description.trim());
 }
+
+/** Official URL supplied by the package publisher's WinGet locale manifest. */
+export function manifestReleaseNotesUrl(manifest) {
+  const value = manifest?.ReleaseNotesUrl;
+  if (typeof value !== 'string' || value.length > 2048) return null;
+  try {
+    const url = new URL(value);
+    return ['http:', 'https:'].includes(url.protocol) && !url.username && !url.password ? url.href : null;
+  } catch { return null; }
+}

--- a/scripts/backfill-release-note-links.mjs
+++ b/scripts/backfill-release-note-links.mjs
@@ -1,0 +1,33 @@
+import { createClient } from '@supabase/supabase-js';
+import { createWingetManifestClient, manifestReleaseNotesUrl } from '../lib/winget-sync-resolution.mjs';
+
+const limit = Number(process.env.MAX_VERSIONS || 200);
+if (!Number.isInteger(limit) || limit < 1 || limit > 1000) throw new Error('MAX_VERSIONS must be 1-1000');
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) throw new Error('Supabase service credentials are required');
+const db = createClient(url, key, { auth: { persistSession: false } });
+const manifests = createWingetManifestClient({ token: process.env.GITHUB_TOKEN, preferRaw: true, maxRetries: 2 });
+const { data, error } = await db.from('version_history').select('id,winget_id,version')
+  .is('release_notes_url_checked_at', null).order('created_at', { ascending: false }).limit(limit);
+if (error) throw new Error(error.message);
+let checked = 0, linked = 0, failed = 0;
+const queue = [...data];
+await Promise.all(Array.from({ length: 4 }, async () => {
+  for (let row; (row = queue.shift());) {
+    try {
+      const manifest = await manifests.fetchLocaleManifest(row.winget_id, row.version);
+      const release_notes_url = manifestReleaseNotesUrl(manifest);
+      const { error: updateError } = await db.from('version_history').update({
+        release_notes_url, release_notes_url_checked_at: new Date().toISOString(),
+      }).eq('id', row.id);
+      if (updateError) throw new Error(updateError.message);
+      checked++; if (release_notes_url) linked++;
+    } catch (error) {
+      failed++;
+      console.error(`${row.winget_id} ${row.version}: ${error.message}`);
+    }
+  }
+}));
+console.log(JSON.stringify({ checked, linked, failed }));
+if (failed) process.exitCode = 1;

--- a/scripts/build-catalog-snapshot.mjs
+++ b/scripts/build-catalog-snapshot.mjs
@@ -43,7 +43,7 @@ const CURATED_COLUMNS = [
 ];
 const VERSION_COLUMNS = [
   'winget_id', 'version', 'installer_url', 'installer_sha256', 'installer_type',
-  'installer_scope', 'silent_args', 'installers', 'created_at', 'release_date', 'release_notes',
+  'installer_scope', 'silent_args', 'installers', 'created_at', 'release_date', 'release_notes_url',
 ];
 const SCCM_COLUMNS = [
   'id', 'sccm_display_name_normalized', 'sccm_ci_id', 'sccm_product_code',
@@ -83,7 +83,7 @@ const jsonOrNull = (v) => (v == null ? null : JSON.stringify(v));
  * Build the SQLite snapshot file at dbPath from in-memory rows. Pure and
  * deterministic given the inputs, so the self-test can exercise it offline.
  */
-export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings, qaResults = [] }) {
+export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings, qaResults = [], fileReputations = [] }) {
   const db = new Database(dbPath);
   try {
     db.pragma('journal_mode = DELETE');
@@ -106,7 +106,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       CREATE TABLE version_history (
         winget_id TEXT, version TEXT, installer_url TEXT, installer_sha256 TEXT,
         installer_type TEXT, installer_scope TEXT, silent_args TEXT, installers TEXT,
-        created_at TEXT, release_date TEXT, release_notes TEXT, PRIMARY KEY (winget_id, version)
+        created_at TEXT, release_date TEXT, release_notes_url TEXT, PRIMARY KEY (winget_id, version)
       );
       CREATE INDEX idx_vh_winget ON version_history(winget_id);
 
@@ -147,9 +147,9 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
       VALUES (@id, @name, @publisher, @description, @tags)`);
     const insVersion = db.prepare(`INSERT OR IGNORE INTO version_history
       (winget_id, version, installer_url, installer_sha256, installer_type, installer_scope,
-       silent_args, installers, created_at, release_date, release_notes)
+       silent_args, installers, created_at, release_date, release_notes_url)
       VALUES (@winget_id,@version,@installer_url,@installer_sha256,@installer_type,@installer_scope,
-       @silent_args,@installers,@created_at,@release_date,@release_notes)`);
+       @silent_args,@installers,@created_at,@release_date,@release_notes_url)`);
     const insSccm = db.prepare(`INSERT OR IGNORE INTO sccm_winget_mappings
       (id, sccm_display_name_normalized, sccm_ci_id, sccm_product_code, winget_package_id,
        winget_package_name, confidence, is_verified)
@@ -171,7 +171,14 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
        @packager_commit,@package_content_sha256,@virustotal_status,@virustotal_malicious,
        @virustotal_suspicious,@virustotal_total_engines,@virustotal_scanned_at_utc)`);
 
+    db.exec(`CREATE TABLE catalog_file_reputation (
+      sha256 TEXT PRIMARY KEY, status TEXT, malicious INTEGER, suspicious INTEGER,
+      total_engines INTEGER, analyzed_at TEXT
+    )`);
+    const insReputation = db.prepare(`INSERT INTO catalog_file_reputation VALUES
+      (@sha256,@status,@malicious,@suspicious,@total_engines,@analyzed_at)`);
     const tx = db.transaction(() => {
+      for (const report of fileReputations) insReputation.run(report);
       for (const a of curatedApps) {
         const tags = a.tags ? JSON.stringify(a.tags) : null;
         insCurated.run({
@@ -195,7 +202,7 @@ export function buildSqlite(dbPath, { curatedApps, versionHistory, sccmMappings,
           winget_id: v.winget_id, version: v.version, installer_url: v.installer_url ?? null,
           installer_sha256: v.installer_sha256 ?? null, installer_type: v.installer_type ?? null,
           installer_scope: v.installer_scope ?? null, silent_args: v.silent_args ?? null,
-          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null, release_date: v.release_date ?? null, release_notes: v.release_notes ?? null,
+          installers: jsonOrNull(v.installers), created_at: v.created_at ?? null, release_date: v.release_date ?? null, release_notes_url: v.release_notes_url ?? null,
         });
       }
       for (const m of sccmMappings) {
@@ -276,7 +283,7 @@ async function exportFromSupabase(outDir) {
 
   const supabase = createClient(url, key);
   console.log('Reading catalog from Supabase...');
-  const [curatedApps, versionHistory, sccmMappings, qaResults] = await Promise.all([
+  const [curatedApps, versionHistory, sccmMappings, qaResults, fileReputations] = await Promise.all([
     fetchAll(supabase, 'curated_apps', CURATED_COLUMNS),
     fetchAll(supabase, 'version_history', VERSION_COLUMNS),
     // Only GLOBAL mappings (no tenant data) reach a public snapshot.
@@ -290,13 +297,14 @@ async function exportFromSupabase(outDir) {
       console.warn(`QA results were omitted from this snapshot: ${error.message}`);
       return [];
     }),
+    fetchAll(supabase, 'catalog_file_reputation', ['sha256', 'status', 'malicious', 'suspicious', 'total_engines', 'analyzed_at']),
   ]);
   console.log(`  curated_apps: ${curatedApps.length}`);
   console.log(`  version_history: ${versionHistory.length}`);
   console.log(`  sccm_winget_mappings (global): ${sccmMappings.length}`);
   console.log(`  qa_results: ${qaResults.length}`);
 
-  return writeSnapshot(outDir, { curatedApps, versionHistory, sccmMappings, qaResults });
+  return writeSnapshot(outDir, { curatedApps, versionHistory, sccmMappings, qaResults, fileReputations });
 }
 
 async function writeSnapshot(outDir, rows, generatedAt = new Date().toISOString()) {
@@ -336,7 +344,7 @@ async function selfTest() {
     { id: 3, winget_id: 'Zoom.Zoom', name: 'Zoom Workplace', publisher: 'Zoom', latest_version: '6.0', tags: null, category: 'Communication', is_verified: true, is_locale_variant: false, popularity_rank: 5 },
   ];
   const versionHistory = [
-    { winget_id: 'Google.Chrome', version: '120.0', installer_url: 'https://x/chrome.msi', installer_sha256: 'abc', installer_type: 'msi', installers: [{ Architecture: 'x64', InstallerUrl: 'https://x/chrome.msi' }], created_at: '2026-01-01T00:00:00Z' },
+    { winget_id: 'Google.Chrome', version: '120.0', installer_url: 'https://x/chrome.msi', installer_sha256: 'a'.repeat(64), release_notes_url: 'https://example.com/releases/120', installer_type: 'msi', installers: [{ Architecture: 'x64', InstallerUrl: 'https://x/chrome.msi' }], created_at: '2026-01-01T00:00:00Z' },
   ];
   const sccmMappings = [
     { id: 'm1', sccm_display_name_normalized: 'google chrome', sccm_ci_id: '123', sccm_product_code: null, winget_package_id: 'Google.Chrome', winget_package_name: 'Google Chrome', confidence: 1, is_verified: true },
@@ -372,10 +380,14 @@ async function selfTest() {
     },
   ];
 
-  const { dbPath, manifest } = await writeSnapshot(outDir, { curatedApps, versionHistory, sccmMappings, qaResults });
+  const fileReputations = [{sha256:'a'.repeat(64),status:'found',malicious:2,suspicious:1,total_engines:72,analyzed_at:'2026-09-06T01:00:00Z'}];
+  const { dbPath, manifest } = await writeSnapshot(outDir, { curatedApps, versionHistory, sccmMappings, qaResults, fileReputations });
 
   const db = new Database(dbPath, { readonly: true });
   const assert = (cond, msg) => { if (!cond) throw new Error(`SELF-TEST FAIL: ${msg}`); };
+
+  assert(db.prepare('SELECT release_notes_url FROM version_history').get().release_notes_url === 'https://example.com/releases/120', 'official vendor URL round-trip');
+  assert(db.prepare('SELECT malicious FROM catalog_file_reputation WHERE sha256 = ?').get('a'.repeat(64)).malicious === 2, 'hash findings round-trip');
 
   // FTS search for "chrome" should hit the Chrome row
   const ftsHit = db.prepare(

--- a/supabase/migrations/20260906073557_catalog_release_links_and_file_reputation.sql
+++ b/supabase/migrations/20260906073557_catalog_release_links_and_file_reputation.sql
@@ -1,0 +1,56 @@
+ALTER TABLE public.version_history
+  ADD COLUMN IF NOT EXISTS release_notes_url text,
+  ADD COLUMN IF NOT EXISTS release_notes_url_checked_at timestamptz;
+CREATE INDEX IF NOT EXISTS idx_version_history_installer_hash
+  ON public.version_history(lower(installer_sha256)) WHERE installer_sha256 IS NOT NULL;
+
+CREATE TABLE public.catalog_file_reputation (
+  sha256 text PRIMARY KEY CHECK (sha256 ~ '^[a-f0-9]{64}$'),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'found', 'not_found', 'error')),
+  malicious integer CHECK (malicious >= 0),
+  suspicious integer CHECK (suspicious >= 0),
+  total_engines integer CHECK (total_engines > 0),
+  analyzed_at timestamptz,
+  checked_at timestamptz,
+  retry_after timestamptz NOT NULL DEFAULT now(),
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  priority integer NOT NULL DEFAULT 0 CHECK (priority IN (0, 1)),
+  CHECK (status <> 'found' OR (malicious IS NOT NULL AND suspicious IS NOT NULL AND total_engines IS NOT NULL AND malicious + suspicious <= total_engines))
+);
+ALTER TABLE public.catalog_file_reputation ENABLE ROW LEVEL SECURITY;
+GRANT SELECT ON public.catalog_file_reputation TO anon, authenticated;
+GRANT ALL ON public.catalog_file_reputation TO service_role;
+CREATE POLICY "Public installer reputation is readable" ON public.catalog_file_reputation
+  FOR SELECT TO anon, authenticated USING (true);
+CREATE INDEX idx_catalog_reputation_queue ON public.catalog_file_reputation(priority DESC, requested_at DESC) INCLUDE (retry_after);
+
+-- A file hash identifies the same file across apps and versions. Reuse existing
+-- VirusTotal evidence without requiring a new installation or QA run.
+INSERT INTO public.catalog_file_reputation (sha256, status, malicious, suspicious, total_engines, analyzed_at, checked_at, retry_after)
+SELECT DISTINCT ON (lower(installer_sha256)) lower(installer_sha256),
+  'found', virustotal_malicious, virustotal_suspicious, virustotal_total_engines,
+  virustotal_scanned_at_utc, NULL, now()
+FROM (
+  SELECT installer_sha256, virustotal_status, virustotal_malicious, virustotal_suspicious, virustotal_total_engines, virustotal_scanned_at_utc FROM public.qa_results
+  UNION ALL
+  SELECT installer_sha256, virustotal_status, virustotal_malicious, virustotal_suspicious, virustotal_total_engines, virustotal_scanned_at_utc FROM public.qa_package_results
+) evidence
+WHERE installer_sha256 ~* '^[a-f0-9]{64}$' AND virustotal_status IN ('clean', 'flagged', 'suspicious')
+  AND virustotal_malicious >= 0 AND virustotal_suspicious >= 0
+  AND virustotal_total_engines > 0 AND virustotal_malicious + virustotal_suspicious <= virustotal_total_engines
+ORDER BY lower(installer_sha256), virustotal_scanned_at_utc DESC NULLS LAST;
+
+CREATE OR REPLACE FUNCTION public.request_catalog_file_reputation(hashes text[], prioritized boolean DEFAULT true)
+RETURNS void LANGUAGE sql SECURITY INVOKER SET search_path = '' AS $$
+  INSERT INTO public.catalog_file_reputation (sha256, priority)
+  SELECT DISTINCT lower(h), CASE WHEN prioritized THEN 1 ELSE 0 END
+  FROM unnest(hashes[1:40]) AS h
+  WHERE h ~* '^[a-f0-9]{64}$' AND EXISTS (
+    SELECT 1 FROM public.version_history v WHERE lower(v.installer_sha256) = lower(h)
+  )
+  ON CONFLICT (sha256) DO UPDATE
+  SET requested_at = now(), priority = greatest(public.catalog_file_reputation.priority, excluded.priority)
+  WHERE public.catalog_file_reputation.retry_after <= now();
+$$;
+REVOKE ALL ON FUNCTION public.request_catalog_file_reputation(text[], boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.request_catalog_file_reputation(text[], boolean) TO service_role;

--- a/supabase/migrations/20260906074517_restrict_catalog_reputation_queue.sql
+++ b/supabase/migrations/20260906074517_restrict_catalog_reputation_queue.sql
@@ -1,0 +1,3 @@
+REVOKE ALL ON FUNCTION public.request_catalog_file_reputation(text[], boolean) FROM anon, authenticated;
+REVOKE ALL ON TABLE public.catalog_file_reputation FROM anon, authenticated;
+GRANT SELECT ON TABLE public.catalog_file_reputation TO anon, authenticated;

--- a/supabase/tests/catalog_file_reputation.sql
+++ b/supabase/tests/catalog_file_reputation.sql
@@ -1,0 +1,32 @@
+BEGIN;
+DO $$
+DECLARE h text; before_count integer;
+BEGIN
+  IF has_function_privilege('anon','public.request_catalog_file_reputation(text[],boolean)','execute')
+    OR has_function_privilege('authenticated','public.request_catalog_file_reputation(text[],boolean)','execute') THEN
+    RAISE EXCEPTION 'Public roles can queue lookups';
+  END IF;
+  IF NOT has_function_privilege('service_role','public.request_catalog_file_reputation(text[],boolean)','execute') THEN
+    RAISE EXCEPTION 'Service cannot queue lookups';
+  END IF;
+  SELECT lower(installer_sha256) INTO h FROM public.version_history WHERE installer_sha256 ~* '^[a-f0-9]{64}$' LIMIT 1;
+  DELETE FROM public.catalog_file_reputation WHERE sha256 = h;
+  PERFORM public.request_catalog_file_reputation(ARRAY[h]);
+  IF NOT EXISTS (SELECT 1 FROM public.catalog_file_reputation WHERE sha256=h AND status='pending' AND priority=1) THEN
+    RAISE EXCEPTION 'Known catalog hash not queued';
+  END IF;
+  UPDATE public.catalog_file_reputation SET status='found', malicious=2,suspicious=1,total_engines=72 WHERE sha256=h;
+  PERFORM public.request_catalog_file_reputation(ARRAY[h]);
+  IF NOT EXISTS (SELECT 1 FROM public.catalog_file_reputation WHERE sha256=h AND malicious=2 AND status='found') THEN
+    RAISE EXCEPTION 'Queue changed recorded findings';
+  END IF;
+  SELECT count(*) INTO before_count FROM public.catalog_file_reputation;
+  PERFORM public.request_catalog_file_reputation(ARRAY['invalid',repeat('0',64)]);
+  IF (SELECT count(*) FROM public.catalog_file_reputation) <> before_count THEN
+    RAISE EXCEPTION 'Unknown hashes entered queue';
+  END IF;
+END $$;
+SET LOCAL ROLE anon;
+SELECT count(*) FROM public.catalog_file_reputation;
+RESET ROLE;
+ROLLBACK;


### PR DESCRIPTION
Release History now links to the publisher's official release notes instead of embedding their text. VirusTotal reports are matched by exact installer SHA-256 and retrieved independently of QA installation tests, so a missing QA result no longer implies the file was never scanned.

Known hashes link directly to VirusTotal. Cached findings show malicious/suspicious counts and the original analysis date; pending, missing, and unavailable reports have distinct labels. The website queues only known catalog hashes through its service role. A separate hourly worker in IntuneGet-Workflows uses the existing API key, with bounded requests and preservation of previous evidence during outages.

Manifest sync saves official URLs for new records, and a bounded backfill fills older versions. Snapshots carry both URLs and cached file reports. Additive migrations and explicit queue permissions are already applied. Initial backfill checked 200 records, found 123 official URLs, and had no errors.

Validation: production build and lint pass; 90 focused tests pass; snapshot round-trip self-test and actionlint pass; database checks confirm public reads, restricted queueing, known-hash validation, and preservation of findings. Browser verification confirms no inline release notes, official external links, and no mobile overflow. Includes a new immutable public changelog entry. Website and workflow update only, no versioned release.
