### PR TITLE
Activate PostgreSQL repair with safely staged QA retry

### DIFF
--- a/app/api/cron/qa-enqueue/route.test.ts
+++ b/app/api/cron/qa-enqueue/route.test.ts
@@ -424,13 +424,36 @@ describe('GET /api/cron/qa-enqueue', () => {
     ]);
   });
 
-  it('does not poll or mutate the queue while maintenance is paused by the server switch', async () => {
+  it('queues only an explicit recovery target while paused without advancing background scans', async () => {
+    const { client, candidateInserts, cursorUpdates, pipelineControlUpdates, rpcCalls } = createSupabaseStub({
+      paused: true,
+      supportedApps: [
+        { winget_id: 'Opera.Opera', name: 'Opera', publisher: 'Opera', latest_version: '1.0.0' },
+        { winget_id: 'Unrelated.App', name: 'Unrelated', publisher: 'Example', latest_version: '1.0.0' },
+      ],
+      deployedApps: ['Opera.Opera', 'Unrelated.App'],
+      demandBackfillApps: ['Unrelated.App'],
+      catalogBackfillApps: ['Unrelated.App'],
+    });
+    createServerClientMock.mockReturnValue(client);
+    resolveManifestMock.mockResolvedValue(resolvedManifest());
+    const response = await GET(cronRequest('?id=Opera.Opera'));
+    expect(response.status).toBe(200);
+    expect(candidateInserts).toHaveLength(1);
+    expect(candidateInserts[0]).toMatchObject({ winget_id: 'Opera.Opera', status: 'queued' });
+    expect(detectWingetChangesMock).not.toHaveBeenCalled();
+    expect(cursorUpdates).toEqual([]);
+    expect(rpcCalls.some((call) => call.name === 'record_qa_demand_backfill_selection')).toBe(false);
+    expect(pipelineControlUpdates.some((update) => update.paused === false)).toBe(false);
+  });
+
+  it.each(['', '?id=Opera.Opera'])('keeps server maintenance authoritative for request %s', async (search) => {
     process.env.QA_MAINTENANCE_MODE = 'true';
     const { client, pollRunInserts, candidateInserts, pipelineControlUpdates } =
       createSupabaseStub({ paused: false });
     createServerClientMock.mockReturnValue(client);
 
-    const response = await GET(cronRequest());
+    const response = await GET(cronRequest(search));
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -451,13 +474,13 @@ describe('GET /api/cron/qa-enqueue', () => {
     ]);
   });
 
-  it('does not poll or mutate the queue when production serves the wrong packager release', async () => {
+  it.each(['', '?id=Opera.Opera'])('keeps the required release authoritative for request %s', async (search) => {
     const { client, pollRunInserts, candidateInserts } = createSupabaseStub({
       requiredPackagerCommit: 'F'.repeat(40),
     });
     createServerClientMock.mockReturnValue(client);
 
-    const response = await GET(cronRequest());
+    const response = await GET(cronRequest(search));
     const body = await response.json();
 
     expect(body).toMatchObject({

--- a/app/api/cron/qa-enqueue/route.ts
+++ b/app/api/cron/qa-enqueue/route.ts
@@ -561,7 +561,10 @@ export async function GET(request: Request) {
       startedAt
     );
     const control = await getQaPipelineControl(supabase);
-    if (control.paused || isQaMaintenanceMode()) {
+    // Authenticated, explicitly targeted recovery may prepare a queue row while
+    // dispatch remains paused. Never advance background scans in this mode.
+    const targetedRecovery = control.paused && requestedPackageIds.length > 0;
+    if ((control.paused && !targetedRecovery) || isQaMaintenanceMode()) {
       return NextResponse.json({
         success: true,
         paused: true,
@@ -611,7 +614,14 @@ export async function GET(request: Request) {
     const lookbackStart = new Date(
       Date.now() - INITIAL_LOOKBACK_MINUTES * 60 * 1000
     ).toISOString();
-    const changes = await detectWingetChanges({
+    const changes = targetedRecovery ? {
+      baseSha,
+      headSha: baseSha || '',
+      changedPackageIds: [] as string[],
+      etag: stateResult.data?.github_etag || null,
+      rateLimitedUntil: null,
+      comparisonTruncated: false,
+    } : await detectWingetChanges({
       token: process.env.GITHUB_PAT,
       baseSha,
       since: stateResult.data?.last_checked_at || lookbackStart,
@@ -649,9 +659,9 @@ export async function GET(request: Request) {
       );
     }
     const [backfill, demandBackfillIds, catalogBackfillIds] = await Promise.all([
-      findToolchainBackfillIds(supabase),
-      findDemandBackfillIds(supabase),
-      findIdleCatalogBackfillIds(supabase),
+      targetedRecovery ? { ids: [] as string[], pagesScanned: 0 } : findToolchainBackfillIds(supabase),
+      targetedRecovery ? [] as string[] : findDemandBackfillIds(supabase),
+      targetedRecovery ? [] as string[] : findIdleCatalogBackfillIds(supabase),
     ]);
     toolchainBackfillPagesScanned = backfill.pagesScanned;
     demandBackfillRequestedCount = demandBackfillIds.length;
@@ -833,10 +843,12 @@ export async function GET(request: Request) {
         .map((result) => result.winget_id)
     );
     supportedApps = supportedApps.filter((app) =>
-      demandedIds.has(app.winget_id) ||
-      backfillIds.has(app.winget_id) ||
-      catalogBackfillIdSet.has(app.winget_id) ||
-      (targetedIdSet.has(app.winget_id) && failedCatalogQaIds.has(app.winget_id))
+      (!targetedRecovery || targetedIdSet.has(app.winget_id)) && (
+        demandedIds.has(app.winget_id) ||
+        backfillIds.has(app.winget_id) ||
+        catalogBackfillIdSet.has(app.winget_id) ||
+        (targetedIdSet.has(app.winget_id) && failedCatalogQaIds.has(app.winget_id))
+      )
     );
     targetedCount = supportedApps.filter((app) => targetedIdSet.has(app.winget_id)).length;
     for (const app of supportedApps) {
@@ -1244,7 +1256,7 @@ export async function GET(request: Request) {
     // error; demanded apps that still lack QA are retried by the bounded
     // reconciliation query on subsequent polls. A GitHub rate-limit deferral
     // is different: no new comparison was performed, so preserve the cursor.
-    if (!changes.rateLimitedUntil) {
+    if (!targetedRecovery && !changes.rateLimitedUntil) {
       const { error: cursorError } = await supabase
         .from('qa_winget_poll_state')
         .update({

--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: 'a27749fb895eaa142da413bb6b4b9ebaa5477ad4',
+  packagerCommit: '0ff16a2420976f28a232ad1c015c8023f805fbb3',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -585,6 +585,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // SketchUp 2025 gains unattended removal. Other application profiles keep
   // their existing execution behavior and remain eligible for compatibility.
   'd33825c2b786af7c3f22f4b828108c4129299ef9',
+  // PostgreSQL receives a longer bounded vendor removal window. Its canonical
+  // config changes; unrelated matching execution profiles remain compatible.
+  'a27749fb895eaa142da413bb6b4b9ebaa5477ad4',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -1526,6 +1526,17 @@ describe('QA toolchain targeted retries', () => {
     )).toBe(false);
   });
 
+  it('adds PostgreSQL 16 to the bounded removal release without arbitrary retries', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      '0ff16a2420976f28a232ad1c015c8023f805fbb3',
+      { wingetId: 'PostgreSQL.PostgreSQL.16', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '0ff16a2420976f28a232ad1c015c8023f805fbb3',
+      { wingetId: 'Example.UnreviewedApp', status: 'failed' }
+    )).toBe(false);
+  });
+
   it('retries PostgreSQL 13 once with the family unattended lifecycle', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       '2c40f49e2cb0b5a1f7a1c27996f5aee72553a074',

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -666,6 +666,13 @@ const ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '0ff16a2420976f28a232ad1c015c8023f805fbb3': [
+    'PostgreSQL.PostgreSQL.16',
+    // Preserve existing unconsumed targets; security eligibility still blocks
+    // quarantined releases before a candidate can enter the VM.
+    'Trimble.SketchUp.2025',
+    ...ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
+  ],
   'a27749fb895eaa142da413bb6b4b9ebaa5477ad4': [
     'Trimble.SketchUp.2025',
     ...ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,


### PR DESCRIPTION
PostgreSQL 16.15-3 needs a longer bounded vendor-removal window. Activate protected shared packager 0ff16a2420976f28a232ad1c015c8023f805fbb3 (#1125) and its reviewed retry target.

The authenticated enqueue endpoint now permits explicitly named recovery targets while database dispatch is paused. It does not poll WinGet changes, advance background cursors, enqueue unrelated apps, or resume dispatch. Server maintenance and exact packager release checks remain authoritative. This lets an operator stage and prioritize the failed tuple before resuming one lifecycle.

Validation: 314 profile/retry/customer payload tests and 41 enqueue route tests passed; changed route lint passed. Full clean-install CI is required before merge. Both QA and customer workflow pins are promoted together in IntuneGet-Workflows#3296. Production stays paused until fresh scheduler alignment and exact-tuple staging.
