### PR TITLE
Quarantine failed Copilot payload across QA and customer deployment

### DIFF
--- a/docs/qa/cohort-20260830-strict.sql
+++ b/docs/qa/cohort-20260830-strict.sql
@@ -19,8 +19,11 @@ with strict as (
     and r.virustotal_malicious = 0 and r.virustotal_suspicious = 0
     and r.packager_commit = ((c.test_config->>'packageProfileCanonicalJson')::jsonb#>>'{toolchain,packagerCommit}')
 ), historical as (
-  select distinct lower(trim(winget_id)) id from strict
-  where finished_at <= '2026-08-30T08:28:35Z'
+  -- Older compact-result rows may lack phase/context evidence. Conservatively
+  -- exclude every recorded historical pass rather than count uncertain IDs.
+  select distinct lower(trim(winget_id)) id from public.qa_candidates
+  where status = 'passed' and test_level = 'psadt-package'
+    and finished_at <= '2026-08-30T08:28:35Z'
 )
 select count(distinct lower(trim(s.winget_id))) strict_count,
        max(s.finished_at) latest_strict_finish

--- a/docs/qa/cohort-20260830-strict.sql
+++ b/docs/qa/cohort-20260830-strict.sql
@@ -1,0 +1,33 @@
+-- Exact current-pin evidence audit. The guardian status-only counter is broader.
+with strict as (
+  select c.winget_id, c.finished_at, c.version, c.architecture,
+         c.installer_sha256, r.packager_commit
+  from public.qa_candidates c
+  join public.qa_package_results r
+    on r.package_profile_sha256 = c.package_profile_sha256
+   and r.installer_sha256 = c.installer_sha256
+   and r.winget_id = c.winget_id
+   and r.tested_version = c.version
+   and r.architecture = c.architecture
+  where c.status = 'passed' and c.test_level = 'psadt-package'
+    and r.outcome = 'Passed'
+    and r.phase_results#>>'{install,exitCode}' = '0'
+    and r.phase_results#>>'{detectionAfterInstall,exitCode}' = '0'
+    and r.phase_results#>>'{uninstall,exitCode}' = '0'
+    and r.phase_results#>>'{detectionAfterUninstall,exitCode}' = '1'
+    and r.environment->>'executionContext' = 'LocalSystem'
+    and r.virustotal_malicious = 0 and r.virustotal_suspicious = 0
+    and r.packager_commit = ((c.test_config->>'packageProfileCanonicalJson')::jsonb#>>'{toolchain,packagerCommit}')
+), historical as (
+  select distinct lower(trim(winget_id)) id from strict
+  where finished_at <= '2026-08-30T08:28:35Z'
+)
+select count(distinct lower(trim(s.winget_id))) strict_count,
+       max(s.finished_at) latest_strict_finish
+from strict s
+where s.finished_at > '2026-08-30T08:28:35Z'
+  and s.packager_commit = (select required_packager_commit from public.qa_pipeline_control where id = 'global')
+  and not exists (select 1 from historical h where h.id = lower(trim(s.winget_id)))
+  and not exists (select 1 from public.package_eligibility_blocks b where lower(b.winget_id) = lower(s.winget_id))
+  and not exists (select 1 from public.qa_package_blocks b where b.winget_id = s.winget_id
+    and b.version = s.version and b.architecture = s.architecture and b.installer_sha256 = s.installer_sha256);

--- a/docs/qa/copilot-20260911.md
+++ b/docs/qa/copilot-20260911.md
@@ -34,3 +34,10 @@ The guardian status script's 195 count is based only on candidate status and
 test level. It does not check result phase exits, execution context, exact
 hash/profile, current pin or VirusTotal. Do not use that number to declare
 the immutable 2026-08-30T08:28:35Z cohort complete.
+
+At 08:13 UTC, 20 current-pin apps matched full result evidence when historical
+exclusion also required complete retained result evidence. Conservatively
+excluding every recorded pre-boundary pass leaves **7 verified apps**. Older
+result rows can lack phase/context evidence, so the 13 uncertain historical
+identities must not inflate the reported count. The committed audit query
+deliberately reports this conservative lower bound; the milestone is incomplete.

--- a/docs/qa/copilot-20260911.md
+++ b/docs/qa/copilot-20260911.md
@@ -1,0 +1,36 @@
+# Copilot exact-payload containment
+
+Production observation: 2026-09-11. Pipeline auto-paused, zero active lifecycles,
+129 queued. Failed candidate: `4a5328ee-dd82-4605-ab96-abcb7d30af8b`.
+GitHub run: https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34576597565
+
+Microsoft.365Copilot 19.2609.33020.0 x64 failed with phase exits
+`-2002583501/1/60001/1`. The vendor install exited before detection succeeded;
+the generated uninstall refused removal because zero exact ARP entries existed.
+The compact result and sanitized job tail agree. VirusTotal was clean (0/0).
+The designated host diagnostic could not be read due to its filesystem ACL;
+no runner directory was accessed.
+
+Official WinGet metadata identifies this EXE as user scope, supplies
+`--quiet --start -p`, and declares an MSIX identity:
+`Microsoft.MicrosoftOfficeHub_8wekyb3d8bbwe`. Microsoft's deployment guide
+documents elevation for those device-provisioning switches. The current
+profile instead uses user context and generic registry uninstall. A scope-only
+change would not establish correct MSIX detection or managed removal.
+The precise vendor exit-code cause has not been established.
+
+Sources:
+- https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/365Copilot/19.2609.33020.0/Microsoft.365Copilot.installer.yaml
+- https://learn.microsoft.com/en-us/microsoft-365/copilot/deploy-microsoft-365-copilot-app
+
+Containment uses the existing `failed_managed_lifecycle` exact-payload gate,
+shared by customer packaging and QA. It does not classify Microsoft software
+as malicious or block future versions/hashes. The failed candidate remains
+failed as evidence. No executable adapter or packager-pin change is necessary.
+Before removing the block, implement and review the complete scope, exact
+package identity, detection and managed removal contract and retest in isolation.
+
+The guardian status script's 195 count is based only on candidate status and
+test level. It does not check result phase exits, execution context, exact
+hash/profile, current pin or VirusTotal. Do not use that number to declare
+the immutable 2026-08-30T08:28:35Z cohort complete.

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -706,15 +706,14 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
   });
 
-  it('never sends a customer Actions payload for the quarantined HEC-RAS tuple, even with override', async () => {
+  it.each([
+    { wingetId: 'HydrologicEngineeringCenter.HEC-RAS', version: '7.0', architecture: 'x86' as const,
+      installerSha256: '166CA2458830C7646ECACD542C40C07E5DA7E48138BD81DA4EBEBD7B5C2A9532' },
+    { wingetId: 'Microsoft.365Copilot', version: '19.2609.33020.0', architecture: 'x64' as const,
+      installerSha256: '7B2A6D88E87F068E8775D1DE267EE932914F430BFA054A2012DEC43FA279E61A' },
+  ])('never sends a customer Actions payload for quarantined $wingetId, even with override', async (tuple) => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
-    const tuple = {
-      wingetId: 'HydrologicEngineeringCenter.HEC-RAS',
-      version: '7.0',
-      architecture: 'x86' as const,
-      installerSha256: '166CA2458830C7646ECACD542C40C07E5DA7E48138BD81DA4EBEBD7B5C2A9532',
-    };
     enforceQaGateMock.mockRejectedValueOnce(new QaCompatibilityGateError({
       ...tuple, blockCode: 'failed_managed_lifecycle',
     }));

--- a/lib/qa/demand.test.ts
+++ b/lib/qa/demand.test.ts
@@ -150,6 +150,26 @@ describe('ensureQaDemand app-version evidence reuse', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
+  it('blocks the failed Copilot profile before normalization or queue insertion', async () => {
+    const tuple = {
+      wingetId: 'Microsoft.365Copilot', version: '19.2609.33020.0',
+      architecture: 'x64' as const,
+      installerSha256: '7B2A6D88E87F068E8775D1DE267EE932914F430BFA054A2012DEC43FA279E61A',
+    };
+    getPackageCompatibilityBlockMock.mockResolvedValue({
+      ...tuple, code: 'failed_managed_lifecycle', detail: 'Reviewed compatibility quarantine.',
+    });
+    const client = { from: vi.fn() };
+    await expect(ensureQaDemand(client as never, {
+      ...demandInput(), ...tuple, installerType: 'exe', installScope: 'user',
+      silentSwitches: '--quiet --start -p',
+      uninstallCommand: 'REGISTRY_UNINSTALL:Microsoft 365 Copilot',
+    })).resolves.toMatchObject({ state: 'failed', candidateId: null });
+    expect(getPackageCompatibilityBlockMock).toHaveBeenCalledWith(client, tuple);
+    expect(resolveWingetPackageDependenciesMock).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
   it('persists dependency download metadata on a newly queued customer candidate', async () => {
     const dependency = {
       packageIdentifier: 'Microsoft.VCRedist.2015+.x64',

--- a/supabase/migrations/20260911080700_quarantine_copilot_failed_managed_lifecycle.sql
+++ b/supabase/migrations/20260911080700_quarantine_copilot_failed_managed_lifecycle.sql
@@ -1,0 +1,23 @@
+-- Exact-payload containment for candidate 4a5328ee-dd82-4605-ab96-abcb7d30af8b.
+-- Run 34576597565: user-context PSADT 4.1.8, packager
+-- 0ff16a2420976f28a232ad1c015c8023f805fbb3, tuple -2002583501/1/60001/1.
+-- The vendor process failed and no exact uninstall registration was found.
+-- Microsoft documents elevated device provisioning for --quiet --start -p:
+-- https://learn.microsoft.com/en-us/microsoft-365/copilot/deploy-microsoft-365-copilot-app
+-- The precise vendor exit cause remains unverified. Do not guess a scope-only
+-- repair without a verified package identity and managed removal contract.
+-- This is a compatibility quarantine, not a security finding (VT 0/0).
+-- Shared QA demand and customer packaging both enforce this immutable tuple.
+-- New versions/hashes remain eligible. Release only after controlled retest.
+insert into public.qa_package_blocks (
+  winget_id, version, architecture, installer_sha256, block_code, detail
+) values (
+  'Microsoft.365Copilot', '19.2609.33020.0', 'x64',
+  '7B2A6D88E87F068E8775D1DE267EE932914F430BFA054A2012DEC43FA279E61A',
+  'failed_managed_lifecycle',
+  'Reviewed compatibility quarantine: isolated PSADT run 34576597565 returned -2002583501/1/60001/1 in user context. Device-provisioning switches were invoked without elevation; vendor exit cause remains unverified and no exact uninstall registration was found. Requires reviewed install scope, exact package identity, managed removal and controlled retest before release. VirusTotal was clean (0/0).'
+)
+on conflict (winget_id, version, architecture, installer_sha256) do update
+set block_code = excluded.block_code,
+    detail = excluded.detail,
+    updated_at = now();


### PR DESCRIPTION
Microsoft.365Copilot 19.2609.33020.0 failed the isolated PSADT lifecycle with -2002583501/1/60001/1. Its user-scope EXE invokes device provisioning, while the generic ARP uninstall has no matching registration. Quarantine only that exact version/architecture/SHA through the existing shared QA/customer compatibility gate; future payloads remain eligible.

Adds regression coverage that rejects the failed profile before queue insertion and prevents customer Actions dispatch even with override. No executable packager changes or pin rotation. Preserves failure evidence and records the current-pin cohort audit query.

Validation: 69 focused tests passed; changed-test ESLint and changelog validation passed. Full Test, Lint and production Build must pass before merge. Apply the reviewed data migration while paused; verify the exact block and fresh aligned pins before guarded resume.
