### PR TITLE
Block VCLibs Desktop standalone deployment after removal failure

### DIFF
--- a/.ugurlabs/entries/20260910-vclibs-desktop-availability.json
+++ b/.ugurlabs/entries/20260910-vclibs-desktop-availability.json
@@ -1,0 +1,5 @@
+{
+  "title": "VCLibs Desktop deployment availability",
+  "summary": "Standalone VCLibs Desktop 14 deployment is unavailable because Windows can prevent safe removal of the shared framework. Existing dependent applications are preserved.",
+  "type": "fixed"
+}

--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -423,6 +423,7 @@ describe('POST /api/package (workflow dispatch)', () => {
   it.each([
     ['Autodesk.DesktopApp', 'vendor_retired'],
     ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
+    ['Microsoft.VCLibs.Desktop.14', 'unsupported_managed_uninstall'],
   ])('blocks %s before QA or customer workflow payload creation', async (wingetId, code) => {
     getPackageEligibilityBlocksMock.mockResolvedValueOnce([
       { wingetId, code },

--- a/docs/qa-vclibs-desktop-20260910.md
+++ b/docs/qa-vclibs-desktop-20260910.md
@@ -1,0 +1,41 @@
+# VCLibs Desktop standalone deployment eligibility
+
+Production auto-paused after candidate `2aeaf6a0-71b6-457f-80ca-d49d4fd32051`,
+run https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34436253877.
+Fresh production and GitHub state confirmed zero active lifecycles.
+
+Microsoft.VCLibs.Desktop.14 14.0.33728.0 x64 used PSADT 4.1.8 under
+LocalSystem, shared packager `a27749fb895eaa142da413bb6b4b9ebaa5477ad4`,
+installer SHA `EEBA62F08531C8669B3E5FB895CE8800AE66D798739CDA2B4AEF2A1D80A5F3C5`,
+and profile SHA `F8E6BFEC5EB35835580D8D280716B73505BA9944B79CFDAE839E69020223B975`.
+The compact result reports VirusTotal 0/0 and lifecycle 0/0/60001/0.
+The bounded PSADT GitHub diagnostic tail identifies `Remove-AppxPackage`
+rejecting exact identity
+`Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64__8wekyb3d8bbwe`
+with 0x80073CF3. Independent removal detection remained present.
+The permitted local diagnostic was inaccessible; no runner files were accessed.
+
+Official WinGet manifest:
+https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCLibs/Desktop/14/14.0.33728.0/Microsoft.VCLibs.Desktop.14.installer.yaml
+Microsoft documents dependency/update/conflict validation for this error:
+https://learn.microsoft.com/en-us/windows/win32/appxpkg/troubleshooting
+
+Use the existing shared `unsupported_managed_uninstall` eligibility gate for
+this exact WinGet ID. PR #1123 blocked the different Microsoft.VCLibs.14
+identity; this migration addresses the now-observed Desktop failure. Preserve
+failed evidence and supersede only never-dispatched queued rows. Do not remove
+dependent applications or bypass Windows framework validation.
+
+Executable QA demand and customer package route tests cover this ID: no
+dependency resolution or candidate creation, and HTTP 409 before preflight,
+job creation, or customer GitHub payload dispatch. No adapter/profile/generator
+change is needed. The shared packager pin remains unchanged.
+
+Apply only after protected merge and required CI. Verify the production block,
+deployment, and zero active lifecycles; refresh enqueue and resume only with
+matching required/scheduler pins and a fresh heartbeat. The blocked exact
+app/version/architecture must not be dispatched for another unsafe removal.
+
+The immutable cohort boundary remains 2026-08-30T08:28:35Z. The status helper's
+182 is a status-only total, not strict proof; audit exact evidence and VirusTotal
+0/0 before reporting progress or writing a milestone.

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -81,6 +81,7 @@ describe('ensureQaDemand app-version evidence reuse', () => {
   it.each([
     ['Example.App', 'vendor_retired'],
     ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
+    ['Microsoft.VCLibs.Desktop.14', 'unsupported_managed_uninstall'],
   ])('does not queue or resolve dependencies for blocked %s', async (wingetId, code) => {
     getPackageEligibilityBlocksMock.mockResolvedValue([
       { wingetId, code },

--- a/supabase/migrations/20260910042608_block_vclibs_desktop_14_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260910042608_block_vclibs_desktop_14_unsupported_managed_uninstall.sql
@@ -1,0 +1,28 @@
+-- Exact isolated LocalSystem run 34436253877: 14.0.33728.0 x64,
+-- lifecycle 0/0/60001/0. Windows rejected Remove-AppxPackage -AllUsers
+-- for Microsoft.VCLibs.140.00.UWPDesktop with 0x80073CF3. Do not force
+-- framework removal, remove dependent applications, or ignore the failure.
+-- Shared customer/QA eligibility gate; generator and pins are unchanged.
+insert into public.package_eligibility_blocks (winget_id, block_code, detail, source_url)
+values (
+  'Microsoft.VCLibs.Desktop.14',
+  'unsupported_managed_uninstall',
+  'VCLibs Desktop 14 AppX framework 14.0.33728.0 x64 installs and detects under LocalSystem, but Windows rejects exact all-user removal with 0x80073CF3 dependency/conflict validation and the framework remains detected. Standalone automated deployment is blocked until a safe managed removal contract is available.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34436253877'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'Microsoft.VCLibs.Desktop.14';
+
+-- Preserve failed lifecycle and security evidence, and all dispatched work.
+update public.qa_candidates
+set status = 'superseded', finished_at = now(), updated_at = now(),
+    failure_summary = 'This app is not available for automated deployment.'
+where winget_id = 'Microsoft.VCLibs.Desktop.14'
+  and status = 'queued' and dispatched_at is null and attempts = 0;


### PR DESCRIPTION
Microsoft.VCLibs.Desktop.14 14.0.33728.0 x64 installed and detected, but exact AppX removal returned Windows dependency/conflict error 0x80073CF3 and left the framework detected (run 34436253877). Block standalone deployment through the existing shared customer/QA eligibility gate.

The migration preserves failed and security evidence and supersedes only never-dispatched queued rows for this exact ID. Regression cases prove QA demand stops before dependency resolution or candidate creation, and the customer API returns 409 before preflight, jobs, or GitHub workflow payload dispatch. Generator behavior and packager pins are unchanged.

Validation: 69 focused tests passed; changelog validation and git diff checks passed. Required CI will validate full tests, lint, packager build, and production build. After protected merge, apply the migration while paused, verify the deployed gate and fresh matching pins with zero active lifecycles, then resume.
