### PR TITLE
Show completed catalog checks as a quiet timestamp

### DIFF
--- a/.ugurlabs/entries/quiet-release-history-sync-status.json
+++ b/.ugurlabs/entries/quiet-release-history-sync-status.json
@@ -1,0 +1,5 @@
+{
+  "title": "Simpler release history status",
+  "summary": "Completed catalog checks now appear as a quiet Last checked timestamp. The persistent unavailable-package banner and explanatory paragraph have been removed from release history. Running syncs and actual failures still display their status.",
+  "type": "improved"
+}

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -16,7 +16,7 @@ export default function Loading() {
           <T>Loading catalog release history</T>
         </p>
         <div aria-hidden="true">
-          <div className="mb-10 grid gap-8 lg:grid-cols-[1fr_300px] lg:items-end">
+          <div className="mb-10">
             <div>
               <div className={`${bone} h-5 w-24`} />
               <div className={`${bone} mb-3 mt-6 h-4 w-44`} />
@@ -24,11 +24,7 @@ export default function Loading() {
               <div className={`${bone} mt-5 h-6 w-full`} />
               <div className={`${bone} mt-2 h-6 w-3/4`} />
             </div>
-            <div className="space-y-4 rounded-xl border border-overlay/10 bg-bg-elevated p-5">
-              <div className={`${bone} h-5 w-full`} />
-              <div className={`${bone} h-4 w-4/5`} />
-              <div className={`${bone} h-4 w-3/5`} />
-            </div>
+            <div className={`${bone} mt-5 h-5 w-72 max-w-full`} />
           </div>
           <div className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
             {[0, 1, 2].map((i) => (

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -71,16 +71,10 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
   }
   const pages = Math.max(1, Math.ceil((result?.total ?? 0) / 40));
   const sync = result?.sync;
-  const status =
-    sync?.status === "success"
-      ? "Last run completed successfully"
-      : sync?.status === "running"
-        ? "Catalog sync in progress"
-        : sync?.status === "partial"
-          ? "Completed with unavailable packages"
-          : sync
-            ? "Latest sync failed"
-            : "History from the catalog snapshot";
+  const completed = sync?.status === "success" || sync?.status === "partial";
+  const status = sync?.status === "running"
+    ? "Catalog sync in progress"
+    : sync ? "Latest sync failed" : "History from the catalog snapshot";
 
   return (
     <div className="flex min-h-screen flex-col bg-bg-deepest">
@@ -89,7 +83,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
         id="main-content"
         className="mx-auto w-full max-w-6xl flex-1 px-4 pb-20 pt-28 lg:px-8 lg:pt-36"
       >
-        <header className="mb-10 grid gap-8 lg:grid-cols-[1fr_300px] lg:items-end">
+        <header className="mb-10">
           <div>
             <Link
               href="/apps"
@@ -111,18 +105,14 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
             </p>
           </div>
           {result && (
-            <aside className="rounded-xl border border-overlay/10 bg-bg-elevated p-5 text-sm">
-              <p className="flex items-center gap-2 font-medium text-text-primary">
-                <span
-                  aria-hidden="true"
-                  className={`h-2 w-2 shrink-0 rounded-full ${sync?.status === "success" ? "bg-emerald-500" : "bg-amber-500"}`}
-                />
-                <T>
-                  <Var>{status}</Var>
-                </T>
-              </p>
-              <p className="mt-3 leading-relaxed text-text-secondary">
-                <T>Last completed catalog check:</T>{" "}
+            <aside className="mt-5 text-sm text-text-muted">
+              {!completed && (
+                <p className="mb-2 font-medium text-text-secondary">
+                  <T><Var>{status}</Var></T>
+                </p>
+              )}
+              <p>
+                <T>Last checked:</T>{" "}
                 {sync?.lastSuccessfulAt ? (
                   <time dateTime={sync.lastSuccessfulAt}>
                     {syncDateFormat.format(new Date(sync.lastSuccessfulAt))}{" "}
@@ -132,16 +122,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                   <T>Not yet recorded</T>
                 )}
               </p>
-              {sync?.status === "partial" && (
-                <p className="mt-3 text-xs leading-relaxed text-text-secondary">
-                  <T>
-                    The check completed, but some manifests were unavailable
-                    from WinGet. Existing records are retained and retried on
-                    the next sync.
-                  </T>
-                </p>
-              )}
-              {sync?.completedAt &&
+              {!completed && sync?.completedAt &&
                 sync.completedAt !== sync.lastSuccessfulAt && (
                   <p className="mt-2 text-xs text-text-muted">
                     <T>Last attempt:</T>{" "}

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -17,9 +17,7 @@ The installation scanner is independent of release history. It now installs the 
 ## Sync status and installation scans
 
 A `partial` manifest sync means the check finished with unavailable upstream
-manifests, not an operational failure. The release page labels this separately
-from `failed`, retains existing records, and shows the completed check time in
-UTC. The next scheduled manifest sync retries unavailable records.
+manifests, not an operational failure. The release page shows a quiet Last checked timestamp for both completed outcomes, retains existing records, and reserves a visible status message for running or failed syncs. Timestamps use UTC. The next scheduled manifest sync retries unavailable records.
 
 Installation scanning is independent of version-history ingestion. The scanner
 retries only WinGet error `-1978335146` (installer prohibits elevation) using a


### PR DESCRIPTION
Completed catalog syncs now show a muted Last checked timestamp beneath the introduction. Remove the persistent unavailable-packages notice, colored indicator and status card. Running and failed syncs retain a visible status message. Match the loading skeleton to the simpler layout and update operator documentation.

Validation: local production build and lint passed; changelog entry validated. Production verification will check the removed banner and timestamp on desktop and mobile.
