### PR TITLE
fix: hold SketchUp payload pending file reputation verification

### DIFF
--- a/.ugurlabs/entries/sketchup-2025-verification-hold.json
+++ b/.ugurlabs/entries/sketchup-2025-verification-hold.json
@@ -1,0 +1,5 @@
+{
+  "title": "SketchUp 2025 deployment availability",
+  "summary": "Automated deployment of SketchUp 2025 version 25.0.660 is temporarily unavailable while file reputation verification is pending. Its silent removal correction is retained for future eligible packages.",
+  "type": "maintenance"
+}

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -112,7 +112,7 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
-  it.each(['expired_signing_certificate', 'failed_managed_lifecycle'])(
+  it.each(['expired_signing_certificate', 'failed_managed_lifecycle', 'unverified_file_reputation'])(
     'blocks an exact %s tuple before resolving dependencies', async (code) => {
     getPackageCompatibilityBlockMock.mockResolvedValue({
       wingetId: 'r12f.DivoomGateway',

--- a/lib/qa/gate.test.ts
+++ b/lib/qa/gate.test.ts
@@ -189,7 +189,7 @@ describe('enforceQaGate', () => {
     ).rejects.toBeInstanceOf(QaSecurityGateError);
   });
 
-  it.each(['expired_signing_certificate', 'failed_managed_lifecycle'])(
+  it.each(['expired_signing_certificate', 'failed_managed_lifecycle', 'unverified_file_reputation'])(
     'does not allow a QA override to bypass an exact %s block', async (code) => {
     getPackageCompatibilityBlockMock.mockResolvedValueOnce({
       wingetId: 'r12f.DivoomGateway',

--- a/supabase/migrations/20260910000220_block_sketchup_unverified_file_reputation.sql
+++ b/supabase/migrations/20260910000220_block_sketchup_unverified_file_reputation.sql
@@ -1,0 +1,31 @@
+-- Exact-payload verification hold, not a malware finding or vendor-wide block.
+-- Run 34418186636 repaired SketchUp's managed lifecycle (0/0/0/1), but its
+-- protected hash lookup returned not_found, with no malicious/suspicious counts.
+-- Release this tuple only after clean 0/0 reputation evidence is verified.
+-- Future versions and changed payloads remain eligible through normal gates.
+alter table public.qa_package_blocks
+  drop constraint if exists qa_package_blocks_block_code_check;
+alter table public.qa_package_blocks
+  add constraint qa_package_blocks_block_code_check
+  check (block_code in (
+    'user_scope_machine_dependencies',
+    'user_scope_elevation_required',
+    'machine_scope_system_profile_install',
+    'missing_authoritative_install_identity',
+    'trusted_installer_tuple_unavailable',
+    'unsupported_dependency_shape',
+    'expired_signing_certificate',
+    'unreviewed_dependency',
+    'failed_managed_lifecycle',
+    'unverified_file_reputation'
+  ));
+
+insert into public.qa_package_blocks (
+  winget_id, version, architecture, installer_sha256, block_code, detail
+) values (
+  'Trimble.SketchUp.2025', '25.0.660', 'x64',
+  '0AB6635E4740F415FC102F4DE23E28F6DE95BF4085E84001791A17C5FCBF320E',
+  'unverified_file_reputation',
+  'Verification hold: shared PSADT LocalSystem run 34418186636 completed 0/0/0/1 on packager a27749fb895eaa142da413bb6b4b9ebaa5477ad4. VirusTotal returned not_found with null malicious/suspicious counts. Required clean 0/0 reputation evidence is unavailable. This is not a malware finding. Verify a clean report for this exact hash before releasing this tuple.'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do nothing;

--- a/types/database.ts
+++ b/types/database.ts
@@ -330,6 +330,7 @@ export interface Database {
             | 'machine_scope_system_profile_install'
             | 'missing_authoritative_install_identity'
             | 'failed_managed_lifecycle'
+            | 'unverified_file_reputation'
             | 'trusted_installer_tuple_unavailable'
             | 'unsupported_dependency_shape'
             | 'expired_signing_certificate'


### PR DESCRIPTION
SketchUp 2025 25.0.660 x64 now completes the corrected shared PSADT lifecycle with 0/0/0/1 under LocalSystem (run 34418186636), but the protected VirusTotal hash lookup returns not_found with null malicious/suspicious counts. It cannot satisfy the required strict reputation audit.

Add an exact installer-tuple verification hold through the existing shared QA/customer compatibility gate, with a distinct unverified_file_reputation reason. Preserve every existing block reason, the successful lifecycle evidence, and the shipped silent-removal adapter. This is not a malware finding; future versions and different payloads remain eligible. Releasing this tuple requires verified clean 0/0 reputation evidence for the exact hash.

Validation: 38 eligibility, QA demand, and customer gate tests pass, including refusal of qaOverride for the new reason. Changelog validation and diff checks pass. Required CI runs full tests, lint, and build. The migration adds an allowed reason and one tuple row; no authentication, grants, RLS, result rewriting, or packager-pin change.
