### PR TITLE
Activate Philips SmartControl exact identity packager

### DIFF
--- a/lib/qa/package-profile.ts
+++ b/lib/qa/package-profile.ts
@@ -14,7 +14,7 @@ import type { PackagedWingetDependency } from '@/lib/winget-dependencies';
 
 export const QA_PSADT_TOOLCHAIN = {
   packagerRepository: 'ugurkocde/IntuneGet',
-  packagerCommit: '7238616608f888449fa2e132fffc8d7314c26745',
+  packagerCommit: '5fdfc187c77c3223dc76287b41232770108ee7be',
   packagerScriptPath: '.github/scripts/Create-PSADTPackage.ps1',
   psadtVersion: '4.1.8',
   templateUrl:
@@ -593,6 +593,9 @@ export const QA_PACKAGER_RELEASE_HISTORY = [
   // Archived EXE-family MSI identities now survive normalization. Unchanged
   // profiles remain compatible; old archive display fallbacks are excluded below.
   '6bdefc387d1402c71d30a6fbfcf850038f60f37a',
+  // Philips' exact NSIS key changes only its failing identity path. Other
+  // canonical execution profiles remain compatible with the preceding pin.
+  '7238616608f888449fa2e132fffc8d7314c26745',
   QA_PSADT_TOOLCHAIN.packagerCommit,
 ] as const;
 

--- a/lib/qa/toolchain-backfill.test.ts
+++ b/lib/qa/toolchain-backfill.test.ts
@@ -6,6 +6,14 @@ import {
 } from './toolchain-backfill';
 
 describe('QA toolchain targeted retries', () => {
+  it('retries Philips only after the exact NSIS identity repair', () => {
+    expect(shouldRetryTerminalToolchainCandidate(QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Philips.SmartControl', status: 'failed' })).toBe(true);
+    expect(shouldRetryTerminalToolchainCandidate('7238616608f888449fa2e132fffc8d7314c26745',
+      { wingetId: 'Philips.SmartControl', status: 'failed' })).toBe(false);
+    expect(shouldRetryTerminalToolchainCandidate(QA_PSADT_TOOLCHAIN.packagerCommit,
+      { wingetId: 'Philips.Other', status: 'failed' })).toBe(false);
+  });
   it('retries Acrobat only after its archive MSI identity repair', () => {
     expect(shouldRetryTerminalToolchainCandidate(QA_PSADT_TOOLCHAIN.packagerCommit,
       { wingetId: 'Adobe.Acrobat.Pro', status: 'failed' })).toBe(true);

--- a/lib/qa/toolchain-backfill.ts
+++ b/lib/qa/toolchain-backfill.ts
@@ -666,6 +666,14 @@ const ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS = [
 ] as const;
 
 const TOOLCHAIN_TERMINAL_RETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  '5fdfc187c77c3223dc76287b41232770108ee7be': [
+    'Philips.SmartControl',
+    'Adobe.Acrobat.Pro',
+    'WithSecure.ElementsAgent',
+    'PostgreSQL.PostgreSQL.16',
+    'Trimble.SketchUp.2025',
+    ...ARVIS_USER_SCOPE_RELEASE_RETRY_TARGETS,
+  ],
   '7238616608f888449fa2e132fffc8d7314c26745': [
     'Adobe.Acrobat.Pro',
     'WithSecure.ElementsAgent',


### PR DESCRIPTION
Activate protected shared packager `5fdfc187c77c3223dc76287b41232770108ee7be` from #1153. Philips SmartControl now uses its exact NSIS registration for install verification and managed removal in QA and customer packages.

Allow the failed Philips tuple to be regenerated by the normal scheduler, retaining prior reviewed retry targets and all security exclusions. Preserve compatible history for unrelated profiles; Philips' corrected command changes its canonical profile.

Validation: targeted profile/retry tests and lint locally; required full Test, Lint, Workflow lint and Build checks before merge. The underlying repair passed 1,848 local tests, lint and production build.
