### PR TITLE
fix: enable SketchUp 2025 unattended removal

### DIFF
--- a/.ugurlabs/entries/sketchup-2025-unattended-removal.json
+++ b/.ugurlabs/entries/sketchup-2025-unattended-removal.json
@@ -1,0 +1,5 @@
+{
+  "title": "SketchUp 2025 unattended removal",
+  "summary": "SketchUp 2025 packages now request silent removal through the registered vendor uninstaller, preventing an interactive prompt from stalling managed uninstallations.",
+  "type": "fixed"
+}

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -145,6 +145,26 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(JSON.parse(payload.client_payload.installer.successCodes)).toEqual([1223]);
   });
 
+  it('dispatches SketchUp 2025 unattended removal through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Trimble.SketchUp.2025',
+      displayName: 'SketchUp 2025',
+      publisher: 'Trimble, Inc.',
+      version: '25.0.660',
+      installerSha256: '0AB6635E4740F415FC102F4DE23E28F6DE95BF4085E84001791A17C5FCBF320E',
+      sourceType: 'winget',
+      installerType: 'exe',
+      silentSwitches: '/silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{BF6A8902-D556-5B2D-9FD7-83F19CE65B5C}:SketchUp 2025',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+    const payload = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(JSON.parse(payload.client_payload.config.psadtConfig))
+      .toMatchObject({ reviewedUninstallArguments: ['-silent'] });
+  });
+
   it('dispatches JetBrains Toolbox headless removal through the customer packager', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -765,6 +765,14 @@ describe('application packaging adapters', () => {
       ).reviewedUninstallArguments
     ).toEqual(['-silent']);
     expect(
+      applyApplicationPackagingAdapter('Trimble.SketchUp.2025', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).toEqual(['-silent']);
+    expect(
+      applyApplicationPackagingAdapter('Trimble.SketchUp.2025.Other', DEFAULT_PSADT_CONFIG)
+        .reviewedUninstallArguments
+    ).not.toContain('-silent');
+    expect(
       applyApplicationPackagingAdapter('Tricentis.NeoLoad', DEFAULT_PSADT_CONFIG)
         .reviewedUninstallArguments
     ).toEqual(['-q']);

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1596,6 +1596,15 @@ export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapte
     reviewedUninstallArguments: ['-silent'],
   },
   {
+    // QA run 34414113432 observed the exact SketchUp 2025 InstallShield
+    // registration invoking -remove -runfromtemp without unattended mode.
+    // Reuse the reviewed wrapper contract; retain exact registration lookup
+    // and bounded removal verification for QA and customer packages.
+    // https://forums.sketchup.com/t/unattended-uninstall-leaves-sketchup-entry-in-the-control-panel/342617
+    wingetId: 'Trimble.SketchUp.2025',
+    reviewedUninstallArguments: ['-silent'],
+  },
+  {
     // NeoLoad registers its install4j uninstaller without an unattended
     // argument. install4j documents -q for both installers and uninstallers;
     // append it to the exact captured registration instead of guessing a

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -161,6 +161,30 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.successCodes).toEqual([1223]);
   });
 
+  it('binds SketchUp 2025 QA and customer profiles to exact unattended removal', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Trimble.SketchUp.2025',
+      displayName: 'SketchUp 2025',
+      publisher: 'Trimble, Inc.',
+      version: '25.0.660',
+      architecture: 'x64',
+      installerSha256: '0AB6635E4740F415FC102F4DE23E28F6DE95BF4085E84001791A17C5FCBF320E',
+      installerType: 'exe',
+      silentSwitches: '/silent',
+      uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{BF6A8902-D556-5B2D-9FD7-83F19CE65B5C}:SketchUp 2025',
+      installScope: 'machine',
+    });
+    expect(normalized.identity.profile).toMatchObject({
+      installer: {
+        silentArgs: '/silent',
+        uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{BF6A8902-D556-5B2D-9FD7-83F19CE65B5C}:SketchUp 2025',
+      },
+      psadtConfig: { reviewedUninstallArguments: ['-silent'] },
+    });
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments)
+      .toEqual(['-silent']);
+  });
+
   it('binds JetBrains Toolbox customer packages to headless removal', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'JetBrains.Toolbox',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -11,6 +11,8 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 
 const packager = readFileSync(
   resolve(process.cwd(), '.github/scripts/Create-PSADTPackage.ps1'),
@@ -611,6 +613,39 @@ describe('PSADT vendor argument contract', () => {
       expect(uninstallFunction).toContain(
         '$registeredUninstallArguments += $reviewedArgument'
       );
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'executes SketchUp 2025 reviewed argument merging without duplicating silent mode',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe', 'SketchUp 2025', [],
+        applyApplicationPackagingAdapter('Trimble.SketchUp.2025', DEFAULT_PSADT_CONFIG),
+        [], 'Trimble.SketchUp.2025', 'SketchUp 2025', '25.0.660',
+        'REGISTRY_UNINSTALL_PRODUCT:{BF6A8902-D556-5B2D-9FD7-83F19CE65B5C}:SketchUp 2025',
+        '/silent'
+      );
+      const uninstall = generated.slice(generated.indexOf('function Uninstall-ADTDeployment'));
+      expect(uninstall).toContain("$configuredProductCode = '{BF6A8902-D556-5B2D-9FD7-83F19CE65B5C}'");
+      const configLine = uninstall.split('\n').find(line => line.includes('$reviewedUninstallArguments ='));
+      const merge = uninstall.match(/foreach \(\$reviewedArgument in \$reviewedUninstallArguments\) \{[\s\S]*?\$registeredUninstallArguments \+= \$reviewedArgument\s*\}\s*\}/)?.[0];
+      expect(configLine).toBeTruthy();
+      expect(merge).toBeTruthy();
+      const result = spawnSync('pwsh', ['-NoProfile', '-Command', `
+${configLine}
+$registeredUninstallArguments = @('-remove', '-runfromtemp')
+${merge}
+$first = @($registeredUninstallArguments)
+${merge}
+[pscustomobject]@{ First = $first; Repeated = @($registeredUninstallArguments) } | ConvertTo-Json -Compress
+`], { encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout.trim())).toEqual({
+        First: ['-remove', '-runfromtemp', '-silent'],
+        Repeated: ['-remove', '-runfromtemp', '-silent'],
+      });
+      expect(uninstall).toContain('The vendor uninstall command did not remove registration');
     }
   );
 
@@ -3743,7 +3778,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         'Array Config Contract App',
         [],
         [{ processesToClose: [] }]
-      )).toThrow('top-level PSADT_CONFIG value');
+      )).toThrow(/top-level PSADT_CONFIG\s+value/);
 
       expect(() => generateRegistryUninstallPackage(
         'inno',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -3778,7 +3778,7 @@ $ambiguous = Select-Localized @('Mozilla Firefox (x64 de)', 'Mozilla Firefox (x8
         'Array Config Contract App',
         [],
         [{ processesToClose: [] }]
-      )).toThrow(/top-level PSADT_CONFIG\s+value/);
+      )).toThrow(/top-level PSADT_CONFIG[\s|]+value/);
 
       expect(() => generateRegistryUninstallPackage(
         'inno',


### PR DESCRIPTION
SketchUp 2025 25.0.660 installed and detected under LocalSystem, but its registered InstallShield command (`-remove -runfromtemp`) remained interactive and retained the exact registration until the bounded uninstall deadline in QA run 34414113432.

Apply the existing reviewed SketchUp `-silent` removal argument to the exact 2025 catalog ID in the shared QA/customer adapter. Exact registration lookup, managed removal verification, and security checks remain enforced.

Validation: adapter, normalized profile, customer Actions payload, and executable generated PowerShell argument-merge coverage. Production build and lint pass (one existing lint warning). Full local suite ran: 98 suites passed; SQLite setup and PowerShell output wrapping are corrected and being rechecked. The existing translation-provider test uses a POSIX fake executable and times out on Windows; required Linux CI will verify the full suite. Public changelog JSON validates.

Vendor-family reference: https://forums.sketchup.com/t/unattended-uninstall-leaves-sketchup-entry-in-the-control-panel/342617
