### PR TITLE
fix(qa): soften preview glow and move it outside the frame

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.module.css
+++ b/app/(marketing)/qa/QaLiveClient.module.css
@@ -6,12 +6,10 @@
 
 .viewerBorder {
   position: absolute;
-  inset: 0;
-  z-index: 20;
-  overflow: hidden;
-  border-radius: inherit;
+  inset: -2px;
+  z-index: -1;
+  border-radius: calc(0.75rem + 2px);
   pointer-events: none;
-  box-shadow: inset 0 0 22px rgb(6 182 212 / 45%);
 }
 
 .viewerBorder::before,
@@ -19,19 +17,19 @@
   content: '';
   position: absolute;
   inset: 0;
-  padding: 4px;
+  padding: 2px;
   border-radius: inherit;
   background: conic-gradient(
     from var(--qa-viewer-angle),
-    rgb(6 182 212 / 65%),
-    #22d3ee 15%,
-    #ecfeff 22%,
-    rgb(6 182 212 / 65%) 32%,
-    rgb(139 92 246 / 65%) 50%,
-    #a78bfa 65%,
-    #f5f3ff 72%,
-    rgb(139 92 246 / 65%) 82%,
-    rgb(6 182 212 / 65%)
+    rgb(6 182 212 / 35%),
+    #06b6d4 15%,
+    #a5f3fc 22%,
+    rgb(6 182 212 / 35%) 32%,
+    rgb(139 92 246 / 35%) 50%,
+    #8b5cf6 65%,
+    #c4b5fd 72%,
+    rgb(139 92 246 / 35%) 82%,
+    rgb(6 182 212 / 35%)
   );
   mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   mask-composite: exclude;
@@ -39,9 +37,8 @@
 }
 
 .viewerBorder::after {
-  padding: 9px;
-  filter: blur(5px);
-  opacity: 0.9;
+  filter: blur(4px);
+  opacity: 0.45;
 }
 
 @keyframes viewerBorderOrbit {

--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -306,21 +306,23 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
 
             <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_360px] xl:grid-cols-[minmax(0,1fr)_400px]">
               <div
-                className="relative -mx-5 aspect-video w-[calc(100%+2.5rem)] self-start overflow-hidden bg-black sm:mx-0 sm:w-auto sm:rounded-xl"
+                className="relative isolate aspect-video w-full self-start rounded-xl"
                 aria-label={`Preparing the isolated QA VM for ${next.displayName}`}
               >
                 <span className={styles.viewerBorder} aria-hidden="true" />
-                <div className="absolute inset-0 animate-shimmer bg-[radial-gradient(circle_at_center,rgba(8,145,178,0.12),transparent_45%)] motion-reduce:animate-none" />
-                <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
-                  <span className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-accent-cyan">
-                    <span className="absolute inset-0 animate-ping rounded-2xl border border-accent-cyan/20 motion-reduce:animate-none" aria-hidden="true" />
-                    <Monitor className="h-7 w-7" aria-hidden="true" />
-                  </span>
-                  <div>
-                    <p className="font-medium text-white/85"><T>Preparing a clean test VM</T></p>
-                    <p className="mt-1 max-w-md text-sm text-white/50">
-                      <T>The runner will start <Var>{next.displayName}</Var> automatically and the live preview will appear here.</T>
-                    </p>
+                <div className="absolute inset-0 overflow-hidden rounded-[inherit] bg-black">
+                  <div className="absolute inset-0 animate-shimmer bg-[radial-gradient(circle_at_center,rgba(8,145,178,0.12),transparent_45%)] motion-reduce:animate-none" />
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
+                    <span className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-accent-cyan">
+                      <span className="absolute inset-0 animate-ping rounded-2xl border border-accent-cyan/20 motion-reduce:animate-none" aria-hidden="true" />
+                      <Monitor className="h-7 w-7" aria-hidden="true" />
+                    </span>
+                    <div>
+                      <p className="font-medium text-white/85"><T>Preparing a clean test VM</T></p>
+                      <p className="mt-1 max-w-md text-sm text-white/50">
+                        <T>The runner will start <Var>{next.displayName}</Var> automatically and the live preview will appear here.</T>
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -422,7 +424,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
 
         <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_360px] xl:grid-cols-[minmax(0,1fr)_400px]">
           <div
-            className="relative -mx-5 aspect-video w-[calc(100%+2.5rem)] self-start overflow-hidden bg-black sm:mx-0 sm:w-auto sm:rounded-xl"
+            className="relative isolate aspect-video w-full self-start rounded-xl"
             aria-labelledby="live-console-heading"
           >
             <span className={styles.viewerBorder} aria-hidden="true" />
@@ -432,7 +434,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
                 <T>Live</T>
               </span>
             ) : null}
-            <div className="absolute inset-0">
+            <div className="absolute inset-0 overflow-hidden rounded-[inherit] bg-black">
               {data.viewer.available && data.viewer.sequence != null && data.viewer.candidateId ? (
                 <LiveFrameImage
                   key={data.viewer.candidateId}


### PR DESCRIPTION
The preview glow was overlapping the VM desktop and looked too heavy. Put the animated border behind an opaque, rounded screenshot layer, move the 2px border outside the frame, and reduce the gradient and halo intensity. Keep enough mobile gutter for the outer glow to remain visible.

Validation: repository ESLint, CSS parsing, and whitespace checks passed. Reduced-motion behavior is preserved.
