### PR TITLE
Block VCLibs 14 standalone deployment after AppX removal failure

### DIFF
--- a/.ugurlabs/entries/20260910-vclibs-availability.json
+++ b/.ugurlabs/entries/20260910-vclibs-availability.json
@@ -1,0 +1,5 @@
+{
+  "title": "VCLibs deployment availability",
+  "summary": "Standalone VCLibs 14 deployment is unavailable because Windows can prevent safe removal of the shared framework. Existing dependent applications are preserved.",
+  "type": "fixed"
+}

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -420,9 +420,12 @@ describe('POST /api/package (workflow dispatch)', () => {
     expect(triggerPackagingWorkflowMock).not.toHaveBeenCalled();
   });
 
-  it('blocks a retired catalog app before QA or customer packaging begins', async () => {
+  it.each([
+    ['Autodesk.DesktopApp', 'vendor_retired'],
+    ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
+  ])('blocks %s before QA or customer workflow payload creation', async (wingetId, code) => {
     getPackageEligibilityBlocksMock.mockResolvedValueOnce([
-      { wingetId: 'Autodesk.DesktopApp', code: 'vendor_retired' },
+      { wingetId, code },
     ]);
     const request = new NextRequest('http://localhost:3000/api/package', {
       method: 'POST',
@@ -432,8 +435,8 @@ describe('POST /api/package (workflow dispatch)', () => {
       },
       body: JSON.stringify({
         items: [makeWin32Item({
-          wingetId: 'Autodesk.DesktopApp',
-          displayName: 'Autodesk Desktop App',
+          wingetId,
+          displayName: wingetId,
         })],
       }),
     });
@@ -446,7 +449,7 @@ describe('POST /api/package (workflow dispatch)', () => {
       error: 'App unavailable',
       message: 'This app is not available for automated deployment.',
       code: 'PACKAGE_UNAVAILABLE',
-      package: { wingetId: 'Autodesk.DesktopApp' },
+      package: { wingetId },
     });
     expect(enforceInstallerPreflightMock).not.toHaveBeenCalled();
     expect(ensureQaDemandMock).not.toHaveBeenCalled();

--- a/docs/qa-vclibs-20260910.md
+++ b/docs/qa-vclibs-20260910.md
@@ -1,0 +1,44 @@
+# VCLibs standalone deployment eligibility
+
+Production auto-paused at 2026-09-10T03:53:13Z after candidate
+`2693e820-c5af-4045-b7b7-472bf036015b`, run
+https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34434594832.
+Fresh production and GitHub evidence confirmed zero active lifecycles.
+
+Microsoft.VCLibs.14 14.0.33519.0 x64 used shared packager
+`a27749fb895eaa142da413bb6b4b9ebaa5477ad4`, PSADT 4.1.8, LocalSystem,
+installer SHA `906CAD3B2BE067D816B20EA4EB1DF541F8A23AC4A4AA9FED70CE675CD918E6A6`,
+profile SHA `90B3B3AF52DC117C7B38F52F1615AEC56BCC83C643B161A5D40F247C7EEFC9BA`.
+The compact result has VirusTotal 0/0 and lifecycle tuple 0/0/60001/0.
+The generated machine MSIX uninstall removed provisioning then failed at
+`Remove-AppxPackage -AllUsers` for exact full identity
+`Microsoft.VCLibs.140.00_14.0.33519.0_x64__8wekyb3d8bbwe` with 0x80073CF3.
+Independent detection confirmed the framework remained. The bounded GitHub
+PSADT tail was available; the local diagnostic file was inaccessible.
+
+The official WinGet manifest identifies this as a nested MSIX framework:
+https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCLibs/14/14.0.33519.0/Microsoft.VCLibs.14.installer.yaml
+Microsoft documents 0x80073CF3 as dependency/update/conflict validation:
+https://learn.microsoft.com/en-us/windows/win32/appxpkg/troubleshooting
+
+Use the existing shared `package_eligibility_blocks` gate with
+`unsupported_managed_uninstall`. This follows the existing .NET Native Runtime
+framework policy. Do not remove dependent applications, force removal, or
+manufacture success. The failed row and security evidence stay intact. Only
+never-dispatched queued VCLibs.14 rows are superseded. VCLibs.Desktop.14 is a
+different identity and is not blocked by this migration.
+
+Regression coverage executes the QA demand and customer package API branches:
+blocked demand returns no candidate, and the customer route returns 409 before
+preflight, job creation, or GitHub Actions payload dispatch. No adapter, profile,
+generator, or pin change is required. Apply the migration only after protected
+PR merge; verify the shared block and paused/zero-active state, refresh enqueue,
+then resume only with matching required/scheduler pins and a fresh heartbeat.
+
+Reporting caveat: the guardian status script counted 182 distinct candidate
+passes after boundary `2026-08-30T08:28:35Z`. It does not enforce exact current
+pin or VirusTotal 0/0. At this audit, the only new IDs with passes on the current
+pin were SketchUp 2025 and WinDbg, both with VirusTotal `not_found` / null
+counts in committed results. Neither qualifies for the requested strict cohort.
+The five other evidence-join matches had pre-boundary passes. Thus the verified
+strict current-pin count is 0, and no completion milestone may be written.

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -78,13 +78,16 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     getPackageCompatibilityBlockMock.mockResolvedValue(null);
   });
 
-  it('does not queue or resolve dependencies for a retired catalog app', async () => {
+  it.each([
+    ['Example.App', 'vendor_retired'],
+    ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
+  ])('does not queue or resolve dependencies for blocked %s', async (wingetId, code) => {
     getPackageEligibilityBlocksMock.mockResolvedValue([
-      { wingetId: 'Example.App', code: 'vendor_retired' },
+      { wingetId, code },
     ]);
     const client = { from: vi.fn() };
 
-    const result = await ensureQaDemand(client as never, demandInput());
+    const result = await ensureQaDemand(client as never, { ...demandInput(), wingetId });
 
     expect(result).toMatchObject({
       state: 'failed',

--- a/supabase/migrations/20260910035807_block_vclibs_14_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260910035807_block_vclibs_14_unsupported_managed_uninstall.sql
@@ -1,0 +1,33 @@
+-- Exact isolated LocalSystem run 34434594832 installed/detected VCLibs 14
+-- 14.0.33519.0 x64, but Remove-AppxPackage -AllUsers failed with 0x80073CF3
+-- and removal detection remained 0 (present). This shared AppX framework
+-- cannot satisfy our standalone managed removal contract. Never remove its
+-- dependent applications or ignore the Windows dependency validation.
+-- Official identity: microsoft/winget-pkgs manifests/m/Microsoft/VCLibs/14/
+-- Microsoft error reference: https://learn.microsoft.com/en-us/windows/win32/appxpkg/troubleshooting
+-- This uses the existing customer packaging / QA eligibility gate; no
+-- generator behavior or packager pin changes are needed.
+insert into public.package_eligibility_blocks (winget_id, block_code, detail, source_url)
+values (
+  'Microsoft.VCLibs.14',
+  'unsupported_managed_uninstall',
+  'VCLibs 14 AppX framework 14.0.33519.0 x64 installs and detects under LocalSystem, but Windows rejects exact all-user removal with 0x80073CF3 dependency/conflict validation and the framework remains detected. Standalone automated deployment is blocked until a safe managed removal contract is available.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34434594832'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.VCLibs.14';
+
+-- Preserve the failed lifecycle and all security evidence. Only undispatched
+-- work is superseded; the block also prevents fresh demand and queue claims.
+update public.qa_candidates
+set status = 'superseded', finished_at = now(), updated_at = now(),
+    failure_summary = 'This app is not available for automated deployment.'
+where winget_id = 'Microsoft.VCLibs.14'
+  and status = 'queued' and dispatched_at is null and attempts = 0;


### PR DESCRIPTION
Microsoft.VCLibs.14 14.0.33519.0 x64 installed and detected under LocalSystem, but exact all-user AppX removal failed with 0x80073CF3 and left the framework detected (run 34434594832). Block standalone deployment through the existing shared customer/QA eligibility gate instead of attempting unsafe dependency removal.

The migration preserves the failed result and security evidence, clears catalog verification, and supersedes only never-dispatched queued rows for this exact WinGet ID. No generator or packager pin change is needed. Executable regression tests prove QA demand creates no candidate and the customer package API rejects the app before preflight, job creation, or GitHub workflow payload dispatch.

Validation: 67 focused tests passed; changelog validation and git diff checks passed. Required CI covers full tests, lint, packager build, and production build. The migration will be applied only after protected merge, then production pins/heartbeat and zero active lifecycles will be checked before resuming.
