### PR TITLE
fix(qa): strengthen VM preview border glow

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.module.css
+++ b/app/(marketing)/qa/QaLiveClient.module.css
@@ -11,7 +11,7 @@
   overflow: hidden;
   border-radius: inherit;
   pointer-events: none;
-  box-shadow: inset 0 0 14px rgb(6 182 212 / 18%);
+  box-shadow: inset 0 0 22px rgb(6 182 212 / 45%);
 }
 
 .viewerBorder::before,
@@ -19,19 +19,19 @@
   content: '';
   position: absolute;
   inset: 0;
-  padding: 2px;
+  padding: 4px;
   border-radius: inherit;
   background: conic-gradient(
     from var(--qa-viewer-angle),
-    rgb(6 182 212 / 20%),
-    #06b6d4 15%,
-    #a5f3fc 22%,
-    rgb(6 182 212 / 20%) 32%,
-    rgb(139 92 246 / 20%) 50%,
-    #8b5cf6 65%,
-    #c4b5fd 72%,
-    rgb(139 92 246 / 20%) 82%,
-    rgb(6 182 212 / 20%)
+    rgb(6 182 212 / 65%),
+    #22d3ee 15%,
+    #ecfeff 22%,
+    rgb(6 182 212 / 65%) 32%,
+    rgb(139 92 246 / 65%) 50%,
+    #a78bfa 65%,
+    #f5f3ff 72%,
+    rgb(139 92 246 / 65%) 82%,
+    rgb(6 182 212 / 65%)
   );
   mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   mask-composite: exclude;
@@ -39,9 +39,9 @@
 }
 
 .viewerBorder::after {
-  padding: 5px;
-  filter: blur(6px);
-  opacity: 0.65;
+  padding: 9px;
+  filter: blur(5px);
+  opacity: 0.9;
 }
 
 @keyframes viewerBorderOrbit {


### PR DESCRIPTION
The animated VM screenshot border was too faint. Increase its thickness from 2px to 4px, brighten the cyan and violet gradient, and strengthen the glow so it is easier to see against the screenshot.

Validation: repository ESLint, CSS parsing, and whitespace checks passed. Reduced-motion behavior is preserved.
