### PR TITLE
Say why a deployment could not be started

### DIFF
--- a/app/api/package/route.ts
+++ b/app/api/package/route.ts
@@ -694,6 +694,10 @@ export async function POST(request: NextRequest) {
               createdAt: jobRecord?.created_at || new Date().toISOString(),
             });
           } catch (error) {
+            console.error(
+              `[package] Job creation failed for ${item.wingetId} ${item.version}:`,
+              error
+            );
             errors.push({
               wingetId: item.wingetId,
               error: error instanceof Error ? error.message : 'Unknown error',
@@ -829,8 +833,11 @@ export async function POST(request: NextRequest) {
       success: totalJobs > 0,
       jobs,
       errors: errors.length > 0 ? errors : undefined,
+      // Name the reasons, not just the count: this string is what a client
+      // shows when no job was created, and "1 failed" is not actionable.
       message: errors.length > 0
-        ? `${totalJobs} job(s) processed, ${errors.length} failed`
+        ? `${totalJobs} job(s) processed, ${errors.length} failed - ` +
+          errors.map((entry) => `${entry.wingetId}: ${entry.error}`).join('; ')
         : storeDeployed > 0 && win32Queued > 0
           ? `${storeDeployed} Store app(s) deployed, ${win32Queued} Win32 app(s) queued`
           : storeDeployed > 0

--- a/components/UploadCart.tsx
+++ b/components/UploadCart.tsx
@@ -58,6 +58,27 @@ interface PackageApiResponse {
   message?: string;
 }
 
+/**
+ * Turn a package API response into something an operator can act on.
+ *
+ * Names the app each reason belongs to, because a cart can hold several and
+ * "1 failed" does not say which. Falls back to the server's summary only when
+ * no per-app reason came back.
+ */
+function describeDeploymentFailure(data: PackageApiResponse): string {
+  const reasons = (data.errors ?? []).filter((entry) => entry?.error);
+
+  if (reasons.length === 0) {
+    return data.message || 'No jobs were created';
+  }
+
+  if (reasons.length === 1) {
+    return `${reasons[0].wingetId}: ${reasons[0].error}`;
+  }
+
+  return reasons.map((entry) => `${entry.wingetId}: ${entry.error}`).join('\n');
+}
+
 interface DeploymentError {
   title: string;
   message: string;
@@ -242,7 +263,10 @@ export function UploadCart() {
       const data: PackageApiResponse = await response.json();
 
       if (!data.success || !data.jobs || data.jobs.length === 0) {
-        throw new Error(data.message || 'No jobs were created');
+        // data.message only counts the failures ("0 job(s) processed, 1
+        // failed"); the reasons are per app in data.errors. Show those - a
+        // count alone leaves the operator with nothing to act on.
+        throw new Error(describeDeploymentFailure(data));
       }
 
       const jobCount = data.jobs.length;
@@ -516,7 +540,11 @@ export function UploadCart() {
                             .join(' ')}
                         </p>
                       )}
-                      <p className="text-status-error/70 mt-1">{error.message}</p>
+                      {/* whitespace-pre-line: one line per app when several
+                          failed for different reasons. */}
+                      <p className="text-status-error/70 mt-1 whitespace-pre-line break-words">
+                        {error.message}
+                      </p>
                       {error.blockedBeforeDispatch && (
                         <p className="text-text-muted mt-2">
                           No packaging pipeline was started and no changes were made in Intune.


### PR DESCRIPTION
When no job is created, the cart shows:

> **Deployment could not be started**
> 0 job(s) processed, 1 failed

and nothing else. The reasons are already in the response, per app, in `data.errors` — the cart reads `data.message` instead, which only counts. The route logs nothing either, so the only copy of the reason is a response field the UI discards.

Diagnosing a blocked deployment currently means opening devtools and reading the API response by hand. On a self-hosted install that is the difference between a five-minute fix and an afternoon: the same opaque message covered a QA verdict, a proxy timeout and an SQLite error in our case, and only the last one was guessable.

### Changes

- `components/UploadCart.tsx`: name the app and its reason; one line per app when several failed differently (`whitespace-pre-line` so the lines survive rendering)
- `app/api/package/route.ts`: log the per-item failure with its stack, and carry the reasons in the summary string for any client that falls back to it

No behaviour changes — the same deployments succeed and fail as before, they just say why.
