### PR TITLE
Match Resources hover to Docs and align navbar items

### DIFF
--- a/.ugurlabs/entries/navbar-dropdown-consistency.json
+++ b/.ugurlabs/entries/navbar-dropdown-consistency.json
@@ -1,0 +1,5 @@
+{
+  "title": "Consistent navigation hover and alignment",
+  "summary": "Resources now opens on hover with the same timing, underline, and chevron animation as Docs. All desktop navigation items share the same height, typography, and vertical alignment. Both dropdowns also support click, keyboard focus, Escape, and outside-click dismissal.",
+  "type": "fixed"
+}

--- a/components/landing/DocsDropdown.tsx
+++ b/components/landing/DocsDropdown.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { ChevronDown, Rocket, Cloud, Database, Container, ClipboardList, RefreshCw, Building2, FileText, ArrowRight } from "lucide-react";
+import {
+  Rocket,
+  Cloud,
+  Database,
+  Container,
+  ClipboardList,
+  RefreshCw,
+  Building2,
+  FileText,
+  ArrowRight,
+} from "lucide-react";
 import { T } from "gt-next";
 
-const OPEN_DELAY = 150;
-const CLOSE_DELAY = 200;
+import { NavigationDropdown } from "./NavigationDropdown";
 
 const setupLinks = [
   { href: "/docs/getting-started", label: "Getting Started", icon: Rocket },
@@ -17,150 +24,96 @@ const setupLinks = [
 ];
 
 const featureLinks = [
-  { href: "/docs/sccm-migration", label: "SCCM Migration", icon: ClipboardList },
-  { href: "/docs/updates-policies", label: "Updates & Policies", icon: RefreshCw },
+  {
+    href: "/docs/sccm-migration",
+    label: "SCCM Migration",
+    icon: ClipboardList,
+  },
+  {
+    href: "/docs/updates-policies",
+    label: "Updates & Policies",
+    icon: RefreshCw,
+  },
   { href: "/docs/msp", label: "MSP Features", icon: Building2 },
   { href: "/docs/api-reference", label: "API Reference", icon: FileText },
 ];
 
 export function DocsDropdown() {
-  const [isOpen, setIsOpen] = useState(false);
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const shouldReduceMotion = useReducedMotion();
-
-  const clearTimers = useCallback(() => {
-    if (openTimer.current) clearTimeout(openTimer.current);
-    if (closeTimer.current) clearTimeout(closeTimer.current);
-  }, []);
-
-  const handleMouseEnter = useCallback(() => {
-    clearTimers();
-    openTimer.current = setTimeout(() => setIsOpen(true), OPEN_DELAY);
-  }, [clearTimers]);
-
-  const handleMouseLeave = useCallback(() => {
-    clearTimers();
-    closeTimer.current = setTimeout(() => setIsOpen(false), CLOSE_DELAY);
-  }, [clearTimers]);
-
-  useEffect(() => {
-    return clearTimers;
-  }, [clearTimers]);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
-    };
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      document.addEventListener("keydown", handleEscape);
-    }
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isOpen]);
-
   return (
-    <div
-      ref={containerRef}
-      className="relative"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+    <NavigationDropdown
+      label={<T id="docs.trigger">Docs</T>}
+      panelClassName="left-1/2 -translate-x-1/2 w-[420px] p-4"
     >
-      <button
-        className="relative text-sm font-medium text-text-secondary hover:text-text-primary transition-colors duration-200 group inline-flex items-center gap-1"
-        aria-expanded={isOpen}
-        aria-haspopup="true"
-        onClick={() => setIsOpen((prev) => !prev)}
-      >
-        <span><T id="docs.trigger">Docs</T></span>
-        <motion.span
-          animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
-        >
-          <ChevronDown className="h-3.5 w-3.5" />
-        </motion.span>
-        <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-accent-cyan transition-all duration-300 group-hover:w-full" />
-      </button>
-
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-[420px] bg-bg-elevated/95 backdrop-blur-xl border border-overlay/[0.06] rounded-xl shadow-soft-lg p-4 z-50"
-            initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{
-              duration: shouldReduceMotion ? 0 : 0.2,
-              ease: [0.25, 0.46, 0.45, 0.94],
-            }}
-          >
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <span className="block text-[11px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-2">
-                  <T id="docs.heading.setup">Setup</T>
-                </span>
-                <div className="space-y-0.5">
-                  {setupLinks.map((link) => {
-                    const Icon = link.icon;
-                    return (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        onClick={() => setIsOpen(false)}
-                        className="flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150"
-                      >
-                        <Icon className="h-4 w-4 flex-shrink-0 text-text-muted" />
-                        <span><T>{link.label}</T></span>
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-              <div>
-                <span className="block text-[11px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-2">
-                  <T id="docs.heading.features">Features</T>
-                </span>
-                <div className="space-y-0.5">
-                  {featureLinks.map((link) => {
-                    const Icon = link.icon;
-                    return (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        onClick={() => setIsOpen(false)}
-                        className="flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150"
-                      >
-                        <Icon className="h-4 w-4 flex-shrink-0 text-text-muted" />
-                        <span><T>{link.label}</T></span>
-                      </Link>
-                    );
-                  })}
-                </div>
+      {(close) => (
+        <>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <span className="block text-[11px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-2">
+                <T id="docs.heading.setup">Setup</T>
+              </span>
+              <div className="space-y-0.5">
+                {setupLinks.map((link) => {
+                  const Icon = link.icon;
+                  return (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      onClick={close}
+                      className="flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        className="h-4 w-4 flex-shrink-0 text-text-muted"
+                      />
+                      <span>
+                        <T>{link.label}</T>
+                      </span>
+                    </Link>
+                  );
+                })}
               </div>
             </div>
-            <div className="mt-3 pt-3 border-t border-overlay/[0.06]">
-              <Link
-                href="/docs"
-                onClick={() => setIsOpen(false)}
-                className="flex items-center justify-between px-2 py-2 rounded-lg text-sm font-medium text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150"
-              >
-                <span><T id="docs.view-all">View all documentation</T></span>
-                <ArrowRight className="h-4 w-4" />
-              </Link>
+            <div>
+              <span className="block text-[11px] font-semibold uppercase tracking-wider text-text-muted px-2 mb-2">
+                <T id="docs.heading.features">Features</T>
+              </span>
+              <div className="space-y-0.5">
+                {featureLinks.map((link) => {
+                  const Icon = link.icon;
+                  return (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      onClick={close}
+                      className="flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        className="h-4 w-4 flex-shrink-0 text-text-muted"
+                      />
+                      <span>
+                        <T>{link.label}</T>
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
+          </div>
+          <div className="mt-3 pt-3 border-t border-overlay/[0.06]">
+            <Link
+              href="/docs"
+              onClick={close}
+              className="flex items-center justify-between px-2 py-2 rounded-lg text-sm font-medium text-text-secondary hover:text-accent-cyan hover:bg-overlay/[0.04] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+            >
+              <span>
+                <T id="docs.view-all">View all documentation</T>
+              </span>
+              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+          </div>
+        </>
+      )}
+    </NavigationDropdown>
   );
 }

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -13,6 +13,10 @@ import { useAuthHint } from "@/hooks/useAuthHint";
 import { ChangelogBell } from "@/components/changelog/ChangelogBell";
 import { DocsDropdown } from "./DocsDropdown";
 import { ResourcesDropdown, resourceLinks } from "./ResourcesDropdown";
+import {
+  navigationItemClassName,
+  navigationUnderlineClassName,
+} from "./navigation-styles";
 import { LocaleSwitcher } from "./LocaleSwitcher";
 
 const AuthedAvatar = dynamic(
@@ -92,7 +96,7 @@ export function Header() {
         </Link>
         <nav
           aria-label={t("Main navigation")}
-          className="ml-4 hidden items-center gap-6 whitespace-nowrap xl:flex"
+          className="ml-4 hidden h-16 items-center gap-6 whitespace-nowrap xl:flex"
         >
           {primaryLinks.map((link) => (
             <Link
@@ -100,14 +104,18 @@ export function Header() {
               href={link.href}
               aria-current={active(link.href) ? "page" : undefined}
               className={cn(
-                "relative inline-flex h-16 items-center border-b-2 text-sm font-medium transition-colors",
-                focus,
-                active(link.href)
-                  ? "border-accent-cyan text-accent-cyan"
-                  : "border-transparent text-text-secondary hover:text-text-primary",
+                navigationItemClassName,
+                active(link.href) && "text-accent-cyan",
               )}
             >
               <T>{link.label}</T>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  navigationUnderlineClassName,
+                  active(link.href) && "scale-x-100",
+                )}
+              />
             </Link>
           ))}
           <DocsDropdown />

--- a/components/landing/NavigationDropdown.tsx
+++ b/components/landing/NavigationDropdown.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useId,
+  type ReactNode,
+} from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  navigationItemClassName,
+  navigationUnderlineClassName,
+} from "./navigation-styles";
+
+export function NavigationDropdown({
+  label,
+  panelClassName,
+  children,
+}: {
+  label: ReactNode;
+  panelClassName: string;
+  children: (close: () => void) => ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const container = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+  const reduceMotion = useReducedMotion();
+  const clearTimer = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = null;
+  }, []);
+  const close = useCallback(() => {
+    clearTimer();
+    setIsOpen(false);
+  }, [clearTimer]);
+  useEffect(() => clearTimer, [clearTimer]);
+  useEffect(() => {
+    const outside = (event: PointerEvent) => {
+      if (!container.current?.contains(event.target as Node)) close();
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (container.current?.contains(document.activeElement))
+        trigger.current?.focus();
+      close();
+    };
+    if (isOpen) {
+      document.addEventListener("pointerdown", outside);
+      document.addEventListener("keydown", escape);
+    }
+    return () => {
+      document.removeEventListener("pointerdown", outside);
+      document.removeEventListener("keydown", escape);
+    };
+  }, [isOpen, close]);
+
+  return (
+    <div
+      ref={container}
+      className="relative flex h-10 items-center"
+      onPointerEnter={(event) => {
+        if (event.pointerType !== "mouse") return;
+        clearTimer();
+        timer.current = setTimeout(() => setIsOpen(true), 150);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType !== "mouse") return;
+        clearTimer();
+        timer.current = setTimeout(() => setIsOpen(false), 200);
+      }}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) close();
+      }}
+    >
+      <button
+        ref={trigger}
+        type="button"
+        className={navigationItemClassName}
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? panelId : undefined}
+        onClick={() => {
+          clearTimer();
+          setIsOpen((open) => !open);
+        }}
+      >
+        <span>{label}</span>
+        <motion.span
+          className="inline-flex"
+          aria-hidden="true"
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={{ duration: reduceMotion ? 0 : 0.2 }}
+        >
+          <ChevronDown className="h-3.5 w-3.5" />
+        </motion.span>
+        <span
+          aria-hidden="true"
+          className={cn(navigationUnderlineClassName, isOpen && "scale-x-100")}
+        />
+      </button>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            id={panelId}
+            className={cn(
+              "absolute top-full z-50 mt-3 rounded-xl border border-overlay/[0.06] bg-bg-elevated/95 shadow-soft-lg backdrop-blur-xl",
+              panelClassName,
+            )}
+            initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+            transition={{
+              duration: reduceMotion ? 0 : 0.2,
+              ease: [0.25, 0.46, 0.45, 0.94],
+            }}
+          >
+            {children(close)}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/landing/ResourcesDropdown.tsx
+++ b/components/landing/ResourcesDropdown.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronDown } from "lucide-react";
 import { T } from "gt-next";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@/components/ui/dropdown-menu";
+import { NavigationDropdown } from "./NavigationDropdown";
 
 export const resourceLinks = [
   { href: "/#how-it-works", label: "How It Works" },
@@ -21,28 +15,24 @@ export const resourceLinks = [
 ];
 export function ResourcesDropdown() {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="inline-flex items-center gap-1 rounded-sm text-sm font-medium text-text-secondary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-4">
-        <T>Resources</T>
-        <ChevronDown aria-hidden="true" className="h-3.5 w-3.5" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        sideOffset={20}
-        className="w-52 rounded-xl p-2"
-      >
-        {resourceLinks.map((link) => (
-          <DropdownMenuItem
-            key={link.href}
-            asChild
-            className="rounded-lg px-3 py-2.5"
-          >
-            <Link href={link.href}>
+    <NavigationDropdown
+      label={<T>Resources</T>}
+      panelClassName="right-0 w-52 p-2"
+    >
+      {(close) => (
+        <div className="space-y-0.5">
+          {resourceLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={close}
+              className="flex items-center rounded-lg px-3 py-2.5 text-sm text-text-secondary transition-colors duration-150 hover:bg-overlay/[0.04] hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+            >
               <T>{link.label}</T>
             </Link>
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          ))}
+        </div>
+      )}
+    </NavigationDropdown>
   );
 }

--- a/components/landing/navigation-styles.ts
+++ b/components/landing/navigation-styles.ts
@@ -1,0 +1,5 @@
+export const navigationItemClassName =
+  "group relative inline-flex h-10 shrink-0 items-center gap-1 rounded-sm text-sm font-medium leading-5 text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-4";
+
+export const navigationUnderlineClassName =
+  "pointer-events-none absolute bottom-0 left-0 h-0.5 w-full origin-left scale-x-0 bg-accent-cyan transition-transform duration-300 motion-reduce:transition-none group-hover:scale-x-100 group-focus-visible:scale-x-100";


### PR DESCRIPTION
Resources now uses the same hover interaction as Docs, including delayed opening/closing, the cyan underline, and chevron animation. A shared dropdown component keeps click, keyboard focus, Escape, and outside-click dismissal consistent.

The font sizes already matched, but the links and dropdown triggers used different heights and Docs sat lower. All five desktop navigation items now share 40px height, 14px medium text, 20px line height, and identical vertical alignment. Active indicators do not shift the text.

Validation: lint and production build pass. Browser checks confirm matching computed geometry and typography, hover persistence while moving into both panels, Enter/Tab access, Escape focus restoration, and outside dismissal. No overflow at 390px, 1280px, or 1440px; mobile menu works. Includes an immutable public changelog entry. Website-only update, no versioned release.
