### PR TITLE
fix(qa): smooth viewer expand and collapse transitions

### DIFF
--- a/components/qa/QaVmViewer.module.css
+++ b/components/qa/QaVmViewer.module.css
@@ -1,0 +1,31 @@
+/* Fade the large frame without moving or rescaling the desktop mid-transition. */
+.dialog[data-state='open'],
+.overlay[data-state='open'] {
+  animation: viewerEnter 180ms ease-out both;
+}
+
+.dialog[data-state='closed'],
+.overlay[data-state='closed'] {
+  animation: viewerExit 140ms ease-in both;
+}
+
+.overlay {
+  backdrop-filter: none;
+}
+
+@keyframes viewerEnter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes viewerExit {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dialog[data-state],
+  .overlay[data-state] {
+    animation: none;
+  }
+}

--- a/components/qa/QaVmViewer.tsx
+++ b/components/qa/QaVmViewer.tsx
@@ -6,6 +6,7 @@ import { Maximize2, Minimize2, Monitor } from 'lucide-react';
 import { T } from 'gt-next';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import type { QaFrameState } from '@/lib/qa/presentation';
+import styles from './QaVmViewer.module.css';
 
 const CONTROL_CLASS = 'inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-white/20 bg-black/70 text-white shadow-sm transition-colors hover:bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan';
 
@@ -19,14 +20,11 @@ export function QaVmViewer({ src, appName, phaseLabel, frameState }: {
   const [visibleSrc, setVisibleSrc] = useState<string | null>(null);
   const alt = `Read-only live view of the isolated QA VM while testing ${appName}`;
 
-  // Keep one active frame surface and the last decoded image when expanding.
-  // Only swap once the new frame is decoded; do not fade or animate VM frames.
+  // Both surfaces retain their image through the dialog's entrance and exit.
+  // A single persistent loader swaps frames only after decoding.
   const frame = (
     <>
       {src && visibleSrc ? <Image src={visibleSrc} alt={alt} fill unoptimized loading="eager" className="object-contain" /> : null}
-      {src && src !== visibleSrc ? (
-        <Image key={src} src={src} alt="" aria-hidden="true" fill unoptimized loading="eager" fetchPriority="high" className="object-contain opacity-0" onLoad={() => setVisibleSrc(src)} />
-      ) : null}
       {!src || !visibleSrc ? (
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
           <Monitor className="h-8 w-8 text-white/30" aria-hidden="true" />
@@ -44,14 +42,17 @@ export function QaVmViewer({ src, appName, phaseLabel, frameState }: {
   return (
     <Dialog open={expanded} onOpenChange={setExpanded}>
       <div className="absolute inset-0 overflow-hidden rounded-[inherit] bg-black">
-        {!expanded ? frame : null}
+        {frame}
+        {src && src !== visibleSrc ? (
+          <Image key={src} src={src} alt="" aria-hidden="true" fill unoptimized loading="eager" fetchPriority="high" className="pointer-events-none object-contain opacity-0" onLoad={() => setVisibleSrc(src)} />
+        ) : null}
         <DialogTrigger asChild>
           <button type="button" className={`absolute left-3 top-3 z-20 ${CONTROL_CLASS}`} title="Expand VM view" aria-label="Expand VM view">
             <Maximize2 className="h-5 w-5" aria-hidden="true" /><span className="sr-only"><T>Expand VM view</T></span>
           </button>
         </DialogTrigger>
       </div>
-      <DialogContent hideCloseButton className="w-[min(96vw,calc((92dvh_-_5rem)_*_16_/_9))] max-w-[1920px] bg-bg-surface">
+      <DialogContent hideCloseButton overlayClassName={styles.overlay} className={`${styles.dialog} w-[min(96vw,calc((92dvh_-_5rem)_*_16_/_9))] max-w-[1920px] bg-bg-surface`}>
         <div className="flex h-20 items-center justify-between gap-4 px-4 sm:px-5">
           <div className="min-w-0">
             <DialogTitle className="truncate text-base">{appName}</DialogTitle>
@@ -63,7 +64,7 @@ export function QaVmViewer({ src, appName, phaseLabel, frameState }: {
             </button>
           </DialogClose>
         </div>
-        <div className="relative aspect-video w-full overflow-hidden bg-black">{expanded ? frame : null}</div>
+        <div className="relative aspect-video w-full overflow-hidden bg-black">{frame}</div>
       </DialogContent>
     </Dialog>
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -32,11 +32,12 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     hideCloseButton?: boolean;
+    overlayClassName?: string;
     onInteractOutside?: (event: Event) => void;
   }
->(({ className, children, hideCloseButton, ...props }, ref) => (
+>(({ className, children, hideCloseButton, overlayClassName, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
Expanding the QA VM viewer combined slide/zoom animations with removal of the underlying frame, and closing cleared the modal image before its exit finished. Keep both frame surfaces populated with one persistent frame loader and use a short opacity-only transition. Disable backdrop blur for this viewer and respect reduced motion.

Validation: full repository ESLint passed via commit hook; focused TypeScript check and git diff --check passed. Browser visual verification was unavailable in this session.
