### PR TITLE
Fix transient QA polling warning

### DIFF
--- a/.ugurlabs/entries/20260910-qa-polling-status.json
+++ b/.ugurlabs/entries/20260910-qa-polling-status.json
@@ -1,0 +1,5 @@
+{
+  "title": "Clearer WinGet polling status",
+  "summary": "The live QA page now shows an active WinGet catalog check as scanning instead of briefly reporting a degraded service. A poll is only marked degraded when it actually fails or remains unfinished beyond the allowed window.",
+  "type": "fixed"
+}

--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -155,6 +155,7 @@ function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
 function ServiceHealth({ data }: { data: QaLiveResponse }) {
   const runnerAge = formatRelativeTime(data.runner.heartbeatAt, data.serverTime);
   const pollAge = formatRelativeTime(data.scheduler.lastPollAt, data.serverTime);
+  const pollIsRunning = data.scheduler.lastOutcome === 'running';
   const schedulerIssue = schedulerIssueLabel(data.scheduler.issue);
   const hasIncident = data.runner.state === 'stalled' || data.scheduler.state === 'degraded';
   const passCount = data.recent.filter((item) => item.outcome === 'Passed').length;
@@ -193,10 +194,16 @@ function ServiceHealth({ data }: { data: QaLiveResponse }) {
             <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>WinGet polling</T></p>
             <div className="mt-1 flex flex-wrap items-center gap-2">
               <StatusBadge tone={healthTone(data.scheduler.state)}>
-                <T>{data.scheduler.state === 'healthy' ? 'Healthy' : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
+                <T>{data.scheduler.state === 'healthy' ? (pollIsRunning ? 'Scanning' : 'Healthy') : data.scheduler.state === 'degraded' ? 'Degraded' : 'Waiting for first scan'}</T>
               </StatusBadge>
               <span className="text-xs text-text-muted">
-                {pollAge ? <T>Last scan <Var>{pollAge}</Var></T> : <T>No scan recorded yet</T>}
+                {pollIsRunning
+                  ? pollAge
+                    ? <T>Started <Var>{pollAge}</Var></T>
+                    : <T>Scanning now</T>
+                  : pollAge
+                    ? <T>Last scan <Var>{pollAge}</Var></T>
+                    : <T>No scan recorded yet</T>}
               </span>
             </div>
           </div>

--- a/lib/qa/live.test.ts
+++ b/lib/qa/live.test.ts
@@ -242,6 +242,32 @@ describe('buildQaLiveResponse', () => {
     }
   });
 
+  it('keeps a fresh in-progress poll healthy while it scans', () => {
+    const response = buildQaLiveResponse({
+      now: new Date('2026-08-08T17:00:00.000Z'),
+      current: null,
+      queuedCount: 0,
+      queued: [],
+      poll: {
+        status: 'running',
+        started_at: '2026-08-08T16:59:30.000Z',
+        finished_at: null,
+        errors: [],
+      },
+      consecutivePollFailures: 0,
+      recent: [],
+      apps: [],
+      frame: null,
+    });
+
+    expect(response.scheduler).toMatchObject({
+      state: 'healthy',
+      lastOutcome: 'running',
+      issue: null,
+      consecutiveFailures: 0,
+    });
+  });
+
   it('marks stale runners and abandoned poll runs as degraded', () => {
     const response = buildQaLiveResponse({
       now: new Date('2026-08-08T17:00:00.000Z'),

--- a/lib/qa/live.ts
+++ b/lib/qa/live.ts
@@ -261,8 +261,9 @@ function schedulerIssue(
   poll: PollRow | null,
   staleRunning: boolean
 ): QaLiveResponse['scheduler']['issue'] {
-  if (!poll || poll.status === 'succeeded') return null;
-  if (staleRunning) return 'stalled';
+  if (!poll) return null;
+  if (poll.status === 'running') return staleRunning ? 'stalled' : null;
+  if (poll.status === 'succeeded') return null;
   const errors = Array.isArray(poll.errors) ? poll.errors : [];
   const combined = errors.filter((error): error is string => typeof error === 'string').join(' ');
   if (


### PR DESCRIPTION
## Summary
- keep fresh in-progress WinGet polls healthy instead of mapping them to an upstream error
- show Scanning and the poll start age while a poll is active
- retain degraded states for stale polls and real failures
- add regression coverage and a public changelog entry

## Verification
- npm test -- lib/qa/live.test.ts
- npx eslint lib/qa/live.ts lib/qa/live.test.ts app/(marketing)/qa/QaLiveClient.tsx
- npm run build:ci
- node scripts/publish-changelog.mjs --validate
- local /qa browser verification against live data