### PR TITLE
Recover from temporary release-detail loading failures

### DIFF
--- a/.ugurlabs/entries/resilient-release-detail-loading.json
+++ b/.ugurlabs/entries/resilient-release-detail-loading.json
@@ -1,0 +1,5 @@
+{
+  "title": "More reliable release history details",
+  "summary": "Release history now loads vendor links and scan details in smaller groups and retries temporary database failures. A failed group no longer hides details for every app on the page. Existing sync status remains separate from detail-loading errors.",
+  "type": "fixed"
+}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
 const loadHistory = unstable_cache(
   (filters: ReleaseHistoryFilters) =>
     getCatalogSource().getReleaseHistory(filters),
-  ["catalog-release-history-v3"],
+  ["catalog-release-history-v4"],
   { revalidate: 300 },
 );
 const dateFormat = new Intl.DateTimeFormat("en-GB", {

--- a/lib/catalog/release-metadata.test.ts
+++ b/lib/catalog/release-metadata.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { loadReleaseMetadata, releasePairKey } from './release-metadata';
+const rows = Array.from({length: 40}, (_, i) => ({winget_id: `Example.${i}`, version: '1.0'}));
+const evidence = (batch: typeof rows) => batch.map(row => ({...row, release_notes_url: 'https://example.com/notes', installer_sha256: 'a'.repeat(64)}));
+describe('release metadata loading', () => {
+  it('retries a transient failure with a new request', async () => {
+    const fetch = vi.fn().mockResolvedValueOnce({data:null,error:{},status:0}).mockResolvedValueOnce({data:evidence(rows.slice(0,1)),error:null,status:200});
+    const result = await loadReleaseMetadata(rows.slice(0,1),fetch);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.metadata).toHaveLength(1);
+    expect(result.unavailable.size).toBe(0);
+  });
+  it('preserves three successful groups when one group times out twice', async () => {
+    const warn = vi.spyOn(console,'warn').mockImplementation(()=>{});
+    const fetch = vi.fn(async (batch: typeof rows) => {
+      if(batch[0].winget_id==='Example.0') throw new Error('Timeout');
+      return {data:evidence(batch),error:null,status:200};
+    });
+    const result = await loadReleaseMetadata(rows,fetch);
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(result.metadata).toHaveLength(30);
+    expect(result.unavailable.size).toBe(10);
+    expect(result.unavailable.has(releasePairKey(rows[10]))).toBe(false);
+    warn.mockRestore();
+  });
+  it('does not retry permanent errors or confuse absent metadata with a failed request', async () => {
+    const warn = vi.spyOn(console,'warn').mockImplementation(()=>{});
+    const fetch = vi.fn().mockResolvedValue({data:null,error:{code:'42501'},status:403});
+    expect((await loadReleaseMetadata(rows.slice(0,1),fetch)).unavailable.size).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect((await loadReleaseMetadata(rows.slice(0,1),async()=>({data:[],error:null,status:200}))).unavailable.size).toBe(0);
+    warn.mockRestore();
+  });
+});

--- a/lib/catalog/release-metadata.ts
+++ b/lib/catalog/release-metadata.ts
@@ -1,0 +1,40 @@
+import type { ReleaseMetadata } from './release-enrichment';
+
+interface ReleasePair { winget_id: string; version: string }
+interface MetadataResponse {
+  data: ReleaseMetadata[] | null;
+  error: { code?: string } | null;
+  status: number;
+}
+export const releasePairKey = (row: ReleasePair) => JSON.stringify([row.winget_id, row.version]);
+
+/** Keep one failed request from hiding evidence for every card on the page. */
+export async function loadReleaseMetadata(
+  rows: ReleasePair[],
+  fetchBatch: (batch: ReleasePair[]) => PromiseLike<MetadataResponse>,
+) {
+  const batches = Array.from({ length: Math.ceil(rows.length / 10) }, (_, i) => rows.slice(i * 10, (i + 1) * 10));
+  const results = await Promise.allSettled(batches.map(async batch => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await fetchBatch(batch);
+        if (!response.error && response.data) return response.data;
+        const transient = response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500 || response.error?.code === '57014';
+        if (!transient || attempt === 1) throw new Error(`Release metadata unavailable (HTTP ${response.status})`);
+      } catch (error) {
+        if (attempt === 1 || (error instanceof Error && error.message.startsWith('Release metadata unavailable'))) throw error;
+      }
+    }
+    throw new Error('Release metadata unavailable');
+  }));
+  const metadata: ReleaseMetadata[] = [];
+  const unavailable = new Set<string>();
+  results.forEach((result, i) => {
+    if (result.status === 'fulfilled') metadata.push(...result.value);
+    else {
+      batches[i].forEach(row => unavailable.add(releasePairKey(row)));
+      console.warn('Release metadata batch unavailable', { batchSize: batches[i].length });
+    }
+  });
+  return { metadata, unavailable };
+}

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -1,4 +1,5 @@
-import { enrichRelease, type ReleaseMetadata, type FileReputation } from './release-enrichment';
+import { loadReleaseMetadata, releasePairKey } from './release-metadata';
+import { enrichRelease, type FileReputation } from './release-enrichment';
 import type { ReleaseHistoryFilters, ReleaseHistoryResult } from './release-history';
 /**
  * Supabase-backed CatalogSource.
@@ -70,10 +71,11 @@ export class SupabaseCatalogSource implements CatalogSource {
     if (error) throw new Error('Catalog history unavailable', { cause: error });
     const result = data as ReleaseHistoryResult;
     if (!result.rows.length) return result;
-    const pairs = result.rows.map(row => `and(winget_id.eq.${quotePostgrestValue(row.winget_id)},version.eq.${quotePostgrestValue(row.version)})`).join(',');
-    const metadata = await client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(40).abortSignal(AbortSignal.timeout(5000));
-    if (metadata.error || !metadata.data) return {...result, rows: result.rows.map(row => ({...row, detailsUnavailable: true}))};
-    const hashes = [...new Set(metadata.data.map(v => v.installer_sha256?.toLowerCase()).filter((hash): hash is string => typeof hash === 'string' && /^[a-f0-9]{64}$/.test(hash)))];
+    const {metadata, unavailable} = await loadReleaseMetadata(result.rows, batch => {
+      const pairs = batch.map(row => `and(winget_id.eq.${quotePostgrestValue(row.winget_id)},version.eq.${quotePostgrestValue(row.version)})`).join(',');
+      return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(batch.length).abortSignal(AbortSignal.timeout(10_000));
+    });
+    const hashes = [...new Set(metadata.map(v => v.installer_sha256?.toLowerCase()).filter((hash): hash is string => typeof hash === 'string' && /^[a-f0-9]{64}$/.test(hash)))];
     let reputations: FileReputation[] = [];
     if (hashes.length) {
       const responses = await Promise.allSettled([
@@ -83,7 +85,7 @@ export class SupabaseCatalogSource implements CatalogSource {
       const cached = responses[0];
       if (cached.status === 'fulfilled' && cached.value && !cached.value.error) reputations = (cached.value.data ?? []) as FileReputation[];
     }
-    return {...result, rows: result.rows.map(row => enrichRelease(row, metadata.data as ReleaseMetadata[], reputations))};
+    return {...result, rows: result.rows.map(row => unavailable.has(releasePairKey(row)) ? {...row, detailsUnavailable: true} : enrichRelease(row, metadata, reputations))};
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
A transient metadata query failure could hide release-note links and scan details for all 40 release cards, with the degraded result cached for five minutes. Load metadata in groups of ten with a fresh timeout and one retry for transient errors. Preserve successful groups when another fails, and reset the history cache namespace for rollout.

Validation: nine metadata/enrichment tests passed, including transient retry, permanent-error behavior, and partial-failure isolation. Production build and lint passed locally. The separate catalog sync banner is unchanged and reflects the stored completed sync with unavailable upstream manifests.
