### PR TITLE
Block GlassWire deployment until managed removal is supported

### DIFF
--- a/app/api/package/route.test.ts
+++ b/app/api/package/route.test.ts
@@ -422,6 +422,7 @@ describe('POST /api/package (workflow dispatch)', () => {
 
   it.each([
     ['Autodesk.DesktopApp', 'vendor_retired'],
+    ['GlassWire.GlassWire', 'unsupported_managed_uninstall'],
     ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
     ['Microsoft.VCLibs.Desktop.14', 'unsupported_managed_uninstall'],
   ])('blocks %s before QA or customer workflow payload creation', async (wingetId, code) => {

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -80,6 +80,7 @@ describe('ensureQaDemand app-version evidence reuse', () => {
 
   it.each([
     ['Example.App', 'vendor_retired'],
+    ['GlassWire.GlassWire', 'unsupported_managed_uninstall'],
     ['Microsoft.VCLibs.14', 'unsupported_managed_uninstall'],
     ['Microsoft.VCLibs.Desktop.14', 'unsupported_managed_uninstall'],
   ])('does not queue or resolve dependencies for blocked %s', async (wingetId, code) => {

--- a/supabase/migrations/20260911034018_block_glasswire_unsupported_managed_uninstall.sql
+++ b/supabase/migrations/20260911034018_block_glasswire_unsupported_managed_uninstall.sql
@@ -1,0 +1,34 @@
+-- GlassWire 3.10.1138 x64 installed/detected under LocalSystem, but its exact
+-- registered C:\Program Files\GlassWire\uninstall.exe /S left registration
+-- [GlassWire 3.10] after the 310-second deadline (0/0/60001/0).
+-- Evidence: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34558003501
+-- Vendor removal guide: https://www.glasswire.com/userguide/#Uninstall
+-- The current guide documents interactive removal; no reviewed alternative
+-- unattended removal contract is available. Block shared customer/QA demand
+-- until a supported lifecycle is established. Preserve the failed audit record.
+insert into public.package_eligibility_blocks (winget_id, block_code, detail, source_url)
+values (
+  'GlassWire.GlassWire',
+  'unsupported_managed_uninstall',
+  'GlassWire 3.10.1138 x64 installed and detected under LocalSystem, but the exact registered uninstaller with /S left GlassWire 3.10 registered after the 310-second completion deadline. Managed removal remains unverified; a supported unattended lifecycle is required before automated deployment can be enabled.',
+  'https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34558003501'
+)
+on conflict (winget_id) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    source_url = excluded.source_url,
+    updated_at = now();
+
+update public.curated_apps
+set is_verified = false
+where winget_id = 'GlassWire.GlassWire';
+
+-- Only undispatched demand is superseded; terminal/security evidence is retained.
+update public.qa_candidates
+set status = 'superseded', finished_at = coalesce(finished_at, now()),
+    failure_summary = 'This app is not available for automated deployment.',
+    updated_at = now()
+where winget_id = 'GlassWire.GlassWire'
+  and status = 'queued'
+  and dispatched_at is null
+  and github_run_id is null;


### PR DESCRIPTION
GlassWire 3.10.1138 x64 installed and detected under LocalSystem, but its exact registered uninstaller with `/S` left `GlassWire 3.10` registered after the 310-second deadline in QA run 34558003501 (0/0/60001/0). The vendor guide documents interactive removal; no reviewed alternative unattended contract was found.

Add an existing shared eligibility block so customer packaging and QA reject GlassWire before constructing workflows. Clear catalog verification and supersede only undispatched queued demand, preserving terminal and security evidence. No generator or packager pin changes are required.

Validation: 71 focused tests pass, including GlassWire rejection before QA demand/dependency resolution and customer workflow payload creation. Touched-file lint and git diff --check pass. Local full suite: 1,806 tests passed; one unrelated translation test fails because its POSIX fake npx is not used on Windows, and three worker errors report missing happy-dom in the existing dependency installation. Required CI uses a fresh npm ci and runs full tests, lint, packager compilation, and production build. Production remains paused until protected merge and verified application of this block.