### PR TITLE
feat(qa): add animated glow around VM preview

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.module.css
+++ b/app/(marketing)/qa/QaLiveClient.module.css
@@ -1,0 +1,58 @@
+@property --qa-viewer-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.viewerBorder {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  overflow: hidden;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 14px rgb(6 182 212 / 18%);
+}
+
+.viewerBorder::before,
+.viewerBorder::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  border-radius: inherit;
+  background: conic-gradient(
+    from var(--qa-viewer-angle),
+    rgb(6 182 212 / 20%),
+    #06b6d4 15%,
+    #a5f3fc 22%,
+    rgb(6 182 212 / 20%) 32%,
+    rgb(139 92 246 / 20%) 50%,
+    #8b5cf6 65%,
+    #c4b5fd 72%,
+    rgb(139 92 246 / 20%) 82%,
+    rgb(6 182 212 / 20%)
+  );
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  animation: viewerBorderOrbit 6s linear infinite;
+}
+
+.viewerBorder::after {
+  padding: 5px;
+  filter: blur(6px);
+  opacity: 0.65;
+}
+
+@keyframes viewerBorderOrbit {
+  to {
+    --qa-viewer-angle: 360deg;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .viewerBorder::before,
+  .viewerBorder::after {
+    animation: none;
+  }
+}

--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/lib/qa/presentation';
 import { cn } from '@/lib/utils';
 import type { QaLivePhase, QaLiveResponse, QaVirusTotalStatus } from '@/types/qa';
+import styles from './QaLiveClient.module.css';
 
 function healthTone(state: string): StatusTone {
   if (state === 'healthy' || state === 'testing' || state === 'idle') return 'success';
@@ -308,6 +309,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
                 className="relative -mx-5 aspect-video w-[calc(100%+2.5rem)] overflow-hidden bg-black sm:mx-0 sm:w-auto sm:rounded-xl lg:aspect-auto lg:min-h-[36rem]"
                 aria-label={`Preparing the isolated QA VM for ${next.displayName}`}
               >
+                <span className={styles.viewerBorder} aria-hidden="true" />
                 <div className="absolute inset-0 animate-shimmer bg-[radial-gradient(circle_at_center,rgba(8,145,178,0.12),transparent_45%)] motion-reduce:animate-none" />
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
                   <span className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-accent-cyan">
@@ -423,6 +425,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
             className="relative -mx-5 aspect-video w-[calc(100%+2.5rem)] overflow-hidden bg-black sm:mx-0 sm:w-auto sm:rounded-xl lg:aspect-auto lg:min-h-[36rem]"
             aria-labelledby="live-console-heading"
           >
+            <span className={styles.viewerBorder} aria-hidden="true" />
             <h3 id="live-console-heading" className="sr-only"><T>Live test VM</T></h3>
             {frameState === 'live' ? (
               <span className="absolute right-4 top-4 z-10 animate-pulse text-xs font-semibold uppercase tracking-[0.16em] text-status-success drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] motion-reduce:animate-none">


### PR DESCRIPTION
Adds a cyan-and-violet animated glow around the live VM screenshot area and its preparation state. The border stays static when reduced motion is enabled.

Validation: repository ESLint check, CSS parsing, and git diff whitespace check passed. Browser appearance has not been verified.
