### PR TITLE
feat(qa): simplify live evidence and completed result flows

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -6,6 +6,7 @@ import { T, Var } from 'gt-next';
 import {
   AlertTriangle,
   CheckCircle2,
+  ChevronRight,
   ListOrdered,
   Loader2,
   Monitor,
@@ -112,12 +113,6 @@ function QaVirusTotalCell({ status }: { status: QaVirusTotalStatus | null }) {
     );
   }
   return <span className="text-xs text-text-muted" aria-hidden="true">—</span>;
-}
-
-function resultEdgeClass(outcome: 'Passed' | 'Failed'): string {
-  return outcome === 'Passed'
-    ? 'border-l-status-success/60'
-    : 'border-l-status-error/60';
 }
 
 function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
@@ -455,6 +450,7 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           />
           <div className="lg:col-start-1 lg:row-start-2">
             <QaLiveActivityDialog
+              app={data.current}
               activity={data.activity}
               log={data.log}
               phase={data.current.phase}
@@ -484,8 +480,8 @@ function DashboardContent() {
         <div className="space-y-6" aria-hidden="true">
           <div className="h-64 sm:h-32 lg:h-16 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
           <div className="h-[600px] lg:h-[480px] animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
-            <div className="h-80 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
+          <div className="space-y-6">
+            <div className="h-40 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
             <div className="h-80 animate-pulse rounded-2xl border border-overlay/10 bg-bg-elevated motion-reduce:animate-none" />
           </div>
         </div>
@@ -508,7 +504,7 @@ function DashboardContent() {
       <ServiceHealth data={data} />
       <CurrentTest data={data} />
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+      <div className="space-y-6">
         <section className="min-w-0 rounded-2xl border border-overlay/10 bg-bg-elevated p-5 sm:p-6" aria-labelledby="queue-heading">
           <div className="mb-4 flex items-baseline justify-between gap-3">
             <h2 id="queue-heading" className="text-lg font-semibold text-text-primary"><T>Next in queue</T></h2>
@@ -516,11 +512,11 @@ function DashboardContent() {
           </div>
           {data.queue.next.length ? (
             <>
-              <ol id="qa-queue-list" className="divide-y divide-overlay/10">
+              <ol id="qa-queue-list" className="grid gap-x-5 sm:grid-cols-3">
                 {data.queue.next.map((item, index) => (
                   <li
                     key={`${item.wingetId}-${item.version}-${item.architecture}`}
-                    className={cn('items-center gap-3 py-3', index >= 3 && !showFullQueue ? 'hidden sm:flex' : 'flex')}
+                    className={cn('items-center gap-3 py-3', index >= 3 && !showFullQueue ? 'hidden' : 'flex')}
                   >
                     <span className="w-5 text-xs tabular-nums text-text-muted">{index + 1}</span>
                     <AppIcon packageId={item.wingetId} packageName={item.displayName} size="sm" />
@@ -535,7 +531,7 @@ function DashboardContent() {
                 <button
                   type="button"
                   onClick={() => setShowFullQueue((current) => !current)}
-                  className="mt-3 min-h-10 w-full rounded-lg border border-overlay/10 px-3 text-sm text-text-secondary hover:bg-overlay/5 hover:text-text-primary sm:hidden"
+                  className="mt-3 min-h-10 w-full rounded-lg border border-overlay/10 px-3 text-sm text-text-secondary hover:bg-overlay/5 hover:text-text-primary"
                   aria-expanded={showFullQueue}
                   aria-controls="qa-queue-list"
                 >
@@ -553,99 +549,33 @@ function DashboardContent() {
           </div>
 
           {data.recent.length ? (
-            <>
-              <div className="divide-y divide-overlay/10 sm:hidden">
-                {data.recent.map((item) => (
+            <ul className="divide-y divide-overlay/10 border-t border-overlay/10">
+              {data.recent.map((item) => (
+                <li key={item.packageProfileSha256}>
                   <button
-                    key={item.packageProfileSha256}
                     type="button"
-                    onClick={() => setSelected({
-                      wingetId: item.wingetId,
-                      catalogVersion: item.catalogVersion,
-                      packageProfileSha256: item.packageProfileSha256,
-                    })}
-                    className={cn(
-                      'flex min-h-20 w-full items-center gap-3 border-l-2 px-5 py-3 text-left transition-colors hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan',
-                      resultEdgeClass(item.outcome)
-                    )}
+                    onClick={() => setSelected({ wingetId: item.wingetId, catalogVersion: item.catalogVersion, packageProfileSha256: item.packageProfileSha256 })}
+                    aria-label={`View QA result for ${item.displayName}, version ${item.testedVersion}`}
+                    className="group flex w-full items-center gap-3 px-5 py-4 text-left transition-colors hover:bg-overlay/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan sm:gap-4 sm:px-6"
                   >
-                    <AppIcon packageId={item.wingetId} packageName={item.displayName} size="sm" />
+                    <AppIcon packageId={item.wingetId} packageName={item.displayName} size="md" />
                     <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-medium text-text-primary">{item.displayName}</span>
-                      <span className="mt-0.5 block text-xs text-text-muted">
-                        {item.testedVersion} · {item.architecture} · {formatQaDuration(item.durationSeconds)}
-                      </span>
-                      <span className="mt-0.5 block text-xs text-text-muted">
-                        {formatRelativeTime(item.testedAtUtc, data.serverTime) ?? <T>Test time unavailable</T>}
+                      <span className="block break-words text-sm font-semibold text-text-primary [overflow-wrap:anywhere]">{item.displayName}</span>
+                      <span className="mt-1 block break-words text-xs text-text-muted [overflow-wrap:anywhere]">{item.testedVersion} · {item.architecture}</span>
+                      <span className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-muted">
+                        <span><T>Duration</T> {formatQaDuration(item.durationSeconds)}</span>
+                        <span>{formatRelativeTime(item.testedAtUtc, data.serverTime) ?? <T>Test time unavailable</T>}</span>
+                        <QaVirusTotalCell status={item.virusTotalStatus} />
                       </span>
                     </span>
-                    <span className="flex flex-col items-end gap-1">
+                    <span className="flex shrink-0 flex-col items-end gap-2">
                       <QaResultStatus outcome={item.outcome} />
-                      {item.virusTotalStatus === 'clean' ||
-                      item.virusTotalStatus === 'flagged' ||
-                      item.virusTotalStatus === 'suspicious' ? (
-                        <QaVirusTotalCell status={item.virusTotalStatus} />
-                      ) : null}
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-accent-cyan"><T>Details</T><ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" aria-hidden="true" /></span>
                     </span>
                   </button>
-                ))}
-              </div>
-
-              <div className="hidden overflow-x-auto sm:block">
-                <table className="w-full text-left text-sm">
-                  <thead className="border-y border-overlay/10 text-xs text-text-muted">
-                    <tr>
-                      <th className="w-full px-6 py-3 font-medium"><T>Application</T></th>
-                      <th className="whitespace-nowrap px-3 py-3 font-medium"><T>Result</T></th>
-                      <th className="whitespace-nowrap px-3 py-3 font-medium"><T>VirusTotal</T></th>
-                      <th className="whitespace-nowrap px-3 py-3 font-medium"><T>Duration</T></th>
-                      <th className="whitespace-nowrap px-6 py-3 font-medium"><T>Tested</T></th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-overlay/10">
-                    {data.recent.map((item) => (
-                      <tr
-                        key={item.packageProfileSha256}
-                        onClick={() => setSelected({
-                          wingetId: item.wingetId,
-                          catalogVersion: item.catalogVersion,
-                          packageProfileSha256: item.packageProfileSha256,
-                        })}
-                        className="cursor-pointer transition-colors hover:bg-overlay/5"
-                      >
-                        <td className={cn('w-full max-w-0 border-l-2 px-6 py-3', resultEdgeClass(item.outcome))}>
-                          <button
-                            type="button"
-                            onClick={() => setSelected({
-                              wingetId: item.wingetId,
-                              catalogVersion: item.catalogVersion,
-                              packageProfileSha256: item.packageProfileSha256,
-                            })}
-                            className="flex min-w-0 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
-                          >
-                            <AppIcon packageId={item.wingetId} packageName={item.displayName} size="sm" />
-                            <span className="min-w-0">
-                              <span className="block truncate font-medium text-text-primary">{item.displayName}</span>
-                              <span className="block text-xs text-text-muted">{item.testedVersion} · {item.architecture}</span>
-                            </span>
-                          </button>
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-3">
-                          <QaResultStatus outcome={item.outcome} />
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-3">
-                          <QaVirusTotalCell status={item.virusTotalStatus} />
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-3 font-mono text-xs text-text-secondary">{formatQaDuration(item.durationSeconds)}</td>
-                        <td className="whitespace-nowrap px-6 py-3 text-xs text-text-muted">
-                          {formatRelativeTime(item.testedAtUtc, data.serverTime) ?? <T>Not recorded</T>}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </>
+                </li>
+              ))}
+            </ul>
           ) : (
             <p className="border-t border-overlay/10 px-6 py-8 text-sm text-text-muted"><T>No QA results have been published yet.</T></p>
           )}

--- a/components/qa/QaDetailsDialog.tsx
+++ b/components/qa/QaDetailsDialog.tsx
@@ -13,12 +13,15 @@ import {
   RefreshCw,
   Settings2,
   ShieldCheck,
+  ShieldQuestion,
   TerminalSquare,
   XCircle,
 } from 'lucide-react';
 import { VirusTotalIcon } from '@/components/qa/VirusTotalIcon';
 import { T, Var } from 'gt-next';
 import { AppIcon } from '@/components/AppIcon';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { getEvidencePhaseStatus, getEvidenceSummary, QA_RESULT_PHASES, type QaPhaseKey } from '@/lib/qa/evidence-presentation';
 import {
   Dialog,
   DialogContent,
@@ -57,23 +60,6 @@ const CATEGORY_LABELS: Record<(typeof QA_CHANGE_CATEGORIES)[number], string> = {
   scheduledTasks: 'Scheduled tasks',
   shortcuts: 'Shortcuts',
 };
-
-function phaseStatus(
-  name: string,
-  result: QaPhaseResult | null
-): { label: string; passed: boolean | null } {
-  if (!result) return { label: 'Not run', passed: null };
-  if (result.timedOut) return { label: 'Timed out', passed: false };
-  if (name === 'Detection after uninstall') {
-    return result.exitCode !== 0
-      ? { label: 'Not detected (expected)', passed: true }
-      : { label: 'Still detected', passed: false };
-  }
-  const passed = name.includes('Detection')
-    ? result.exitCode === 0
-    : [0, 3010, 1641].includes(result.exitCode);
-  return { label: passed ? 'Passed' : 'Failed', passed };
-}
 
 function PromptConfigurationSummary({ configuration }: { configuration: QaPromptConfiguration }) {
   const enabled: Array<{ key: string; content: ReactNode }> = [];
@@ -167,14 +153,14 @@ function SummaryItem({
       </span>
       <span className="min-w-0">
         <span className="block text-xs text-text-muted">{label}</span>
-        <span className="mt-1 block truncate text-sm font-medium text-text-primary">{children}</span>
+        <span className="mt-1 block break-words text-sm font-medium text-text-primary">{children}</span>
       </span>
     </div>
   );
 }
 
-function LifecycleCard({ name, result }: { name: string; result: QaPhaseResult | null }) {
-  const status = phaseStatus(name, result);
+function LifecycleCard({ name, phaseKey, result }: { name: string; phaseKey: QaPhaseKey; result: QaPhaseResult | null }) {
+  const status = getEvidencePhaseStatus(phaseKey, result);
   const Icon = status.passed === true ? CheckCircle2 : status.passed === false ? XCircle : Clock3;
 
   return (
@@ -204,108 +190,43 @@ function LifecycleCard({ name, result }: { name: string; result: QaPhaseResult |
   );
 }
 
-function VirusTotalBanner({
-  virusTotal,
-  installerSha256,
-}: {
-  virusTotal: QaVirusTotalSummary;
-  installerSha256: string | null;
-}) {
+function VirusTotalBanner({ virusTotal, installerSha256 }: { virusTotal: QaVirusTotalSummary; installerSha256: string | null }) {
   const clean = virusTotal.status === 'clean';
   const flagged = virusTotal.status === 'flagged';
   const suspicious = virusTotal.status === 'suspicious';
-  const totalEngines = virusTotal.totalEngines ?? 0;
-  const neutral = !clean && !flagged && !suspicious;
+  const attention = flagged || suspicious;
+  const Icon = clean ? ShieldCheck : ShieldQuestion;
+  const reportLink = installerSha256 ? (
+    <a href={`https://www.virustotal.com/gui/file/${installerSha256.toLowerCase()}`} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-9 items-center gap-1.5 text-xs font-medium text-accent-cyan hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan">
+      <T>View VirusTotal report</T><ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+    </a>
+  ) : null;
 
+  if (!attention) {
+    return (
+      <section className="flex flex-wrap items-start justify-between gap-3 rounded-xl border border-overlay/10 px-4 py-3" aria-label="Installer reputation">
+        <div className="flex min-w-0 items-start gap-3">
+          <Icon className={cn('mt-0.5 h-5 w-5 shrink-0', clean ? 'text-status-success' : 'text-text-muted')} aria-hidden="true" />
+          <div>
+            <h3 className="text-sm font-medium text-text-primary"><T>{clean ? 'VirusTotal: no detections reported' : 'VirusTotal: no verdict available'}</T></h3>
+            <p className="mt-1 text-xs leading-5 text-text-muted">{clean ? <T><Var>{virusTotal.malicious ?? 0}</Var> malicious detections<Var>{virusTotal.totalEngines ? ` across ${virusTotal.totalEngines} vendors` : ""}</Var> at the time of this check.</T> : <T>No reputation verdict was recorded for this installer.</T>}</p>
+            {virusTotal.scannedAtUtc ? <p className="mt-1 text-xs text-text-muted"><T>Analyzed <Var>{new Date(virusTotal.scannedAtUtc).toLocaleDateString()}</Var></T></p> : null}
+          </div>
+        </div>
+        {reportLink}
+      </section>
+    );
+  }
   return (
-    <section
-      aria-labelledby="qa-virustotal-heading"
-      className={cn(
-        'relative overflow-hidden rounded-2xl border p-5 sm:p-6',
-        clean && 'border-status-success/25 bg-gradient-to-br from-status-success/15 via-status-success/5 to-transparent',
-        flagged && 'border-status-error/25 bg-gradient-to-br from-status-error/15 via-status-error/5 to-transparent',
-        suspicious && 'border-status-warning/25 bg-gradient-to-br from-status-warning/15 via-status-warning/5 to-transparent',
-        neutral && 'border-overlay/10 bg-bg-elevated/40'
-      )}
-    >
-      <VirusTotalIcon
-        className={cn(
-          'pointer-events-none absolute -right-5 -top-5 h-32 w-32 opacity-[0.07]',
-          clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-muted'
-        )}
-      />
-      <div className="relative flex items-start gap-4">
-        <span
-          className={cn(
-            'flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white text-[#394EFF] ring-4',
-            clean && 'ring-status-success/15',
-            flagged && 'ring-status-error/15',
-            suspicious && 'ring-status-warning/15',
-            neutral && 'ring-overlay/10'
-          )}
-        >
-          <VirusTotalIcon className="h-6 w-6" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p
-            className={cn(
-              'text-xs font-medium uppercase tracking-[0.16em]',
-              clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-muted'
-            )}
-          >
-            <T>VirusTotal security check</T>
-          </p>
-          <h3
-            id="qa-virustotal-heading"
-            className={cn(
-              'mt-1 text-lg font-semibold sm:text-xl',
-              clean ? 'text-status-success' : flagged ? 'text-status-error' : suspicious ? 'text-status-warning' : 'text-text-primary'
-            )}
-          >
-            {clean ? (
-              <T>No threats found</T>
-            ) : flagged ? (
-              <T><Var>{virusTotal.malicious ?? 0}</Var><Var>{totalEngines > 0 ? ` of ${totalEngines}` : ""}</Var> security vendors flagged this installer as malicious</T>
-            ) : suspicious ? (
-              <T><Var>{virusTotal.suspicious ?? 0}</Var><Var>{totalEngines > 0 ? ` of ${totalEngines}` : ""}</Var> security vendors rated this installer suspicious</T>
-            ) : virusTotal.status === 'not_found' ? (
-              <T>No verdict available yet</T>
-            ) : (
-              <T>Security check unavailable</T>
-            )}
-          </h3>
-          <p className="mt-1.5 text-sm leading-6 text-text-secondary">
-            {clean ? (
-              <T><Var>{virusTotal.malicious ?? 0}</Var><Var>{totalEngines > 0 ? ` of ${totalEngines}` : ""}</Var> security vendors flagged this installer when its verified hash was checked against the VirusTotal database.</T>
-            ) : flagged ? (
-              <T>Packaging of this version is blocked until the finding is reviewed. <Var>{virusTotal.malicious ?? 0}</Var> vendors rated it malicious and <Var>{virusTotal.suspicious ?? 0}</Var> suspicious; earlier versions with a clean verdict remain available.</T>
-            ) : suspicious ? (
-              <T>No vendor rated it malicious, so this version is not blocked. Suspicious verdicts are heuristic and often false positives — review the engines on VirusTotal if in doubt.</T>
-            ) : virusTotal.status === 'not_found' ? (
-              <T>This installer version is not in the VirusTotal database yet, so no reputation verdict is available.</T>
-            ) : virusTotal.status === 'skipped' ? (
-              <T>The VirusTotal lookup was not configured when this run executed.</T>
-            ) : (
-              <T>The VirusTotal lookup could not be completed for this run.</T>
-            )}
-          </p>
-          <p className="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
-            {installerSha256 ? (
-              <a
-                href={`https://www.virustotal.com/gui/file/${installerSha256.toLowerCase()}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 font-medium text-accent-cyan transition-colors hover:text-accent-cyan-bright"
-              >
-                <T>Open on VirusTotal</T>
-                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-              </a>
-            ) : null}
-            <span><T>Hash-only lookup — the installer is never uploaded</T></span>
-            {virusTotal.scannedAtUtc ? (
-              <span><T>Last analyzed <Var>{new Date(virusTotal.scannedAtUtc).toLocaleDateString()}</Var></T></span>
-            ) : null}
-          </p>
+    <section className={cn('rounded-xl border p-4', flagged ? 'border-status-error/25 bg-status-error/5' : 'border-status-warning/25 bg-status-warning/5')} aria-label="Installer reputation finding">
+      <div className="flex items-start gap-3">
+        <VirusTotalIcon className={cn('mt-0.5 h-6 w-6 shrink-0', flagged ? 'text-status-error' : 'text-status-warning')} />
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-text-primary"><T>{flagged ? 'Installer flagged by VirusTotal' : 'Suspicious VirusTotal verdict'}</T></h3>
+          <p className="mt-1 text-sm leading-6 text-text-secondary"><T><Var>{virusTotal.malicious ?? 0}</Var> malicious and <Var>{virusTotal.suspicious ?? 0}</Var> suspicious detections<Var>{virusTotal.totalEngines ? ` across ${virusTotal.totalEngines} vendors` : ""}</Var>.</T></p>
+          <p className="mt-1 text-xs leading-5 text-text-secondary"><T>{flagged ? 'Packaging of this version is blocked until the finding is reviewed.' : 'This verdict does not block this version. Review the vendor findings for details.'}</T></p>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">{reportLink}<span className="text-xs text-text-muted"><T>Hash-only lookup; the installer is not uploaded.</T></span></div>
+          {virusTotal.scannedAtUtc ? <p className="text-xs text-text-muted"><T>Analyzed <Var>{new Date(virusTotal.scannedAtUtc).toLocaleDateString()}</Var></T></p> : null}
         </div>
       </div>
     </section>
@@ -351,13 +272,13 @@ export function QaDetailsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[92vh] max-w-5xl flex-col bg-bg-surface shadow-[0_28px_90px_rgba(0,0,0,0.35)]">
-        <DialogHeader className="shrink-0 border-b border-overlay/10 bg-gradient-to-br from-bg-elevated/80 via-bg-surface to-accent-cyan/5 px-6 py-5 pr-14 sm:px-8 sm:py-6 sm:pr-16">
+      <DialogContent className="flex h-[min(48rem,92dvh)] w-[calc(100%_-_1.5rem)] max-w-4xl flex-col bg-bg-surface">
+        <DialogHeader className="shrink-0 px-5 py-5 pr-12 sm:px-6 sm:pr-14">
           <div className="flex items-center gap-4">
             <AppIcon
               packageId={wingetId}
               packageName={data?.displayName || wingetId}
-              size="xl"
+              size="lg"
               className="shadow-sm"
             />
             <div className="min-w-0 flex-1">
@@ -375,10 +296,10 @@ export function QaDetailsDialog({
                   </span>
                 ) : null}
               </div>
-              <DialogTitle className="truncate text-xl sm:text-2xl">
+              <DialogTitle className="break-words text-xl [overflow-wrap:anywhere]">
                 {data?.displayName || <T>Installation test details</T>}
               </DialogTitle>
-              <DialogDescription className="mt-1 truncate">
+              <DialogDescription className="mt-1 break-words [overflow-wrap:anywhere]">
                 {data
                   ? <>{wingetId} · <T>Version <Var>{data.testedVersion}</Var></T> · {data.architecture}</>
                   : <T>Loading the exact isolated test run and its evidence.</T>}
@@ -387,11 +308,11 @@ export function QaDetailsDialog({
           </div>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6 sm:px-8 sm:py-7">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {isLoading ? (
-            <DetailsSkeleton wingetId={wingetId} />
+            <div className="overflow-y-auto p-5 sm:p-6"><DetailsSkeleton wingetId={wingetId} /></div>
           ) : !data ? (
-            <div className="mx-auto flex min-h-80 max-w-xl flex-col items-center justify-center text-center" role="alert">
+            <div className="mx-auto flex min-h-0 max-w-xl flex-1 flex-col items-center overflow-y-auto p-6 text-center" role="alert">
               <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-status-warning/10 text-status-warning">
                 {isPublishing
                   ? <FileClock className="h-6 w-6" aria-hidden="true" />
@@ -418,121 +339,137 @@ export function QaDetailsDialog({
               </button>
             </div>
           ) : (
-            <div className="space-y-7">
-              <section aria-labelledby="qa-summary-heading">
-                <h3 id="qa-summary-heading" className="sr-only"><T>Test summary</T></h3>
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                  <SummaryItem icon={ShieldCheck} label={<T>Result</T>}>
-                    <span className={data.outcome === 'Passed' ? 'text-status-success' : 'text-status-error'}><T>{data.outcome}</T></span>
-                  </SummaryItem>
-                  <SummaryItem icon={Clock3} label={<T>Total duration</T>}>
-                    {formatQaDuration(data.overallDurationSeconds)}
-                  </SummaryItem>
-                  <SummaryItem icon={PackageCheck} label={<T>Installer</T>}>
-                    {data.installerType?.toUpperCase() || <T>Type unknown</T>}
-                  </SummaryItem>
-                  <SummaryItem icon={Gauge} label={<T>Tested</T>}>
-                    {new Date(data.testedAtUtc).toLocaleString()}
-                  </SummaryItem>
-                </div>
-              </section>
+            <Tabs key={`${wingetId}-${packageProfileSha256 || 'latest'}`} defaultValue="overview" className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 border-b border-overlay/10 px-5 py-3 sm:px-6">
+                <TabsList className="grid w-full grid-cols-3 sm:w-fit" aria-label="Completed test evidence">
+                  <TabsTrigger value="overview" className="min-h-9 px-2 sm:px-3"><T>Overview</T></TabsTrigger>
+                  <TabsTrigger value="changes" className="min-h-9 px-2 sm:px-3"><T>Changes</T></TabsTrigger>
+                  <TabsTrigger value="technical" className="min-h-9 px-2 text-xs sm:px-3 sm:text-sm"><T>Technical details</T></TabsTrigger>
+                </TabsList>
+              </div>
+              <TabsContent value="overview" className="m-0 min-h-0 flex-1 space-y-6 overflow-y-auto p-5 sm:p-6">
+                <section className={cn('rounded-xl border p-4', data.outcome === 'Passed' ? 'border-status-success/20 bg-status-success/5' : 'border-status-error/20 bg-status-error/5')}>
+                  <h3 className="text-base font-semibold text-text-primary"><T>{data.outcome === 'Passed' ? 'Test passed' : 'Test failed'}</T></h3>
+                  <p className="mt-1 text-sm leading-6 text-text-secondary"><T>{getEvidenceSummary(data.outcome, data.phases)}</T></p>
+                </section>
+                {data.testedVersion !== catalogVersion ? (
+                  <div className="flex gap-3 rounded-2xl border border-status-warning/20 bg-status-warning/10 p-4 text-sm leading-6 text-status-warning">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                    <p><QaVersionMismatchNotice testedVersion={data.testedVersion} catalogVersion={catalogVersion} /></p>
+                  </div>
+                ) : null}
 
-              {data.virusTotal ? (
-                <VirusTotalBanner virusTotal={data.virusTotal} installerSha256={data.installerSha256} />
-              ) : null}
+                {data.virusTotal && (data.virusTotal.status === 'flagged' || data.virusTotal.status === 'suspicious') ? (
+                  <VirusTotalBanner virusTotal={data.virusTotal} installerSha256={data.installerSha256} />
+                ) : null}
+                <section aria-labelledby="qa-summary-heading">
+                  <h3 id="qa-summary-heading" className="sr-only"><T>Test summary</T></h3>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <SummaryItem icon={Clock3} label={<T>Total duration</T>}>
+                      {formatQaDuration(data.overallDurationSeconds)}
+                    </SummaryItem>
+                    <SummaryItem icon={PackageCheck} label={<T>Installer</T>}>
+                      {data.installerType?.toUpperCase() || <T>Type unknown</T>}
+                    </SummaryItem>
+                    <SummaryItem icon={Gauge} label={<T>Tested</T>}>
+                      {new Date(data.testedAtUtc).toLocaleString()}
+                    </SummaryItem>
+                  </div>
+                </section>
 
-              {data.testedVersion !== catalogVersion ? (
-                <div className="flex gap-3 rounded-2xl border border-status-warning/20 bg-status-warning/10 p-4 text-sm leading-6 text-status-warning">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-                  <p><QaVersionMismatchNotice testedVersion={data.testedVersion} catalogVersion={catalogVersion} /></p>
-                </div>
-              ) : null}
+                <section className="space-y-3" aria-labelledby="qa-lifecycle-heading">
+                  <div>
+                    <h3 id="qa-lifecycle-heading" className="text-base font-semibold text-text-primary"><T>Installation lifecycle</T></h3>
+                    <p className="mt-1 text-sm text-text-muted"><T>Recorded checks from this isolated Windows test.</T></p>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {QA_RESULT_PHASES.map(({ key, label }) => (
+                      <LifecycleCard key={key} phaseKey={key} name={label} result={data.phases[key]} />
+                    ))}
+                  </div>
+                </section>
 
-              <section className="space-y-3" aria-labelledby="qa-lifecycle-heading">
-                <div>
-                  <h3 id="qa-lifecycle-heading" className="text-base font-semibold text-text-primary"><T>Installation lifecycle</T></h3>
-                  <p className="mt-1 text-sm text-text-muted"><T>The package was installed, detected, removed, and checked again inside a clean Windows VM.</T></p>
-                </div>
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                  <LifecycleCard name="Install" result={data.phases.install} />
-                  <LifecycleCard name="Detection after install" result={data.phases.detectionAfterInstall} />
-                  <LifecycleCard name="Uninstall" result={data.phases.uninstall} />
-                  <LifecycleCard name="Detection after uninstall" result={data.phases.detectionAfterUninstall} />
-                </div>
-              </section>
+                {data.virusTotal && data.virusTotal.status !== 'flagged' && data.virusTotal.status !== 'suspicious' ? (
+                  <VirusTotalBanner virusTotal={data.virusTotal} installerSha256={data.installerSha256} />
+                ) : null}
 
-              {data.effectiveConfiguration ? (
-                <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-configuration-heading">
-                  <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
-                    <Settings2 className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
+              </TabsContent>
+              <TabsContent value="changes" className="m-0 min-h-0 flex-1 space-y-6 overflow-y-auto p-5 sm:p-6">
+                {data.changes ? (
+                  <section className="space-y-3" aria-labelledby="qa-changes-heading">
                     <div>
-                      <h3 id="qa-configuration-heading" className="text-sm font-semibold text-text-primary"><T>Test configuration</T></h3>
-                      <p className="mt-0.5 text-xs text-text-muted"><T>The effective PSADT settings used for this exact run.</T></p>
+                      <h3 id="qa-changes-heading" className="text-base font-semibold text-text-primary"><T>Observed system changes</T></h3>
+                      <p className="mt-1 text-sm text-text-muted"><T>Compare installation counts with the changes remaining after uninstall. Detailed paths are not retained in this result.</T></p>
+                    </div>
+                    <p className="text-xs leading-relaxed text-text-muted"><T>Counts are correlated with the test window, not attributed to the app; background Windows activity is included. A nonzero residual does not mean the uninstall was dirty.</T></p>
+                    <ChangeTable title="Changes after installation" changes={data.changes.afterInstall} />
+                    {data.phases.uninstall ? <ChangeTable title="Residual changes after uninstall" changes={data.changes.residualAfterUninstall} /> : <p className="rounded-xl border border-overlay/10 p-4 text-sm text-text-muted"><T>Uninstall was not run; no removal comparison is available.</T></p>}
+                  </section>
+                ) : <p className="rounded-xl border border-dashed border-overlay/15 p-6 text-sm text-text-muted"><T>System-change counts were not recorded for this run.</T></p>}
+
+              </TabsContent>
+              <TabsContent value="technical" className="m-0 min-h-0 flex-1 space-y-6 overflow-y-auto p-5 sm:p-6">
+                {data.effectiveConfiguration ? (
+                  <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-configuration-heading">
+                    <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
+                      <Settings2 className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
+                      <div>
+                        <h3 id="qa-configuration-heading" className="text-sm font-semibold text-text-primary"><T>Test configuration</T></h3>
+                        <p className="mt-0.5 text-xs text-text-muted"><T>The effective PSADT settings used for this exact run.</T></p>
+                      </div>
+                    </div>
+                    <div className="grid gap-x-6 gap-y-5 p-5 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                      <div><span className="block text-xs text-text-muted"><T>Deploy mode</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.deployMode}</code></div>
+                      <div><span className="block text-xs text-text-muted"><T>Restart behavior</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.restartBehavior}</code></div>
+                      <div><span className="block text-xs text-text-muted"><T>Processes to close</T></span><span className="mt-1 block font-medium text-text-primary">{data.effectiveConfiguration.processCloseCount}</span></div>
+                      <div><span className="block text-xs text-text-muted"><T>UI evidence expected</T></span><span className="mt-1 block font-medium text-text-primary"><T>{data.effectiveConfiguration.uiEvidenceExpected ? 'Yes' : 'No'}</T></span></div>
+                      <div className="sm:col-span-2 lg:col-span-4"><span className="block text-xs text-text-muted"><T>Prompt configuration</T></span><span className="mt-1 block text-text-primary"><PromptConfigurationSummary configuration={data.effectiveConfiguration.promptConfiguration} /></span></div>
+                      <div className="sm:col-span-2 lg:col-span-4">
+                        <span className="block text-xs text-text-muted"><T>Vendor silent arguments</T></span>
+                        <code className="mt-1.5 block overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 px-3 py-2.5 text-xs text-text-secondary">
+                          {data.effectiveConfiguration.vendorSilentArguments === null
+                            ? <T>Custom deployment arguments withheld</T>
+                            : data.effectiveConfiguration.vendorSilentArguments || <T>No arguments required</T>}
+                        </code>
+                      </div>
+                    </div>
+                  </section>
+                ) : null}
+
+                <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-method-heading">
+                  <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
+                    <TerminalSquare className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
+                    <div>
+                      <h3 id="qa-method-heading" className="text-sm font-semibold text-text-primary"><T>Installation method</T></h3>
+                      <p className="mt-0.5 text-xs text-text-muted"><T>Commands and detection logic used by the package.</T></p>
                     </div>
                   </div>
-                  <div className="grid gap-x-6 gap-y-5 p-5 text-sm sm:grid-cols-2 lg:grid-cols-4">
-                    <div><span className="block text-xs text-text-muted"><T>Deploy mode</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.deployMode}</code></div>
-                    <div><span className="block text-xs text-text-muted"><T>Restart behavior</T></span><code className="mt-1 block text-text-primary">{data.effectiveConfiguration.restartBehavior}</code></div>
-                    <div><span className="block text-xs text-text-muted"><T>Processes to close</T></span><span className="mt-1 block font-medium text-text-primary">{data.effectiveConfiguration.processCloseCount}</span></div>
-                    <div><span className="block text-xs text-text-muted"><T>UI evidence expected</T></span><span className="mt-1 block font-medium text-text-primary"><T>{data.effectiveConfiguration.uiEvidenceExpected ? 'Yes' : 'No'}</T></span></div>
-                    <div className="sm:col-span-2 lg:col-span-4"><span className="block text-xs text-text-muted"><T>Prompt configuration</T></span><span className="mt-1 block text-text-primary"><PromptConfigurationSummary configuration={data.effectiveConfiguration.promptConfiguration} /></span></div>
-                    <div className="sm:col-span-2 lg:col-span-4">
-                      <span className="block text-xs text-text-muted"><T>Vendor silent arguments</T></span>
-                      <code className="mt-1.5 block overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 px-3 py-2.5 text-xs text-text-secondary">
-                        {data.effectiveConfiguration.vendorSilentArguments === null
-                          ? <T>Custom deployment arguments withheld</T>
-                          : data.effectiveConfiguration.vendorSilentArguments || <T>No arguments required</T>}
-                      </code>
+                  <div className="space-y-5 p-5">
+                    <div>
+                      <p className="mb-1.5 text-xs text-text-muted"><T>Install command</T></p>
+                      <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.install}</pre>
                     </div>
+                    <div>
+                      <p className="mb-1.5 text-xs text-text-muted"><T>Uninstall command</T></p>
+                      <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.uninstall}</pre>
+                    </div>
+                    <p className="text-xs leading-5 text-text-secondary">
+                      {data.detection.type === 'fileVersion' ? (
+                        <T>Detection: file version at <Var><code className="rounded bg-bg-deepest px-1 py-0.5">{data.detection.path}</code></Var> must be at least <Var>{data.detection.minimumVersion}</Var>.</T>
+                      ) : (
+                        <T>Detection: <Var>{data.detection.description}</Var>.</T>
+                      )}
+                    </p>
                   </div>
                 </section>
-              ) : null}
 
-              <section className="overflow-hidden rounded-2xl border border-overlay/10" aria-labelledby="qa-method-heading">
-                <div className="flex items-center gap-3 border-b border-overlay/10 bg-bg-elevated/50 px-5 py-4">
-                  <TerminalSquare className="h-4.5 w-4.5 text-accent-cyan" aria-hidden="true" />
-                  <div>
-                    <h3 id="qa-method-heading" className="text-sm font-semibold text-text-primary"><T>Installation method</T></h3>
-                    <p className="mt-0.5 text-xs text-text-muted"><T>Commands and detection logic used by the package.</T></p>
-                  </div>
-                </div>
-                <div className="space-y-5 p-5">
-                  <div>
-                    <p className="mb-1.5 text-xs text-text-muted"><T>Install command</T></p>
-                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.install}</pre>
-                  </div>
-                  <div>
-                    <p className="mb-1.5 text-xs text-text-muted"><T>Uninstall command</T></p>
-                    <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-xl bg-bg-deepest/60 p-3 text-xs text-text-secondary">{data.commands.uninstall}</pre>
-                  </div>
-                  <p className="text-xs leading-5 text-text-secondary">
-                    {data.detection.type === 'fileVersion' ? (
-                      <T>Detection: file version at <Var><code className="rounded bg-bg-deepest px-1 py-0.5">{data.detection.path}</code></Var> must be at least <Var>{data.detection.minimumVersion}</Var>.</T>
-                    ) : (
-                      <T>Detection: <Var>{data.detection.description}</Var>.</T>
-                    )}
-                  </p>
-                </div>
-              </section>
-
-              {data.changes ? (
-                <section className="space-y-3" aria-labelledby="qa-changes-heading">
-                  <div>
-                    <h3 id="qa-changes-heading" className="text-base font-semibold text-text-primary"><T>Observed system changes</T></h3>
-                    <p className="mt-1 text-sm text-text-muted"><T>Compact counts captured before and after the installation lifecycle.</T></p>
-                  </div>
-                  <ChangeTable title="Changes after installation" changes={data.changes.afterInstall} />
-                  <ChangeTable title="Residual changes after uninstall" changes={data.changes.residualAfterUninstall} />
-                  <p className="text-xs leading-relaxed text-text-muted"><T>Counts are correlated with the test window, not attributed to the app; background Windows activity is included. A nonzero residual does not mean the uninstall was dirty.</T></p>
+                <section className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-overlay/10 pt-5 text-xs text-text-muted">
+                  <span><T>Publisher</T>: <span className="text-text-secondary">{data.publisher || <T>Not recorded</T>}</span></span>
+                  <span>PSADT <span className="text-text-secondary">{data.package?.psadtVersion || <T>version unknown</T>}</span></span>
+                  <span><T>Windows events</T>: <span className="text-text-secondary">{data.relevantEventCount ?? <T>Not recorded</T>}</span></span>
                 </section>
-              ) : null}
-
-              <section className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-overlay/10 pt-5 text-xs text-text-muted">
-                <span><T>Publisher</T>: <span className="text-text-secondary">{data.publisher || <T>Not recorded</T>}</span></span>
-                <span>PSADT <span className="text-text-secondary">{data.package?.psadtVersion || <T>version unknown</T>}</span></span>
-                <span><T>Windows events</T>: <span className="text-text-secondary">{data.relevantEventCount ?? <T>Not recorded</T>}</span></span>
-              </section>
-            </div>
+              </TabsContent>
+            </Tabs>
           )}
         </div>
       </DialogContent>

--- a/components/qa/QaLiveActivityDialog.tsx
+++ b/components/qa/QaLiveActivityDialog.tsx
@@ -3,6 +3,8 @@
 import { ChevronRight, FileCode2, ListTree, ScrollText } from 'lucide-react';
 import { T, Var } from 'gt-next';
 import { QaLiveActivityPanel } from '@/components/qa/QaLiveActivityPanel';
+import { AppIcon } from '@/components/AppIcon';
+import { getQaPhasePresentation } from '@/lib/qa/presentation';
 import {
   Dialog,
   DialogContent,
@@ -18,11 +20,13 @@ export function QaLiveActivityDialog({
   log,
   phase,
   serverTime,
+  app,
 }: {
   activity: QaLiveActivity | null;
   log: QaLiveLog | null;
   phase: QaLivePhase;
   serverTime: string;
+  app: { wingetId: string; displayName: string; version: string; architecture: string; startedAt: string };
 }) {
   const fileCount = activity
     ? activity.counts.filesAdded + activity.counts.filesChanged + activity.counts.filesRemoved
@@ -45,7 +49,7 @@ export function QaLiveActivityDialog({
             <span className="min-w-0">
               <span className="block text-sm font-medium text-text-primary"><T>Detected system changes</T></span>
               <span className="mt-0.5 block text-xs text-text-muted">
-                <T>Open live files, registry activity, and the sanitized PSADT log</T>
+                <T>View file changes, registry entries, and installation log</T>
               </span>
             </span>
           </span>
@@ -67,22 +71,24 @@ export function QaLiveActivityDialog({
           </span>
         </button>
       </DialogTrigger>
-      <DialogContent className="flex max-h-[92vh] w-[calc(100%_-_1.5rem)] max-w-6xl flex-col">
-        <DialogHeader className="shrink-0 pr-10">
-          <DialogTitle><T>Live installation evidence</T></DialogTitle>
-          <DialogDescription>
-            <T>Sanitized snapshot changes and PSADT activity from the isolated test VM.</T>
-          </DialogDescription>
+      <DialogContent className="flex h-[min(48rem,92dvh)] w-[calc(100%_-_1.5rem)] max-w-4xl flex-col bg-bg-surface">
+        <DialogHeader className="shrink-0 px-5 py-5 pr-12 sm:px-6 sm:pr-14">
+          <div className="flex items-center gap-3">
+            <AppIcon packageId={app.wingetId} packageName={app.displayName} size="lg" />
+            <div className="min-w-0">
+              <p className="mb-1 flex flex-wrap items-center gap-2 text-xs font-medium text-accent-cyan"><span className="h-1.5 w-1.5 rounded-full bg-accent-cyan" aria-hidden="true" /><T>Live test</T><span className="text-text-muted">· <T>{getQaPhasePresentation(phase).label}</T></span></p>
+              <DialogTitle className="break-words text-xl [overflow-wrap:anywhere]">{app.displayName}</DialogTitle>
+              <DialogDescription className="mt-1 break-words"><T>Version <Var>{app.version}</Var></T> · {app.architecture}</DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
-        <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-5">
           <QaLiveActivityPanel
+            key={`${app.wingetId}-${app.startedAt}`}
             activity={activity}
             log={log}
             phase={phase}
             serverTime={serverTime}
-            mode="dialog"
           />
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/components/qa/QaLiveActivityPanel.tsx
+++ b/components/qa/QaLiveActivityPanel.tsx
@@ -1,351 +1,117 @@
 'use client';
 
-import { memo, useMemo, useState, type KeyboardEvent } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { T, Var } from 'gt-next';
 import { ChevronLeft, ChevronRight, FileCode2, ListTree, Minus, Pencil, Plus, ScrollText } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { evidenceTargetName } from '@/lib/qa/evidence-presentation';
 import { cn } from '@/lib/utils';
 import type { QaLiveActivity, QaLiveActivityChange, QaLiveActivityKind, QaLiveLog, QaLivePhase } from '@/types/qa';
 
 type Filter = 'all' | QaLiveActivityKind;
-type MobileView = 'changes' | 'log';
-
 const ITEMS_PER_PAGE = 6;
-
-const FILTERS: Array<{ id: Filter; label: string }> = [
-  { id: 'all', label: 'All' },
-  { id: 'file', label: 'Files' },
-  { id: 'registry', label: 'Registry' },
-];
-
+const FILTERS: Array<{ id: Filter; label: string }> = [{ id: 'all', label: 'All changes' }, { id: 'file', label: 'Files' }, { id: 'registry', label: 'Registry' }];
 const CHANGE_PRESENTATION: Record<QaLiveActivityChange, { label: string; className: string; Icon: typeof Plus }> = {
-  added: { label: 'Added', className: 'bg-status-success/10 text-status-success', Icon: Plus },
-  changed: { label: 'Updated', className: 'bg-status-warning/10 text-status-warning', Icon: Pencil },
-  removed: { label: 'Removed', className: 'bg-status-error/10 text-status-error', Icon: Minus },
+  added: { label: 'Added', className: 'text-status-success', Icon: Plus },
+  changed: { label: 'Updated', className: 'text-status-warning', Icon: Pencil },
+  removed: { label: 'Removed', className: 'text-text-secondary', Icon: Minus },
 };
-
-const KNOWN_OS_NOISE_TARGET_PREFIXES = [
-  '%programdata%\\microsoft\\diagnosis\\aggregatorstorage',
-];
+const PAGE_BUTTON = 'inline-flex min-h-10 items-center gap-1 rounded-lg border border-overlay/10 px-3 text-sm text-text-secondary hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan disabled:opacity-40';
 
 function isKnownOsNoiseTarget(target: string): boolean {
-  const normalizedTarget = target.trim().toLowerCase();
-  return KNOWN_OS_NOISE_TARGET_PREFIXES.some(
-    (prefix) => normalizedTarget === prefix || normalizedTarget.startsWith(`${prefix}\\`)
-  );
-}
-
-function compactTarget(target: string): string {
-  if (target.length <= 56) return target;
-  const separator = target.lastIndexOf('\\');
-  const leaf = separator >= 0 ? target.slice(separator + 1) : target.slice(-24);
-  const prefixLength = Math.max(18, 52 - leaf.length);
-  return `${target.slice(0, prefixLength)}…\\${leaf}`;
-}
-
-function ChangeBadge({ change }: { change: QaLiveActivityChange }) {
-  const presentation = CHANGE_PRESENTATION[change];
-  return (
-    <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium', presentation.className)}>
-      <presentation.Icon className="h-3 w-3" aria-hidden="true" />
-      <T>{presentation.label}</T>
-    </span>
-  );
-}
-
-function KindLabel({ kind }: { kind: QaLiveActivityKind }) {
-  const Icon = kind === 'file' ? FileCode2 : ListTree;
-  return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-text-secondary">
-      <Icon className="h-3.5 w-3.5 text-text-muted" aria-hidden="true" />
-      <T>{kind === 'file' ? 'File' : 'Registry'}</T>
-    </span>
-  );
+  const normalized = target.trim().toLowerCase();
+  const prefix = '%programdata%\\microsoft\\diagnosis\\aggregatorstorage';
+  return normalized === prefix || normalized.startsWith(`${prefix}\\`);
 }
 
 function emptyMessage(phase: QaLivePhase): string {
-  if (phase === 'installing') return 'Changes appear after installation completes and the clean and installed snapshots are compared.';
-  if (phase === 'uninstalling') return 'The install comparison is complete. Uninstall changes appear after removal finishes.';
-  if (phase === 'detecting_install' || phase === 'verifying_removal') return 'The VM is comparing trusted before-and-after snapshots.';
-  return 'System-change evidence will appear when an installation snapshot is available.';
+  if (phase === 'installing') return 'Collecting installation activity. File and registry samples will appear as evidence becomes available.';
+  if (phase === 'uninstalling') return 'Removal changes will appear when the uninstall comparison is available.';
+  return 'File and registry changes will appear when the VM publishes its next comparison.';
 }
 
-export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({
-  activity,
-  log,
-  phase,
-  serverTime,
-  mode = 'panel',
-}: {
+export const QaLiveActivityPanel = memo(function QaLiveActivityPanel({ activity, log, phase, serverTime }: {
   activity: QaLiveActivity | null;
   log: QaLiveLog | null;
   phase: QaLivePhase;
   serverTime: string;
-  mode?: 'panel' | 'dialog';
 }) {
   const [filter, setFilter] = useState<Filter>('all');
   const [page, setPage] = useState(1);
-  const [mobileView, setMobileView] = useState<MobileView>('changes');
-  const fileCount = activity
-    ? activity.counts.filesAdded + activity.counts.filesChanged + activity.counts.filesRemoved
-    : 0;
-  const registryCount = activity
-    ? activity.counts.registryAdded + activity.counts.registryChanged + activity.counts.registryRemoved
-    : 0;
-  const filteredItems = useMemo(
-    () => activity?.items.filter(
-      (item) => !isKnownOsNoiseTarget(item.target) && (filter === 'all' || item.kind === filter)
-    ) ?? [],
-    [activity, filter]
-  );
-  const pageCount = Math.max(1, Math.ceil(filteredItems.length / ITEMS_PER_PAGE));
+  const fileCount = activity ? activity.counts.filesAdded + activity.counts.filesChanged + activity.counts.filesRemoved : 0;
+  const registryCount = activity ? activity.counts.registryAdded + activity.counts.registryChanged + activity.counts.registryRemoved : 0;
+  const counts: Record<Filter, number> = { all: fileCount + registryCount, file: fileCount, registry: registryCount };
+  const items = useMemo(() => activity?.items.filter((item) => !isKnownOsNoiseTarget(item.target) && (filter === 'all' || item.kind === filter)) ?? [], [activity, filter]);
+  const pageCount = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
   const currentPage = Math.min(page, pageCount);
   const pageStart = (currentPage - 1) * ITEMS_PER_PAGE;
-  const paginatedItems = filteredItems.slice(pageStart, pageStart + ITEMS_PER_PAGE);
-  const filterCounts: Record<Filter, number> = {
-    all: fileCount + registryCount,
-    file: fileCount,
-    registry: registryCount,
-  };
-  const detailsMissingFromSample = Boolean(
-    activity && filterCounts[filter] > 0 && filteredItems.length === 0
-  );
-  const logAgeSeconds = log ? Math.max(0, Math.floor((new Date(serverTime).getTime() - new Date(log.lastWriteAt).getTime()) / 1000)) : null;
-  const logAgeMinutes = logAgeSeconds == null ? null : Math.floor(logAgeSeconds / 60);
-  const logLastEntryTime = log
-    ? new Date(log.lastWriteAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-    : null;
-
-  function moveFilter(event: KeyboardEvent<HTMLButtonElement>, index: number) {
-    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
-    event.preventDefault();
-    const nextIndex = event.key === 'Home'
-      ? 0
-      : event.key === 'End'
-        ? FILTERS.length - 1
-        : (index + (event.key === 'ArrowRight' ? 1 : -1) + FILTERS.length) % FILTERS.length;
-    setFilter(FILTERS[nextIndex].id);
-    setPage(1);
-    document.getElementById(`qa-activity-tab-${FILTERS[nextIndex].id}`)?.focus();
-  }
-
-  function selectFilter(nextFilter: Filter) {
-    setFilter(nextFilter);
-    setPage(1);
-  }
+  const logAgeMinutes = log ? Math.max(0, Math.floor((Date.parse(serverTime) - Date.parse(log.lastWriteAt)) / 60000)) : null;
 
   return (
-    <section
-      className={cn(
-        'flex flex-col overflow-hidden rounded-xl border border-overlay/10 bg-bg-surface/45',
-        mode === 'dialog' ? 'min-h-[34rem]' : 'min-h-[22rem]'
-      )}
-      aria-labelledby="system-changes-heading"
-    >
-      <div className="border-b border-overlay/10 px-4 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h3 id="system-changes-heading" className="text-sm font-medium text-text-primary"><T>Detected system changes</T></h3>
-            <p className="mt-1 text-xs text-text-muted">
-              <T>{activity?.stage === 'during_install'
-                ? 'Live installation activity'
-                : activity?.stage === 'after_uninstall'
-                  ? 'Removal comparison'
-                  : activity
-                    ? 'Installation comparison'
-                    : 'Awaiting comparison'}</T>
-            </p>
-          </div>
-          <span className="flex items-center gap-1.5 text-xs text-text-muted">
-            <span className={cn('h-1.5 w-1.5 rounded-full', activity ? 'bg-status-success' : 'animate-pulse bg-accent-cyan motion-reduce:animate-none')} aria-hidden="true" />
-            <T>{activity ? 'Observed' : 'Collecting'}</T>
-          </span>
-        </div>
-        <p className="sr-only" aria-live="polite">
-          <T><Var>{fileCount}</Var> file changes and <Var>{registryCount}</Var> registry changes observed</T>
-        </p>
-        <div className="mt-3 hidden grid-cols-2 gap-2 sm:grid">
-          <div className="rounded-lg border border-overlay/10 bg-overlay/[0.03] px-3 py-2">
-            <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>Files</T></p>
-            <p className="mt-0.5 font-mono text-lg font-semibold text-text-primary">{fileCount}</p>
-          </div>
-          <div className="rounded-lg border border-overlay/10 bg-overlay/[0.03] px-3 py-2">
-            <p className="text-[11px] uppercase tracking-wide text-text-muted"><T>Registry</T></p>
-            <p className="mt-0.5 font-mono text-lg font-semibold text-text-primary">{registryCount}</p>
-          </div>
-        </div>
-        <div className="mt-3 flex items-center justify-between rounded-lg border border-overlay/10 bg-overlay/[0.03] px-3 py-2 text-xs sm:hidden">
-          <span className="text-text-secondary"><T><Var>{fileCount}</Var> files · <Var>{registryCount}</Var> registry</T></span>
-          <span className="text-text-muted">
-            <T>{activity?.stage === 'during_install' ? 'Live activity' : activity ? 'Snapshot ready' : 'Collecting'}</T>
-          </span>
-        </div>
-        <div className="mt-3 grid grid-cols-2 rounded-lg border border-overlay/10 bg-overlay/[0.02] p-1 sm:hidden" role="group" aria-label="Live evidence view">
-          {(['changes', 'log'] as const).map((view) => (
-            <button
-              key={view}
-              type="button"
-              aria-pressed={mobileView === view}
-              onClick={() => setMobileView(view)}
-              className={cn(
-                'min-h-9 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan',
-                mobileView === view ? 'bg-overlay/10 text-text-primary' : 'text-text-muted'
-              )}
-            >
-              <T>{view === 'changes' ? 'Changes' : 'Log'}</T>
-            </button>
-          ))}
-        </div>
+    <Tabs defaultValue="changes" className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 border-b border-overlay/10 px-5 py-3 sm:px-6">
+        <TabsList className="grid w-full grid-cols-2 sm:w-fit" aria-label="Live test evidence">
+          <TabsTrigger value="changes" className="min-h-9 gap-2"><ListTree className="h-4 w-4" aria-hidden="true" /><T>Changes</T></TabsTrigger>
+          <TabsTrigger value="log" className="min-h-9 gap-2"><ScrollText className="h-4 w-4" aria-hidden="true" /><T>Log</T></TabsTrigger>
+        </TabsList>
       </div>
-
-      <div className={cn('border-b border-overlay/10 bg-black/15 px-4 py-3', mobileView !== 'log' && 'hidden sm:block')}>
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <span className="flex items-center gap-2 text-xs font-medium text-text-secondary">
-            <ScrollText className="h-3.5 w-3.5 text-accent-cyan" aria-hidden="true" />
-            <T>Live PSADT log</T>
-          </span>
-          <span className="text-[10px] text-text-muted">
-            {logAgeMinutes != null && logAgeMinutes >= 1 ? (
-              <T>No new entry for <Var>{logAgeMinutes}</Var>m</T>
-            ) : logLastEntryTime ? (
-              <T>Last entry <Var>{logLastEntryTime}</Var></T>
-            ) : (
-              <T>Waiting for output</T>
-            )}
-          </span>
+      <TabsContent value="changes" className="m-0 min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6">
+        <div className="mb-5 space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold text-text-primary"><T>{activity?.stage === 'during_install' ? 'During installation' : activity?.stage === 'after_uninstall' ? 'After uninstall' : activity ? 'After installation' : 'Collecting changes'}</T></h3>
+            {activity ? <span className="text-xs text-text-muted"><T>Updated <Var>{new Date(activity.observedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</Var></T></span> : null}
+          </div>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Filter system changes">
+            {FILTERS.map((item) => (
+              <button key={item.id} type="button" aria-pressed={filter === item.id} onClick={() => { setFilter(item.id); setPage(1); }}
+                className={cn('min-h-10 rounded-lg border px-3 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan', filter === item.id ? 'border-accent-cyan/30 bg-accent-cyan/10 text-accent-cyan' : 'border-overlay/10 text-text-secondary hover:bg-overlay/5')}>
+                <T>{item.label}</T><span className="ml-2 tabular-nums">{counts[item.id]}</span>
+              </button>
+            ))}
+          </div>
+          <p className="text-xs leading-5 text-text-muted"><T><Var>{items.length}</Var> sampled paths available · <Var>{counts[filter]}</Var> changes observed in this category.</T>{' '}<T>Counts cover the test window and may include background Windows activity.</T></p>
         </div>
-        {log?.lines.length ? (
-          <ol className="max-h-28 space-y-1 overflow-y-auto font-mono text-[10px] leading-relaxed text-text-muted" aria-label="Latest sanitized PSADT log entries">
-            {log.lines.map((line, index) => <li key={`${index}-${line}`}>{line}</li>)}
-          </ol>
-        ) : (
-          <p className="text-xs text-text-muted"><T>Sanitized toolkit messages will appear while the installer is running.</T></p>
-        )}
-      </div>
-
-      <div className={cn('border-b border-overlay/10 px-3 py-2', mobileView !== 'changes' && 'hidden sm:block')}>
-        <div className="flex gap-1" role="tablist" aria-label="System change type">
-          {FILTERS.map((item, index) => (
-            <button
-              id={`qa-activity-tab-${item.id}`}
-              key={item.id}
-              type="button"
-              role="tab"
-              aria-selected={filter === item.id}
-              aria-controls="qa-activity-panel"
-              tabIndex={filter === item.id ? 0 : -1}
-              onClick={() => selectFilter(item.id)}
-              onKeyDown={(event) => moveFilter(event, index)}
-              className={cn(
-                'min-h-9 rounded-md px-2.5 py-1.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan',
-                filter === item.id ? 'bg-overlay/10 text-text-primary' : 'text-text-muted hover:text-text-secondary'
-              )}
-            >
-              <T>{item.label}</T> <span className="font-mono text-[10px]">{filterCounts[item.id]}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div
-        id="qa-activity-panel"
-        role="tabpanel"
-        aria-labelledby={`qa-activity-tab-${filter}`}
-        className={cn(
-          'min-h-0 flex-1 overflow-y-auto',
-          paginatedItems.length > 0 && 'min-h-72 sm:min-h-88',
-          mobileView !== 'changes' && 'hidden sm:block'
-        )}
-      >
-        {paginatedItems.length ? (
-          <>
-            <div className="hidden sm:block">
-              <table className="w-full table-fixed text-left">
-                <caption className="sr-only"><T>Sanitized file and registry changes detected by snapshot comparison</T></caption>
-                <thead className="sticky top-0 z-10 border-b border-overlay/10 bg-bg-elevated text-[11px] text-text-muted">
-                  <tr>
-                    <th scope="col" className="w-24 px-4 py-2 font-medium"><T>Kind</T></th>
-                    <th scope="col" className="w-24 px-2 py-2 font-medium"><T>Change</T></th>
-                    <th scope="col" className="px-2 py-2 pr-4 font-medium"><T>Target</T></th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-overlay/10">
-                  {paginatedItems.map((item) => (
-                    <tr key={`${item.kind}|${item.change}|${item.target}`}>
-                      <td className="px-4 py-2.5"><KindLabel kind={item.kind} /></td>
-                      <td className="px-2 py-2.5"><ChangeBadge change={item.change} /></td>
-                      <td className="px-2 py-2.5 pr-4">
-                        <code
-                          className={cn('block text-[11px] text-text-secondary', mode === 'dialog' ? 'break-all' : 'truncate')}
-                          title={item.target}
-                        >
-                          {mode === 'dialog' ? item.target : compactTarget(item.target)}
-                        </code>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <ul className="divide-y divide-overlay/10 sm:hidden" aria-label="Detected system changes">
-              {paginatedItems.map((item) => (
-                <li key={`${item.kind}|${item.change}|${item.target}`} className="space-y-2 px-4 py-3">
-                  <div className="flex items-center justify-between gap-3"><KindLabel kind={item.kind} /><ChangeBadge change={item.change} /></div>
-                  <code className="block break-all text-[11px] leading-relaxed text-text-secondary">{item.target}</code>
+        {items.length ? (
+          <ul className="divide-y divide-overlay/10 rounded-xl border border-overlay/10">
+            {items.slice(pageStart, pageStart + ITEMS_PER_PAGE).map((item) => {
+              const KindIcon = item.kind === 'file' ? FileCode2 : ListTree;
+              const change = CHANGE_PRESENTATION[item.change];
+              return (
+                <li key={`${item.kind}|${item.change}|${item.target}`}>
+                  <details className="group">
+                    <summary className="flex min-h-16 cursor-pointer list-none items-center gap-3 px-4 py-3 hover:bg-overlay/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-cyan [&::-webkit-details-marker]:hidden">
+                      <KindIcon className="h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
+                      <span className="min-w-0 flex-1"><span className="block break-words text-sm font-medium text-text-primary [overflow-wrap:anywhere]">{evidenceTargetName(item.target)}</span><span className="mt-0.5 block text-xs text-text-muted"><T>{item.kind === 'file' ? 'File or directory' : 'Registry entry'}</T></span></span>
+                      <span className={cn('inline-flex shrink-0 items-center gap-1 text-xs font-medium', change.className)}><change.Icon className="h-3.5 w-3.5" aria-hidden="true" /><T>{change.label}</T></span>
+                      <ChevronRight className="h-4 w-4 shrink-0 text-text-muted transition-transform group-open:rotate-90 motion-reduce:transition-none" aria-hidden="true" />
+                      <span className="sr-only"><T>Show full sanitized path</T></span>
+                    </summary>
+                    <div className="border-t border-overlay/5 bg-bg-elevated/40 px-4 py-3"><p className="mb-1 text-xs text-text-muted"><T>Full sanitized path</T></p><code className="select-text break-all text-xs leading-6 text-text-secondary">{item.target}</code></div>
+                  </details>
                 </li>
-              ))}
-            </ul>
-          </>
+              );
+            })}
+          </ul>
         ) : (
-          <div className="flex h-full min-h-44 items-center justify-center px-6 py-8 text-center">
-            <div>
-              <ListTree className="mx-auto h-6 w-6 text-text-muted" aria-hidden="true" />
-              <p className="mt-3 text-sm text-text-secondary">
-                {detailsMissingFromSample ? (
-                  <T><Var>{filterCounts[filter]}</Var> changes were counted, but their detailed paths were not included in this run&apos;s evidence sample.</T>
-                ) : (
-                  <T>{activity ? 'No changes in this category were detected.' : emptyMessage(phase)}</T>
-                )}
-              </p>
-            </div>
+          <div className="flex min-h-52 flex-col items-center justify-center rounded-xl border border-dashed border-overlay/15 px-6 text-center">
+            <ListTree className="mb-3 h-7 w-7 text-text-muted" aria-hidden="true" />
+            <p className="max-w-md text-sm leading-6 text-text-secondary"><T>{counts[filter] > 0 ? 'Changes were counted, but paths for this category were not included in the evidence sample.' : activity ? 'No changes were observed in this category.' : emptyMessage(phase)}</T></p>
           </div>
         )}
-      </div>
-
-      {filteredItems.length > ITEMS_PER_PAGE ? (
-        <nav className={cn('items-center justify-between gap-3 border-t border-overlay/10 px-3 py-2.5 sm:flex', mobileView === 'changes' ? 'flex' : 'hidden')} aria-label="System changes pagination">
-          <button
-            type="button"
-            onClick={() => setPage(Math.max(1, currentPage - 1))}
-            disabled={currentPage === 1}
-            className="inline-flex min-h-9 items-center gap-1 rounded-md border border-overlay/10 px-2.5 text-xs text-text-secondary transition-colors hover:bg-overlay/5 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
-            <T>Previous</T>
-          </button>
-          <span className="text-center text-[11px] text-text-muted" aria-live="polite">
-            <T>Page <Var>{currentPage}</Var> of <Var>{pageCount}</Var></T>
-            <span className="hidden sm:inline"> · {pageStart + 1}–{Math.min(pageStart + ITEMS_PER_PAGE, filteredItems.length)} of {filteredItems.length}</span>
-          </span>
-          <button
-            type="button"
-            onClick={() => setPage(Math.min(pageCount, currentPage + 1))}
-            disabled={currentPage === pageCount}
-            className="inline-flex min-h-9 items-center gap-1 rounded-md border border-overlay/10 px-2.5 text-xs text-text-secondary transition-colors hover:bg-overlay/5 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <T>Next</T>
-            <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        </nav>
-      ) : null}
-
-      <p className={cn('border-t border-overlay/10 px-4 py-2.5 text-[11px] leading-relaxed text-text-muted sm:block', mobileView !== 'changes' && 'hidden')}>
-        {activity ? <T>Compared at <Var>{new Date(activity.observedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</Var>. </T> : null}
-        {activity?.truncated ? (
-          <T>Snapshot comparison, not a complete real-time trace. Paths are sanitized and a 40-entry sample is shown.</T>
-        ) : (
-          <T>Snapshot comparison, not a complete real-time trace. Paths are sanitized and up to 40 entries are shown.</T>
-        )}
-      </p>
-    </section>
+        {pageCount > 1 ? (
+          <nav className="mt-4 flex items-center justify-between gap-3" aria-label="Sampled changes pagination">
+            <button type="button" onClick={() => setPage(currentPage - 1)} disabled={currentPage === 1} className={PAGE_BUTTON}><ChevronLeft className="h-4 w-4" aria-hidden="true" /><T>Previous</T></button>
+            <span className="text-xs text-text-muted" aria-live="polite"><T><Var>{pageStart + 1}</Var>–<Var>{Math.min(pageStart + ITEMS_PER_PAGE, items.length)}</Var> of <Var>{items.length}</Var> paths</T></span>
+            <button type="button" onClick={() => setPage(currentPage + 1)} disabled={currentPage === pageCount} className={PAGE_BUTTON}><T>Next</T><ChevronRight className="h-4 w-4" aria-hidden="true" /></button>
+          </nav>
+        ) : null}
+        <p className="mt-5 text-xs leading-5 text-text-muted"><T>Paths are sanitized. This is a sample of observed activity, not a complete real-time trace.</T></p>
+      </TabsContent>
+      <TabsContent value="log" className="m-0 min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2"><h3 className="text-sm font-semibold text-text-primary"><T>PSADT log</T></h3><span className="text-xs text-text-muted">{logAgeMinutes !== null && logAgeMinutes >= 1 ? <T>No new entry for <Var>{logAgeMinutes}</Var>m</T> : log ? <T>Last entry <Var>{new Date(log.lastWriteAt).toLocaleTimeString()}</Var></T> : <T>Waiting for output</T>}</span></div>
+        {log?.lines.length ? <ol className="space-y-2 rounded-xl border border-overlay/10 bg-bg-elevated/50 p-4 font-mono text-xs leading-6 text-text-secondary" aria-label="Latest sanitized PSADT log entries">{log.lines.map((line, index) => <li key={`${index}-${line}`} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{line}</li>)}</ol> : <p className="rounded-xl border border-dashed border-overlay/15 p-6 text-sm leading-6 text-text-muted"><T>Toolkit messages will appear here when PSADT publishes output.</T></p>}
+        <p className="mt-4 text-xs text-text-muted"><T>Latest sanitized entries from this test. Earlier log entries may not be included.</T></p>
+      </TabsContent>
+    </Tabs>
   );
 });

--- a/lib/qa/evidence-presentation.test.ts
+++ b/lib/qa/evidence-presentation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { evidenceTargetName, getEvidencePhaseStatus, getEvidenceSummary } from './evidence-presentation';
+import type { QaPhaseResults } from '@/types/qa';
+
+const passed = { exitCode: 0, durationSeconds: 4, timedOut: false };
+const complete: QaPhaseResults = {
+  install: passed,
+  detectionAfterInstall: passed,
+  uninstall: passed,
+  detectionAfterUninstall: { ...passed, exitCode: 1 },
+};
+
+describe('QA evidence wording', () => {
+  it('only describes a fully recorded passing lifecycle as passed', () => {
+    expect(getEvidenceSummary('Passed', complete)).toContain('all passed');
+    expect(getEvidenceSummary('Failed', complete)).toContain('reported a failure');
+    expect(getEvidenceSummary('Passed', { ...complete, detectionAfterUninstall: null })).toContain('not recorded');
+  });
+
+  it('distinguishes a stopped lifecycle from one that continued after failure', () => {
+    const install = { ...passed, exitCode: 1603 };
+    expect(getEvidenceSummary('Failed', { install, detectionAfterInstall: null, uninstall: null, detectionAfterUninstall: null }))
+      .toBe('Install failed. Later checks were not run.');
+    expect(getEvidenceSummary('Failed', { ...complete, install })).toBe('Install failed. Review the recorded checks below.');
+  });
+
+  it('does not treat a timed-out removal check as successful non-detection', () => {
+    const timedOut = { ...passed, exitCode: 1, timedOut: true };
+    expect(getEvidencePhaseStatus('detectionAfterUninstall', timedOut).passed).toBe(false);
+    expect(getEvidenceSummary('Failed', { ...complete, detectionAfterUninstall: timedOut })).toContain('timed out');
+    expect(getEvidencePhaseStatus('detectionAfterUninstall', passed).label).toBe('Still detected');
+  });
+
+  it('accepts reboot success for installation but not detection', () => {
+    for (const exitCode of [3010, 1641]) {
+      expect(getEvidencePhaseStatus('install', { ...passed, exitCode }).passed).toBe(true);
+      expect(getEvidencePhaseStatus('detectionAfterInstall', { ...passed, exitCode }).passed).toBe(false);
+    }
+    expect(getEvidencePhaseStatus('uninstall', null).label).toBe('Not run');
+  });
+
+  it('extracts a readable leaf while preserving root-only targets', () => {
+    expect(evidenceTargetName('%PROGRAMFILES%\\Example\\app.exe')).toBe('app.exe');
+    expect(evidenceTargetName('HKLM\\Software\\Example\\')).toBe('Example');
+    expect(evidenceTargetName('HKLM')).toBe('HKLM');
+    expect(evidenceTargetName('/')).toBe('/');
+  });
+});

--- a/lib/qa/evidence-presentation.ts
+++ b/lib/qa/evidence-presentation.ts
@@ -1,0 +1,46 @@
+import type { QaOutcome, QaPhaseResult, QaPhaseResults } from '@/types/qa';
+
+export type QaPhaseKey = keyof QaPhaseResults;
+
+export const QA_RESULT_PHASES: Array<{ key: QaPhaseKey; label: string }> = [
+  { key: 'install', label: 'Install' },
+  { key: 'detectionAfterInstall', label: 'Detection after install' },
+  { key: 'uninstall', label: 'Uninstall' },
+  { key: 'detectionAfterUninstall', label: 'Detection after uninstall' },
+];
+
+export function getEvidencePhaseStatus(key: QaPhaseKey, result: QaPhaseResult | null) {
+  if (!result) return { label: 'Not run', passed: null };
+  if (result.timedOut) return { label: 'Timed out', passed: false };
+  if (key === 'detectionAfterUninstall') {
+    return result.exitCode !== 0
+      ? { label: 'Removal verified', passed: true }
+      : { label: 'Still detected', passed: false };
+  }
+  const passed = key === 'detectionAfterInstall'
+    ? result.exitCode === 0
+    : [0, 3010, 1641].includes(result.exitCode);
+  return { label: passed ? 'Passed' : 'Failed', passed };
+}
+
+export function getEvidenceSummary(outcome: QaOutcome, phases: QaPhaseResults): string {
+  const failed = QA_RESULT_PHASES.find(({ key }) => getEvidencePhaseStatus(key, phases[key]).passed === false);
+  if (failed) {
+    const message = phases[failed.key]?.timedOut ? `${failed.label} timed out.` : `${failed.label} failed.`;
+    const later = QA_RESULT_PHASES.slice(QA_RESULT_PHASES.indexOf(failed) + 1);
+    return later.length > 0 && later.every(({ key }) => !phases[key])
+      ? `${message} Later checks were not run.`
+      : `${message} Review the recorded checks below.`;
+  }
+  if (QA_RESULT_PHASES.some(({ key }) => !phases[key])) {
+    return 'The full installation lifecycle was not recorded. Review the available checks below.';
+  }
+  return outcome === 'Passed'
+    ? 'Installation, detection, uninstall, and removal verification all passed.'
+    : 'The run reported a failure. Review the recorded checks and technical details.';
+}
+
+export function evidenceTargetName(target: string): string {
+  const withoutTrailingSeparators = target.replace(/[\\/]+$/, '');
+  return withoutTrailingSeparators.split(/[\\/]/).pop() || target;
+}


### PR DESCRIPTION
The QA page made users scan dense logs, configuration, and narrow result columns to understand what happened. Live evidence now uses consistent Changes and Log tabs with an app-specific header, readable expandable paths, sample counts beside filters, and six-path pagination. Completed results open on the outcome and recorded lifecycle, with separate Changes and Technical details tabs; failed and incomplete runs no longer imply the entire lifecycle succeeded. Security findings stay prominent and clean verdicts are compact.

Recent results now use full-width, keyboard-accessible rows below a compact expandable queue. Both modals share sizing, spacing, persistent tab navigation, and one vertically scrollable body per tab. Exact result selection, sanitized evidence, and bounded loading retries remain intact.

Validation: full repository ESLint passed; focused UI/import TypeScript check passed; 13 targeted tests passed, including timeout, partial lifecycle, reboot-exit, and target-label cases. The broad standalone TypeScript check reports unrelated existing test-file errors. No connected browser was available for visual verification.
