### PR TITLE
Make RSS subscriptions easy to copy into a reader

### DIFF
--- a/.ugurlabs/entries/release-rss-subscription-dialog.json
+++ b/.ugurlabs/entries/release-rss-subscription-dialog.json
@@ -1,0 +1,5 @@
+{
+  "title": "Copy release feed URLs directly into your RSS reader",
+  "summary": "Subscribe via RSS now opens a dialog with a selectable feed URL and a Copy URL button, instead of opening a raw feed that your browser may download. The URL follows the selected app or the full catalog. Copy confirmation and manual copying instructions make subscribing straightforward even when clipboard access is unavailable.",
+  "type": "fixed"
+}

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -1,4 +1,5 @@
 import { AppIcon } from "@/components/AppIcon";
+import { ReleaseFeedDialog } from "@/components/landing/ReleaseFeedDialog";
 import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 import Link from "next/link";
@@ -139,7 +140,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
 
         <div className="mb-5 flex flex-wrap gap-x-5 gap-y-2 text-sm">
           {filters.app && <Link href="/apps/releases" className="text-accent-cyan hover:underline"><T>All app releases</T></Link>}
-          <a href={`/apps/releases/feed${filters.app ? `?app=${encodeURIComponent(filters.app)}` : ""}`} className="text-accent-cyan hover:underline"><T>Subscribe via RSS</T></a>
+          <ReleaseFeedDialog key={filters.app ?? "all"} app={filters.app} />
         </div>
         {result && (
           <dl className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">

--- a/components/landing/ReleaseFeedDialog.tsx
+++ b/components/landing/ReleaseFeedDialog.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useId, useRef, useState } from "react";
+import { T } from "gt-next";
+import { Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+
+export function ReleaseFeedDialog({ app }: { app?: string }) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<"idle" | "copying" | "copied" | "error">("idle");
+  const feedUrl = `https://www.intuneget.com/apps/releases/feed${app ? `?app=${encodeURIComponent(app)}` : ""}`;
+
+  async function copyUrl() {
+    setStatus("copying");
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={() => setStatus("idle")}>
+      <DialogTrigger asChild>
+        <button type="button" className="rounded-sm text-accent-cyan hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan">
+          <T>Subscribe via RSS</T>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain motion-reduce:animate-none">
+        <DialogHeader className="pr-12">
+          <DialogTitle><T>Subscribe via RSS</T></DialogTitle>
+          <DialogDescription className="mt-2">
+            <T>Copy this URL and paste it into your RSS reader to follow release updates.</T>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 p-6">
+          {app && <p className="break-words text-sm text-text-secondary" translate="no">{app}</p>}
+          <label htmlFor={inputId} className="block text-sm font-medium text-text-primary"><T>Feed URL</T></label>
+          <input
+            ref={inputRef} id={inputId} name="feedUrl" type="url" readOnly value={feedUrl}
+            autoComplete="off" spellCheck={false} translate="no"
+            onFocus={(event) => event.currentTarget.select()}
+            className="w-full min-w-0 rounded-lg border border-overlay/15 bg-bg-elevated px-3 py-2.5 text-base text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan sm:text-sm"
+          />
+          <Button type="button" onClick={copyUrl} disabled={status === "copying"} className="w-full bg-accent-cyan text-white hover:bg-accent-cyan/90 sm:w-auto">
+            {status === "copied" ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+            {status === "copied" ? <T>Copied</T> : status === "copying" ? <T>Copying…</T> : <T>Copy URL</T>}
+          </Button>
+          <p role="status" className="text-sm text-text-secondary">
+            {status === "copied" && <T>Feed URL copied. Paste it into your RSS reader.</T>}
+            {status === "error" && <T>Automatic copying is unavailable. Select and copy the URL above.</T>}
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Subscribe via RSS now opens a dialog with the absolute feed URL and a Copy URL action. It preserves the selected app, confirms successful copying, and provides a selectable URL with manual instructions when clipboard access is unavailable. This avoids opening the raw feed as a browser download while retaining the existing RSS endpoint and reader discovery metadata.

Validation: TypeScript, full repository lint, RSS feed tests, and changelog validation passed. Browser verification covered copying, keyboard dismissal and focus restoration, app-specific URLs, and a 390px mobile layout without horizontal overflow.