### PR TITLE
fix(qa): fill VM viewer with live frames

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -133,7 +133,7 @@ function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
           unoptimized
           loading="eager"
           sizes="(min-width: 1024px) 960px, 100vw"
-          className="animate-fade-in object-contain motion-reduce:animate-none"
+          className="animate-fade-in object-fill motion-reduce:animate-none"
         />
       ) : null}
       {src !== visibleSrc ? (
@@ -145,7 +145,7 @@ function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
           unoptimized
           loading="eager"
           sizes="(min-width: 1024px) 960px, 100vw"
-          className="object-contain opacity-0"
+          className="object-fill opacity-0"
           onLoad={() => setVisibleSrc(src)}
         />
       ) : null}


### PR DESCRIPTION
Resize live VM frames to fill the viewer in both the visible and preloaded image paths. This avoids layout letterboxing while retaining the full desktop, including the taskbar, with some stretching when aspect ratios differ.

Companion capture fix removes black side bars embedded by Hyper-V before telemetry is drawn: https://github.com/ugurkocde/IntuneGet-Workflows/pull/3465

Validation: repository ESLint passed.
