### PR TITLE
Quarantine failed HEC-RAS 7.0 payload across QA and customer deployment

### DIFF
--- a/.ugurlabs/entries/20260909-hecras-version-quarantine.json
+++ b/.ugurlabs/entries/20260909-hecras-version-quarantine.json
@@ -1,0 +1,5 @@
+{
+  "title": "HEC-RAS 7.0 deployment availability",
+  "summary": "The tested HEC-RAS 7.0 installer is unavailable for automated deployment after installation validation failed. Future releases remain eligible for testing.",
+  "type": "maintenance"
+}

--- a/docs/qa-cohort-strict-20260830.sql
+++ b/docs/qa-cohort-strict-20260830.sql
@@ -1,0 +1,46 @@
+-- Read-only current-pin cohort audit. Status-only qa-status.mjs is not enough.
+with strict as (
+  select c.*, r.packager_commit
+  from public.qa_candidates c
+  join public.qa_package_results r
+    on r.package_profile_sha256 = c.package_profile_sha256
+   and r.installer_sha256 = c.installer_sha256
+   and lower(r.winget_id) = lower(c.winget_id)
+   and r.tested_version = c.version
+   and r.architecture = c.architecture
+  where c.status = 'passed' and c.test_level = 'psadt-package'
+    and r.outcome = 'Passed'
+    and r.phase_results->'install'->>'exitCode' = '0'
+    and r.phase_results->'detectionAfterInstall'->>'exitCode' = '0'
+    and r.phase_results->'uninstall'->>'exitCode' = '0'
+    and r.phase_results->'detectionAfterUninstall'->>'exitCode' = '1'
+    and r.environment->>'executionContext' = 'LocalSystem'
+    and r.virustotal_malicious = 0 and r.virustotal_suspicious = 0
+    and (c.test_config->>'packageProfileCanonicalJson')::jsonb
+        ->'toolchain'->>'packagerCommit' = r.packager_commit
+)
+select count(distinct lower(trim(c.winget_id))) strict_count,
+       max(c.finished_at) latest_strict_finish
+from strict c
+where c.finished_at > timestamptz '2026-08-30T08:28:35Z'
+  and c.packager_commit = (
+    select required_packager_commit from public.qa_pipeline_control where id = 'global'
+  )
+  and not exists (
+    select 1 from strict h
+    where lower(trim(h.winget_id)) = lower(trim(c.winget_id))
+      and h.finished_at <= timestamptz '2026-08-30T08:28:35Z'
+  )
+  and not exists (
+    select 1 from public.package_eligibility_blocks b
+    where lower(b.winget_id) = lower(c.winget_id)
+  )
+  and not exists (
+    select 1 from public.curated_excluded_apps b
+    where lower(b.winget_id) = lower(c.winget_id)
+  )
+  and not exists (
+    select 1 from public.qa_package_blocks b
+    where b.winget_id = c.winget_id and b.version = c.version
+      and b.architecture = c.architecture and b.installer_sha256 = c.installer_sha256
+  );

--- a/docs/qa-hecras-20260909.md
+++ b/docs/qa-hecras-20260909.md
@@ -1,0 +1,43 @@
+# HEC-RAS 7.0 exact-payload quarantine
+
+Production was paused with zero active QA candidates on 2026-09-09. Failed
+candidate `a8fed9fd-aae4-4147-9552-4e0d1fad6436`, Actions run `33533285860`,
+used packager `d33825c2b786af7c3f22f4b828108c4129299ef9`, profile SHA
+`2CBB61E917691737E9287CED37FA4E71FEFFCC7624B51BB520B7746355D4BB3E`.
+
+Compact result and bounded Actions diagnostics show LocalSystem PSADT 4.1.8,
+install/detect/uninstall/removal `60001/1/0/1`, and VirusTotal `0/0`.
+Uninstall found exact HEC-RAS 7.0 MSI identity
+`{4c3e30d1-8fd1-41fe-b883-221546541205}` and removed it successfully.
+The published tail contains uninstall evidence, not the install exception.
+Windows denied access to the retained sanitized diagnostic even outside the
+Codex sandbox. No ACLs, runner files, VM contents, or installer bytes were accessed.
+
+The official WinGet 7.0 manifest specifies x86 and `/S /v/qn`, matching the
+tested profile. This does not establish the root cause of exit 60001.
+The vendor documents independent version installations and currently offers
+7.0.1. Neither source supports inventing a silent-argument repair here.
+
+- https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/33533285860
+- https://github.com/microsoft/winget-pkgs/blob/master/manifests/h/HydrologicEngineeringCenter/HEC-RAS/7.0/HydrologicEngineeringCenter.HEC-RAS.installer.yaml
+- https://www.hec.usace.army.mil/confluence/rasdocs/rasrn/7.0
+- https://www.hec.usace.army.mil/software/hec-ras/download.aspx
+
+Resolution: reviewed `failed_managed_lifecycle` block for the exact
+ID/version/architecture/installer-SHA tuple. Existing shared compatibility
+lookup rejects it in QA demand and customer dispatch, including QA override.
+This is a lifecycle quarantine, not a security finding or permanent app ban.
+Future versions or different installer hashes remain eligible. Do not remove
+the block without diagnosis and a controlled strict retest. No packager code
+changes are needed; customer and QA pins remain unchanged.
+
+Deployment sequence: merge protected PR after CI, apply the migration, verify
+the exact block and zero active candidates, refresh scheduler heartbeat,
+resume only with matching fresh pins, then dispatch one general candidate.
+Preserve the failed result. Only undispatched queued copies of this exact
+blocked tuple may be superseded.
+
+Cohort boundary remains `2026-08-30T08:28:35Z`. The existing status script
+reported 178 status-only passes; a fresh join to package results requiring
+the current pin, exact tuple, LocalSystem, 0/0/0/1 and VirusTotal 0/0 yielded
+20. Do not use the status-only number as proof of the strict 500 milestone.

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowInputs,
 } from './github-actions';
 import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
+import { QaCompatibilityGateError } from './qa/gate';
 
 const { enforceInstallerPreflightMock, enforceQaGateMock, reconcileCatalogInstallerMock, resolveDependenciesMock } = vi.hoisted(() => ({
   enforceInstallerPreflightMock: vi.fn(),
@@ -662,6 +663,29 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(enforceQaGateMock).toHaveBeenCalledWith(
       expect.objectContaining({ installerSha256: sha, requirePassed: true })
     );
+  });
+
+  it('never sends a customer Actions payload for the quarantined HEC-RAS tuple, even with override', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const tuple = {
+      wingetId: 'HydrologicEngineeringCenter.HEC-RAS',
+      version: '7.0',
+      architecture: 'x86' as const,
+      installerSha256: '166CA2458830C7646ECACD542C40C07E5DA7E48138BD81DA4EBEBD7B5C2A9532',
+    };
+    enforceQaGateMock.mockRejectedValueOnce(new QaCompatibilityGateError({
+      ...tuple, blockCode: 'failed_managed_lifecycle',
+    }));
+    await expect(triggerPackagingWorkflow(
+      workflowInputs({ ...tuple, sourceType: 'winget', qaOverride: true }),
+      config,
+      { skipRunCapture: true },
+    )).rejects.toBeInstanceOf(QaCompatibilityGateError);
+    expect(enforceQaGateMock).toHaveBeenCalledWith(expect.objectContaining({
+      ...tuple, qaOverride: true,
+    }));
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('uses qaOverride only at the server gate and does not forward it to GitHub', async () => {

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -112,13 +112,14 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
-  it('blocks an exact reviewed installer tuple before resolving dependencies', async () => {
+  it.each(['expired_signing_certificate', 'failed_managed_lifecycle'])(
+    'blocks an exact %s tuple before resolving dependencies', async (code) => {
     getPackageCompatibilityBlockMock.mockResolvedValue({
       wingetId: 'r12f.DivoomGateway',
       version: '0.1.42.0',
       architecture: 'x64',
       installerSha256: 'A'.repeat(64),
-      code: 'expired_signing_certificate',
+      code,
       detail: 'The signing certificate is expired.',
     });
     const client = { from: vi.fn() };

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -189,13 +189,14 @@ describe('enforceQaGate', () => {
     ).rejects.toBeInstanceOf(QaSecurityGateError);
   });
 
-  it('does not allow a QA override to bypass an exact compatibility block', async () => {
+  it.each(['expired_signing_certificate', 'failed_managed_lifecycle'])(
+    'does not allow a QA override to bypass an exact %s block', async (code) => {
     getPackageCompatibilityBlockMock.mockResolvedValueOnce({
       wingetId: 'r12f.DivoomGateway',
       version: '0.1.42.0',
       architecture: 'x64',
       installerSha256,
-      code: 'expired_signing_certificate',
+      code,
       detail: 'The signing certificate is expired.',
     });
 

--- a/supabase/migrations/20260909205230_quarantine_hecras_failed_managed_lifecycle.sql
+++ b/supabase/migrations/20260909205230_quarantine_hecras_failed_managed_lifecycle.sql
@@ -1,0 +1,38 @@
+-- Reviewed exact-payload quarantine, not a claim that all HEC-RAS releases
+-- lack unattended support. Run 33533285860 used the current shared packager
+-- d33825c2b786af7c3f22f4b828108c4129299ef9 and returned 60001/1/0/1.
+-- Published sanitized evidence proves exact MSI removal succeeded, but the
+-- install exception is unavailable to this operator. Do not guess switches,
+-- synthesize detection, or call this a VirusTotal finding (verdict was 0/0).
+-- Remove this reviewed block only after diagnosis and a controlled strict
+-- lifecycle retest; newer versions and changed payloads remain eligible.
+
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency',
+    'failed_managed_lifecycle'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id, version, architecture, installer_sha256, block_code, detail
+) values (
+  'HydrologicEngineeringCenter.HEC-RAS', '7.0', 'x86',
+  '166CA2458830C7646ECACD542C40C07E5DA7E48138BD81DA4EBEBD7B5C2A9532',
+  'failed_managed_lifecycle',
+  'Reviewed quarantine: isolated LocalSystem PSADT run 33533285860 returned install 60001, install detection 1, uninstall 0, removal detection 1. Exact MSI removal succeeded, but install validation failed. Root exception remains unverified; this payload requires diagnosis and controlled strict retest before release. VirusTotal was clean (0/0).'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    updated_at = now();

--- a/types/database.ts
+++ b/types/database.ts
@@ -329,6 +329,7 @@ export interface Database {
             | 'user_scope_elevation_required'
             | 'machine_scope_system_profile_install'
             | 'missing_authoritative_install_identity'
+            | 'failed_managed_lifecycle'
             | 'trusted_installer_tuple_unavailable'
             | 'unsupported_dependency_shape'
             | 'expired_signing_certificate'


### PR DESCRIPTION
HEC-RAS 7.0 x86 failed its isolated LocalSystem PSADT lifecycle in run 33533285860 with 60001/1/0/1. Exact MSI removal succeeded, but the install exception is not available in published telemetry and Windows denies access to the retained diagnostic. A guessed adapter would not be justified.

Add a reviewed `failed_managed_lifecycle` compatibility block for the exact installer SHA. The existing shared QA demand and customer dispatch gate rejects this tuple, including QA override, while future versions and payloads remain eligible. This is a reversible lifecycle quarantine, not a malware finding or permanent app exclusion. Preserve failed evidence and all security controls. The shared packager is unchanged, so both workflow pins remain d33825c2b786af7c3f22f4b828108c4129299ef9.

Validation: 60 focused QA gate, demand, compatibility, and customer GitHub Actions tests passed. Changelog validation passed. Required PR CI covers full tests, packager compilation, lint, and production build. After merge, apply only the included quarantine migration, verify the production block, and resume only with zero active candidates and identical fresh required/scheduler pins.

Evidence and recovery steps are recorded in docs/qa-hecras-20260909.md. The status helper's 178 figure is status-only; the included stricter current-pin cohort query yielded 20 at the immutable 2026-08-30T08:28:35Z boundary.
