### PR TITLE
feat(qa): add an expandable live VM viewer

### DIFF
--- a/app/(marketing)/qa/QaLiveClient.tsx
+++ b/app/(marketing)/qa/QaLiveClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import { T, Var } from 'gt-next';
 import {
   AlertTriangle,
@@ -20,6 +19,7 @@ import {
 import { AppIcon } from '@/components/AppIcon';
 import { QueryProvider } from '@/components/providers/QueryProvider';
 import { QaDetailsDialog } from '@/components/qa/QaDetailsDialog';
+import { QaVmViewer } from '@/components/qa/QaVmViewer';
 import { QaLiveActivityDialog } from '@/components/qa/QaLiveActivityDialog';
 import { QaLiveStepTimeline } from '@/components/qa/QaLiveStepTimeline';
 import { StatusBadge, type StatusTone } from '@/components/ui/status-badge';
@@ -113,39 +113,6 @@ function QaVirusTotalCell({ status }: { status: QaVirusTotalStatus | null }) {
     );
   }
   return <span className="text-xs text-text-muted" aria-hidden="true">—</span>;
-}
-
-function LiveFrameImage({ src, alt }: { src: string; alt: string }) {
-  const [visibleSrc, setVisibleSrc] = useState<string | null>(null);
-
-  return (
-    <>
-      {visibleSrc ? (
-        <Image
-          src={visibleSrc}
-          alt={alt}
-          fill
-          unoptimized
-          loading="eager"
-          sizes="(min-width: 1024px) 960px, 100vw"
-          className="animate-fade-in object-contain motion-reduce:animate-none"
-        />
-      ) : null}
-      {src !== visibleSrc ? (
-        <Image
-          src={src}
-          alt=""
-          aria-hidden="true"
-          fill
-          unoptimized
-          loading="eager"
-          sizes="(min-width: 1024px) 960px, 100vw"
-          className="object-contain opacity-0"
-          onLoad={() => setVisibleSrc(src)}
-        />
-      ) : null}
-    </>
-  );
 }
 
 function ServiceHealth({ data }: { data: QaLiveResponse }) {
@@ -424,25 +391,15 @@ function CurrentTest({ data }: { data: QaLiveResponse }) {
           >
             <span className={styles.viewerBorder} aria-hidden="true" />
             <h3 id="live-console-heading" className="sr-only"><T>Live test VM</T></h3>
-            {frameState === 'live' ? (
-              <span className="absolute right-4 top-4 z-10 animate-pulse text-xs font-semibold uppercase tracking-[0.16em] text-status-success drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] motion-reduce:animate-none">
-                <T>Live</T>
-              </span>
-            ) : null}
-            <div className="absolute inset-0 overflow-hidden rounded-[inherit] bg-black">
-              {data.viewer.available && data.viewer.sequence != null && data.viewer.candidateId ? (
-                <LiveFrameImage
-                  key={data.viewer.candidateId}
-                  src={`/api/qa/live/frame?candidate=${encodeURIComponent(data.viewer.candidateId)}&sequence=${data.viewer.sequence}`}
-                  alt={`Read-only live view of the isolated QA VM while testing ${data.current.displayName}`}
-                />
-              ) : (
-                <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
-                  <Monitor className="h-8 w-8 text-white/25" aria-hidden="true" />
-                  <p className="max-w-md text-sm text-white/50"><T>The private host is preparing a safe, read-only VM console view. No keyboard, mouse, clipboard, or audio channel is exposed.</T></p>
-                </div>
-              )}
-            </div>
+            <QaVmViewer
+              key={`${data.current.wingetId}-${data.current.startedAt}`}
+              src={data.viewer.available && data.viewer.sequence != null && data.viewer.candidateId
+                ? `/api/qa/live/frame?candidate=${encodeURIComponent(data.viewer.candidateId)}&sequence=${data.viewer.sequence}`
+                : null}
+              appName={data.current.displayName}
+              phaseLabel={phase.label}
+              frameState={frameState}
+            />
           </div>
           <QaLiveStepTimeline
             phase={data.current.phase}

--- a/components/qa/QaVmViewer.tsx
+++ b/components/qa/QaVmViewer.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Maximize2, Minimize2, Monitor } from 'lucide-react';
+import { T } from 'gt-next';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import type { QaFrameState } from '@/lib/qa/presentation';
+
+const CONTROL_CLASS = 'inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-white/20 bg-black/70 text-white shadow-sm transition-colors hover:bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan';
+
+export function QaVmViewer({ src, appName, phaseLabel, frameState }: {
+  src: string | null;
+  appName: string;
+  phaseLabel: string;
+  frameState: QaFrameState;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [visibleSrc, setVisibleSrc] = useState<string | null>(null);
+  const alt = `Read-only live view of the isolated QA VM while testing ${appName}`;
+
+  // Keep one active frame surface and the last decoded image when expanding.
+  // Only swap once the new frame is decoded; do not fade or animate VM frames.
+  const frame = (
+    <>
+      {src && visibleSrc ? <Image src={visibleSrc} alt={alt} fill unoptimized loading="eager" className="object-contain" /> : null}
+      {src && src !== visibleSrc ? (
+        <Image key={src} src={src} alt="" aria-hidden="true" fill unoptimized loading="eager" fetchPriority="high" className="object-contain opacity-0" onLoad={() => setVisibleSrc(src)} />
+      ) : null}
+      {!src || !visibleSrc ? (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
+          <Monitor className="h-8 w-8 text-white/30" aria-hidden="true" />
+          <p className="max-w-md text-sm text-white/60"><T>{src ? 'Loading the live VM view…' : 'Waiting for the next VM frame.'}</T></p>
+        </div>
+      ) : null}
+      {frameState === 'live' ? (
+        <span className="absolute right-4 top-4 z-10 animate-pulse text-xs font-semibold uppercase tracking-[0.16em] text-status-success drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] motion-reduce:animate-none"><T>Live</T></span>
+      ) : frameState === 'paused' ? (
+        <span className="absolute right-4 top-4 z-10 rounded-md bg-black/70 px-2 py-1 text-xs text-white/80"><T>Waiting for updates</T></span>
+      ) : null}
+    </>
+  );
+
+  return (
+    <Dialog open={expanded} onOpenChange={setExpanded}>
+      <div className="absolute inset-0 overflow-hidden rounded-[inherit] bg-black">
+        {!expanded ? frame : null}
+        <DialogTrigger asChild>
+          <button type="button" className={`absolute left-3 top-3 z-20 ${CONTROL_CLASS}`} title="Expand VM view" aria-label="Expand VM view">
+            <Maximize2 className="h-5 w-5" aria-hidden="true" /><span className="sr-only"><T>Expand VM view</T></span>
+          </button>
+        </DialogTrigger>
+      </div>
+      <DialogContent hideCloseButton className="w-[min(96vw,calc((92dvh_-_5rem)_*_16_/_9))] max-w-[1920px] bg-bg-surface">
+        <div className="flex h-20 items-center justify-between gap-4 px-4 sm:px-5">
+          <div className="min-w-0">
+            <DialogTitle className="truncate text-base">{appName}</DialogTitle>
+            <DialogDescription className="mt-1 truncate text-xs"><T>{phaseLabel}</T> · <T>Read-only VM view</T></DialogDescription>
+          </div>
+          <DialogClose asChild>
+            <button type="button" className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-overlay/15 text-text-primary hover:bg-overlay/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan" title="Return to page" aria-label="Return to page">
+              <Minimize2 className="h-5 w-5" aria-hidden="true" /><span className="sr-only"><T>Return to page</T></span>
+            </button>
+          </DialogClose>
+        </div>
+        <div className="relative aspect-video w-full overflow-hidden bg-black">{expanded ? frame : null}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Adds a square expand control at the top-left of the live VM viewer. The larger dialog preserves 16:9 proportions, continues receiving live frames, and returns to the page through its collapse control or Escape. The existing buffered frame remains available across expansion, with only one active image surface and no additional polling subscription. Removes the decorative image fade and prioritizes pending frame image loads.

The underlying screenshot capture and polling cadence are unchanged; this does not claim a higher frame rate.

Validation: full repository ESLint and focused UI/import TypeScript checks passed. No connected browser was available for visual verification.
