### PR TITLE
Fix Philips SmartControl installation identity and managed removal

### DIFF
--- a/.ugurlabs/entries/20260912-philips-smartcontrol-identity.json
+++ b/.ugurlabs/entries/20260912-philips-smartcontrol-identity.json
@@ -1,0 +1,5 @@
+{
+  "title": "Philips SmartControl package detection and removal",
+  "summary": "Philips SmartControl packages now use the application's exact registered identity to verify installation and remove the correct application.",
+  "type": "fixed"
+}

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -438,6 +438,23 @@ describe('triggerPackagingWorkflow hash validation payload', () => {
     );
   });
 
+  it('dispatches Philips customer packages with the same exact NSIS identity as QA', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await triggerPackagingWorkflow(workflowInputs({
+      wingetId: 'Philips.SmartControl', displayName: 'Smart Control', publisher: 'Philips',
+      version: '7.2.0', architecture: 'x64', installerSha256: '8'.repeat(64),
+      sourceType: 'winget', installerType: 'zip', nestedInstallerType: 'nullsoft',
+      silentSwitches: '/S', installScope: 'user',
+      uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{EAF31A0E-C98A-5E6E-9883-2A487A3337A1}:Smart Control',
+    }), config, { skipRunCapture: true });
+    const payload = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(payload.client_payload.installer.uninstallCommand).toBe(
+      'REGISTRY_UNINSTALL_KEY:eaf31a0e-c98a-5e6e-9883-2a487a3337a1:SmartControl'
+    );
+    expect(payload.client_payload.config.installScope).toBe('user');
+  });
+
   it('dispatches DSH Desktop with the reviewed NSIS key to the customer packager', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/lib/packaging-adapters.test.ts
+++ b/lib/packaging-adapters.test.ts
@@ -151,6 +151,17 @@ describe('application packaging adapters', () => {
     )).toBe('vendor-uninstall.exe --custom');
   });
 
+  it('binds Philips SmartControl only to its reviewed exact NSIS identity', () => {
+    const original = 'REGISTRY_UNINSTALL_PRODUCT:{EAF31A0E-C98A-5E6E-9883-2A487A3337A1}:Smart Control';
+    const expected = 'REGISTRY_UNINSTALL_KEY:eaf31a0e-c98a-5e6e-9883-2a487a3337a1:SmartControl';
+    expect(resolveApplicationUninstallCommand(' Philips.SmartControl ', original)).toBe(expected);
+    expect(resolveApplicationUninstallCommand('Philips.SmartControl', expected)).toBe(expected);
+    expect(resolveApplicationUninstallCommand('Philips.Other', original)).toBe(original);
+    for (const command of ['vendor-uninstall.exe --custom', original.replace('EAF31A0E', 'AAF31A0E')]) {
+      expect(resolveApplicationUninstallCommand('Philips.SmartControl', command)).toBe(command);
+    }
+  });
+
   it('binds DSH Desktop to its exact unbraced NSIS key despite the catalog typo', () => {
     expect(resolveApplicationUninstallCommand(
       'JustGenius-s.DSHDesktop',

--- a/lib/packaging-adapters.ts
+++ b/lib/packaging-adapters.ts
@@ -1955,6 +1955,15 @@ const REVIEWED_REGISTRY_UNINSTALL_IDENTITIES: Readonly<Record<string, Readonly<{
     generatedDisplayName: 'MSYS2 Installer',
     registeredDisplayName: 'MSYS2',
   },
+  // WinGet 7.2.0 and QA run 34666488057 agree on this unbraced NSIS
+  // key. The generated catalog command incorrectly decorates it as an MSI
+  // GUID and uses a spaced title. Preserve the exact vendor registration.
+  'philips.smartcontrol': {
+    generatedDisplayName: 'Smart Control',
+    manifestRegistryKey: '{EAF31A0E-C98A-5E6E-9883-2A487A3337A1}',
+    registeredDisplayName: 'SmartControl',
+    registeredRegistryKey: 'eaf31a0e-c98a-5e6e-9883-2a487a3337a1',
+  },
   // Quassel's WinGet ProductCode omits the space used by the application's
   // actual NSIS ARP identity, and the registered build version is a Git
   // revision instead of the manifest version. Bind the observed stable key so

--- a/lib/qa/package-profile.test.ts
+++ b/lib/qa/package-profile.test.ts
@@ -1486,6 +1486,24 @@ describe('PSADT QA package identity', () => {
     expect(profile.installer.uninstallCommand).toBe(uninstallCommand);
   });
 
+  it('binds Philips QA to its exact NSIS identity while preserving user scope and ZIP metadata', () => {
+    const normalized = normalizeQaWorkflowPackageInput({
+      wingetId: 'Philips.SmartControl', displayName: 'Smart Control', publisher: 'Philips',
+      version: '7.2.0', architecture: 'x64',
+      installerSha256: '82D3632C51CAB9819420F98B885B8499A526CB1A96DCE6893E90E9DE6D2F7E00',
+      installerType: 'zip', nestedInstallerType: 'nullsoft',
+      nestedInstallerPath: 'SmartControl Setup 7.2.0.exe',
+      silentSwitches: '/S', installScope: 'user',
+      uninstallCommand: 'REGISTRY_UNINSTALL_PRODUCT:{EAF31A0E-C98A-5E6E-9883-2A487A3337A1}:Smart Control',
+      detectionRules: '[]', psadtConfig: JSON.stringify({ detectionRules: [] }),
+    });
+    expect(normalized.identity.profile).toMatchObject({ installer: {
+      installScope: 'user', sourceType: 'zip', nestedInstallerType: 'nullsoft',
+      nestedInstallerFiles: ['SmartControl Setup 7.2.0.exe'], silentArgs: '/S',
+      uninstallCommand: 'REGISTRY_UNINSTALL_KEY:eaf31a0e-c98a-5e6e-9883-2a487a3337a1:SmartControl',
+    } });
+  });
+
   it('binds DSH Desktop QA to the exact NSIS key used by customer packages', () => {
     const normalized = normalizeQaWorkflowPackageInput({
       wingetId: 'JustGenius-s.DSHDesktop',

--- a/lib/qa/psadt-packager-contract.test.ts
+++ b/lib/qa/psadt-packager-contract.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { applyApplicationPackagingAdapter } from '@/lib/packaging-adapters';
+import { applyApplicationPackagingAdapter, resolveApplicationUninstallCommand } from '@/lib/packaging-adapters';
 import { DEFAULT_PSADT_CONFIG } from '@/types/psadt';
 import { generateUninstallCommand } from '@/lib/detection-rules';
 
@@ -2324,6 +2324,38 @@ if (@($selectedApplications).Count -ne 0) { throw 'Unrelated product selected' }
 `], { encoding: 'utf8' });
       expect(result.status, result.stderr).toBe(0);
       expect(generated).toContain("$configuredProductCode = '{AC76BA86-1033-FFFF-7760-BC15014EA700}'");
+    }, 30_000
+  );
+
+  it.runIf(canRunWindowsPowerShellPackager)(
+    'selects only the Philips NSIS key despite Edge and OneDrive registry changes',
+    () => {
+      const key = 'eaf31a0e-c98a-5e6e-9883-2a487a3337a1';
+      const command = resolveApplicationUninstallCommand('Philips.SmartControl',
+        'REGISTRY_UNINSTALL_PRODUCT:{EAF31A0E-C98A-5E6E-9883-2A487A3337A1}:Smart Control');
+      const generated = generateRegistryUninstallPackage('zip', 'Smart Control', [], {}, [],
+        'Philips.SmartControl', 'Smart Control', '7.2.0', command, '/S', 'user',
+        'nullsoft', 'SmartControl Setup 7.2.0.exe');
+      const identity = generated.split('\n').find(line => line.includes('$configuredUninstallProductCode ='));
+      const selection = generated.split('\n').find(line => line.includes('$selectedApplications = @($changedApplications | Where-Object { [string]$_.PSChildName -eq'));
+      expect(identity).toBeDefined();
+      expect(selection).toBeDefined();
+      const result = spawnSync('pwsh', ['-NoProfile', '-Command', `
+${identity}
+$changedApplications = @(
+  [pscustomobject]@{ PSChildName = '${key}'; DisplayName = 'SmartControl' },
+  [pscustomobject]@{ PSChildName = 'OneDriveSetup.exe'; DisplayName = 'Microsoft OneDrive' },
+  [pscustomobject]@{ PSChildName = 'Microsoft Edge'; DisplayName = 'Microsoft Edge' }
+)
+${selection}
+if (@($selectedApplications).Count -ne 1 -or $selectedApplications[0].DisplayName -ne 'SmartControl') { throw 'Wrong product selected' }
+$changedApplications = @($changedApplications[1], $changedApplications[2])
+${selection}
+if (@($selectedApplications).Count -ne 0) { throw 'Unrelated product selected' }
+`], { encoding: 'utf8' });
+      expect(result.status, result.stderr).toBe(0);
+      expect(generated).toContain("$configuredProductCode = '" + key + "'");
+      expect(generated).toContain("$registeredInstallerType = 'nullsoft'");
     }, 30_000
   );
 


### PR DESCRIPTION
Philips SmartControl 7.2.0 installs as `SmartControl` under the unbraced NSIS key `eaf31a0e-c98a-5e6e-9883-2a487a3337a1`. The generated catalog command expected a braced GUID and `Smart Control`, so QA run 34666488057 refused install verification and managed removal after unrelated Edge and OneDrive registry changes.

Bind the known generated identity to the exact vendor key through the shared QA/customer adapter. Preserve user scope, NSIS quiet removal, custom commands, and fail-closed identity selection.

Validation includes adapter and normalized-profile tests, customer GitHub payload coverage, and execution of generated PowerShell against synthetic SmartControl/Edge/OneDrive records. Full tests, lint and production build run in required CI; local lockfile verification is also in progress after detecting a stale dependency cache.

Source: https://github.com/microsoft/winget-pkgs/blob/master/manifests/p/Philips/SmartControl/7.2.0/Philips.SmartControl.installer.yaml
