### PR TITLE
Group catalog release history and stabilize release-note backfill

### DIFF
--- a/.ugurlabs/entries/grouped-release-history.json
+++ b/.ugurlabs/entries/grouped-release-history.json
@@ -1,0 +1,5 @@
+{
+  "title": "Release history grouped for easier scanning",
+  "summary": "Release history now groups apps into compact lists by date, with app icons, subtle row separators, and aligned version and report links. The loading skeleton follows the same layout. Release-note discovery also uses a targeted database index and bounded retries to avoid intermittent backfill timeouts.",
+  "type": "improved"
+}

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -46,23 +46,14 @@ export default function Loading() {
           <div className={`${bone} mb-10 h-5 w-3/4`} />
           <div className="grid gap-3 lg:grid-cols-[130px_1fr]">
             <div className={`${bone} mt-4 h-5 w-28`} />
-            <div className="min-w-0 space-y-2">
+            <div className="min-w-0 divide-y divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
               {[0, 1, 2, 3, 4].map((i) => (
-                <div
-                  key={i}
-                  className="grid gap-x-4 gap-y-2 rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 sm:grid-cols-[1fr_auto] sm:items-start"
-                >
-                  <div>
-                    <div className={`${bone} h-6 w-3/5`} />
-                  </div>
-                  <div className={`${bone} h-5 w-28`} />
-                  <div className="space-y-2 sm:col-span-2">
-                    <div className={`${bone} h-4 w-1/2`} />
-                    <div className="flex items-center justify-between border-t border-overlay/[0.06] pt-1.5">
-                      <div className={`${bone} h-8 w-44`} />
-                      <div className={`${bone} h-8 w-24`} />
-                    </div>
-                  </div>
+                <div key={i} className="grid grid-cols-[32px_minmax(0,1fr)] gap-x-3 gap-y-2 px-4 py-3 sm:grid-cols-[32px_minmax(0,1fr)_auto]">
+                  <div className={`${bone} col-start-1 row-start-1 row-span-3 h-8 w-8`} />
+                  <div className={`${bone} col-start-2 row-start-1 h-7 w-3/4`} />
+                  <div className={`${bone} col-start-2 h-7 w-36 sm:col-start-3 sm:row-start-1`} />
+                  <div className={`${bone} col-start-2 h-5 w-3/5 sm:row-start-2`} />
+                  <div className={`${bone} col-start-2 h-6 w-3/4 max-w-full sm:col-[2/-1] sm:row-start-3`} />
                 </div>
               ))}
             </div>

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -1,3 +1,4 @@
+import { AppIcon } from "@/components/AppIcon";
 import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 import Link from "next/link";
@@ -251,7 +252,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
           </p>
           <Link
             href="/apps/releases"
-            className="inline-flex min-h-8 items-center font-medium text-text-secondary underline decoration-overlay/20 underline-offset-4 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+            className="inline-flex min-h-6 items-center font-medium text-text-secondary underline decoration-overlay/20 underline-offset-4 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
           >
             <T>Clear filters</T>
           </Link>
@@ -299,14 +300,17 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                 >
                   <time dateTime={day}>{dateLabel(day)}</time>
                 </h2>
-                <ul className="min-w-0 space-y-2">
+                <ul className="min-w-0 divide-y divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
                   {rows.map((row) => (
                     <li
                       key={`${row.winget_id}:${row.version}`}
-                      className="grid min-w-0 gap-x-4 gap-y-2 rounded-xl border border-overlay/10 bg-bg-elevated px-4 py-3 shadow-sm transition-shadow hover:shadow-md sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start"
+                      className="grid min-w-0 grid-cols-[32px_minmax(0,1fr)] gap-x-3 gap-y-1 px-4 py-3 first:rounded-t-xl last:rounded-b-xl hover:bg-overlay/[0.025] focus-within:bg-overlay/[0.025] sm:grid-cols-[32px_minmax(0,1fr)_auto]"
                     >
+                      <div className="col-start-1 row-start-1 row-span-3 pt-0.5" aria-hidden="true">
+                        <AppIcon packageId={row.winget_id} packageName={row.name} size="sm" />
+                      </div>
                       <div className="min-w-0">
-                        <div className="flex min-h-8 flex-wrap items-center gap-x-2 gap-y-1">
+                        <div className="flex min-h-6 flex-wrap items-center gap-x-2 gap-y-1">
                           <Link
                             href={`/apps/${encodeURIComponent(row.winget_id)}`}
                             className="break-words text-[15px] font-semibold leading-6 text-text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
@@ -320,7 +324,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                           )}
                         </div>
                       </div>
-                      <div className="flex min-w-0 flex-wrap items-center gap-2 font-mono text-xs tabular-nums sm:max-w-72 sm:justify-end">
+                      <div className="col-start-2 flex min-w-0 flex-wrap items-center gap-2 font-mono text-xs tabular-nums sm:col-start-3 sm:row-start-1 sm:max-w-64 sm:justify-end">
                         {row.previous_version && (
                           <>
                             <span className="break-all text-text-muted">
@@ -336,7 +340,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                           {row.version}
                         </span>
                       </div>
-                      <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-muted sm:col-span-2">
+                      <div className="col-start-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-muted sm:row-start-2 sm:self-center">
                         <span className="break-all">{row.winget_id}</span>
                         {row.release_date && (
                           <span className="inline-flex items-center gap-1.5">
@@ -353,7 +357,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                           </span>
                         )}
                       </div>
-                      <div className="flex min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-overlay/[0.06] pt-1.5 text-xs text-text-muted sm:col-span-2">
+                      <div className="col-start-2 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted sm:col-[2/-1] sm:row-start-3 sm:justify-between">
                         {row.detailsUnavailable ? (
                           <p>
                             <T>
@@ -363,7 +367,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                           </p>
                         ) : (
                           <>
-                            <p className="flex min-h-8 flex-wrap items-center gap-x-2 gap-y-1">
+                            <p className="flex min-h-6 flex-wrap items-center gap-x-2 gap-y-1">
                               <span className="font-medium text-text-secondary">
                                 VirusTotal:
                               </span>
@@ -373,7 +377,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                     href={`https://www.virustotal.com/gui/file/${row.virusTotal.hash}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex min-h-8 items-center font-medium text-text-secondary underline decoration-overlay/20 underline-offset-4 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+                                    className="inline-flex min-h-6 items-center font-medium text-text-secondary underline decoration-overlay/20 underline-offset-4 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
                                   >
                                     {row.virusTotal.status === "found" &&
                                     row.virusTotal.total != null &&
@@ -395,7 +399,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                     ) : row.virusTotal.status === "error" ? (
                                       <T>Lookup unavailable</T>
                                     ) : (
-                                      <T>View report</T>
+                                      <T>Open report</T>
                                     )}
                                   </a>
                                   {row.virusTotal.architecture && (
@@ -417,7 +421,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                 href={row.release_notes_url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex min-h-8 shrink-0 items-center gap-1 font-medium text-text-secondary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+                                className="inline-flex min-h-6 shrink-0 items-center gap-1 font-medium text-text-secondary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
                               >
                                 <T>Release notes</T>
                                 <ArrowUpRight

--- a/scripts/backfill-release-note-links.mjs
+++ b/scripts/backfill-release-note-links.mjs
@@ -1,3 +1,4 @@
+import { withDatabaseRetry } from './release-note-db-retry.mjs';
 import { createClient } from '@supabase/supabase-js';
 import { createWingetManifestClient, manifestReleaseNotesUrl } from '../lib/winget-sync-resolution.mjs';
 
@@ -8,9 +9,9 @@ const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!url || !key) throw new Error('Supabase service credentials are required');
 const db = createClient(url, key, { auth: { persistSession: false } });
 const manifests = createWingetManifestClient({ token: process.env.GITHUB_TOKEN, preferRaw: true, maxRetries: 2 });
-const { data, error } = await db.from('version_history').select('id,winget_id,version')
-  .is('release_notes_url_checked_at', null).order('created_at', { ascending: false }).limit(limit);
-if (error) throw new Error(error.message);
+const { data } = await withDatabaseRetry(() => db.from('version_history').select('id,winget_id,version')
+  .is('release_notes_url_checked_at', null).order('created_at', { ascending: false }).order('id', { ascending: false }).limit(limit)
+  .abortSignal(AbortSignal.timeout(15_000)));
 let checked = 0, linked = 0, failed = 0;
 const queue = [...data];
 await Promise.all(Array.from({ length: 4 }, async () => {
@@ -18,10 +19,9 @@ await Promise.all(Array.from({ length: 4 }, async () => {
     try {
       const manifest = await manifests.fetchLocaleManifest(row.winget_id, row.version);
       const release_notes_url = manifestReleaseNotesUrl(manifest);
-      const { error: updateError } = await db.from('version_history').update({
+      await withDatabaseRetry(() => db.from('version_history').update({
         release_notes_url, release_notes_url_checked_at: new Date().toISOString(),
-      }).eq('id', row.id);
-      if (updateError) throw new Error(updateError.message);
+      }).eq('id', row.id).abortSignal(AbortSignal.timeout(15_000)));
       checked++; if (release_notes_url) linked++;
     } catch (error) {
       failed++;

--- a/scripts/release-note-db-retry.mjs
+++ b/scripts/release-note-db-retry.mjs
@@ -1,0 +1,10 @@
+/** Retry transient database responses using a fresh request on each attempt. */
+export async function withDatabaseRetry(operation, {sleep = ms => new Promise(resolve => setTimeout(resolve, ms))} = {}) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const result = await operation();
+    if (!result.error) return result;
+    const transient = result.status === 0 || result.status === 408 || result.status === 429 || result.status >= 500 || result.error.code === '57014' || result.error.code === '40001' || result.error.code === '40P01';
+    if (!transient || attempt === 2) throw new Error(`Release-note database request failed (${result.error.code || result.status || 'transport'})`);
+    await sleep(1000 * 2 ** attempt);
+  }
+}

--- a/scripts/release-note-db-retry.test.ts
+++ b/scripts/release-note-db-retry.test.ts
@@ -1,0 +1,14 @@
+import {it,expect,vi} from 'vitest';
+import {withDatabaseRetry} from './release-note-db-retry.mjs';
+it('retries statement timeout then returns the successful result',async()=>{
+ const op=vi.fn().mockResolvedValueOnce({error:{code:'57014'},status:500}).mockResolvedValueOnce({data:[{id:1}],error:null,status:200});
+ const sleep=vi.fn();
+ expect(await withDatabaseRetry(op,{sleep})).toMatchObject({data:[{id:1}]});
+ expect(op).toHaveBeenCalledTimes(2); expect(sleep).toHaveBeenCalledWith(1000);
+});
+it('bounds retries and rejects permanent permission errors immediately',async()=>{
+ const op=vi.fn().mockResolvedValue({error:{code:'57014'},status:500}); const sleep=vi.fn();
+ await expect(withDatabaseRetry(op,{sleep})).rejects.toThrow('57014'); expect(op).toHaveBeenCalledTimes(3);
+ const denied=vi.fn().mockResolvedValue({error:{code:'42501'},status:403});
+ await expect(withDatabaseRetry(denied,{sleep})).rejects.toThrow('42501'); expect(denied).toHaveBeenCalledTimes(1);
+});

--- a/supabase/migrations/20260910185530_index_pending_release_notes.sql
+++ b/supabase/migrations/20260910185530_index_pending_release_notes.sql
@@ -1,0 +1,5 @@
+-- Find unchecked versions directly instead of scanning already processed history.
+CREATE INDEX IF NOT EXISTS idx_version_history_pending_release_notes
+ON public.version_history (created_at DESC, id DESC)
+INCLUDE (winget_id, version)
+WHERE release_notes_url_checked_at IS NULL;


### PR DESCRIPTION
Group each date’s releases into a shared list with app icons, subtle separators, compact rows, and aligned version and report links. Match the loading skeleton to the grouped layout.

Prevent intermittent release-note backfill statement timeouts with an index over unchecked versions and bounded retries for transient database responses. The applied index reduced the measured selection query from 769 ms to 2.4 ms.

Validation: production build, lint, seven focused tests, changelog validation, and desktop/mobile browser checks.