### PR TITLE
Preserve exact MSI identity for archived EXE installers

### DIFF
--- a/.ugurlabs/entries/20260911-archive-product-identity.json
+++ b/.ugurlabs/entries/20260911-archive-product-identity.json
@@ -1,0 +1,5 @@
+{
+  "title": "Reliable removal for archived installers",
+  "summary": "Fixed packaging for applications such as Adobe Acrobat whose ZIP archive contains an executable installer. Packages now retain the manifest's exact installed product identity for installation verification and managed removal.",
+  "type": "fixed"
+}

--- a/docs/qa-acrobat-20260911.md
+++ b/docs/qa-acrobat-20260911.md
@@ -1,0 +1,42 @@
+# Acrobat archive identity repair
+
+Production candidate `f8d5e099-cf31-4cc7-a454-8235f838441d`, run
+`34615842886`, failed on Acrobat Pro `26.002.21901` x64. The pipeline
+automatically paused and had zero active lifecycles at 15:43 UTC.
+
+The ZIP bootstrapper returned 0. Post-install capture then rejected the
+registration `Adobe Acrobat (64-bit)`, MSI key
+`{AC76BA86-1033-FFFF-7760-BC15014EA700}`, version `26.002.21901`.
+The canonical profile carried `REGISTRY_UNINSTALL:Adobe Acrobat Pro` even
+though the official WinGet manifest supplied that exact MSI product code.
+The shared ZIP command generator preserved codes for MSI/WiX but discarded
+them for EXE-family nested installers. Preserve canonical MSI GUIDs for those
+families too; retain existing named-key adapters and portable/AppX behavior.
+
+Sources:
+- https://github.com/microsoft/winget-pkgs/blob/master/manifests/a/Adobe/Acrobat/Pro/26.002.21901/Adobe.Acrobat.Pro.installer.yaml
+- https://www.adobe.com/devnet-docs/acrobatetk/tools/DesktopDeployment/singleinstaller.html
+- https://github.com/ugurkocde/IntuneGet-Workflows/actions/runs/34615842886
+
+The exact failed installer SHA is
+`ECE5D3816C32DE1374B1D228B04D01ABB1621A7AEA6D61728D97A65718053035`.
+Required and scheduler pin were
+`6bdefc387d1402c71d30a6fbfcf850038f60f37a`.
+The failed result has VirusTotal `not_found` with null verdict counts; it
+cannot qualify as a strict pass without subsequent zero/zero evidence.
+
+Regression coverage includes shared command generation, normalized catalog
+QA, customer workflow payload, and generated PowerShell identity selection
+against synthetic Acrobat and Reader registrations. No installer is executed
+outside the isolated QA VM.
+
+The guardian status script reported 197 for the immutable cohort boundary
+`2026-08-30T08:28:35Z`, but only filters passed candidate status. A read-only
+exact-result audit at 15:52 UTC found one distinct post-boundary app on the
+current exact pin with matching hashes, 0/0/0/1 lifecycle, LocalSystem and
+VirusTotal 0/0: `WithSecure.ElementsAgent`. This distinction must remain
+explicit; the 500 milestone has not been met.
+
+Next: protected PR checks and merge, production activation and workflow pins,
+guarded release pin update with zero active lifecycles, fresh scheduler
+heartbeat, exact Acrobat retry before general queue continuation.

--- a/lib/__tests__/detection-rules.test.ts
+++ b/lib/__tests__/detection-rules.test.ts
@@ -950,6 +950,25 @@ describe('generateUninstallCommand', () => {
     );
   });
 
+  it.each(['exe', 'inno', 'nullsoft', 'burn'] as const)(
+    'preserves exact product identity for a ZIP-wrapped %s installer',
+    (nestedInstallerType) => {
+      const installer: NormalizedInstaller = {
+        architecture: 'x64', url: 'https://example.com/acrobat.zip',
+        sha256: 'abc123', type: 'zip', nestedInstallerType,
+        nestedInstallerPath: 'Adobe Acrobat\\setup.exe',
+        productCode: '{AC76BA86-1033-FFFF-7760-BC15014EA700}',
+      };
+      expect(generateUninstallCommand(installer, 'Adobe Acrobat Pro')).toBe(
+        'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FFFF-7760-BC15014EA700}:Adobe Acrobat Pro'
+      );
+      expect(generateUninstallCommand({ ...installer, productCode: undefined }, 'Adobe Acrobat Pro'))
+        .toBe('REGISTRY_UNINSTALL:Adobe Acrobat Pro');
+      expect(generateUninstallCommand({ ...installer, productCode: 'Unsafe:key' }, 'Adobe Acrobat Pro'))
+        .toBe('REGISTRY_UNINSTALL:Adobe Acrobat Pro');
+    }
+  );
+
   it('should preserve a nested MSI product code for archive packages', () => {
     const installer: NormalizedInstaller = {
       architecture: 'x86',

--- a/lib/detection-rules.ts
+++ b/lib/detection-rules.ts
@@ -446,17 +446,20 @@ export function generateUninstallCommand(
         }
         return 'MSIX_UNINSTALL:{PACKAGE_NAME}';
       }
-      // Archive packages execute their nested installer, so a nested MSI/WiX
-      // ProductCode is the authoritative installed-product identity. Preserve
-      // it for post-install capture and removal instead of falling back to a
-      // localized display name that may not match the registered MSI title.
-      if (displayName) {
-        const nestedMsiProductCode = ['msi', 'wix'].includes(
-          installer.nestedInstallerType || ''
-        )
-          ? installer.productCode
-          : undefined;
-        return generateRegistryUninstallCommand(displayName, nestedMsiProductCode);
+        // Archive packages execute their nested installer. MSI and EXE-family
+        // installers both use the manifest's exact registered product identity;
+        // an EXE bootstrapper can register an MSI whose name differs from the
+        // catalog title (for example Acrobat's unified installer).
+        if (displayName) {
+          const nestedType = installer.nestedInstallerType || '';
+          // Extend the archive contract only for canonical MSI product GUIDs.
+          // Named EXE keys can be catalog titles; retain their reviewed adapters.
+          const hasNestedMsiIdentity = ['exe', 'inno', 'nullsoft', 'burn'].includes(nestedType) &&
+            /^\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?$/.test(installer.productCode?.trim() || '');
+          const nestedProductCode = ['msi', 'wix'].includes(nestedType) || hasNestedMsiIdentity
+            ? installer.productCode
+            : undefined;
+          return generateRegistryUninstallCommand(displayName, nestedProductCode);
       }
       return '# Manual uninstall required';
 

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -6,6 +6,7 @@ import {
 } from './github-actions';
 import { buildQaPackageIdentityFromWorkflowInput } from './qa/package-profile';
 import { QaCompatibilityGateError } from './qa/gate';
+import { generateUninstallCommand } from './detection-rules';
 
 const { enforceInstallerPreflightMock, enforceQaGateMock, reconcileCatalogInstallerMock, resolveDependenciesMock } = vi.hoisted(() => ({
   enforceInstallerPreflightMock: vi.fn(),
@@ -296,6 +297,33 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
     expect(JSON.parse(payload.client_payload.config.psadtConfig))
       .toMatchObject({ reviewedUninstallArguments: ['/S'] });
+  });
+
+  it('dispatches the generated Acrobat archive product identity to customer packaging', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    reconcileCatalogInstallerMock.mockImplementationOnce(async (item) => ({
+      item: { ...item, nestedInstallerType: 'exe', nestedInstallerPath: 'Adobe Acrobat\\setup.exe' },
+      trustedInstallers: [],
+    }));
+    const uninstallCommand = generateUninstallCommand({
+      type: 'zip', nestedInstallerType: 'exe', architecture: 'x64',
+      url: 'https://example.com/acrobat.zip', sha256: 'E'.repeat(64),
+      nestedInstallerPath: 'Adobe Acrobat\\setup.exe',
+      productCode: '{AC76BA86-1033-FFFF-7760-BC15014EA700}',
+    }, 'Adobe Acrobat Pro');
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Adobe.Acrobat.Pro', displayName: 'Adobe Acrobat Pro', publisher: 'Adobe',
+      version: '26.002.21901', installerUrl: 'https://example.com/acrobat.zip',
+      installerSha256: 'E'.repeat(64), sourceType: 'winget', installerType: 'zip',
+      nestedInstallerType: 'exe', nestedInstallerPath: 'Adobe Acrobat\\setup.exe',
+      silentSwitches: '/sAll /rs /msi EULA_ACCEPT=YES', uninstallCommand, installScope: 'machine',
+    }), config, { skipRunCapture: true });
+    const payload = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FFFF-7760-BC15014EA700}:Adobe Acrobat Pro'
+    );
+    expect(payload.client_payload.installer.nestedInstallerType).toBe('exe');
   });
 
   it('dispatches Teradata silent archive removal through the customer packager', async () => {

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -13,6 +13,7 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
+import { generateUninstallCommand } from '@/lib/detection-rules';
 
 const packager = readFileSync(
   resolve(process.cwd(), '.github/scripts/Create-PSADTPackage.ps1'),
@@ -2290,6 +2291,41 @@ describe('PSADT registry uninstall identity contract', () => {
     expect(packager).toContain('$configuredMatches = @($postInstallApplications');
     expect(packager).not.toContain('$existingNameMatches');
   });
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'captures the Acrobat ZIP bootstrapper MSI identity despite its different registered name',
+    () => {
+      const command = generateUninstallCommand({
+        type: 'zip', nestedInstallerType: 'exe', architecture: 'x64',
+        url: 'https://example.com/acrobat.zip', sha256: 'E'.repeat(64),
+        productCode: '{AC76BA86-1033-FFFF-7760-BC15014EA700}',
+        nestedInstallerPath: 'Adobe Acrobat\\setup.exe',
+      }, 'Adobe Acrobat Pro');
+      const generated = generateRegistryUninstallPackage(
+        'zip', 'Adobe Acrobat Pro', [], {}, [], 'Adobe.Acrobat.Pro',
+        'Adobe Acrobat Pro', '26.002.21901', command,
+        '/sAll /rs /msi EULA_ACCEPT=YES', 'machine', 'exe', 'Adobe Acrobat\\setup.exe'
+      );
+      const identityLine = generated.split('\n').find(line => line.includes('$configuredUninstallProductCode ='));
+      const selectionLine = generated.split('\n').find(line => line.includes('$selectedApplications = @($changedApplications | Where-Object { [string]$_.PSChildName -eq'));
+      expect(identityLine).toBeDefined();
+      expect(selectionLine).toBeDefined();
+      const result = spawnSync('pwsh', ['-NoProfile', '-Command', `
+${identityLine}
+$changedApplications = @(
+  [pscustomobject]@{ PSChildName = '{AC76BA86-1033-FFFF-7760-BC15014EA700}'; DisplayName = 'Adobe Acrobat (64-bit)' },
+  [pscustomobject]@{ PSChildName = '{AC76BA86-1033-FF00-7760-BC15014EA700}'; DisplayName = 'Adobe Acrobat Reader (64-bit)' }
+)
+${selectionLine}
+if (@($selectedApplications).Count -ne 1 -or $selectedApplications[0].DisplayName -ne 'Adobe Acrobat (64-bit)') { throw 'Wrong product selected' }
+$changedApplications = @($changedApplications[1])
+${selectionLine}
+if (@($selectedApplications).Count -ne 0) { throw 'Unrelated product selected' }
+`], { encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+      expect(generated).toContain("$configuredProductCode = '{AC76BA86-1033-FFFF-7760-BC15014EA700}'");
+    }, 30_000
+  );
 
   it('supports a reviewed exact non-MSI uninstall registry key', () => {
     expect(packager).toContain(

--- a/lib/qa/test-config.test.ts
+++ b/lib/qa/test-config.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { buildQaCatalogTestConfig } from './test-config';
 
 describe('buildQaCatalogTestConfig', () => {
+  it('preserves Acrobat unified MSI identity through ZIP/EXE QA normalization', () => {
+    const config = buildQaCatalogTestConfig({
+      app: { wingetId: 'Adobe.Acrobat.Pro', name: 'Adobe Acrobat Pro', publisher: 'Adobe', version: '26.002.21901' },
+      manifest: {
+        InstallerType: 'zip', NestedInstallerType: 'exe', Scope: 'machine',
+        NestedInstallerFiles: [{ RelativeFilePath: 'Adobe Acrobat\\setup.exe' }],
+        ProductCode: '{AC76BA86-1033-FFFF-7760-BC15014EA700}',
+        InstallerSwitches: { Silent: '/sAll /rs /msi', Custom: 'EULA_ACCEPT=YES' },
+      },
+      installer: { Architecture: 'x64' },
+    });
+    expect(config.uninstallCommand).toBe('REGISTRY_UNINSTALL_PRODUCT:{AC76BA86-1033-FFFF-7760-BC15014EA700}:Adobe Acrobat Pro');
+    expect(config.productCode).toBe('{AC76BA86-1033-FFFF-7760-BC15014EA700}');
+    expect(config.nestedInstallerType).toBe('exe');
+    expect(config.nestedInstallerFiles).toEqual(['Adobe Acrobat\\setup.exe']);
+    expect(config.silentArgs).toBe('/sAll /rs /msi EULA_ACCEPT=YES');
+    expect(config.scope).toBe('machine');
+  });
+
   it('adds the reviewed Movavi success code to catalog QA packaging', () => {
     const config = buildQaCatalogTestConfig({
       app: {

--- a/scripts/qa-acrobat-audit.mjs
+++ b/scripts/qa-acrobat-audit.mjs
@@ -1,0 +1,21 @@
+// Read-only, bounded operational evidence. Run through the linked production environment.
+const base = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (new URL(base).hostname !== 'mbhajocqtogfbgojkwhd.supabase.co' || !key) throw new Error('Production environment required');
+async function rows(table, params) {
+  const response = await fetch(`${base}/rest/v1/${table}?${new URLSearchParams(params)}`, {
+    headers: { apikey: key, Authorization: `Bearer ${key}` }, signal: AbortSignal.timeout(30000),
+  });
+  if (!response.ok) throw new Error(`Read failed: ${table} ${response.status}`);
+  return response.json();
+}
+const candidates = await rows('qa_candidates', {
+  winget_id: 'eq.Adobe.Acrobat.Pro', order: 'enqueued_at.desc', limit: '2',
+  select: 'id,version,architecture,status,phase,github_run_id,installer_sha256,package_profile_sha256,test_config,live_log',
+});
+console.log(JSON.stringify(candidates.map(({test_config: config, live_log, ...row}) => {
+  const canonical = JSON.parse(config.packageProfileCanonicalJson || '{}');
+  return {...row, profile: { toolchain: canonical.toolchain, installer: canonical.installer },
+    config: Object.fromEntries(['sourceInstallerType','productCode','uninstallCommand','nestedInstallerType','nestedInstallerFiles'].map(k=>[k,config[k]])),
+    liveLog: live_log ? JSON.stringify(live_log).slice(-10000) : null };
+}), null, 2));

--- a/scripts/qa-strict-cohort-audit.mjs
+++ b/scripts/qa-strict-cohort-audit.mjs
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+const base = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!base || new URL(base).hostname !== 'mbhajocqtogfbgojkwhd.supabase.co' || !key) throw new Error('Production environment required');
+const boundary = '2026-08-30T08:28:35Z';
+async function rows(table, params) {
+  const all = [];
+  for (let offset = 0; ; offset += 500) {
+    const response = await fetch(`${base}/rest/v1/${table}?${new URLSearchParams({...params, offset: String(offset), limit: '500'})}`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` }, signal: AbortSignal.timeout(30000),
+    });
+    if (!response.ok) throw new Error(`Read failed: ${table} ${response.status}`);
+    const page = await response.json(); all.push(...page);
+    if (page.length < 500) return all;
+  }
+}
+const [controls, candidates, results] = await Promise.all([
+  rows('qa_pipeline_control', {id: 'eq.global', select: 'required_packager_commit,scheduler_packager_commit,paused'}),
+  rows('qa_candidates', {status: 'eq.passed', test_level: 'eq.psadt-package', order: 'id.asc', select: 'id,winget_id,version,architecture,installer_sha256,package_profile_sha256,finished_at,test_config,github_run_id'}),
+  rows('qa_package_results', {outcome: 'eq.Passed', order: 'package_profile_sha256.asc', select: 'winget_id,tested_version,architecture,installer_sha256,package_profile_sha256,outcome,phase_results,environment,packager_commit,tested_at_utc,virustotal_malicious,virustotal_suspicious,github_run_id'}),
+]);
+const norm = s => String(s || '').trim().toLowerCase();
+const byProfile = new Map(results.map(r=>[norm(r.package_profile_sha256), r]));
+const reasons = {};
+const strict = [];
+for (const c of candidates) {
+  const r = byProfile.get(norm(c.package_profile_sha256));
+  let why;
+  let profile;
+  try { profile = JSON.parse(c.test_config.packageProfileCanonicalJson); } catch { why = 'missingCanonicalProfile'; }
+  const phases = r?.phase_results;
+  if (!why && !r) why = 'missingExactResult';
+  if (!why && (norm(c.winget_id) !== norm(r.winget_id) || c.version !== r.tested_version || c.architecture !== r.architecture || norm(c.installer_sha256) !== norm(r.installer_sha256))) why = 'tupleMismatch';
+  if (!why && (createHash('sha256').update(c.test_config.packageProfileCanonicalJson).digest('hex') !== norm(c.package_profile_sha256) || norm(profile.installer?.sha256) !== norm(c.installer_sha256))) why = 'profileHashMismatch';
+  if (!why && (phases?.install?.exitCode !== 0 || phases?.detectionAfterInstall?.exitCode !== 0 || phases?.uninstall?.exitCode !== 0 || phases?.detectionAfterUninstall?.exitCode !== 1)) why = 'lifecycleTuple';
+  if (!why && r.environment?.executionContext !== 'LocalSystem') why = 'executionContext';
+  if (!why && (r.virustotal_malicious !== 0 || r.virustotal_suspicious !== 0)) why = 'virusTotalNotZeroZero';
+  if (!why && norm(profile.toolchain?.packagerCommit) !== norm(r.packager_commit)) why = 'resultPinMismatch';
+  if (why) {reasons[why] = (reasons[why] || 0)+1; continue;}
+  strict.push({c,r});
+}
+const historical = new Set(strict.filter(({c})=>Date.parse(c.finished_at)<=Date.parse(boundary)).map(({c})=>norm(c.winget_id)));
+const eligible = strict.filter(({c,r})=>Date.parse(c.finished_at)>Date.parse(boundary) && !historical.has(norm(c.winget_id)) && norm(r.packager_commit)===norm(controls[0].required_packager_commit));
+console.log(JSON.stringify({observedAtUtc:new Date().toISOString(), boundary, requiredPin:controls[0].required_packager_commit,
+  strictCount:new Set(eligible.map(({c})=>norm(c.winget_id))).size,
+  latestStrictFinish:eligible.map(({c})=>c.finished_at).sort().at(-1)||null,
+  auditedPassedCandidates:candidates.length, strictEvidenceCandidates:strict.length, rejectedReasons:reasons,
+  currentPinStrictIds:[...new Set(eligible.map(({c})=>c.winget_id))]},null,2));


### PR DESCRIPTION
Acrobat Pro 26.002.21901 installed successfully but PSADT could not capture its registered MSI because the ZIP uninstall generator discarded the nested EXE's manifest ProductCode. Preserve canonical MSI GUIDs for archived EXE-family installers so QA and customer packages verify and remove the exact product. Existing named-key adapters remain unchanged.

Regression coverage exercises shared generation, QA normalization, customer Actions payloads, and generated PowerShell selection against synthetic Acrobat/Reader registrations. Focused tests pass; lint passes with one existing warning. Full Windows tests encounter unrelated native SQLite bindings and a Unix-shell translation fixture; required Linux Test, Lint, Build and Workflow lint checks remain mandatory. Production stays paused pending activation and the exact isolated retry.
