### PR TITLE
Fix WithSecure Elements Agent unattended removal

### DIFF
--- a/.ugurlabs/entries/withsecure-silent-removal.json
+++ b/.ugurlabs/entries/withsecure-silent-removal.json
@@ -1,0 +1,5 @@
+{
+  "title": "WithSecure unattended removal",
+  "summary": "WithSecure Elements Agent packages now request the vendor's silent uninstall mode during managed removal.",
+  "type": "fixed"
+}

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -145,6 +145,22 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     expect(JSON.parse(payload.client_payload.installer.successCodes)).toEqual([1223]);
   });
 
+  it('dispatches WithSecure silent removal through the customer packager', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'WithSecure.ElementsAgent', displayName: 'WithSecure Elements Agent',
+      publisher: 'WithSecure', version: '26.3.298.0',
+      installerSha256: '1DC76B171B77161754BA6AC883CCFD2D7730D80E7A827779BAD905B1F9483D55',
+      sourceType: 'winget', installerType: 'msi', silentSwitches: '/quiet ALLUSERS=1',
+      uninstallCommand: 'msiexec /x "{26E3718A-7CCD-40E0-BE8B-7F1E756A05F5}" /qn /norestart',
+      installScope: 'machine',
+    }), config, { skipRunCapture: true });
+    const payload = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(JSON.parse(payload.client_payload.config.psadtConfig))
+      .toMatchObject({ reviewedUninstallArguments: ['--silent'] });
+  });
+
   it('dispatches SketchUp 2025 unattended removal through the customer packager', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -10,6 +10,12 @@ import {
 } from './packaging-adapters';
 
 describe('application packaging adapters', () => {
+  it('requires WithSecure unattended removal only for its exact application identity', () => {
+    expect(applyApplicationPackagingAdapter('WithSecure.ElementsAgent', DEFAULT_PSADT_CONFIG)
+      .reviewedUninstallArguments).toEqual(['--silent']);
+    expect(applyApplicationPackagingAdapter('WithSecure.Other', DEFAULT_PSADT_CONFIG)
+      .reviewedUninstallArguments).toEqual(DEFAULT_PSADT_CONFIG.reviewedUninstallArguments);
+  });
   it('attests Amazon Music as an argument-free unattended bootstrapper', () => {
     const adapted = applyApplicationPackagingAdapter(
       'Amazon.Music',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -144,6 +144,14 @@ const SSMS_VISUAL_STUDIO_INSTALLER_WINGET_IDS = [
  */
 export const APPLICATION_PACKAGING_ADAPTERS: readonly ApplicationPackagingAdapter[] = [
   {
+    // WithSecure's Intune deployment guide requires --silent for the registered
+    // OneClient uninstaller. QA run 34599096712 captured fs_uninstall_32.exe
+    // without arguments and correctly failed while its exact ARP key remained.
+    // https://support.withsecure.com/userguides/data/pdf/wseep_portal_adminguide_eng.pdf
+    wingetId: 'WithSecure.ElementsAgent',
+    reviewedUninstallArguments: ['--silent'],
+  },
+  {
     // Amazon's official WinGet submission intentionally declares its user-scope
     // bootstrapper without switches and passed Microsoft's unattended validation
     // (winget-pkgs#94441). Preserve that exact argument-free vendor contract.

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -459,6 +459,19 @@ describe('PSADT QA package identity', () => {
     ).toEqual(expected);
   });
 
+  it('binds WithSecure silent removal to the normalized QA profile', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'WithSecure.ElementsAgent', displayName: 'WithSecure Elements Agent',
+      publisher: 'WithSecure', version: '26.3.298.0', architecture: 'x64',
+      installerSha256: '1DC76B171B77161754BA6AC883CCFD2D7730D80E7A827779BAD905B1F9483D55',
+      installerType: 'msi', silentSwitches: '/quiet ALLUSERS=1',
+      uninstallCommand: 'msiexec /x "{26E3718A-7CCD-40E0-BE8B-7F1E756A05F5}" /qn /norestart',
+      installScope: 'machine',
+    });
+    expect(JSON.parse(normalized.psadtConfigJson).reviewedUninstallArguments).toEqual(['--silent']);
+    expect(normalized.identity.profile.psadtConfig.reviewedUninstallArguments).toEqual(['--silent']);
+  });
+
   it('binds FSLogix restart suppression to customer and QA package identity', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'Microsoft.FSLogix',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -633,6 +633,35 @@ describe('PSADT vendor argument contract', () => {
   );
 
   it.runIf(canRunWindowsPowerShellPackager)(
+    'executes WithSecure captured uninstall argument merging without install-only switches',
+    () => {
+      const generated = generateRegistryUninstallPackage(
+        'msi', 'WithSecure Elements Agent', [],
+        applyApplicationPackagingAdapter('WithSecure.ElementsAgent', DEFAULT_PSADT_CONFIG),
+        [], 'WithSecure.ElementsAgent', 'WithSecure Elements Agent', '26.3.298.0',
+        'REGISTRY_UNINSTALL_PRODUCT:{C9EF1C7D-16FA-4C43-B764-1A127CDBAECB}:WithSecure Elements Agent',
+        '/quiet ALLUSERS=1'
+      );
+      const uninstall = generated.slice(generated.indexOf('function Uninstall-ADTDeployment'));
+      const configLine = uninstall.split('\n').find(line => line.includes('$reviewedUninstallArguments ='));
+      const merge = uninstall.match(/foreach \(\$reviewedArgument in \$reviewedUninstallArguments\) \{[\s\S]*?\$registeredUninstallArguments \+= \$reviewedArgument\s*\}\s*\}/)?.[0];
+      expect(configLine).toBeTruthy();
+      expect(merge).toBeTruthy();
+      const result = spawnSync('pwsh', ['-NoProfile', '-Command', `
+${configLine}
+$registeredUninstallArguments = @()
+${merge}
+${merge}
+ConvertTo-Json -InputObject @($registeredUninstallArguments) -Compress
+`], { encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout.trim())).toEqual(['--silent']);
+      expect(uninstall).toContain("$configuredProductCode = '{C9EF1C7D-16FA-4C43-B764-1A127CDBAECB}'");
+      expect(uninstall).toContain('The vendor uninstall command did not remove registration');
+    }
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
     'executes SketchUp 2025 reviewed argument merging without duplicating silent mode',
     () => {
       const generated = generateRegistryUninstallPackage(


### PR DESCRIPTION
WithSecure Elements Agent 26.3.298.0 installed and detected in QA run 34599096712, but its captured `fs_uninstall_32.exe` ran without arguments and left exact registration `{C9EF1C7D-16FA-4C43-B764-1A127CDBAECB}` after the bounded removal deadline.

Apply WithSecure's documented `--silent` removal argument through the shared application adapter. Both normalized QA packages and customer GitHub Actions packages receive it. Exact registration removal, executable validation, and the existing completion deadline remain authoritative.

Vendor reference: https://support.withsecure.com/userguides/data/pdf/wseep_portal_adminguide_eng.pdf (Microsoft Intune deployment, registered OneClient uninstall command).

Validation: all 1,819 tests pass across 103 files, including the generated PowerShell executable argument-merging contract, normalized QA profile, and customer payload regressions. Lint has zero errors (one existing warning); TypeScript and the production build pass. Required protected CI passes. Production remains paused pending pin promotion and the exact isolated retry.
