### PR TITLE
Activate WithSecure shared removal repair

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '0ff16a2420976f28a232ad1c015c8023f805fbb3',
+  packagerCommit: '6bdefc387d1402c71d30a6fbfcf850038f60f37a',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -588,6 +588,8 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // PostgreSQL receives a longer bounded vendor removal window. Its canonical
   // config changes; unrelated matching execution profiles remain compatible.
   'a27749fb895eaa142da413bb6b4b9ebaa5477ad4',
+  // WithSecure gains silent removal; unchanged application profiles remain compatible.
+  '0ff16a2420976f28a232ad1c015c8023f805fbb3',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,16 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries WithSecure only on the reviewed silent-removal release', () => {
+    expect(shouldRetryTerminalToolchainCandidate(
+      QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'WithSecure.ElementsAgent', status: 'failed' }
+    )).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate(
+      '0ff16a2420976f28a232ad1c015c8023f805fbb3',
+      { wingetId: 'WithSecure.ElementsAgent', status: 'failed' }
+    )).toBe(false);
+  });
   it('retries SketchUp 2025 only after its unattended removal activation', () => {
     expect(shouldRetryTerminalToolchainCandidate(
       QA_PSADT_TOOLCHAIN.packagerCommit,

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -666,6 +666,13 @@ const ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '6bdefc387d1402c71d30a6fbfcf850038f60f37a': [
+    'WithSecure.ElementsAgent',
+    'PostgreSQL.PostgreSQL.16',
+    'Trimble.SketchUp.2025',
+    // Preserve prior unconsumed reviewed retries; security blocks remain authoritative.
+    ...ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
+  ],
   '0ff16a2420976f28a232ad1c015c8023f805fbb3': [
     'PostgreSQL.PostgreSQL.16',
     // Preserve existing unconsumed targets; security eligibility still blocks


### PR DESCRIPTION
Activate protected packager 6bdefc387d1402c71d30a6fbfcf850038f60f37a from #1135 for QA and customer package profiles. Preserve compatibility only for unchanged canonical application profiles. Validation: 150 profile and customer workflow tests pass; full repair suite and production build passed in #1135. Production stays paused until workflow pins and the fresh scheduler heartbeat agree.