### PR TITLE
Recover release metadata and improve history accessibility

### DIFF
--- a/.ugurlabs/entries/release-history-reliability-accessibility.json
+++ b/.ugurlabs/entries/release-history-reliability-accessibility.json
@@ -1,0 +1,5 @@
+{
+  "title": "More reliable release details and clearer catalog history",
+  "summary": "Release history now retries failed metadata groups as individual records and avoids caching incomplete results. App history links stay available even when release notes or scan details cannot be loaded. Clearer full-catalog check timestamps, queued-sync labels and UTC headings explain freshness accurately. RSS uses the canonical website address and a higher-contrast copy button. Narrow-screen summaries, translated filter labels, accessible version transitions and recovery from out-of-range page links improve browsing.",
+  "type": "fixed"
+}

--- a/app/(marketing)/apps/releases/loading.tsx
+++ b/app/(marketing)/apps/releases/loading.tsx
@@ -26,7 +26,7 @@ export default function Loading() {
             </div>
             <div className={`${bone} mt-5 h-5 w-72 max-w-full`} />
           </div>
-          <div className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
+          <div className="mb-8 grid grid-cols-1 divide-y min-[360px]:grid-cols-3 min-[360px]:divide-y-0 min-[360px]:divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
             {[0, 1, 2].map((i) => (
               <div key={i} className="px-3 py-5 sm:px-6">
                 <div className={`${bone} h-5 w-4/5`} />

--- a/app/(marketing)/apps/releases/page.tsx
+++ b/app/(marketing)/apps/releases/page.tsx
@@ -3,6 +3,9 @@ import { ReleaseFeedDialog } from "@/components/landing/ReleaseFeedDialog";
 import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getGT } from "gt-next/server";
+import { CompleteHistoryError, requireCompleteHistory } from "@/lib/catalog/release-history-cache";
 import { ArrowRight, ArrowUpRight, CalendarDays, Search } from "lucide-react";
 import { T, Var } from "gt-next";
 import { Header } from "@/components/landing/Header";
@@ -38,9 +41,9 @@ export async function generateMetadata({
   };
 }
 const loadHistory = unstable_cache(
-  (filters: ReleaseHistoryFilters) =>
-    getCatalogSource().getReleaseHistory(filters),
-  ["catalog-release-history-v6"],
+  async (filters: ReleaseHistoryFilters) =>
+    requireCompleteHistory(await getCatalogSource().getReleaseHistory(filters)),
+  ["catalog-release-history-v7"],
   { revalidate: 300 },
 );
 const dateFormat = new Intl.DateTimeFormat("en-GB", {
@@ -66,7 +69,11 @@ const control =
 
 export default async function CatalogReleasesPage({ searchParams }: Props) {
   const filters = parseHistoryFilters(await searchParams);
-  const result = await loadHistory(filters).catch(() => null);
+  const gt = await getGT();
+  const result = await loadHistory(filters).catch(error => error instanceof CompleteHistoryError ? error.result : null);
+  if (result && filters.page > Math.max(1, Math.ceil(result.total / 40))) {
+    redirect(historyUrl(filters, Math.max(1, Math.ceil(result.total / 40))));
+  }
   const groups = new Map<string, NonNullable<typeof result>["rows"]>();
   for (const row of result?.rows ?? []) {
     const day = new Date(row.detected_at).toISOString().slice(0, 10);
@@ -76,8 +83,10 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
   const sync = result?.sync;
   const completed = sync?.status === "success" || sync?.status === "partial";
   const status = sync?.status === "running"
-    ? "Catalog sync in progress"
-    : sync ? "Latest sync failed" : "History from the catalog snapshot";
+    ? gt("Catalog sync in progress")
+    : sync?.status === "pending" ? gt("Catalog sync queued")
+    : sync?.status === "failed" || sync?.status === "error" ? gt("Latest sync failed")
+    : sync ? gt("Catalog sync has not completed") : gt("History from the catalog snapshot");
 
   return (
     <div className="flex min-h-screen flex-col bg-bg-deepest">
@@ -111,11 +120,11 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
             <aside className="mt-5 text-sm text-text-muted">
               {!completed && (
                 <p className="mb-2 font-medium text-text-secondary">
-                  <T><Var>{status}</Var></T>
+                  {status}
                 </p>
               )}
               <p>
-                <T>Catalog last checked:</T>{" "}
+                <T>Last completed full catalog check:</T>{" "}
                 {sync?.lastSuccessfulAt ? (
                   <time dateTime={sync.lastSuccessfulAt}>
                     {syncDateFormat.format(new Date(sync.lastSuccessfulAt))}{" "}
@@ -143,11 +152,11 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
           <ReleaseFeedDialog key={filters.app ?? "all"} app={filters.app} />
         </div>
         {result && (
-          <dl className="mb-8 grid grid-cols-3 divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
+          <dl className="mb-8 grid grid-cols-1 divide-y min-[360px]:grid-cols-3 min-[360px]:divide-y-0 min-[360px]:divide-x divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
             {[
-              ["Versions recorded", result.total],
-              ["Apps represented", result.apps],
-              ["First tracked apps", result.firstTracked],
+              [gt("Versions recorded"), result.total],
+              [gt("Apps represented"), result.apps],
+              [gt("First tracked apps"), result.firstTracked],
             ].map(([label, value]) => (
               <div key={label} className="px-3 py-5 sm:px-6">
                 <dt className="text-sm text-text-secondary">
@@ -187,7 +196,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                 autoComplete="off"
                 maxLength={120}
                 defaultValue={filters.query}
-                placeholder="Name, publisher, or WinGet ID…"
+                placeholder={gt("Name, publisher, or WinGet ID…")}
                 className={`${control} pl-10`}
               />
             </div>
@@ -205,7 +214,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
               defaultValue={filters.month}
               className={control}
             >
-              <option value="">All months</option>
+              <option value="">{gt("All months")}</option>
               {[
                 ...new Set([
                   ...(result?.months ?? []),
@@ -238,15 +247,15 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
               defaultValue={filters.kind}
               className={control}
             >
-              <option value="all">All records</option>
-              <option value="updated">Version changes</option>
-              <option value="first">First tracked</option>
+              <option value="all">{gt("All records")}</option>
+              <option value="updated">{gt("Version changes")}</option>
+              <option value="first">{gt("First tracked")}</option>
             </select>
           </div>
           <details open={Boolean(filters.from || filters.to || filters.architecture)} className="sm:col-span-2 lg:col-span-3">
             <summary className="cursor-pointer py-3 text-sm font-medium text-text-secondary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-accent-cyan"><T>Date range and architecture</T></summary>
             <div className="mt-2 grid gap-4 sm:grid-cols-3">
-          {[['from', 'Recorded from (UTC)'], ['to', 'Recorded through (UTC)']].map(([key, label]) => (
+          {[['from', gt('Recorded from (UTC)')], ['to', gt('Recorded through (UTC)')]].map(([key, label]) => (
             <div key={key}>
               <label htmlFor={`history-${key}`} className="mb-2 block text-sm font-medium text-text-primary"><T><Var>{label}</Var></T></label>
               <input id={`history-${key}`} name={key} type="date" defaultValue={key === 'from' ? filters.from : filters.to} className={control} />
@@ -255,7 +264,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
           <div>
             <label htmlFor="history-architecture" className="mb-2 block text-sm font-medium text-text-primary"><T>Installer architecture</T></label>
             <select id="history-architecture" name="architecture" defaultValue={filters.architecture ?? ''} className={control}>
-              <option value="">All architectures</option>
+              <option value="">{gt("All architectures")}</option>
               {['x64', 'x86', 'arm64', 'arm', 'neutral'].map(value => <option key={value} value={value}>{value}</option>)}
             </select>
           </div>
@@ -323,7 +332,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                   id={`day-${day}`}
                   className="pt-3 text-sm font-semibold text-text-secondary"
                 >
-                  <span className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-text-muted"><T>Recorded</T></span><time dateTime={day}>{dateLabel(day)}</time>
+                  <span className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-text-muted"><T>Recorded (UTC)</T></span><time dateTime={day}>{dateLabel(day)}</time>
                 </h2>
                 <ul className="min-w-0 divide-y divide-overlay/10 rounded-xl border border-overlay/10 bg-bg-elevated">
                   {rows.map((row) => (
@@ -355,8 +364,9 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                             <span className="break-all text-text-muted">
                               {row.previous_version}
                             </span>
+                            <span className="sr-only"><T>to</T></span>
                             <ArrowRight
-                              aria-label="to"
+                              aria-hidden="true"
                               className="h-3 w-3 shrink-0 text-text-muted"
                             />
                           </>
@@ -439,8 +449,10 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                 <T>Installer hash unavailable</T>
                               )}
                             </p>
-                            <div className="flex flex-wrap items-center gap-x-4">
-                            {!filters.app && <Link href={appHistoryUrl(row.winget_id)} className="inline-flex min-h-6 items-center text-text-secondary hover:underline focus-visible:ring-2 focus-visible:ring-accent-cyan"><T>History</T></Link>}
+                          </>
+                        )}
+                        <div className="flex flex-wrap items-center gap-x-4">
+                        {!filters.app && <Link href={appHistoryUrl(row.winget_id)} className="inline-flex min-h-6 items-center text-text-secondary hover:underline focus-visible:ring-2 focus-visible:ring-accent-cyan"><T>History</T></Link>}
                             {row.release_notes_url && (
                               <a
                                 href={row.release_notes_url}
@@ -455,9 +467,7 @@ export default async function CatalogReleasesPage({ searchParams }: Props) {
                                 />
                               </a>
                             )}
-                            </div>
-                          </>
-                        )}
+                        </div>
                       </div>
                       <details className="col-start-2 min-w-0 text-xs text-text-muted sm:col-[2/-1]">
                         <summary className="w-fit cursor-pointer py-1 font-medium text-text-secondary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-accent-cyan"><T>Release details</T></summary>

--- a/components/landing/ReleaseFeedDialog.tsx
+++ b/components/landing/ReleaseFeedDialog.tsx
@@ -12,7 +12,7 @@ export function ReleaseFeedDialog({ app }: { app?: string }) {
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<"idle" | "copying" | "copied" | "error">("idle");
-  const feedUrl = `https://www.intuneget.com/apps/releases/feed${app ? `?app=${encodeURIComponent(app)}` : ""}`;
+  const feedUrl = `https://intuneget.com/apps/releases/feed${app ? `?app=${encodeURIComponent(app)}` : ""}`;
 
   async function copyUrl() {
     setStatus("copying");
@@ -49,7 +49,7 @@ export function ReleaseFeedDialog({ app }: { app?: string }) {
             onFocus={(event) => event.currentTarget.select()}
             className="w-full min-w-0 rounded-lg border border-overlay/15 bg-bg-elevated px-3 py-2.5 text-base text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan sm:text-sm"
           />
-          <Button type="button" onClick={copyUrl} disabled={status === "copying"} className="w-full bg-accent-cyan text-white hover:bg-accent-cyan/90 sm:w-auto">
+          <Button type="button" onClick={copyUrl} disabled={status === "copying"} className="w-full bg-accent-cyan-dim text-white hover:bg-accent-cyan-dim/90 sm:w-auto">
             {status === "copied" ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
             {status === "copied" ? <T>Copied</T> : status === "copying" ? <T>Copying…</T> : <T>Copy URL</T>}
           </Button>

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -50,6 +50,6 @@ Validation: run the catalog TypeScript tests and `supabase/tests/catalog_release
 
 ### Metadata request recovery
 
-The website retries failed metadata batches and then falls back to indexed app/version equality lookups with at most four concurrent requests. Each fallback request has a three-second timeout and all fallback work shares an eight-second deadline. Only records whose requests still fail show unavailable details; missing optional vendor metadata is not a request failure.
+Metadata batches have a three-second request timeout. An aborted request skips the batch retry when individual recovery is available; other transient errors receive one retry. The website then falls back to indexed app/version equality lookups with at most four concurrent requests. Each fallback request has a three-second timeout and all fallback work shares an eight-second deadline. Only records whose requests still fail show unavailable details; missing optional vendor metadata is not a request failure.
 
 Incomplete history responses are thrown out of the page-cache callback, preserving the previous complete response during background revalidation. On a cold request the available records can still render without storing the partial result. History links do not depend on enrichment. The displayed full-catalog check timestamp is explicitly labelled to distinguish it from incremental updates.

--- a/docs/operations/catalog-release-history.md
+++ b/docs/operations/catalog-release-history.md
@@ -47,3 +47,9 @@ Apply `20260911120000_release_history_filters.sql` before deploying the website 
 `/apps/releases/feed` returns RSS 2.0 with the latest 40 recorded versions; `?app=Example.App` limits it to that application. RSS item identity is stable per app/version, and publication dates use observation times. Responses cache for five minutes; failures return HTTP 503 with no-store rather than a misleading empty feed. This is a bounded recent feed, not a guaranteed delivery queue or full archive. Subscribe with an RSS reader and use the paginated history for older entries. RSS does not accept the page's other filters.
 
 Validation: run the catalog TypeScript tests and `supabase/tests/catalog_release_history_filters.sql` on a migrated test database. SQL fixtures roll back after checking exact matching, UTC boundaries, architecture, predecessors and pagination totals.
+
+### Metadata request recovery
+
+The website retries failed metadata batches and then falls back to indexed app/version equality lookups with at most four concurrent requests. Each fallback request has a three-second timeout and all fallback work shares an eight-second deadline. Only records whose requests still fail show unavailable details; missing optional vendor metadata is not a request failure.
+
+Incomplete history responses are thrown out of the page-cache callback, preserving the previous complete response during background revalidation. On a cold request the available records can still render without storing the partial result. History links do not depend on enrichment. The displayed full-catalog check timestamp is explicitly labelled to distinguish it from incremental updates.

--- a/lib/catalog/release-feed.ts
+++ b/lib/catalog/release-feed.ts
@@ -4,7 +4,7 @@ export function escapeXml(value: string): string {
   return value.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "").replace(/[<>&"']/g, char => ({"<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&apos;"})[char]!);
 }
 export function releaseFeed(rows: CatalogRelease[], app = ""): string {
-  const origin = "https://www.intuneget.com";
+  const origin = "https://intuneget.com";
   const title = app ? `${app} release history` : "IntuneGet catalog release history";
   const feedUrl = `${origin}/apps/releases/feed${app ? `?app=${encodeURIComponent(app)}` : ""}`;
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/lib/catalog/release-history-cache.test.ts
+++ b/lib/catalog/release-history-cache.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { CompleteHistoryError, requireCompleteHistory } from './release-history-cache';
+import type { ReleaseHistoryResult } from './release-history';
+const result: ReleaseHistoryResult = {rows:[{winget_id:'Example.App',name:'Example',publisher:null,version:'1',previous_version:null,detected_at:'2026-09-11',release_date:null}],total:1,apps:1,firstTracked:1,months:[],coverageStart:null,sync:null};
+describe('release history cache admission', () => {
+  it('allows complete records even when a vendor provides no optional metadata', () => {
+    expect(requireCompleteHistory(result)).toBe(result);
+  });
+  it('rejects transiently incomplete results but preserves the records for rendering', () => {
+    const partial = {...result, rows:result.rows.map(row=>({...row,detailsUnavailable:true}))};
+    expect(() => requireCompleteHistory(partial)).toThrow(CompleteHistoryError);
+    try { requireCompleteHistory(partial); } catch (error) {
+      expect((error as CompleteHistoryError).result).toBe(partial);
+    }
+  });
+});

--- a/lib/catalog/release-history-cache.ts
+++ b/lib/catalog/release-history-cache.ts
@@ -3,6 +3,7 @@ import type { ReleaseHistoryResult } from './release-history';
 export class CompleteHistoryError extends Error {
   constructor(public readonly result: ReleaseHistoryResult) {
     super('Release history metadata is incomplete');
+    Object.defineProperty(this, 'result', {value: result, enumerable: false});
   }
 }
 

--- a/lib/catalog/release-history-cache.ts
+++ b/lib/catalog/release-history-cache.ts
@@ -1,0 +1,15 @@
+import type { ReleaseHistoryResult } from './release-history';
+
+export class CompleteHistoryError extends Error {
+  constructor(public readonly result: ReleaseHistoryResult) {
+    super('Release history metadata is incomplete');
+  }
+}
+
+/** Throw inside the cache callback so degraded results are never stored. The
+ * caller can still render partial records on a cold request, while Next retains
+ * the previous complete result if background revalidation fails. */
+export function requireCompleteHistory(result: ReleaseHistoryResult) {
+  if (result.rows.some(row => row.detailsUnavailable)) throw new CompleteHistoryError(result);
+  return result;
+}

--- a/lib/catalog/release-metadata.test.ts
+++ b/lib/catalog/release-metadata.test.ts
@@ -51,3 +51,13 @@ it('recovers failed batches with bounded single-row lookups and isolates one fai
   expect([...result.unavailable]).toEqual([releasePairKey(rows[3])]);
   warn.mockRestore();
 });
+
+it('skips an aborted batch retry when individual recovery is available', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const batch = vi.fn(async () => ({data:null,error:{},status:0}));
+  const result = await loadReleaseMetadata(rows.slice(0,1), batch, async row => ({data:evidence([row]),error:null,status:200}));
+  expect(batch).toHaveBeenCalledTimes(1);
+  expect(result.unavailable.size).toBe(0);
+  expect(result.metadata).toHaveLength(1);
+  warn.mockRestore();
+});

--- a/lib/catalog/release-metadata.test.ts
+++ b/lib/catalog/release-metadata.test.ts
@@ -32,3 +32,22 @@ describe('release metadata loading', () => {
     warn.mockRestore();
   });
 });
+
+it('recovers failed batches with bounded single-row lookups and isolates one failed file', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  let active = 0;
+  let peak = 0;
+  const singles = vi.fn(async (row: typeof rows[number]) => {
+    peak = Math.max(peak, ++active);
+    await new Promise(resolve => setTimeout(resolve, 1));
+    active--;
+    if (row.winget_id === 'Example.3') throw new Error('Unavailable');
+    return {data: evidence([row]), error:null, status:200};
+  });
+  const result = await loadReleaseMetadata(rows, async () => ({data:null,error:{},status:503}), singles);
+  expect(peak).toBeLessThanOrEqual(4);
+  expect(singles).toHaveBeenCalledTimes(40);
+  expect(result.metadata).toHaveLength(39);
+  expect([...result.unavailable]).toEqual([releasePairKey(rows[3])]);
+  warn.mockRestore();
+});

--- a/lib/catalog/release-metadata.ts
+++ b/lib/catalog/release-metadata.ts
@@ -20,6 +20,7 @@ export async function loadReleaseMetadata(
       try {
         const response = await fetchBatch(batch);
         if (!response.error && response.data) return response.data;
+        if (fetchSingle && response.status === 0) throw new Error('Release metadata unavailable (request aborted)');
         const transient = response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500 || response.error?.code === '57014';
         if (!transient || attempt === 1) throw new Error(`Release metadata unavailable (HTTP ${response.status})`);
       } catch (error) {

--- a/lib/catalog/release-metadata.ts
+++ b/lib/catalog/release-metadata.ts
@@ -12,6 +12,7 @@ export const releasePairKey = (row: ReleasePair) => JSON.stringify([row.winget_i
 export async function loadReleaseMetadata(
   rows: ReleasePair[],
   fetchBatch: (batch: ReleasePair[]) => PromiseLike<MetadataResponse>,
+  fetchSingle?: (row: ReleasePair) => PromiseLike<MetadataResponse>,
 ) {
   const batches = Array.from({ length: Math.ceil(rows.length / 10) }, (_, i) => rows.slice(i * 10, (i + 1) * 10));
   const results = await Promise.allSettled(batches.map(async batch => {
@@ -36,5 +37,22 @@ export async function loadReleaseMetadata(
       console.warn('Release metadata batch unavailable', { batchSize: batches[i].length });
     }
   });
+  // Recover healthy rows individually when a batch fails. Limit database pressure.
+  if (fetchSingle && unavailable.size) {
+    const pending = rows.filter(row => unavailable.has(releasePairKey(row)));
+    let next = 0;
+    await Promise.all(Array.from({length: Math.min(4, pending.length)}, async () => {
+      while (next < pending.length) {
+        const row = pending[next++];
+        try {
+          const response = await fetchSingle(row);
+          if (!response.error && response.data) {
+            metadata.push(...response.data);
+            unavailable.delete(releasePairKey(row));
+          }
+        } catch { /* Preserve the unavailable state only for this pair. */ }
+      }
+    }));
+  }
   return { metadata, unavailable };
 }

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -75,7 +75,7 @@ export class SupabaseCatalogSource implements CatalogSource {
     let recoverySignal: AbortSignal | undefined;
     const {metadata, unavailable} = await loadReleaseMetadata(result.rows, batch => {
       const pairs = batch.map(row => `and(winget_id.eq.${quotePostgrestValue(row.winget_id)},version.eq.${quotePostgrestValue(row.version)})`).join(',');
-      return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(batch.length).abortSignal(AbortSignal.timeout(10_000));
+      return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(batch.length).abortSignal(AbortSignal.timeout(3000));
     }, row => {
       recoverySignal ??= AbortSignal.timeout(8000);
       return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').eq('winget_id', row.winget_id).eq('version', row.version).limit(1).abortSignal(AbortSignal.any([recoverySignal, AbortSignal.timeout(3000)]));

--- a/lib/catalog/supabase-source.ts
+++ b/lib/catalog/supabase-source.ts
@@ -72,9 +72,13 @@ export class SupabaseCatalogSource implements CatalogSource {
     if (error) throw new Error('Catalog history unavailable', { cause: error });
     const result = data as ReleaseHistoryResult;
     if (!result.rows.length) return result;
+    let recoverySignal: AbortSignal | undefined;
     const {metadata, unavailable} = await loadReleaseMetadata(result.rows, batch => {
       const pairs = batch.map(row => `and(winget_id.eq.${quotePostgrestValue(row.winget_id)},version.eq.${quotePostgrestValue(row.version)})`).join(',');
       return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').or(pairs).limit(batch.length).abortSignal(AbortSignal.timeout(10_000));
+    }, row => {
+      recoverySignal ??= AbortSignal.timeout(8000);
+      return client.from('version_history').select('winget_id,version,release_notes_url,installer_sha256,installers').eq('winget_id', row.winget_id).eq('version', row.version).limit(1).abortSignal(AbortSignal.any([recoverySignal, AbortSignal.timeout(3000)]));
     });
     const hashes = [...new Set(result.rows.map(row => enrichRelease(row, metadata, [], Date.now(), filters.architecture).virusTotal?.hash).filter((hash): hash is string => typeof hash === 'string' && /^[a-f0-9]{64}$/.test(hash)))];
     let reputations: FileReputation[] = [];


### PR DESCRIPTION
Release history could cache failed metadata batches, hiding release notes and scan details for otherwise available records. Failed batches now recover through bounded individual app/version requests, and incomplete results cannot replace a complete page-cache entry. History navigation stays available independently of metadata. Aborted batches start individual recovery immediately; batch requests are capped at three seconds and fallback work has an eight-second shared deadline.

The page also distinguishes queued syncs and full-catalog timestamps, labels UTC group dates, recovers out-of-range pages, improves narrow-screen stats and screen-reader version transitions, and translates filter labels. RSS uses the canonical host and a higher-contrast copy button.

Validation: 89 catalog tests, TypeScript, full repository lint, and changelog validation passed. Browser verification with live catalog data showed 40 of 40 rows without metadata-unavailable messages and 40 History links. Fixture checks verified page-number recovery, exact app RSS, and 320px rendering without overflow. Regression tests cover recovery, concurrency limits, partial failures, aborted batch handling, and cache admission. Claude Code Fable reviewed the fixes and found no regressions; its recovery-latency feedback was addressed. No database migration or versioned release is required.