### PR TITLE
chore: activate SketchUp 2025 shared packager repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'd33825c2b786af7c3f22f4b828108c4129299ef9',
+  packagerCommit: 'a27749fb895eaa142da413bb6b4b9ebaa5477ad4',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -582,6 +582,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Arvis now runs in the vendor-supported signed-in user context. Preserve
   // every unrelated compatible pass from the JS8Call exact-identity release.
   'f6bff5d1879b5cd11e285b1f1f0d140349d82215',
+  // SketchUp 2025 gains unattended removal. Other application profiles keep
+  // their existing execution behavior and remain eligible for compatibility.
+  'd33825c2b786af7c3f22f4b828108c4129299ef9',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,16 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries SketchUp 2025 only after its unattended removal activation', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Trimble.SketchUp.2025', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      'd33825c2b786af7c3f22f4b828108c4129299ef9',
+      { wingetId: 'Trimble.SketchUp.2025', status: 'failed' }
+    )).toBe(false);
+  });
   it('retries Retoolkit after activating the 45-minute bounded install wait', () => {
     const wingetId = 'mentebinaria.retoolkit';
     expect(shouldRetryTerminalToolchainCandidate(

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -666,6 +666,10 @@ const ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  'a27749fb895eaa142da413bb6b4b9ebaa5477ad4': [
+    'Trimble.SketchUp.2025',
+    ...ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
+  ],
   'd33825c2b786af7c3f22f4b828108c4129299ef9':
     ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
   'f6bff5d1879b5cd11e285b1f1f0d140349d82215':


### PR DESCRIPTION
Activate protected packager a27749fb895eaa142da413bb6b4b9ebaa5477ad4 from #1118 so normalized QA and customer package profiles include SketchUp 2025 unattended vendor removal. Add only SketchUp 2025 to the inherited bounded retry targets. Unrelated successful profiles retain compatibility; no prior result is relabeled as a current-pin strict pass.

Validation: 311 profile, customer payload, and retry-policy tests passed. Public changelog entries validate. Required CI checks the full suite, lint, and production build. Production remains paused during promotion.
