### PR TITLE
Allow PostgreSQL vendor removal a bounded completion window

### DIFF
--- a/.ugurlabs/entries/20260910-postgresql-uninstall-timeout.json
+++ b/.ugurlabs/entries/20260910-postgresql-uninstall-timeout.json
@@ -1,0 +1,5 @@
+{
+  "title": "More reliable PostgreSQL removal",
+  "summary": "PostgreSQL packages allow more time for the vendor uninstaller to remove server components, while still verifying that removal finishes successfully.",
+  "type": "fixed"
+}

--- a/docs/qa-postgresql16-20260910.md
+++ b/docs/qa-postgresql16-20260910.md
@@ -1,0 +1,11 @@
+# PostgreSQL 16 removal repair
+
+Production auto-paused on candidate `42c342f8-7013-4fdd-942b-a5f4d3afd2a5`, run `34465115340`, PostgreSQL.PostgreSQL.16 16.15-3 x64. Initial fresh state: zero active, 193 queued; required and scheduler pin `a27749fb895eaa142da413bb6b4b9ebaa5477ad4`.
+
+The exact installer SHA is `5AE62E39571AAD71256AC20F769C01B6415E5DBB69A76B44EC643A42037FE45D`. Install/detect/uninstall/removal was `0/0/60001/0`, under LocalSystem, VT 0/0. The registered uninstaller was invoked with the existing unattended arguments. The five-minute completion deadline expired while exact registration `PostgreSQL 16` remained. The service and many installed files were removed by the vendor. Previous 16.15-1 passed in run 34412334941 with an uninstall duration near 280 seconds.
+
+Hypothesis: the generic five-minute deadline is too short for the vendor's bundled component removal. Give the existing versioned PostgreSQL adapter fifteen minutes, keeping exact registration verification and fail-closed marker handling. A retry of the exact failing tuple is required; this change alone does not establish a pass.
+
+Primary references: https://www.enterprisedb.com/docs/supported-open-source/postgresql/uninstalling/ and https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide/_uninstaller.html . No host installer execution or protected runner directory access was performed. The optional local diagnostic was inaccessible; bounded sanitized GitHub PSADT evidence supplied the exception and invocation.
+
+The legacy status helper reports 186/500 for boundary 2026-08-30T08:28:35Z but does not independently enforce all strict-result predicates. Do not certify that number without the strict evidence audit. Keep production paused until protected promotion, aligned fresh pins, and an isolated exact-tuple retry are ready.

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -228,6 +228,27 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     });
   });
 
+  it('dispatches the bounded PostgreSQL 16 removal lifecycle to customer packaging', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'PostgreSQL.PostgreSQL.16',
+      displayName: 'PostgreSQL 16',
+      publisher: 'PostgreSQL',
+      version: '16.15-3',
+      installerSha256: 'A'.repeat(64),
+      sourceType: 'winget',
+      silentSwitches: '--mode unattended --unattendedmodeui none',
+      uninstallCommand: 'REGISTRY_UNINSTALL:PostgreSQL 16',
+    }), config, { skipRunCapture: true });
+    const payload = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe('REGISTRY_UNINSTALL:PostgreSQL 16');
+    expect(JSON.parse(payload.client_payload.config.psadtConfig)).toMatchObject({
+      reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
+      uninstallCompletionTimeoutMinutes: 15,
+    });
+  });
+
   it('dispatches the reviewed Postgres Pro lifecycle through the customer packager', async () => {
     reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
       item: {

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -882,6 +882,7 @@ describe('application packaging adapters', () => {
     for (const wingetId of [
       'PostgreSQL.PostgreSQL.9.6',
       'PostgreSQL.PostgreSQL.13',
+      'PostgreSQL.PostgreSQL.16',
       'PostgreSQL.PostgreSQL.18',
       'postgresql.postgresql.19',
     ]) {
@@ -889,6 +890,8 @@ describe('application packaging adapters', () => {
         applyApplicationPackagingAdapter(wingetId, DEFAULT_PSADT_CONFIG)
           .reviewedUninstallArguments
       ).toEqual(['--mode', 'unattended', '--unattendedmodeui', 'none']);
+      expect(applyApplicationPackagingAdapter(wingetId, DEFAULT_PSADT_CONFIG)
+        .uninstallCompletionTimeoutMinutes).toBe(15);
     }
     expect(
       applyApplicationPackagingAdapter('PostgreSQL.pgAdmin', DEFAULT_PSADT_CONFIG)

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -75,6 +75,11 @@ const POSTGRESQL_PACKAGING_ADAPTER: ApplicationPackagingAdapter = {
   // unattended mode is supplied. Apply this to every versioned PostgreSQL
   // package ID so a new major release cannot silently lose the lifecycle fix.
   wingetId: 'PostgreSQL.PostgreSQL.*',
+  // The vendor removes its server and bundled components asynchronously.
+  // 16.15-1 needed 280 seconds; 16.15-3 was still removing files at the
+  // generic five-minute deadline (QA run 34465115340). Keep exact ARP
+  // removal authoritative while allowing a bounded fifteen-minute lifecycle.
+  uninstallCompletionTimeoutMinutes: 15,
   reviewedUninstallArguments: [
     '--mode',
     'unattended',

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -2090,6 +2090,29 @@ describe('PSADT QA package identity', () => {
     expect(profile.psadtConfig).toMatchObject(expectedConfig);
   });
 
+  it('binds PostgreSQL 16 to the bounded vendor removal lifecycle', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'PostgreSQL.PostgreSQL.16',
+      displayName: 'PostgreSQL 16',
+      publisher: 'PostgreSQL',
+      version: '16.15-3',
+      architecture: 'x64',
+      installerSha256: '5AE62E39571AAD71256AC20F769C01B6415E5DBB69A76B44EC643A42037FE45D',
+      installerType: 'exe',
+      silentSwitches: '--mode unattended --unattendedmodeui none',
+      uninstallCommand: 'REGISTRY_UNINSTALL:PostgreSQL 16',
+      installScope: 'machine',
+      detectionRules: '[]',
+      psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    const expectedConfig = {
+      reviewedUninstallArguments: ['--mode', 'unattended', '--unattendedmodeui', 'none'],
+      uninstallCompletionTimeoutMinutes: 15,
+    };
+    expect(JSON.parse(normalized.psadtConfigJson)).toMatchObject(expectedConfig);
+    expect(normalized.identity.profile).toMatchObject({ psadtConfig: expectedConfig });
+  });
+
   it('binds SSMS 21 Preview to the unattended Visual Studio Installer removal lifecycle', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.SQLServerManagementStudio.21.Preview',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -282,6 +282,22 @@ describe('PSADT Inno packaging contract', () => {
 
 describe('PSADT vendor argument contract', () => {
   it.runIf(canRunWindowsPowerShellPackager)(
+    'generates PostgreSQL 16 bounded removal without relaxing exact registration verification',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'exe', 'PostgreSQL 16', [],
+        applyApplicationPackagingAdapter('PostgreSQL.PostgreSQL.16', DEFAULT_PSADT_CONFIG),
+        [], 'PostgreSQL.PostgreSQL.16', 'PostgreSQL 16', '16.15-3',
+        'REGISTRY_UNINSTALL:PostgreSQL 16', '--mode unattended --unattendedmodeui none'
+      );
+      expect(generated).toContain('else { 15 }');
+      expect(generated).toContain('$uninstallDeadline = [DateTime]::UtcNow.AddMinutes($effectiveUninstallCompletionTimeoutMinutes)');
+      expect(generated).toContain('throw "The vendor uninstall command did not remove registration [$registeredUninstallRegistryKey] before the completion deadline."');
+      expect(generated).toContain("'--mode', 'unattended', '--unattendedmodeui', 'none'");
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'executes a reviewed archive batch from a confined temporary extraction',
     () => {
       const fixtureRoot = mkdtempSync(


### PR DESCRIPTION
PostgreSQL 16.15-3 installs and detects successfully, but the vendor removal exceeds the generic five-minute registration deadline. The shared versioned PostgreSQL adapter now allows fifteen minutes while retaining exact registration removal and fail-closed detection. This applies to both QA profiles and customer packages.

Validation: 249 focused adapter/profile/customer payload tests passed; generated Windows PowerShell package regression passed; changelog validation passed. Full tests, lint and production build are running locally; required clean-install CI must pass before merge. The production pipeline remains paused pending pin promotion and an exact 16.15-3 x64 lifecycle retry.

Evidence and official vendor references: docs/qa-postgresql16-20260910.md.
