### PR TITLE
Return unread_count when notifications are unavailable

### DIFF
--- a/app/api/notifications/unread-count/route.test.ts
+++ b/app/api/notifications/unread-count/route.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server';
+
+const { parseAccessTokenMock, getServerClientOrNullMock } = vi.hoisted(() => ({
+  parseAccessTokenMock: vi.fn(),
+  getServerClientOrNullMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-utils', () => ({
+  parseAccessToken: parseAccessTokenMock,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  getServerClientOrNull: getServerClientOrNullMock,
+}));
+
+import { GET } from '@/app/api/notifications/unread-count/route';
+
+function makeRequest() {
+  const request = new NextRequest('http://localhost:3000/api/notifications/unread-count');
+  request.headers.set('Authorization', 'Bearer test-token');
+  return request;
+}
+
+describe('GET /api/notifications/unread-count', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerClientOrNullMock.mockReturnValue(null);
+    parseAccessTokenMock.mockResolvedValue({
+      userId: 'user-1',
+      userEmail: 'user@example.com',
+      tenantId: 'tenant-1',
+      userName: 'User',
+    });
+  });
+
+  it('returns an empty badge without Supabase instead of crashing', async () => {
+    // Regression: the route called createServerClient() unconditionally, which
+    // throws without Supabase config, so every dashboard load logged a 500.
+    // user_notifications is Supabase-only, so an empty count is the honest
+    // answer here - under the same `unread_count` key the bell reads.
+    getServerClientOrNullMock.mockReturnValue(null);
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.unread_count).toBe(0);
+  });
+
+  it('counts unread notifications when Supabase is configured', async () => {
+    const query: Record<string, unknown> = {};
+    query.select = vi.fn(() => query);
+    query.eq = vi.fn(() => query);
+    query.is = vi.fn(async () => ({ count: 3, error: null }));
+    getServerClientOrNullMock.mockReturnValue({ from: vi.fn(() => query) });
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.unread_count).toBe(3);
+  });
+
+  it('returns 401 without valid auth', async () => {
+    parseAccessTokenMock.mockResolvedValue(null);
+
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -21,9 +21,14 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Notifications live in user_notifications, a Supabase-only table with no
+    // SQLite equivalent, so an empty badge is the honest answer in a
+    // self-hosted install rather than the 500 createServerClient() used to
+    // throw here. Same `unread_count` key as the success path - NotificationBell
+    // and NotificationCenter read that field and nothing else.
     const supabase = getServerClientOrNull();
     if (!supabase) {
-      return NextResponse.json({ count: 0 });
+      return NextResponse.json({ unread_count: 0 });
     }
 
     const { count, error } = await supabase


### PR DESCRIPTION
Without Supabase, `GET /api/notifications/unread-count` answers `{ count: 0 }`. Every consumer reads `unread_count`:

- `components/notifications/NotificationBell.tsx`: `data?.unread_count || 0`
- `components/notifications/NotificationCenter.tsx`: same
- the success path a few lines below in the same route returns `unread_count`

So the badge falls back to 0 by accident rather than by answer, and a client that checks the documented field finds nothing there. `app/api/notifications/route.ts` also returns `unread_count` on its own Supabase-less path, so this was the odd one out.

Six lines, same key on both paths, plus a test covering the Supabase-less answer, the counted answer, and the 401.
